### PR TITLE
[mysql] fix: ensure span name is a string to avoid [object Object] as span name

### DIFF
--- a/plugins/node/opentelemetry-plugin-mysql/src/mysql.ts
+++ b/plugins/node/opentelemetry-plugin-mysql/src/mysql.ts
@@ -18,7 +18,7 @@ import { BasePlugin, isWrapped } from '@opentelemetry/core';
 import { CanonicalCode, Span, SpanKind } from '@opentelemetry/api';
 import type * as mysqlTypes from 'mysql';
 import * as shimmer from 'shimmer';
-import { getConnectionAttributes, getDbStatement } from './utils';
+import { getConnectionAttributes, getDbStatement, getSpanName } from './utils';
 import { VERSION } from './version';
 import { DatabaseAttribute } from '@opentelemetry/semantic-conventions';
 
@@ -207,7 +207,7 @@ export class MysqlPlugin extends BasePlugin<typeof mysqlTypes> {
           return originalQuery.apply(connection, arguments);
         }
 
-        const span = thisPlugin._tracer.startSpan(`${query}`, {
+        const span = thisPlugin._tracer.startSpan(getSpanName(query), {
           kind: SpanKind.CLIENT,
           attributes: {
             ...MysqlPlugin.COMMON_ATTRIBUTES,

--- a/plugins/node/opentelemetry-plugin-mysql/src/utils.ts
+++ b/plugins/node/opentelemetry-plugin-mysql/src/utils.ts
@@ -94,3 +94,16 @@ export function getDbStatement(
       : query.sql;
   }
 }
+
+/**
+ * The span name SHOULD be set to a low cardinality value
+ * representing the statement executed on the database.
+ *
+ * @returns SQL statement without variable arguments or SQL verb
+ */
+export function getSpanName(query: string | Query | QueryOptions): string {
+  if (typeof query === 'object') {
+    return query.sql;
+  }
+  return query.split(' ')[0];
+}

--- a/plugins/node/opentelemetry-plugin-mysql/test/mysql.test.ts
+++ b/plugins/node/opentelemetry-plugin-mysql/test/mysql.test.ts
@@ -124,30 +124,34 @@ describe('mysql@2.x', () => {
     assert.strictEqual(plugin.moduleName, 'mysql');
   });
 
-  it('should name the span correctly when the query is a string', done => {
-    const span = provider.getTracer('default').startSpan('test span');
-    provider.getTracer('default').withSpan(span, () => {
-      const sql = 'SELECT 1+1 as solution';
-      const query = connection.query(sql);
+  describe('when the query is a string', () => {
+    it('should name the span accordingly ', done => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        const sql = 'SELECT 1+1 as solution';
+        const query = connection.query(sql);
 
-      query.on('end', () => {
-        const spans = memoryExporter.getFinishedSpans();
-        assert.strictEqual(spans[0].name, 'SELECT');
-        done();
+        query.on('end', () => {
+          const spans = memoryExporter.getFinishedSpans();
+          assert.strictEqual(spans[0].name, 'SELECT');
+          done();
+        });
       });
     });
   });
 
-  it('should name the span correctly when the query is an object', done => {
-    const span = provider.getTracer('default').startSpan('test span');
-    provider.getTracer('default').withSpan(span, () => {
-      const sql = 'SELECT 1+? as solution';
-      const query = connection.query({ sql, values: [1] });
+  describe('when the query is an object', () => {
+    it('should name the span accordingly ', done => {
+      const span = provider.getTracer('default').startSpan('test span');
+      provider.getTracer('default').withSpan(span, () => {
+        const sql = 'SELECT 1+? as solution';
+        const query = connection.query({ sql, values: [1] });
 
-      query.on('end', () => {
-        const spans = memoryExporter.getFinishedSpans();
-        assert.strictEqual(spans[0].name, sql);
-        done();
+        query.on('end', () => {
+          const spans = memoryExporter.getFinishedSpans();
+          assert.strictEqual(spans[0].name, sql);
+          done();
+        });
       });
     });
   });

--- a/plugins/node/opentelemetry-plugin-mysql/test/mysql.test.ts
+++ b/plugins/node/opentelemetry-plugin-mysql/test/mysql.test.ts
@@ -124,6 +124,34 @@ describe('mysql@2.x', () => {
     assert.strictEqual(plugin.moduleName, 'mysql');
   });
 
+  it('should name the span correctly when the query is a string', done => {
+    const span = provider.getTracer('default').startSpan('test span');
+    provider.getTracer('default').withSpan(span, () => {
+      const sql = 'SELECT 1+1 as solution';
+      const query = connection.query(sql);
+
+      query.on('end', () => {
+        const spans = memoryExporter.getFinishedSpans();
+        assert.strictEqual(spans[0].name, 'SELECT');
+        done();
+      });
+    });
+  });
+
+  it('should name the span correctly when the query is an object', done => {
+    const span = provider.getTracer('default').startSpan('test span');
+    provider.getTracer('default').withSpan(span, () => {
+      const sql = 'SELECT 1+? as solution';
+      const query = connection.query({ sql, values: [1] });
+
+      query.on('end', () => {
+        const spans = memoryExporter.getFinishedSpans();
+        assert.strictEqual(spans[0].name, sql);
+        done();
+      });
+    });
+  });
+
   describe('#Connection', () => {
     it('should intercept connection.query(text: string)', done => {
       const span = provider.getTracer('default').startSpan('test span');
@@ -585,17 +613,17 @@ function assertSpan(
   values?: any,
   errorMessage?: string
 ) {
-  assert.equal(span.attributes[DatabaseAttribute.DB_SYSTEM], 'mysql');
-  assert.equal(span.attributes[DatabaseAttribute.DB_NAME], database);
-  assert.equal(span.attributes[GeneralAttribute.NET_PEER_PORT], port);
-  assert.equal(span.attributes[GeneralAttribute.NET_PEER_HOSTNAME], host);
-  assert.equal(span.attributes[DatabaseAttribute.DB_USER], user);
+  assert.strictEqual(span.attributes[DatabaseAttribute.DB_SYSTEM], 'mysql');
+  assert.strictEqual(span.attributes[DatabaseAttribute.DB_NAME], database);
+  assert.strictEqual(span.attributes[GeneralAttribute.NET_PEER_PORT], port);
+  assert.strictEqual(span.attributes[GeneralAttribute.NET_PEER_HOSTNAME], host);
+  assert.strictEqual(span.attributes[DatabaseAttribute.DB_USER], user);
   assert.strictEqual(
     span.attributes[DatabaseAttribute.DB_STATEMENT],
     mysql.format(sql, values)
   );
   if (errorMessage) {
-    assert.equal(span.status.message, errorMessage);
-    assert.equal(span.status.code, CanonicalCode.UNKNOWN);
+    assert.strictEqual(span.status.message, errorMessage);
+    assert.strictEqual(span.status.code, CanonicalCode.UNKNOWN);
   }
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- #206 

## Short description of the changes

- Ensured that the span name is always a string. The approach differs when the query is a string vs an object:
  - for string, use the verb 
  - for an object, use the sql string without the templated variable

- Also replaced deprecated `equals` method in tests