### PR TITLE
fix(express): listen for `finish` event on response for async express layer #107

### DIFF
--- a/plugins/node/opentelemetry-plugin-express/src/express.ts
+++ b/plugins/node/opentelemetry-plugin-express/src/express.ts
@@ -214,9 +214,9 @@ export class ExpressPlugin extends BasePlugin<typeof express> {
         if (callbackIdx >= 0) {
           arguments[callbackIdx] = function () {
             if (spanHasEnded === false) {
-              span.end();
               spanHasEnded = true;
               req.res?.removeListener('finish', onResponseFinish);
+              span.end();
             }
             if (!(req.route && arguments[0] instanceof Error)) {
               (req[_LAYERS_STORE_PROPERTY] as string[]).pop();

--- a/plugins/node/opentelemetry-plugin-express/src/express.ts
+++ b/plugins/node/opentelemetry-plugin-express/src/express.ts
@@ -227,7 +227,7 @@ export class ExpressPlugin extends BasePlugin<typeof express> {
         }
         const result = original.apply(this, arguments);
         /**
-         * As this point if the callback wasn't called, that means either the
+         * At this point if the callback wasn't called, that means either the
          * layer is asynchronous (so it will call the callback later on) or that
          * the layer directly end the http response, so we'll hook into the "finish"
          * event to handle the later case.

--- a/plugins/node/opentelemetry-plugin-express/src/express.ts
+++ b/plugins/node/opentelemetry-plugin-express/src/express.ts
@@ -201,6 +201,13 @@ export class ExpressPlugin extends BasePlugin<typeof express> {
           span.end(startTime);
           spanHasEnded = true;
         }
+        // listener for response.on('finish')
+        const onResponseFinish = () => {
+          if (spanHasEnded === false) {
+            spanHasEnded = true;
+            span.end(startTime);
+          }
+        };
         // verify we have a callback
         const args = Array.from(arguments);
         const callbackIdx = args.findIndex(arg => typeof arg === 'function');
@@ -209,6 +216,7 @@ export class ExpressPlugin extends BasePlugin<typeof express> {
             if (spanHasEnded === false) {
               span.end();
               spanHasEnded = true;
+              req.res?.removeListener('finish', onResponseFinish);
             }
             if (!(req.route && arguments[0] instanceof Error)) {
               (req[_LAYERS_STORE_PROPERTY] as string[]).pop();
@@ -218,12 +226,13 @@ export class ExpressPlugin extends BasePlugin<typeof express> {
           };
         }
         const result = original.apply(this, arguments);
-        // If the callback is never called, we need to close the span.
-        setImmediate(() => {
-          if (spanHasEnded === false) {
-            span.end(startTime);
-          }
-        });
+        /**
+         * As this point if the callback wasn't called, that means either the
+         * layer is asynchronous (so it will call the callback later on) or that
+         * the layer directly end the http response, so we'll hook into the "finish"
+         * event to handle the later case.
+         */
+        req.res?.once('finish', onResponseFinish);
         return result;
       };
     });

--- a/plugins/node/opentelemetry-plugin-express/test/express.test.ts
+++ b/plugins/node/opentelemetry-plugin-express/test/express.test.ts
@@ -90,8 +90,10 @@ describe('Express Plugin', () => {
       });
       const router = express.Router();
       app.use('/toto', router);
-      router.get('/:id', (req, res, next) => {
-        return res.status(200).end();
+      router.get('/:id', (req, res) => {
+        setTimeout(() => {
+          return res.status(200).end();
+        }, 5);
       });
       const server = http.createServer(app);
       await new Promise(resolve => server.listen(0, resolve));

--- a/plugins/node/opentelemetry-plugin-express/test/express.test.ts
+++ b/plugins/node/opentelemetry-plugin-express/test/express.test.ts
@@ -91,9 +91,9 @@ describe('Express Plugin', () => {
       const router = express.Router();
       app.use('/toto', router);
       router.get('/:id', (req, res) => {
-        setTimeout(() => {
-          return res.status(200).end();
-        }, 5);
+        setImmediate(() => {
+          res.status(200).end();
+        });
       });
       const server = http.createServer(app);
       await new Promise(resolve => server.listen(0, resolve));


### PR DESCRIPTION
I was hesitant of implement it like this from the start (for performance reason since we are adding a listener for every *async* layer) but seeing the half-broken (timing are not accurate) spans reporting, i think it's better like this for end user.