### PR TITLE
Update GraphQL README to note `setTracerProvider` is optional

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-graphql/README.md
+++ b/plugins/node/opentelemetry-instrumentation-graphql/README.md
@@ -44,7 +44,7 @@ const graphQLInstrumentation = new GraphQLInstrumentation({
   // mergeItems: true,
 });
 
-graphQLInstrumentation.setTracerProvider(provider);
+graphQLInstrumentation.setTracerProvider(provider); // optional; uses global tracer by default
 
 graphQLInstrumentation.enable();
 


### PR DESCRIPTION

This caused me some confusion because they node-sdk doesn't give me a tracer provider to pass in here.  But it turned out I don't have to call this at all.
