### PR TITLE
Include client ID in pg query span

### DIFF
--- a/plugins/node/opentelemetry-plugin-pg-pool/src/enums.ts
+++ b/plugins/node/opentelemetry-plugin-pg-pool/src/enums.ts
@@ -33,4 +33,5 @@ export enum AttributeNames {
   // PG-POOL specific -- not specified by spec
   IDLE_TIMEOUT_MILLIS = 'idle.timeout.millis',
   MAX_CLIENT = 'max',
+  CLIENT_ID = 'client.id',
 }

--- a/plugins/node/opentelemetry-plugin-pg-pool/test/pg-pool.test.ts
+++ b/plugins/node/opentelemetry-plugin-pg-pool/test/pg-pool.test.ts
@@ -71,6 +71,7 @@ const DEFAULT_PG_ATTRIBUTES = {
   [AttributeNames.PEER_ADDRESS]: `jdbc:postgresql://${CONFIG.host}:${CONFIG.port}/${CONFIG.database}`,
   [AttributeNames.PEER_PORT]: CONFIG.port,
   [AttributeNames.DB_USER]: CONFIG.user,
+  [AttributeNames.CLIENT_ID]: 1,
 };
 
 const okStatus: Status = {

--- a/plugins/node/opentelemetry-plugin-pg/src/enums.ts
+++ b/plugins/node/opentelemetry-plugin-pg/src/enums.ts
@@ -33,4 +33,5 @@ export enum AttributeNames {
   // PG specific -- not specified by spec
   PG_VALUES = 'pg.values',
   PG_PLAN = 'pg.plan',
+  CLIENT_ID = 'client.id',
 }

--- a/plugins/node/opentelemetry-plugin-pg/src/types.ts
+++ b/plugins/node/opentelemetry-plugin-pg/src/types.ts
@@ -29,6 +29,8 @@ export interface PgClientConnectionParams {
 
 export interface PgClientExtended extends pgTypes.Client {
   connectionParameters: PgClientConnectionParams;
+
+  __clientId?: number;
 }
 
 // Interface name based on original driver implementation

--- a/plugins/node/opentelemetry-plugin-pg/test/pg.test.ts
+++ b/plugins/node/opentelemetry-plugin-pg/test/pg.test.ts
@@ -55,6 +55,7 @@ const DEFAULT_ATTRIBUTES = {
   [AttributeNames.PEER_ADDRESS]: `jdbc:postgresql://${CONFIG.host}:${CONFIG.port}/${CONFIG.database}`,
   [AttributeNames.PEER_PORT]: CONFIG.port,
   [AttributeNames.DB_USER]: CONFIG.user,
+  [AttributeNames.CLIENT_ID]: 1,
 };
 
 const okStatus: Status = {


### PR DESCRIPTION
## Which problem is this PR solving?

- Adds visibility into the pooling/client management behaviour of the application being instrumented. It can be useful to see how the clients are being re-used when an application is under load.

## Short description of the changes

- Whenever a new client object is used, it is assigned an incrementing ID. This is then included in all spans.
