### PR TITLE
Prevent double wrapping pg pool query

### DIFF
--- a/plugins/node/opentelemetry-plugin-pg/src/pg.ts
+++ b/plugins/node/opentelemetry-plugin-pg/src/pg.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { BasePlugin } from '@opentelemetry/core';
+import { BasePlugin, isWrapped } from '@opentelemetry/core';
 import { CanonicalCode, Span } from '@opentelemetry/api';
 import * as pgTypes from 'pg';
 import * as shimmer from 'shimmer';
@@ -43,7 +43,10 @@ export class PostgresPlugin extends BasePlugin<typeof pgTypes> {
   }
 
   protected patch(): typeof pgTypes {
-    if (this._moduleExports.Client.prototype.query) {
+    if (
+      this._moduleExports.Client.prototype.query &&
+      !isWrapped(this._moduleExports.Client.prototype.query)
+    ) {
       shimmer.wrap(
         this._moduleExports.Client.prototype,
         'query',


### PR DESCRIPTION
Looks like for some reason pg-pool tests fail now because pg is not checking if query is already wrapped. Either pg-pool updated or something about the way tests are running changed due to new project structure. Either way, testing to see if a query is already wrapped is a good check.