### PR TITLE
Koa plugin enhancements

### DIFF
--- a/plugins/node/opentelemetry-koa-instrumentation/src/koa.ts
+++ b/plugins/node/opentelemetry-koa-instrumentation/src/koa.ts
@@ -139,8 +139,9 @@ export class KoaInstrumentation extends BasePlugin<typeof koa> {
         context.request.ctx.parentSpan = parent;
       }
 
-      if ( metadata.attributes[AttributeNames.KOA_TYPE] ===
-        KoaLayerType.ROUTER ) {
+      if (
+        metadata.attributes[AttributeNames.KOA_TYPE] === KoaLayerType.ROUTER
+      ) {
         if (context.request.ctx.parentSpan.name) {
           const parentRoute = context.request.ctx.parentSpan.name.split(' ')[1];
           if (

--- a/plugins/node/opentelemetry-koa-instrumentation/src/koa.ts
+++ b/plugins/node/opentelemetry-koa-instrumentation/src/koa.ts
@@ -16,7 +16,7 @@
 
 import * as api from '@opentelemetry/api';
 import { BasePlugin } from '@opentelemetry/core';
-import * as koa from 'koa';
+import type * as koa from 'koa';
 import * as shimmer from 'shimmer';
 import {
   KoaMiddleware,

--- a/plugins/node/opentelemetry-koa-instrumentation/src/koa.ts
+++ b/plugins/node/opentelemetry-koa-instrumentation/src/koa.ts
@@ -16,13 +16,16 @@
 
 import * as api from '@opentelemetry/api';
 import { BasePlugin } from '@opentelemetry/core';
-import type * as koa from 'koa';
+import * as koa from 'koa';
 import * as shimmer from 'shimmer';
 import {
   KoaMiddleware,
   KoaContext,
   KoaComponentName,
   kLayerPatched,
+  KoaLayerType,
+  AttributeNames,
+  KoaPluginSpan,
 } from './types';
 import { VERSION } from './version';
 import { getMiddlewareMetadata } from './utils';
@@ -41,7 +44,7 @@ export class KoaInstrumentation extends BasePlugin<typeof koa> {
    */
   protected patch(): typeof koa {
     this._logger.debug('Patching Koa');
-    if (this._moduleExports == null) {
+    if (this._moduleExports === null) {
       return this._moduleExports;
     }
     this._logger.debug('Patching Koa.use');
@@ -118,7 +121,8 @@ export class KoaInstrumentation extends BasePlugin<typeof koa> {
     middlewareLayer[kLayerPatched] = true;
     this._logger.debug('patching Koa middleware layer');
     return async (context: KoaContext, next: koa.Next) => {
-      if (api.getSpan(api.context.active()) === undefined) {
+      const parent = api.getSpan(api.context.active()) as KoaPluginSpan;
+      if (parent === undefined) {
         return middlewareLayer(context, next);
       }
       const metadata = getMiddlewareMetadata(
@@ -130,6 +134,25 @@ export class KoaInstrumentation extends BasePlugin<typeof koa> {
       const span = this._tracer.startSpan(metadata.name, {
         attributes: metadata.attributes,
       });
+
+      if (!parent?.parentSpanId) {
+        context.request.ctx.parentSpan = parent;
+      }
+
+      if ( metadata.attributes[AttributeNames.KOA_TYPE] ===
+        KoaLayerType.ROUTER ) {
+        if (context.request.ctx.parentSpan.name) {
+          const parentRoute = context.request.ctx.parentSpan.name.split(' ')[1];
+          if (
+            context._matchedRoute &&
+            !context._matchedRoute.toString().includes(parentRoute)
+          ) {
+            context.request.ctx.parentSpan.updateName(
+              `${context.method} ${context._matchedRoute}`
+            );
+          }
+        }
+      }
 
       return api.context.with(
         api.setSpan(api.context.active(), span),

--- a/plugins/node/opentelemetry-koa-instrumentation/src/types.ts
+++ b/plugins/node/opentelemetry-koa-instrumentation/src/types.ts
@@ -43,6 +43,9 @@ export enum KoaLayerType {
 
 export const KoaComponentName = 'koa';
 
+/**
+ * extends opentelemetry/api Span object to instrument the root span name of http plugin by getting parent span id
+ */
 export interface KoaPluginSpan extends Span {
   parentSpanId?: string;
 }

--- a/plugins/node/opentelemetry-koa-instrumentation/src/types.ts
+++ b/plugins/node/opentelemetry-koa-instrumentation/src/types.ts
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { Middleware, ParameterizedContext, DefaultState } from 'koa';
-import type { RouterParamContext } from '@koa/router';
-import type * as Router from '@koa/router';
+import { Middleware, ParameterizedContext, DefaultState } from 'koa';
+import { RouterParamContext } from '@koa/router';
+import * as Router from '@koa/router';
+import { Span } from '@opentelemetry/api';
 
 /**
  * This symbol is used to mark a Koa layer as being already instrumented
@@ -41,3 +42,7 @@ export enum KoaLayerType {
 }
 
 export const KoaComponentName = 'koa';
+
+export interface KoaPluginSpan extends Span {
+  parentSpanId?: string;
+}

--- a/plugins/node/opentelemetry-koa-instrumentation/src/types.ts
+++ b/plugins/node/opentelemetry-koa-instrumentation/src/types.ts
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Middleware, ParameterizedContext, DefaultState } from 'koa';
-import { RouterParamContext } from '@koa/router';
-import * as Router from '@koa/router';
-import { Span } from '@opentelemetry/api';
+import type { Middleware, ParameterizedContext, DefaultState } from 'koa';
+import type { RouterParamContext } from '@koa/router';
+import type * as Router from '@koa/router';
+import type { Span } from '@opentelemetry/api';
 
 /**
  * This symbol is used to mark a Koa layer as being already instrumented

--- a/plugins/node/opentelemetry-koa-instrumentation/test/koa-router.test.ts
+++ b/plugins/node/opentelemetry-koa-instrumentation/test/koa-router.test.ts
@@ -118,7 +118,7 @@ describe('Koa Instrumentation - Router Tests', () => {
 
         const exportedRootSpan = memoryExporter
           .getFinishedSpans()
-          .find(span => span.name === 'rootSpan');
+          .find(span => span.name === 'GET /post/:id');
         assert.notStrictEqual(exportedRootSpan, undefined);
       });
     });
@@ -160,7 +160,7 @@ describe('Koa Instrumentation - Router Tests', () => {
 
         const exportedRootSpan = memoryExporter
           .getFinishedSpans()
-          .find(span => span.name === 'rootSpan');
+          .find(span => span.name === 'GET /:first/post/:id');
         assert.notStrictEqual(exportedRootSpan, undefined);
       });
     });
@@ -200,7 +200,7 @@ describe('Koa Instrumentation - Router Tests', () => {
 
         const exportedRootSpan = memoryExporter
           .getFinishedSpans()
-          .find(span => span.name === 'rootSpan');
+          .find(span => span.name === 'GET /:first/post/:id');
         assert.notStrictEqual(exportedRootSpan, undefined);
       });
     });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/master/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

In addition to #[176](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/176) PR and to #[273](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/273) We should able to instrument the root span name. This way it would be clear from the beginning on what request the span is about, and if in the future there would be an option to remove layers (like in the express plugin) the route will be in the root span.

-

## Short description of the changes
using koa plugin before the change:
![Before](https://user-images.githubusercontent.com/24668683/106145747-947e2280-617e-11eb-9992-d19f97801c4a.png)
using koa plugin after the change:
![After](https://user-images.githubusercontent.com/24668683/106145827-a9f34c80-617e-11eb-8de4-dbeca0e779e4.png)

-
