### PR TITLE
fix: hapi compilation

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-hapi/package.json
+++ b/plugins/node/opentelemetry-instrumentation-hapi/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@hapi/hapi": "20.0.1",
+    "@hapi/podium": "4.1.1",
     "@opentelemetry/context-async-hooks": "0.18.0",
     "@opentelemetry/node": "0.18.0",
     "@opentelemetry/tracing": "0.18.0",

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
@@ -45,7 +45,7 @@
     "@babel/core": "7.11.1",
     "@opentelemetry/context-zone-peer-dep": "0.18.0",
     "@opentelemetry/instrumentation-xml-http-request": "0.18.0",
-    "@opentelemetry/tracing": "0.18.0",
+    "@opentelemetry/tracing": "0.18.2",
     "@types/jquery": "3.5.1",
     "@types/mocha": "7.0.2",
     "@types/node": "14.0.27",


### PR DESCRIPTION
## Short description of the changes

Fix compilation issues by pinning @hapi/podium to 4.1.1 as later version has it's own typings which is not compatible with remaining dependencies.

