### PR TITLE
fix: net instrumentation - change span kind of connect to internal

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-net/src/net.ts
+++ b/plugins/node/opentelemetry-instrumentation-net/src/net.ts
@@ -92,7 +92,7 @@ export class NetInstrumentation extends InstrumentationBase<Net> {
   /* It might still be useful to pick up errors due to invalid connect arguments. */
   private _startGenericSpan(socket: Socket) {
     const span = this.tracer.startSpan('connect', {
-      kind: SpanKind.CLIENT,
+      kind: SpanKind.INTERNAL,
     });
 
     registerListeners(socket, span);
@@ -102,7 +102,7 @@ export class NetInstrumentation extends InstrumentationBase<Net> {
 
   private _startIpcSpan(options: NormalizedOptions, socket: Socket) {
     const span = this.tracer.startSpan('ipc.connect', {
-      kind: SpanKind.CLIENT,
+      kind: SpanKind.INTERNAL,
       attributes: {
         [GeneralAttribute.NET_TRANSPORT]: IPC_TRANSPORT,
         [GeneralAttribute.NET_PEER_NAME]: options.path,
@@ -116,7 +116,7 @@ export class NetInstrumentation extends InstrumentationBase<Net> {
 
   private _startTcpSpan(options: NormalizedOptions, socket: Socket) {
     const span = this.tracer.startSpan('tcp.connect', {
-      kind: SpanKind.CLIENT,
+      kind: SpanKind.INTERNAL,
       attributes: {
         [GeneralAttribute.NET_TRANSPORT]: GeneralAttribute.IP_TCP,
         [GeneralAttribute.NET_PEER_NAME]: options.host,

--- a/plugins/node/opentelemetry-instrumentation-net/src/net.ts
+++ b/plugins/node/opentelemetry-instrumentation-net/src/net.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { diag, Span, SpanKind, SpanStatusCode } from '@opentelemetry/api';
+import { diag, Span, SpanStatusCode } from '@opentelemetry/api';
 import {
   InstrumentationBase,
   InstrumentationConfig,
@@ -91,9 +91,7 @@ export class NetInstrumentation extends InstrumentationBase<Net> {
 
   /* It might still be useful to pick up errors due to invalid connect arguments. */
   private _startGenericSpan(socket: Socket) {
-    const span = this.tracer.startSpan('connect', {
-      kind: SpanKind.INTERNAL,
-    });
+    const span = this.tracer.startSpan('connect');
 
     registerListeners(socket, span);
 
@@ -102,7 +100,6 @@ export class NetInstrumentation extends InstrumentationBase<Net> {
 
   private _startIpcSpan(options: NormalizedOptions, socket: Socket) {
     const span = this.tracer.startSpan('ipc.connect', {
-      kind: SpanKind.INTERNAL,
       attributes: {
         [GeneralAttribute.NET_TRANSPORT]: IPC_TRANSPORT,
         [GeneralAttribute.NET_PEER_NAME]: options.path,
@@ -116,7 +113,6 @@ export class NetInstrumentation extends InstrumentationBase<Net> {
 
   private _startTcpSpan(options: NormalizedOptions, socket: Socket) {
     const span = this.tracer.startSpan('tcp.connect', {
-      kind: SpanKind.INTERNAL,
       attributes: {
         [GeneralAttribute.NET_TRANSPORT]: GeneralAttribute.IP_TCP,
         [GeneralAttribute.NET_PEER_NAME]: options.host,

--- a/plugins/node/opentelemetry-instrumentation-net/test/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-net/test/utils.ts
@@ -43,7 +43,7 @@ export function assertIpcSpan(span: ReadableSpan) {
 }
 
 export function assertClientSpan(span: ReadableSpan) {
-  assert.strictEqual(span.kind, SpanKind.CLIENT);
+  assert.strictEqual(span.kind, SpanKind.INTERNAL);
 }
 
 export function assertAttrib(span: ReadableSpan, attrib: string, value: any) {

--- a/plugins/node/opentelemetry-instrumentation-net/test/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-net/test/utils.ts
@@ -28,7 +28,7 @@ export const HOST = 'localhost';
 export const IPC_PATH = path.join(os.tmpdir(), 'otel-js-net-test-ipc');
 
 export function assertTcpSpan(span: ReadableSpan, socket: Socket) {
-  assertClientSpan(span);
+  assertSpanKind(span);
   assertAttrib(span, GeneralAttribute.NET_TRANSPORT, GeneralAttribute.IP_TCP);
   assertAttrib(span, GeneralAttribute.NET_PEER_NAME, HOST);
   assertAttrib(span, GeneralAttribute.NET_PEER_PORT, PORT);
@@ -37,12 +37,12 @@ export function assertTcpSpan(span: ReadableSpan, socket: Socket) {
 }
 
 export function assertIpcSpan(span: ReadableSpan) {
-  assertClientSpan(span);
+  assertSpanKind(span);
   assertAttrib(span, GeneralAttribute.NET_TRANSPORT, IPC_TRANSPORT);
   assertAttrib(span, GeneralAttribute.NET_PEER_NAME, IPC_PATH);
 }
 
-export function assertClientSpan(span: ReadableSpan) {
+export function assertSpanKind(span: ReadableSpan) {
   assert.strictEqual(span.kind, SpanKind.INTERNAL);
 }
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

From the [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#spankind):
* `CLIENT` Indicates that the span describes a synchronous request to some remote service. This span is the parent of a remote SERVER span and waits for its response.

However there is no corresponding server span for `connect`. Thus I think the least spec violating span kind for `connect` should be `INTERNAL`.

## Short description of the changes

Change span kind of `connect` from `CLIENT` to `INTERNAL`.