### PR TITLE
fix: missing .fields() method in jaeger propagator

### DIFF
--- a/propagators/opentelemetry-propagator-jaeger/src/JaegerHttpTracePropagator.ts
+++ b/propagators/opentelemetry-propagator-jaeger/src/JaegerHttpTracePropagator.ts
@@ -80,6 +80,10 @@ export class JaegerHttpTracePropagator implements TextMapPropagator {
 
     return setExtractedSpanContext(context, spanContext);
   }
+
+  fields(): string[] {
+    return [this._jaegerTraceHeader];
+  }
 }
 
 /**

--- a/propagators/opentelemetry-propagator-jaeger/test/JaegerHttpTracePropagator.test.ts
+++ b/propagators/opentelemetry-propagator-jaeger/test/JaegerHttpTracePropagator.test.ts
@@ -172,6 +172,19 @@ describe('JaegerHttpTracePropagator', () => {
     });
   });
 
+  describe('.fields()', () => {
+    it('returns the default header if not customized', () => {
+      assert.deepStrictEqual(jaegerHttpTracePropagator.fields(), [
+        'uber-trace-id',
+      ]);
+    });
+    it('returns the customized header if customized', () => {
+      assert.deepStrictEqual(customJaegerHttpTracePropagator.fields(), [
+        customHeader,
+      ]);
+    });
+  });
+
   it('should fail gracefully on bad responses from getter', () => {
     const ctx1 = jaegerHttpTracePropagator.extract(
       ROOT_CONTEXT,


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?
- #267 - `.fields()` is missing in `JaegerHttpTracePropagator`, but required by `TextMapPropagator`

## Short description of the changes

- adds `.fields()` to jaeger propagator
