### PR TITLE
feat(opentelemetry-plugin-pg): omit pg.values by default

### DIFF
--- a/plugins/node/opentelemetry-plugin-pg/README.md
+++ b/plugins/node/opentelemetry-plugin-pg/README.md
@@ -65,6 +65,14 @@ const provider = new NodeTracerProvider({
 
 See [examples/postgres](https://github.com/open-telemetry/opentelemetry-js/tree/master/examples/postgres) for a short example.
 
+### PostgreSQL Plugin Options
+
+PostgreSQL plugin has few options available to choose from. You can set the following:
+
+| Options | Type | Description |
+| ------- | ---- | ----------- |
+| [`enhancedDatabaseReporting`](https://github.com/open-telemetry/opentelemetry-js/blob/master/packages/opentelemetry-api/src/trace/instrumentation/Plugin.ts#L90) | `boolean` | If true, additional information about query parameters and results will be attached (as `attributes`) to spans representing database operations |
+
 ## Supported Versions
 
 - [pg](https://npmjs.com/package/pg): `7.x`

--- a/plugins/node/opentelemetry-plugin-pg/src/pg.ts
+++ b/plugins/node/opentelemetry-plugin-pg/src/pg.ts
@@ -132,7 +132,7 @@ export class PostgresPlugin extends BasePlugin<typeof pgTypes> {
           return result
             .then((result: unknown) => {
               // Return a pass-along promise which ends the span and then goes to user's orig resolvers
-              return new Promise((resolve, _) => {
+              return new Promise(resolve => {
                 span.setStatus({ code: CanonicalCode.OK });
                 span.end();
                 resolve(result);

--- a/plugins/node/opentelemetry-plugin-pg/src/pg.ts
+++ b/plugins/node/opentelemetry-plugin-pg/src/pg.ts
@@ -27,8 +27,6 @@ import * as utils from './utils';
 import { VERSION } from './version';
 
 export class PostgresPlugin extends BasePlugin<typeof pgTypes> {
-  protected _config: {};
-
   static readonly COMPONENT = 'pg';
   static readonly DB_TYPE = 'sql';
 
@@ -73,6 +71,7 @@ export class PostgresPlugin extends BasePlugin<typeof pgTypes> {
             span = utils.handleParameterizedQuery.call(
               this,
               plugin._tracer,
+              plugin._config,
               query,
               params
             );
@@ -84,6 +83,7 @@ export class PostgresPlugin extends BasePlugin<typeof pgTypes> {
           span = utils.handleConfigQuery.call(
             this,
             plugin._tracer,
+            plugin._config,
             queryConfig
           );
         } else {

--- a/plugins/node/opentelemetry-plugin-pg/src/pg.ts
+++ b/plugins/node/opentelemetry-plugin-pg/src/pg.ts
@@ -67,17 +67,25 @@ export class PostgresPlugin extends BasePlugin<typeof pgTypes> {
 
         // Handle different client.query(...) signatures
         if (typeof args[0] === 'string') {
+          const query = args[0];
           if (args.length > 1 && args[1] instanceof Array) {
+            const params = args[1];
             span = utils.handleParameterizedQuery.call(
               this,
               plugin._tracer,
-              ...args
+              query,
+              params
             );
           } else {
-            span = utils.handleTextQuery.call(this, plugin._tracer, ...args);
+            span = utils.handleTextQuery.call(this, plugin._tracer, query);
           }
         } else if (typeof args[0] === 'object') {
-          span = utils.handleConfigQuery.call(this, plugin._tracer, ...args);
+          const queryConfig = args[0] as NormalizedQueryConfig;
+          span = utils.handleConfigQuery.call(
+            this,
+            plugin._tracer,
+            queryConfig
+          );
         } else {
           return utils.handleInvalidQuery.call(
             this,

--- a/plugins/node/opentelemetry-plugin-pg/src/pg.ts
+++ b/plugins/node/opentelemetry-plugin-pg/src/pg.ts
@@ -20,7 +20,7 @@ import * as pgTypes from 'pg';
 import * as shimmer from 'shimmer';
 import {
   PgClientExtended,
-  PgPluginQueryConfig,
+  NormalizedQueryConfig,
   PostgresCallback,
 } from './types';
 import * as utils from './utils';
@@ -103,12 +103,12 @@ export class PostgresPlugin extends BasePlugin<typeof pgTypes> {
               );
             }
           } else if (
-            typeof (args[0] as PgPluginQueryConfig).callback === 'function'
+            typeof (args[0] as NormalizedQueryConfig).callback === 'function'
           ) {
             // Patch ConfigQuery callback
             let callback = utils.patchCallback(
               span,
-              (args[0] as PgPluginQueryConfig).callback!
+              (args[0] as NormalizedQueryConfig).callback!
             );
             // If a parent span existed, bind the callback
             if (parentSpan) {

--- a/plugins/node/opentelemetry-plugin-pg/src/pg.ts
+++ b/plugins/node/opentelemetry-plugin-pg/src/pg.ts
@@ -62,10 +62,7 @@ export class PostgresPlugin extends BasePlugin<typeof pgTypes> {
       plugin._logger.debug(
         `Patching ${PostgresPlugin.COMPONENT}.Client.prototype.query`
       );
-      return function query(
-        this: pgTypes.Client & PgClientExtended,
-        ...args: unknown[]
-      ) {
+      return function query(this: PgClientExtended, ...args: unknown[]) {
         let span: Span;
 
         // Handle different client.query(...) signatures

--- a/plugins/node/opentelemetry-plugin-pg/src/types.ts
+++ b/plugins/node/opentelemetry-plugin-pg/src/types.ts
@@ -31,6 +31,8 @@ export interface PgClientExtended extends pgTypes.Client {
   connectionParameters: PgClientConnectionParams;
 }
 
-export interface PgPluginQueryConfig extends pgTypes.QueryConfig {
+// Interface name based on original driver implementation
+// https://github.com/brianc/node-postgres/blob/2ef55503738eb2cbb6326744381a92c0bc0439ab/packages/pg/lib/utils.js#L157
+export interface NormalizedQueryConfig extends pgTypes.QueryConfig {
   callback?: PostgresCallback;
 }

--- a/plugins/node/opentelemetry-plugin-pg/src/types.ts
+++ b/plugins/node/opentelemetry-plugin-pg/src/types.ts
@@ -27,7 +27,7 @@ export interface PgClientConnectionParams {
   user: string;
 }
 
-export interface PgClientExtended {
+export interface PgClientExtended extends pgTypes.Client {
   connectionParameters: PgClientConnectionParams;
 }
 

--- a/plugins/node/opentelemetry-plugin-pg/src/utils.ts
+++ b/plugins/node/opentelemetry-plugin-pg/src/utils.ts
@@ -64,29 +64,26 @@ function pgStartSpan(tracer: Tracer, client: PgClientExtended, name: string) {
 export function handleConfigQuery(
   this: PgClientExtended,
   tracer: Tracer,
-  ...args: unknown[]
+  queryConfig: NormalizedQueryConfig
 ) {
-  const argsConfig = args[0] as NormalizedQueryConfig;
-
   // Set child span name
-  const queryCommand = getCommandFromText(argsConfig.name || argsConfig.text);
+  const queryCommand = getCommandFromText(queryConfig.name || queryConfig.text);
   const name = PostgresPlugin.BASE_SPAN_NAME + ':' + queryCommand;
   const span = pgStartSpan(tracer, this, name);
 
   // Set attributes
-  if (argsConfig.text) {
-    span.setAttribute(AttributeNames.DB_STATEMENT, argsConfig.text);
+  if (queryConfig.text) {
+    span.setAttribute(AttributeNames.DB_STATEMENT, queryConfig.text);
   }
-
-  if (argsConfig.values instanceof Array) {
+  if (queryConfig.values instanceof Array) {
     span.setAttribute(
       AttributeNames.PG_VALUES,
-      arrayStringifyHelper(argsConfig.values)
+      arrayStringifyHelper(queryConfig.values)
     );
   }
   // Set plan name attribute, if present
-  if (argsConfig.name) {
-    span.setAttribute(AttributeNames.PG_PLAN, argsConfig.name);
+  if (queryConfig.name) {
+    span.setAttribute(AttributeNames.PG_PLAN, queryConfig.name);
   }
 
   return span;
@@ -96,18 +93,17 @@ export function handleConfigQuery(
 export function handleParameterizedQuery(
   this: PgClientExtended,
   tracer: Tracer,
-  ...args: unknown[]
+  query: string,
+  values: unknown[]
 ) {
   // Set child span name
-  const queryCommand = getCommandFromText(args[0] as string);
+  const queryCommand = getCommandFromText(query);
   const name = PostgresPlugin.BASE_SPAN_NAME + ':' + queryCommand;
   const span = pgStartSpan(tracer, this, name);
 
   // Set attributes
-  span.setAttribute(AttributeNames.DB_STATEMENT, args[0]);
-  if (args[1] instanceof Array) {
-    span.setAttribute(AttributeNames.PG_VALUES, arrayStringifyHelper(args[1]));
-  }
+  span.setAttribute(AttributeNames.DB_STATEMENT, query);
+  span.setAttribute(AttributeNames.PG_VALUES, arrayStringifyHelper(values));
 
   return span;
 }
@@ -116,15 +112,15 @@ export function handleParameterizedQuery(
 export function handleTextQuery(
   this: PgClientExtended,
   tracer: Tracer,
-  ...args: unknown[]
+  query: string
 ) {
   // Set child span name
-  const queryCommand = getCommandFromText(args[0] as string);
+  const queryCommand = getCommandFromText(query);
   const name = PostgresPlugin.BASE_SPAN_NAME + ':' + queryCommand;
   const span = pgStartSpan(tracer, this, name);
 
   // Set attributes
-  span.setAttribute(AttributeNames.DB_STATEMENT, args[0]);
+  span.setAttribute(AttributeNames.DB_STATEMENT, query);
 
   return span;
 }

--- a/plugins/node/opentelemetry-plugin-pg/src/utils.ts
+++ b/plugins/node/opentelemetry-plugin-pg/src/utils.ts
@@ -44,11 +44,7 @@ function getJDBCString(params: PgClientConnectionParams) {
 }
 
 // Private helper function to start a span
-function pgStartSpan(
-  tracer: Tracer,
-  client: pgTypes.Client & PgClientExtended,
-  name: string
-) {
+function pgStartSpan(tracer: Tracer, client: PgClientExtended, name: string) {
   const jdbcString = getJDBCString(client.connectionParameters);
   return tracer.startSpan(name, {
     kind: SpanKind.CLIENT,
@@ -66,7 +62,7 @@ function pgStartSpan(
 
 // Queries where args[0] is a QueryConfig
 export function handleConfigQuery(
-  this: pgTypes.Client & PgClientExtended,
+  this: PgClientExtended,
   tracer: Tracer,
   ...args: unknown[]
 ) {
@@ -98,7 +94,7 @@ export function handleConfigQuery(
 
 // Queries where args[1] is a 'values' array
 export function handleParameterizedQuery(
-  this: pgTypes.Client & PgClientExtended,
+  this: PgClientExtended,
   tracer: Tracer,
   ...args: unknown[]
 ) {
@@ -118,7 +114,7 @@ export function handleParameterizedQuery(
 
 // Queries where args[0] is a text query and 'values' was not specified
 export function handleTextQuery(
-  this: pgTypes.Client & PgClientExtended,
+  this: PgClientExtended,
   tracer: Tracer,
   ...args: unknown[]
 ) {
@@ -138,7 +134,7 @@ export function handleTextQuery(
  * Create and immediately end a new span
  */
 export function handleInvalidQuery(
-  this: pgTypes.Client & PgClientExtended,
+  this: PgClientExtended,
   tracer: Tracer,
   originalQuery: typeof pgTypes.Client.prototype.query,
   ...args: unknown[]
@@ -162,7 +158,7 @@ export function patchCallback(
   cb: PostgresCallback
 ): PostgresCallback {
   return function patchedCallback(
-    this: pgTypes.Client & PgClientExtended,
+    this: PgClientExtended,
     err: Error,
     res: object
   ) {

--- a/plugins/node/opentelemetry-plugin-pg/src/utils.ts
+++ b/plugins/node/opentelemetry-plugin-pg/src/utils.ts
@@ -18,7 +18,7 @@ import { Span, CanonicalCode, Tracer, SpanKind } from '@opentelemetry/api';
 import { AttributeNames } from './enums';
 import {
   PgClientExtended,
-  PgPluginQueryConfig,
+  NormalizedQueryConfig,
   PostgresCallback,
   PgClientConnectionParams,
 } from './types';
@@ -66,7 +66,7 @@ export function handleConfigQuery(
   tracer: Tracer,
   ...args: unknown[]
 ) {
-  const argsConfig = args[0] as PgPluginQueryConfig;
+  const argsConfig = args[0] as NormalizedQueryConfig;
 
   // Set child span name
   const queryCommand = getCommandFromText(argsConfig.name || argsConfig.text);

--- a/plugins/node/opentelemetry-plugin-pg/test/pg.test.ts
+++ b/plugins/node/opentelemetry-plugin-pg/test/pg.test.ts
@@ -211,7 +211,6 @@ describe('pg@7.x', () => {
       const attributes = {
         ...DEFAULT_ATTRIBUTES,
         [AttributeNames.DB_STATEMENT]: query,
-        [AttributeNames.PG_VALUES]: '[0]',
       };
       const events: TimedEvent[] = [];
       const span = tracer.startSpan('test span');
@@ -273,7 +272,6 @@ describe('pg@7.x', () => {
       const attributes = {
         ...DEFAULT_ATTRIBUTES,
         [AttributeNames.DB_STATEMENT]: query,
-        [AttributeNames.PG_VALUES]: '[0]',
       };
       const events: TimedEvent[] = [];
       const span = tracer.startSpan('test span');
@@ -294,7 +292,6 @@ describe('pg@7.x', () => {
       const attributes = {
         ...DEFAULT_ATTRIBUTES,
         [AttributeNames.DB_STATEMENT]: query,
-        [AttributeNames.PG_VALUES]: '[0]',
       };
       const events: TimedEvent[] = [];
       const span = tracer.startSpan('test span');
@@ -320,7 +317,6 @@ describe('pg@7.x', () => {
         ...DEFAULT_ATTRIBUTES,
         [AttributeNames.PG_PLAN]: name,
         [AttributeNames.DB_STATEMENT]: query,
-        [AttributeNames.PG_VALUES]: '[0]',
       };
       const events: TimedEvent[] = [];
       const span = tracer.startSpan('test span');

--- a/plugins/node/opentelemetry-plugin-pg/test/utils.test.ts
+++ b/plugins/node/opentelemetry-plugin-pg/test/utils.test.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { context, PluginConfig } from '@opentelemetry/api';
+import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/tracing';
+import * as assert from 'assert';
+import * as pg from 'pg';
+import { AttributeNames } from '../src/enums';
+import { PgClientExtended, NormalizedQueryConfig } from '../src/types';
+import * as utils from '../src/utils';
+
+const memoryExporter = new InMemorySpanExporter();
+
+const CONFIG = {
+  user: process.env.POSTGRES_USER || 'postgres',
+  database: process.env.POSTGRES_DB || 'postgres',
+  host: process.env.POSTGRES_HOST || 'localhost',
+  port: process.env.POSTGRES_PORT
+    ? parseInt(process.env.POSTGRES_PORT, 10)
+    : 54320,
+};
+
+const getLatestSpan = () => {
+  const spans = memoryExporter.getFinishedSpans();
+  return spans[spans.length - 1];
+};
+
+describe('utils.ts', () => {
+  const client = new pg.Client(CONFIG) as PgClientExtended;
+  let contextManager: AsyncHooksContextManager;
+  const provider = new BasicTracerProvider();
+  const tracer = provider.getTracer('external');
+
+  const pluginConfig: PluginConfig = {};
+
+  before(() => {
+    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+  });
+
+  beforeEach(() => {
+    contextManager = new AsyncHooksContextManager().enable();
+    context.setGlobalContextManager(contextManager);
+  });
+
+  afterEach(() => {
+    memoryExporter.reset();
+    context.disable();
+  });
+
+  describe('.handleConfigQuery()', () => {
+    const queryConfig: NormalizedQueryConfig = {
+      text: 'SELECT $1::text',
+      values: ['0'],
+    };
+
+    it('does not track pg.values by default', async () => {
+      const querySpan = utils.handleConfigQuery.call(
+        client,
+        tracer,
+        pluginConfig,
+        queryConfig
+      );
+      querySpan.end();
+
+      const readableSpan = getLatestSpan();
+
+      const pgValues = readableSpan.attributes[AttributeNames.PG_VALUES];
+      assert.strictEqual(pgValues, undefined);
+    });
+
+    it('tracks pg.values if enabled explicitly', async () => {
+      const extPluginConfig: PluginConfig = {
+        ...pluginConfig,
+        enhancedDatabaseReporting: true,
+      };
+      const querySpan = utils.handleConfigQuery.call(
+        client,
+        tracer,
+        extPluginConfig,
+        queryConfig
+      );
+      querySpan.end();
+
+      const readableSpan = getLatestSpan();
+
+      const pgValues = readableSpan.attributes[AttributeNames.PG_VALUES];
+      assert.strictEqual(pgValues, '[0]');
+    });
+  });
+
+  describe('.handleParameterizedQuery()', () => {
+    const query = 'SELECT $1::text';
+    const values = ['0'];
+
+    it('does not track pg.values by default', async () => {
+      const querySpan = utils.handleParameterizedQuery.call(
+        client,
+        tracer,
+        pluginConfig,
+        query,
+        values
+      );
+      querySpan.end();
+
+      const readableSpan = getLatestSpan();
+
+      const pgValues = readableSpan.attributes[AttributeNames.PG_VALUES];
+      assert.strictEqual(pgValues, undefined);
+    });
+
+    it('tracks pg.values if enabled explicitly', async () => {
+      const extPluginConfig: PluginConfig = {
+        ...pluginConfig,
+        enhancedDatabaseReporting: true,
+      };
+      const querySpan = utils.handleParameterizedQuery.call(
+        client,
+        tracer,
+        extPluginConfig,
+        query,
+        values
+      );
+      querySpan.end();
+
+      const readableSpan = getLatestSpan();
+
+      const pgValues = readableSpan.attributes[AttributeNames.PG_VALUES];
+      assert.strictEqual(pgValues, '[0]');
+    });
+  });
+});


### PR DESCRIPTION
## Which problem is this PR solving?
This PR solves issue #11, that reports the PostgreSQL plugin must not log `pg.values` by default because they may contain sensitive data such as user credentials.

## Short description of the changes

1. I fixed eslint warnings found in master.
1. I refactored the `PgClientExtended` type to inherit directly from `pgTypes.Client` instead of intersect them all the time.
1. I documented arguments of several methods of `utils.ts` to avoid generic types (`...args: unknown[]`)
1. I renamed `PgPluginQueryConfig` interface to `NormalizedQueryConfig` ([based on the plugin](https://github.com/brianc/node-postgres/blob/2ef55503738eb2cbb6326744381a92c0bc0439ab/packages/pg/lib/utils.js#L157)) to avoid confusion.
1. I changed implementation to log `pg.values` only when `enhancedDatabaseReporting` ([standard property](https://github.com/open-telemetry/opentelemetry-js/blob/master/packages/opentelemetry-api/src/trace/instrumentation/Plugin.ts#L90)) flag is se to true.
1. I implemented several unit tests that validate the behavior of that flag creating a new specific test files for `utils.ts` instead of duplicating the assertions for each valid call.