### PR TITLE
fix(plugin-document-load): check if getEntriesByType is available before using it

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-graphql/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/src/types.ts
@@ -63,9 +63,7 @@ export interface GraphQLInstrumentationConfig {
 /**
  * Merged and parsed config of default instrumentation config and GraphQL
  */
-export type GraphQLInstrumentationParsedConfig = Required<
-  GraphQLInstrumentationConfig
-> &
+export type GraphQLInstrumentationParsedConfig = Required<GraphQLInstrumentationConfig> &
   InstrumentationConfig;
 
 export type executeFunctionWithObj = (

--- a/plugins/web/opentelemetry-plugin-document-load/src/documentLoad.ts
+++ b/plugins/web/opentelemetry-plugin-document-load/src/documentLoad.ts
@@ -73,7 +73,7 @@ export class DocumentLoad extends BasePlugin<unknown> {
    * @param rootSpan
    */
   private _addResourcesSpans(rootSpan: Span): void {
-    const resources: PerformanceResourceTiming[] = otperformance.getEntriesByType(
+    const resources: PerformanceResourceTiming[] = otperformance.getEntriesByType?.(
       'resource'
     ) as PerformanceResourceTiming[];
     if (resources) {
@@ -163,7 +163,7 @@ export class DocumentLoad extends BasePlugin<unknown> {
    */
   private _getEntries() {
     const entries: PerformanceEntries = {};
-    const performanceNavigationTiming = (otperformance.getEntriesByType(
+    const performanceNavigationTiming = (otperformance.getEntriesByType?.(
       'navigation'
     )[0] as unknown) as PerformanceEntries;
 

--- a/plugins/web/opentelemetry-plugin-document-load/test/documentLoad.test.ts
+++ b/plugins/web/opentelemetry-plugin-document-load/test/documentLoad.test.ts
@@ -511,21 +511,7 @@ describe('DocumentLoad Plugin', () => {
     });
   });
 
-  describe('when navigation entries types are NOT available then fallback to "performance.timing"', () => {
-    let spyEntries: any;
-    beforeEach(() => {
-      spyEntries = sinon.stub(window.performance, 'getEntriesByType');
-      spyEntries.withArgs('navigation').returns([]);
-      spyEntries.withArgs('resource').returns([]);
-      Object.defineProperty(window.performance, 'timing', {
-        writable: true,
-        value: entriesFallback,
-      });
-    });
-    afterEach(() => {
-      spyEntries.restore();
-    });
-
+  function shouldExportCorrectSpan() {
     it('should export correct span with events', done => {
       const spyOnEnd = sinon.spy(dummyExporter, 'export');
       plugin.enable(moduleExports, provider, logger, config);
@@ -557,6 +543,41 @@ describe('DocumentLoad Plugin', () => {
         done();
       });
     });
+  }
+
+  describe('when navigation entries types are NOT available then fallback to "performance.timing"', () => {
+    let spyEntries: any;
+    beforeEach(() => {
+      spyEntries = sinon.stub(window.performance, 'getEntriesByType');
+      spyEntries.withArgs('navigation').returns([]);
+      spyEntries.withArgs('resource').returns([]);
+
+      Object.defineProperty(window.performance, 'timing', {
+        writable: true,
+        value: entriesFallback,
+      });
+    });
+    afterEach(() => {
+      spyEntries.restore();
+    });
+
+    shouldExportCorrectSpan();
+  });
+
+  describe('when getEntriesByType is not defined then fallback to "performance.timing"', () => {
+    beforeEach(() => {
+      Object.defineProperty(window.performance, 'getEntriesByType', {
+        writable: true,
+        value: undefined,
+      });
+
+      Object.defineProperty(window.performance, 'timing', {
+        writable: true,
+        value: entriesFallback,
+      });
+    });
+
+    shouldExportCorrectSpan();
   });
 
   describe('when navigation entries types and "performance.timing" are NOT available', () => {


### PR DESCRIPTION
## Which problem is this PR solving?

- When performance.getEntriesByType is undefined error is thrown(and fallback performance.timing is not used). This happens in Safari 10.1 for example where getEntriesByType is undefined but performance.timing is available.

## Short description of the changes

- Check if performance.getEntriesByType is present before using it. 

