### PR TITLE
fix: pin zone.js version and fix tsconfig reference

### DIFF
--- a/plugins/web/opentelemetry-plugin-user-interaction/package.json
+++ b/plugins/web/opentelemetry-plugin-user-interaction/package.json
@@ -86,7 +86,7 @@
     "shimmer": "^1.2.1"
   },
   "peerDependencies": {
-    "zone.js": "^0.10.3"
+    "zone.js": "0.11.1"
   },
   "sideEffects": false
 }

--- a/plugins/web/opentelemetry-plugin-user-interaction/tsconfig.json
+++ b/plugins/web/opentelemetry-plugin-user-interaction/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "build",
     "skipLibCheck": true
   },
-  "files": [ "node_modules/zone.js/dist/zone.js.d.ts"],
+  "files": [ "node_modules/zone.js/zone.js.d.ts"],
   "include": [
     "src/**/*.ts",
     "test/**/*.ts"


### PR DESCRIPTION
## Which problem is this PR solving?
@opentelemetry/plugin-user-interaction was failing to build due to a change in the `zone.js` dependency.

## Short description of the changes
- Pin the version of the `zone.js` dependency (`0.11.1`)
- Fix the reference to `zone.js.d.ts` in `tsconfig.json` to the new path in `0.11.1`.