### PR TITLE
feat: reduce root span cardinality in express plugin

### DIFF
--- a/plugins/node/opentelemetry-plugin-express/src/express.ts
+++ b/plugins/node/opentelemetry-plugin-express/src/express.ts
@@ -187,6 +187,16 @@ export class ExpressPlugin extends BasePlugin<typeof express> {
         if (plugin._tracer.getCurrentSpan() === undefined) {
           return original.apply(this, arguments);
         }
+        // Rename the root http span once we reach the request handler
+        if (
+          metadata.attributes[AttributeNames.EXPRESS_TYPE] ===
+          ExpressLayerType.REQUEST_HANDLER
+        ) {
+          const parent = plugin._tracer.getCurrentSpan();
+          if (parent) {
+            parent.updateName(`${req.method} ${route}`);
+          }
+        }
         const span = plugin._tracer.startSpan(metadata.name, {
           attributes: Object.assign(attributes, metadata.attributes),
         });

--- a/plugins/node/opentelemetry-plugin-express/test/express.test.ts
+++ b/plugins/node/opentelemetry-plugin-express/test/express.test.ts
@@ -130,7 +130,7 @@ describe('Express Plugin', () => {
         );
         const exportedRootSpan = memoryExporter
           .getFinishedSpans()
-          .find(span => span.name === 'rootSpan');
+          .find(span => span.name === 'GET /toto/:id');
         assert.notStrictEqual(exportedRootSpan, undefined);
       });
       server.close();


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes https://github.com/open-telemetry/opentelemetry-js/issues/897 for the express plugin. Span names should be low cardinality, and indicate that a span belongs to a class of spans. 
Spans generated by incoming requests in the http plugin create spans with names such as `GET /users/123`, where `123` is a user identifier. 
This has a high cardinality but the http plugin doesn't have the context to set a low cardinality name such as `GET /users/:id`.

## Short description of the changes

When patching the request handler in express, we call `updateName` on the root span with the method of the request (eg `GET`), and the parameterized route (eg `/users/:id`) to rename it.

