### PR TITLE
chore: fix hapi compilation issue

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-hapi/package.json
+++ b/plugins/node/opentelemetry-instrumentation-hapi/package.json
@@ -41,11 +41,11 @@
     "access": "public"
   },
   "devDependencies": {
-    "@hapi/hapi": "20.0.1",
+    "@hapi/hapi": "20.1.2",
     "@opentelemetry/context-async-hooks": "0.18.0",
     "@opentelemetry/node": "0.18.0",
     "@opentelemetry/tracing": "0.18.0",
-    "@types/hapi__hapi": "20.0.1",
+    "@types/hapi__hapi": "20.0.5",
     "@types/mocha": "7.0.2",
     "@types/node": "12.12.47",
     "codecov": "3.7.0",
@@ -58,7 +58,7 @@
     "ts-node": "9.0.0",
     "tslint-consistent-codestyle": "1.16.0",
     "tslint-microsoft-contrib": "6.2.0",
-    "typescript": "4.1.3"
+    "typescript": "4.2.3"
   },
   "dependencies": {
     "@opentelemetry/api": "^0.18.0",

--- a/plugins/node/opentelemetry-instrumentation-hapi/tsconfig.json
+++ b/plugins/node/opentelemetry-instrumentation-hapi/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "build",
-    "skipDefaultLibCheck": true,
+    "skipLibCheck": true,
   },
   "include": [
     "src/**/*.ts",

--- a/plugins/node/opentelemetry-instrumentation-hapi/tsconfig.json
+++ b/plugins/node/opentelemetry-instrumentation-hapi/tsconfig.json
@@ -1,11 +1,12 @@
 {
-    "extends": "../../../tsconfig.base",
-    "compilerOptions": {
-      "rootDir": ".",
-      "outDir": "build"
-    },
-    "include": [
-      "src/**/*.ts",
-      "test/**/*.ts"
-    ]
-  }
+  "extends": "../../../tsconfig.base",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build",
+    "skipDefaultLibCheck": true,
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ]
+}

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
@@ -45,7 +45,7 @@
     "@babel/core": "7.11.1",
     "@opentelemetry/context-zone-peer-dep": "0.18.0",
     "@opentelemetry/instrumentation-xml-http-request": "0.18.0",
-    "@opentelemetry/tracing": "0.18.0",
+    "@opentelemetry/tracing": "0.18.2",
     "@types/jquery": "3.5.1",
     "@types/mocha": "7.0.2",
     "@types/node": "14.0.27",


### PR DESCRIPTION
Hapi instrumentation is failing to compile due to upstream `@types` issues. Disabling the check for the lib.