### PR TITLE
fix: patch removeEventListener to properly remove patched callbacks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,9 @@ jobs:
           path: |
             node_modules
             packages/*/node_modules
-            metapackages/*/node_modules
+            plugins/node/*/node_modules
+            plugins/web/*/node_modules
+            propagators/*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/package.json') }}
 
       - name: Bootstrap

--- a/plugins/web/opentelemetry-plugin-user-interaction/src/userInteraction.ts
+++ b/plugins/web/opentelemetry-plugin-user-interaction/src/userInteraction.ts
@@ -49,7 +49,10 @@ export class UserInteractionPlugin extends BasePlugin<unknown> {
   private _spansData = new WeakMap<api.Span, SpanData>();
   private _zonePatched = false;
   // for addEventListener/removeEventListener state
-  private _wrappedListeners = new WeakMap<Function, Map<String, Map<HTMLElement, Function>>>();
+  private _wrappedListeners = new WeakMap<
+    Function,
+    Map<string, Map<HTMLElement, Function>>
+  >();
 
   constructor() {
     super('@opentelemetry/plugin-user-interaction', VERSION);
@@ -167,7 +170,12 @@ export class UserInteractionPlugin extends BasePlugin<unknown> {
     }
   }
 
-  private addPatchedListener(on: HTMLElement, type: String, listener: Function, wrappedListener: Function) {
+  private addPatchedListener(
+    on: HTMLElement,
+    type: string,
+    listener: Function,
+    wrappedListener: Function
+  ) {
     let listener2Type = this._wrappedListeners.get(listener);
     if (!listener2Type) {
       listener2Type = new Map();
@@ -181,12 +189,16 @@ export class UserInteractionPlugin extends BasePlugin<unknown> {
     element2patched.set(on, wrappedListener);
   }
 
-  private removePatchedListener(on: HTMLElement, type: String, listener: Function) : Function|undefined {
-    let listener2Type = this._wrappedListeners.get(listener);
+  private removePatchedListener(
+    on: HTMLElement,
+    type: string,
+    listener: Function
+  ): Function | undefined {
+    const listener2Type = this._wrappedListeners.get(listener);
     if (!listener2Type) {
       return undefined;
     }
-    let element2patched = listener2Type.get(type);
+    const element2patched = listener2Type.get(type);
     if (!element2patched) {
       return undefined;
     }
@@ -251,7 +263,11 @@ export class UserInteractionPlugin extends BasePlugin<unknown> {
         listener: any,
         useCapture: any
       ) {
-        const wrappedListener = plugin.removePatchedListener(this, type, listener);
+        const wrappedListener = plugin.removePatchedListener(
+          this,
+          type,
+          listener
+        );
         if (wrappedListener) {
           return original.call(this, type, wrappedListener, useCapture);
         } else {

--- a/plugins/web/opentelemetry-plugin-user-interaction/src/userInteraction.ts
+++ b/plugins/web/opentelemetry-plugin-user-interaction/src/userInteraction.ts
@@ -239,8 +239,12 @@ export class UserInteractionPlugin extends BasePlugin<unknown> {
         listener: any,
         useCapture: any
       ) {
+        const once = useCapture && useCapture.once;
         const patchedListener = (...args: any[]) => {
           const target = this;
+          if (once) {
+            plugin.removePatchedListener(this, type, listener);
+          }
           const span = plugin._createSpan(target, 'click');
           if (span) {
             return plugin._tracer.withSpan(span, () => {

--- a/plugins/web/opentelemetry-plugin-user-interaction/src/userInteraction.ts
+++ b/plugins/web/opentelemetry-plugin-user-interaction/src/userInteraction.ts
@@ -216,6 +216,7 @@ export class UserInteractionPlugin extends BasePlugin<unknown> {
       ) {
         const wrappedListener = plugin._wrappedListeners.get(listener);
         if (wrappedListener) {
+          plugin._wrappedListeners.delete(listener);
           return original.call(this, type, wrappedListener, useCapture);
         } else {
           return original.call(this, type, listener, useCapture);

--- a/plugins/web/opentelemetry-plugin-user-interaction/test/userInteraction.nozone.test.ts
+++ b/plugins/web/opentelemetry-plugin-user-interaction/test/userInteraction.nozone.test.ts
@@ -123,6 +123,23 @@ describe('UserInteractionPlugin', () => {
       assert.strictEqual(called, false);
     });
 
+    it('should only not double-register a listener', () => {
+      let callCount = 0;
+      const listener = function () {
+        callCount++;
+      };
+      // addEventListener semantics treat the second call as a no-op
+      document.body.addEventListener('bodyEvent', listener);
+      document.body.addEventListener('bodyEvent', listener);
+      document.body.dispatchEvent(new Event('bodyEvent'));
+      assert.strictEqual(callCount, 1);
+      // now ensure remove still works
+      callCount = 0;
+      document.body.removeEventListener('bodyEvent', listener);
+      document.body.dispatchEvent(new Event('bodyEvent'));
+      assert.strictEqual(callCount, 0);
+    });
+
     it('should handle task without async operation', () => {
       fakeInteraction();
       assert.equal(exportSpy.args.length, 1, 'should export one span');

--- a/plugins/web/opentelemetry-plugin-user-interaction/test/userInteraction.nozone.test.ts
+++ b/plugins/web/opentelemetry-plugin-user-interaction/test/userInteraction.nozone.test.ts
@@ -123,7 +123,7 @@ describe('UserInteractionPlugin', () => {
       assert.strictEqual(called, false);
     });
 
-    it('should only not double-register a listener', () => {
+    it('should not double-register a listener', () => {
       let callCount = 0;
       const listener = function () {
         callCount++;
@@ -138,6 +138,22 @@ describe('UserInteractionPlugin', () => {
       document.body.removeEventListener('bodyEvent', listener);
       document.body.dispatchEvent(new Event('bodyEvent'));
       assert.strictEqual(callCount, 0);
+    });
+
+    it('should handle once-only callbacks', () => {
+      let callCount = 0;
+      const listener = function () {
+        callCount++;
+      };
+      // addEventListener semantics treat the second call as a no-op
+      document.body.addEventListener('bodyEvent', listener, { once: true });
+      document.body.addEventListener('bodyEvent', listener); // considered a double-register
+      document.body.dispatchEvent(new Event('bodyEvent'));
+      assert.strictEqual(callCount, 1);
+      // now that it's been dispatched once, it's been removed; should be able to re-add
+      document.body.addEventListener('bodyEvent', listener);
+      document.body.dispatchEvent(new Event('bodyEvent'));
+      assert.strictEqual(callCount, 2);
     });
 
     it('should handle task without async operation', () => {

--- a/plugins/web/opentelemetry-plugin-user-interaction/test/userInteraction.nozone.test.ts
+++ b/plugins/web/opentelemetry-plugin-user-interaction/test/userInteraction.nozone.test.ts
@@ -150,10 +150,15 @@ describe('UserInteractionPlugin', () => {
       document.body.addEventListener('bodyEvent', listener); // considered a double-register
       document.body.dispatchEvent(new Event('bodyEvent'));
       assert.strictEqual(callCount, 1);
-      // now that it's been dispatched once, it's been removed; should be able to re-add
+      // now that it's been dispatched once, it's been removed
+      document.body.dispatchEvent(new Event('bodyEvent'));
+      assert.strictEqual(callCount, 1);
+      // should be able to re-add
       document.body.addEventListener('bodyEvent', listener);
       document.body.dispatchEvent(new Event('bodyEvent'));
       assert.strictEqual(callCount, 2);
+      document.body.dispatchEvent(new Event('bodyEvent'));
+      assert.strictEqual(callCount, 3);
     });
 
     it('should handle task without async operation', () => {

--- a/plugins/web/opentelemetry-plugin-user-interaction/test/userInteraction.nozone.test.ts
+++ b/plugins/web/opentelemetry-plugin-user-interaction/test/userInteraction.nozone.test.ts
@@ -94,12 +94,32 @@ describe('UserInteractionPlugin', () => {
       const listener = function () {
         called = true;
       };
-      document.body.addEventListener('testEvent', listener);
-      document.body.dispatchEvent(new Event('testEvent'));
+      // add same listener three different ways
+      document.body.addEventListener('bodyEvent', listener);
+      document.body.addEventListener('bodyEvent2', listener);
+      document.addEventListener('docEvent', listener);
+      document.body.dispatchEvent(new Event('bodyEvent'));
       assert.strictEqual(called, true);
       called = false;
-      document.body.removeEventListener('testEvent', listener);
-      document.body.dispatchEvent(new Event('testEvent'));
+      // Remove first callback, second type should still fire
+      document.body.removeEventListener('bodyEvent', listener);
+      document.body.dispatchEvent(new Event('bodyEvent'));
+      assert.strictEqual(called, false);
+      document.body.dispatchEvent(new Event('bodyEvent2'));
+      assert.strictEqual(called, true);
+      called = false;
+      // Remove doc callback, body 2 should still fire
+      document.removeEventListener('docEvent', listener);
+      document.dispatchEvent(new Event('docEvent'));
+      assert.strictEqual(called, false);
+      document.body.dispatchEvent(new Event('bodyEvent2'));
+      assert.strictEqual(called, true);
+      called = false;
+      // Finally, remove the last one and nothing should fire
+      document.body.removeEventListener('bodyEvent2', listener);
+      document.body.dispatchEvent(new Event('bodyEvent'));
+      document.body.dispatchEvent(new Event('bodyEvent2'));
+      document.dispatchEvent(new Event('docEvent'));
       assert.strictEqual(called, false);
     });
 

--- a/plugins/web/opentelemetry-plugin-user-interaction/test/userInteraction.nozone.test.ts
+++ b/plugins/web/opentelemetry-plugin-user-interaction/test/userInteraction.nozone.test.ts
@@ -89,6 +89,20 @@ describe('UserInteractionPlugin', () => {
       context.disable();
     });
 
+    it('should not break removeEventListener', () => {
+      let called = false;
+      const listener = function () {
+        called = true;
+      };
+      document.body.addEventListener('testEvent', listener);
+      document.body.dispatchEvent(new Event('testEvent'));
+      assert.strictEqual(called, true);
+      called = false;
+      document.body.removeEventListener('testEvent', listener);
+      document.body.dispatchEvent(new Event('testEvent'));
+      assert.strictEqual(called, false);
+    });
+
     it('should handle task without async operation', () => {
       fakeInteraction();
       assert.equal(exportSpy.args.length, 1, 'should export one span');


### PR DESCRIPTION
We need to patch removeEventListener in order to compensate for wrapping callbacks passed to addEventListener.

