### PR TITLE
fix(express): listener leak

### DIFF
--- a/plugins/node/opentelemetry-plugin-express/src/express.ts
+++ b/plugins/node/opentelemetry-plugin-express/src/express.ts
@@ -250,7 +250,9 @@ export class ExpressPlugin extends BasePlugin<typeof express> {
          * the layer directly end the http response, so we'll hook into the "finish"
          * event to handle the later case.
          */
-        req.res?.once('finish', onResponseFinish);
+        if (!spanHasEnded) {
+          req.res?.once('finish', onResponseFinish);
+        }
         return result;
       };
     });

--- a/plugins/node/opentelemetry-plugin-express/test/express.test.ts
+++ b/plugins/node/opentelemetry-plugin-express/test/express.test.ts
@@ -91,8 +91,10 @@ describe('Express Plugin', () => {
       });
       const router = express.Router();
       app.use('/toto', router);
+      let finishListenerCount: number | undefined;
       router.get('/:id', (req, res) => {
         setImmediate(() => {
+          finishListenerCount = req.res?.listenerCount('finish');
           res.status(200).end();
         });
       });
@@ -104,6 +106,7 @@ describe('Express Plugin', () => {
         await httpRequest.get(`http://localhost:${port}/toto/tata`);
         rootSpan.end();
         assert.strictEqual(rootSpan.name, 'GET /toto/:id');
+        assert.strictEqual(finishListenerCount, 1);
         assert.notStrictEqual(
           memoryExporter
             .getFinishedSpans()


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Fixes https://github.com/open-telemetry/opentelemetry-js-contrib/issues/258

## Short description of the changes

When a middleware is calling the callback synchronous inside the middleware the span was already ended and the added `finish` listener below was never removed.
