### PR TITLE
[mongodb] implement semantic db conventions

### DIFF
--- a/plugins/node/opentelemetry-plugin-mongodb/package.json
+++ b/plugins/node/opentelemetry-plugin-mongodb/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@opentelemetry/context-async-hooks": "0.10.2",
     "@opentelemetry/node": "0.10.2",
+    "@opentelemetry/semantic-conventions": "^0.10.2",
     "@opentelemetry/tracing": "0.10.2",
     "@types/mocha": "7.0.2",
     "@types/mongodb": "3.5.25",

--- a/plugins/node/opentelemetry-plugin-mongodb/src/mongodb.ts
+++ b/plugins/node/opentelemetry-plugin-mongodb/src/mongodb.ts
@@ -16,7 +16,7 @@
 
 import { BasePlugin } from '@opentelemetry/core';
 import { CanonicalCode, Span, SpanKind } from '@opentelemetry/api';
-import * as mongodb from 'mongodb';
+import type * as mongodb from 'mongodb';
 import * as shimmer from 'shimmer';
 import {
   Func,
@@ -186,7 +186,9 @@ export class MongoDBPlugin extends BasePlugin<typeof mongodb> {
 
     // The namespace is a combination of the database name and the name of the
     // collection or index, like so: [database-name].[collection-or-index-name].
-    const [dbName, dbCollection] = ns.split('.');
+    // It could be a string or an instance of MongoDBNamespace, as such we
+    // always coerce to a string to extract db and collection.
+    const [dbName, dbCollection] = ns.toString().split('.');
 
     // add database related attributes
     span.setAttributes({

--- a/plugins/node/opentelemetry-plugin-mongodb/src/mongodb.ts
+++ b/plugins/node/opentelemetry-plugin-mongodb/src/mongodb.ts
@@ -183,13 +183,16 @@ export class MongoDBPlugin extends BasePlugin<typeof mongodb> {
         }`,
       });
     }
+
+    // The namespace is a combination of the database name and the name of the
+    // collection or index, like so: [database-name].[collection-or-index-name].
+    const [dbName, dbCollection] = ns.split('.');
+
     // add database related attributes
     span.setAttributes({
       [DatabaseAttribute.DB_SYSTEM]: 'mongodb',
-      // The namespace is a combination of the database name and the name of the
-      // collection or index, like so: [database-name].[collection-or-index-name].
-      [DatabaseAttribute.DB_NAME]: ns.split('.')[0],
-      [DatabaseAttribute.DB_MONGODB_COLLECTION]: ns.split('.')[1],
+      [DatabaseAttribute.DB_NAME]: dbName,
+      [DatabaseAttribute.DB_MONGODB_COLLECTION]: dbCollection,
     });
 
     if (command === undefined) return;

--- a/plugins/node/opentelemetry-plugin-mongodb/src/mongodb.ts
+++ b/plugins/node/opentelemetry-plugin-mongodb/src/mongodb.ts
@@ -19,22 +19,22 @@ import { CanonicalCode, Span, SpanKind } from '@opentelemetry/api';
 import * as mongodb from 'mongodb';
 import * as shimmer from 'shimmer';
 import {
-  AttributeNames,
   Func,
   MongodbCommandType,
   MongoInternalCommand,
   MongoInternalTopology,
 } from './types';
 import { VERSION } from './version';
+import {
+  DatabaseAttribute,
+  GeneralAttribute,
+} from '@opentelemetry/semantic-conventions';
 
 /** MongoDBCore instrumentation plugin for OpenTelemetry */
 export class MongoDBPlugin extends BasePlugin<typeof mongodb> {
   private readonly _SERVER_METHODS = ['insert', 'update', 'remove', 'command'];
   private readonly _CURSOR_METHODS = ['_next', 'next'];
   private _hasPatched: boolean = false;
-
-  private readonly _COMPONENT = 'mongodb';
-  private readonly _DB_TYPE = 'mongodb';
 
   readonly supportedVersions = ['>=2 <4'];
 
@@ -175,19 +175,21 @@ export class MongoDBPlugin extends BasePlugin<typeof mongodb> {
     // add network attributes to determine the remote server
     if (topology && topology.s) {
       span.setAttributes({
-        [AttributeNames.PEER_HOSTNAME]: `${
+        [GeneralAttribute.NET_HOST_NAME]: `${
           topology.s.options?.host ?? topology.s.host
         }`,
-        [AttributeNames.PEER_PORT]: `${
+        [GeneralAttribute.NET_HOST_PORT]: `${
           topology.s.options?.port ?? topology.s.port
         }`,
       });
     }
     // add database related attributes
     span.setAttributes({
-      [AttributeNames.DB_INSTANCE]: `${ns}`,
-      [AttributeNames.DB_TYPE]: this._DB_TYPE,
-      [AttributeNames.COMPONENT]: this._COMPONENT,
+      [DatabaseAttribute.DB_SYSTEM]: 'mongodb',
+      // The namespace is a combination of the database name and the name of the
+      // collection or index, like so: [database-name].[collection-or-index-name].
+      [DatabaseAttribute.DB_NAME]: ns.split('.')[0],
+      [DatabaseAttribute.DB_MONGODB_COLLECTION]: ns.split('.')[1],
     });
 
     if (command === undefined) return;

--- a/plugins/node/opentelemetry-plugin-mongodb/src/types.ts
+++ b/plugins/node/opentelemetry-plugin-mongodb/src/types.ts
@@ -40,21 +40,6 @@ export type MongoInternalTopology = {
   };
 };
 
-export enum AttributeNames {
-  // required by https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-semantic-conventions.md#databases-client-calls
-  COMPONENT = 'component',
-  DB_TYPE = 'db.type',
-  DB_INSTANCE = 'db.instance',
-  DB_STATEMENT = 'db.statement',
-  PEER_ADDRESS = 'peer.address',
-  PEER_HOSTNAME = 'peer.host',
-
-  PEER_PORT = 'peer.port',
-  PEER_IPV4 = 'peer.ipv4',
-  PEER_IPV6 = 'peer.ipv6',
-  PEER_SERVICE = 'peer.service',
-}
-
 export enum MongodbCommandType {
   CREATE_INDEXES = 'createIndexes',
   FIND_AND_MODIFY = 'findAndModify',

--- a/plugins/node/opentelemetry-plugin-mongodb/test/utils.ts
+++ b/plugins/node/opentelemetry-plugin-mongodb/test/utils.ts
@@ -18,7 +18,10 @@ import { CanonicalCode, SpanKind } from '@opentelemetry/api';
 import { ReadableSpan } from '@opentelemetry/tracing';
 import * as assert from 'assert';
 import * as mongodb from 'mongodb';
-import { AttributeNames } from '../src/types';
+import {
+  DatabaseAttribute,
+  GeneralAttribute,
+} from '@opentelemetry/semantic-conventions';
 
 export interface MongoDBAccess {
   client: mongodb.MongoClient;
@@ -75,16 +78,19 @@ export function assertSpans(
   const [mongoSpan] = spans;
   assert.strictEqual(mongoSpan.name, expectedName);
   assert.strictEqual(mongoSpan.kind, expectedKind);
-  assert.strictEqual(mongoSpan.attributes[AttributeNames.COMPONENT], 'mongodb');
   assert.strictEqual(
-    mongoSpan.attributes[AttributeNames.PEER_HOSTNAME],
+    mongoSpan.attributes[DatabaseAttribute.DB_SYSTEM],
+    'mongodb'
+  );
+  assert.strictEqual(
+    mongoSpan.attributes[GeneralAttribute.NET_HOST_NAME],
     process.env.MONGODB_HOST || 'localhost'
   );
   assert.strictEqual(mongoSpan.status.code, CanonicalCode.OK);
 
   if (isEnhancedDatabaseReportingEnabled) {
     const dbStatement = mongoSpan.attributes[
-      AttributeNames.DB_STATEMENT
+      DatabaseAttribute.DB_STATEMENT
     ] as any;
     for (const key in dbStatement) {
       assert.notStrictEqual(dbStatement[key], '?');


### PR DESCRIPTION
## Which problem is this PR solving?

- partially #116

## Short description of the changes

- adhering to spec, worth noting: split `ns` to populate `db.name` and  `db.mongodb.collection` attributes
