### PR TITLE
fix: graphql operation.name span attribute

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-graphql/src/graphql.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/src/graphql.ts
@@ -348,8 +348,8 @@ export class GraphQLInstrumentation extends InstrumentationBase {
 
     const span = this.tracer.startSpan(SpanNames.EXECUTE, {});
     if (operation) {
-      const name = (operation as graphqlTypes.OperationDefinitionNode)
-        .operation;
+      const name = (operation as graphqlTypes.OperationDefinitionNode)?.name
+        ?.value;
       if (name) {
         span.setAttribute(SpanAttributes.OPERATION, name);
       }

--- a/plugins/node/opentelemetry-instrumentation-graphql/test/graphql.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/test/graphql.test.ts
@@ -55,7 +55,7 @@ const sourceBookById = `
 `;
 
 const sourceAddBook = `
-  mutation {
+  mutation Mutation1 {
     addBook(
       name: "Fifth Book"
       authorIds: "0,2"
@@ -150,7 +150,7 @@ describe('graphql', () => {
         );
         assert.deepStrictEqual(
           executeSpan.attributes[SpanAttributes.OPERATION],
-          'query'
+          undefined
         );
         assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
         assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
@@ -252,7 +252,7 @@ describe('graphql', () => {
         );
         assert.deepStrictEqual(
           executeSpan.attributes[SpanAttributes.OPERATION],
-          'query'
+          undefined
         );
         assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
         assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
@@ -338,7 +338,7 @@ describe('graphql', () => {
         );
         assert.deepStrictEqual(
           executeSpan.attributes[SpanAttributes.OPERATION],
-          'query'
+          'Query1'
         );
         assert.deepStrictEqual(
           executeSpan.attributes[`${SpanAttributes.VARIABLES}id`],
@@ -430,7 +430,7 @@ describe('graphql', () => {
         );
         assert.deepStrictEqual(
           executeSpan.attributes[SpanAttributes.OPERATION],
-          'query'
+          undefined
         );
         assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
         assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
@@ -494,7 +494,7 @@ describe('graphql', () => {
         );
         assert.deepStrictEqual(
           executeSpan.attributes[SpanAttributes.OPERATION],
-          'query'
+          undefined
         );
         assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
         assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
@@ -581,7 +581,7 @@ describe('graphql', () => {
         );
         assert.deepStrictEqual(
           executeSpan.attributes[SpanAttributes.OPERATION],
-          'query'
+          undefined
         );
         assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
         assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
@@ -637,7 +637,7 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           parseSpan.attributes[SpanAttributes.SOURCE],
           '\n' +
-            '  mutation {\n' +
+            '  mutation Mutation1 {\n' +
             '    addBook(\n' +
             '      name: "Fifth Book"\n' +
             '      authorIds: "0,2"\n' +
@@ -662,7 +662,7 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           executeSpan.attributes[SpanAttributes.SOURCE],
           '\n' +
-            '  mutation {\n' +
+            '  mutation Mutation1 {\n' +
             '    addBook(\n' +
             '      name: "Fifth Book"\n' +
             '      authorIds: "0,2"\n' +
@@ -673,7 +673,7 @@ describe('graphql', () => {
         );
         assert.deepStrictEqual(
           executeSpan.attributes[SpanAttributes.OPERATION],
-          'mutation'
+          'Mutation1'
         );
         assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
         assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
@@ -759,7 +759,7 @@ describe('graphql', () => {
         );
         assert.deepStrictEqual(
           executeSpan.attributes[SpanAttributes.OPERATION],
-          'query'
+          'Query1'
         );
         assert.deepStrictEqual(
           executeSpan.attributes[`${SpanAttributes.VARIABLES}id`],
@@ -821,7 +821,7 @@ describe('graphql', () => {
       assert.deepStrictEqual(
         parseSpan.attributes[SpanAttributes.SOURCE],
         '\n' +
-          '  mutation {\n' +
+          '  mutation Mutation1 {\n' +
           '    addBook(\n' +
           '      name: "*"\n' +
           '      authorIds: "*"\n' +
@@ -846,7 +846,7 @@ describe('graphql', () => {
       assert.deepStrictEqual(
         executeSpan.attributes[SpanAttributes.SOURCE],
         '\n' +
-          '  mutation {\n' +
+          '  mutation Mutation1 {\n' +
           '    addBook(\n' +
           '      name: "*"\n' +
           '      authorIds: "*"\n' +
@@ -857,7 +857,7 @@ describe('graphql', () => {
       );
       assert.deepStrictEqual(
         executeSpan.attributes[SpanAttributes.OPERATION],
-        'mutation'
+        'Mutation1'
       );
       assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
       assert.deepStrictEqual(executeSpan.parentSpanId, undefined);


### PR DESCRIPTION

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- The operation name is recorded as `query` (or `mutation`) instead of the provided name from the query.

## Short description of the changes

- Uses the name as provided in the query, like NAME in:

```
query NAME {
  ...
}
```
