### PR TITLE
feat(opentelemetry-plugin-ioredis): provide a custom serializer fn for db.statement

### DIFF
--- a/plugins/node/opentelemetry-plugin-ioredis/README.md
+++ b/plugins/node/opentelemetry-plugin-ioredis/README.md
@@ -42,6 +42,14 @@ const { NodeTracerProvider } = require('@opentelemetry/node');
 const provider = new NodeTracerProvider();
 ```
 
+### IORedis Plugin Options
+
+IORedis plugin has few options available to choose from. You can set the following:
+
+| Options | Type | Description |
+| ------- | ---- | ----------- |
+| `dbStatementSerializer` | `DbStatementSerializer` | IORedis plugin will serialize db.statement using the specified function. |
+
 ## Useful links
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
 - For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>

--- a/plugins/node/opentelemetry-plugin-ioredis/README.md
+++ b/plugins/node/opentelemetry-plugin-ioredis/README.md
@@ -50,6 +50,30 @@ IORedis plugin has few options available to choose from. You can set the followi
 | ------- | ---- | ----------- |
 | `dbStatementSerializer` | `DbStatementSerializer` | IORedis plugin will serialize db.statement using the specified function. |
 
+#### Custom db.statement Serializer
+The plugin serializes the whole command into a Span attribute called `db.statement`. The standard serialization format is `{cmdName} {cmdArgs.join(',')}`.
+It is also possible to define a custom serialization function. The function will receive the command name and arguments and must return a string.
+
+Here is a simple example to serialize the command name skipping arguments:
+
+```javascript
+const { NodeTracerProvider } = require('@opentelemetry/node');
+
+const provider = new NodeTracerProvider({
+  plugins: {
+    ioredis: {
+      enabled: true,
+      // You may use a package name or absolute path to the file.
+      path: '@opentelemetry/plugin-ioredis',
+      dbStatementSerializer: function (cmdName, cmdArgs) {
+        return cmdName;
+      }
+    }
+  }
+});
+
+```
+
 ## Useful links
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
 - For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>

--- a/plugins/node/opentelemetry-plugin-ioredis/src/ioredis.ts
+++ b/plugins/node/opentelemetry-plugin-ioredis/src/ioredis.ts
@@ -17,6 +17,7 @@
 import { BasePlugin } from '@opentelemetry/core';
 import * as ioredisTypes from 'ioredis';
 import * as shimmer from 'shimmer';
+import { IORedisPluginConfig } from './types';
 import { traceConnection, traceSendCommand } from './utils';
 import { VERSION } from './version';
 
@@ -24,6 +25,7 @@ export class IORedisPlugin extends BasePlugin<typeof ioredisTypes> {
   static readonly COMPONENT = 'ioredis';
   static readonly DB_TYPE = 'redis';
   readonly supportedVersions = ['>1 <5'];
+  protected _config!: IORedisPluginConfig;
 
   constructor(readonly moduleName: string) {
     super('@opentelemetry/plugin-ioredis', VERSION);
@@ -60,7 +62,7 @@ export class IORedisPlugin extends BasePlugin<typeof ioredisTypes> {
   private _patchSendCommand() {
     const tracer = this._tracer;
     return (original: Function) => {
-      return traceSendCommand(tracer, original);
+      return traceSendCommand(tracer, original, plugin._config);
     };
   }
 

--- a/plugins/node/opentelemetry-plugin-ioredis/src/types.ts
+++ b/plugins/node/opentelemetry-plugin-ioredis/src/types.ts
@@ -31,6 +31,13 @@ export interface IORedisPluginClientTypes {
   options: ioredisTypes.RedisOptions;
 }
 
+/**
+ * Function that can be used to serialize db.statement tag
+ * @param cmdName - The name of the command (eg. set, get, mset)
+ * @param cmdArgs - Array of arguments passed to the command
+ *
+ * @returns serialized string that will be used as the db.statement attribute.
+ */
 export type DbStatementSerializer = (
   cmdName: IORedisCommand['name'],
   cmdArgs: IORedisCommand['args']

--- a/plugins/node/opentelemetry-plugin-ioredis/src/types.ts
+++ b/plugins/node/opentelemetry-plugin-ioredis/src/types.ts
@@ -15,6 +15,7 @@
  */
 
 import * as ioredisTypes from 'ioredis';
+import { PluginConfig } from '@opentelemetry/api';
 
 export interface IORedisCommand {
   reject: (err: Error) => void;
@@ -28,4 +29,17 @@ export interface IORedisCommand {
 export interface IORedisPluginClientTypes {
   // https://github.com/luin/ioredis/blob/master/API.md
   options: ioredisTypes.RedisOptions;
+}
+
+export type DbStatementSerializer = (
+  cmdName: IORedisCommand['name'],
+  cmdArgs: IORedisCommand['args']
+) => string;
+
+/**
+ * Options available for the IORedis Plugin (see [documentation](https://github.com/open-telemetry/opentelemetry-js/tree/master/packages/opentelemetry-plugin-ioredis#ioredis-plugin-options))
+ */
+export interface IORedisPluginConfig extends PluginConfig {
+  /** Custom serializer function for the db.statement tag */
+  dbStatementSerializer?: DbStatementSerializer;
 }

--- a/plugins/node/opentelemetry-plugin-ioredis/src/utils.ts
+++ b/plugins/node/opentelemetry-plugin-ioredis/src/utils.ts
@@ -78,13 +78,13 @@ export const traceSendCommand = (
   original: Function,
   config?: IORedisPluginConfig
 ) => {
+  const dbStatementSerializer =
+    config?.dbStatementSerializer || defaultDbStatementSerializer;
   return function(
     this: ioredisTypes.Redis & IORedisPluginClientTypes,
     cmd?: IORedisCommand
   ) {
     if (arguments.length >= 1 && typeof cmd === 'object') {
-      const dbStatementSerializer =
-        config?.dbStatementSerializer || defaultDbStatementSerializer;
       const span = tracer.startSpan(cmd.name, {
         kind: SpanKind.CLIENT,
         attributes: {

--- a/plugins/node/opentelemetry-plugin-ioredis/test/ioredis.test.ts
+++ b/plugins/node/opentelemetry-plugin-ioredis/test/ioredis.test.ts
@@ -512,7 +512,7 @@ describe('ioredis', () => {
       });
     });
 
-    describe('Instrumenting with specific configuration', () => {
+    describe('Instrumenting with a custom db.statement serializer', () => {
       const dbStatementSerializer: DbStatementSerializer = (cmdName, cmdArgs) =>
         `FOOBAR_${cmdName}: ${cmdArgs[0]}`;
       before(() => {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?
IORedis plugin currently serializes the command name and arguments in the `db.statement` tag. This may yield to a big payload serialized inside the tag (for example, while `mget`ting many values or `set`ting large json objects). It may also be an issue when data saved inside Redis should not be accessible inside logs/traces. 

## Short description of the changes
This PR adds an optional function inside the configuration that can be used to define a custom serialization function for `db.statement`. The function will receive cmdName and cmdArgs and will return a serialized string.
With this, one may decide (for example) to serialize only the `cmdName` for specific commands, or to have a separate handling for each command.

First contribution to the project so I hope I have done everything right :D 
