### PR TITLE
fix: move semantic-conventions to regular dependencies

### DIFF
--- a/plugins/node/opentelemetry-plugin-ioredis/package.json
+++ b/plugins/node/opentelemetry-plugin-ioredis/package.json
@@ -46,7 +46,6 @@
   "devDependencies": {
     "@opentelemetry/context-async-hooks": "^0.14.0",
     "@opentelemetry/node": "^0.14.0",
-    "@opentelemetry/semantic-conventions": "^0.14.0",
     "@opentelemetry/test-utils": "^0.12.1",
     "@opentelemetry/tracing": "^0.14.0",
     "@types/ioredis": "4.17.3",
@@ -69,6 +68,7 @@
   "dependencies": {
     "@opentelemetry/api": "^0.14.0",
     "@opentelemetry/core": "^0.14.0",
+    "@opentelemetry/semantic-conventions": "^0.14.0",
     "shimmer": "^1.2.1"
   }
 }

--- a/plugins/node/opentelemetry-plugin-mongodb/package.json
+++ b/plugins/node/opentelemetry-plugin-mongodb/package.json
@@ -43,7 +43,6 @@
   "devDependencies": {
     "@opentelemetry/context-async-hooks": "^0.14.0",
     "@opentelemetry/node": "^0.14.0",
-    "@opentelemetry/semantic-conventions": "^0.14.0",
     "@opentelemetry/tracing": "^0.14.0",
     "@types/mocha": "7.0.2",
     "@types/mongodb": "3.5.25",
@@ -64,6 +63,7 @@
   "dependencies": {
     "@opentelemetry/api": "^0.14.0",
     "@opentelemetry/core": "^0.14.0",
+    "@opentelemetry/semantic-conventions": "^0.14.0",
     "shimmer": "^1.2.1"
   }
 }


### PR DESCRIPTION
These dependencies are imported at runtime but were only declared as
devDependencies.  This causes problems for people using these
packages with yarn pnp.
