### PR TITLE
document: fix express example

### DIFF
--- a/examples/express/client.js
+++ b/examples/express/client.js
@@ -13,10 +13,11 @@ function makeRequest() {
   api.context.with(api.setSpan(api.ROOT_CONTEXT, span), async () => {
     try {
       const res = await axios.get('http://localhost:8080/run_test');
-      span.setStatus({ code: api.StatusCode.OK });
-      console.log(res.statusText);
+      console.log('status:', res.statusText);
+      span.setStatus({ code: api.SpanStatusCode.OK });
     } catch (e) {
-      span.setStatus({ code: api.StatusCode.ERROR, message: e.message });
+      console.log('failed:', e.message);
+      span.setStatus({ code: api.SpanStatusCode.ERROR, message: e.message });
     }
     span.end();
     console.log('Sleeping 5 seconds before shutdown to ensure all records are flushed.');

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -32,15 +32,14 @@
     "@opentelemetry/exporter-jaeger": "^0.18.0",
     "@opentelemetry/exporter-zipkin": "^0.18.0",
     "@opentelemetry/instrumentation": "^0.18.0",
+    "@opentelemetry/instrumentation-express": "^0.15.0",
+    "@opentelemetry/instrumentation-http": "^0.18.2",
     "@opentelemetry/node": "^0.18.0",
-    "@opentelemetry/plugin-express": "file:../../plugins/node/opentelemetry-plugin-express",
-    "@opentelemetry/plugin-http": "^0.18.0",
     "@opentelemetry/tracing": "^0.18.0",
     "axios": "^0.19.0",
+    "cross-env": "^7.0.3",
     "express": "^4.17.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js#readme",
-  "devDependencies": {
-    "cross-env": "^6.0.0"
-  }
+  "devDependencies": {}
 }

--- a/examples/express/server.js
+++ b/examples/express/server.js
@@ -31,27 +31,24 @@ const authMiddleware = (req, res, next) => {
   }
 };
 
-async function setupRoutes() {
-  app.use(express.json());
-
-  app.get('/run_test', async (req, res) => {
-    const createdCat = await axios.post(`http://localhost:${PORT}/cats`, {
-      name: 'Tom',
-      friends: [
-        'Jerry',
-      ],
-    }, {
-      headers: {
-        Authorization: 'secret_token',
-      },
-    });
-
-    return res.status(201).send(createdCat.data);
+app.use(express.json());
+app.get('/run_test', async (req, res) => {
+  // Calls another endpoint of the same API, somewhat mimicing an external API call
+  const createdCat = await axios.post(`http://localhost:${PORT}/cats`, {
+    name: 'Tom',
+    friends: [
+      'Jerry',
+    ],
+  }, {
+    headers: {
+      Authorization: 'secret_token',
+    },
   });
-  app.use('/cats', authMiddleware, getCrudController());
-}
 
-setupRoutes().then(() => {
-  app.listen(PORT);
+  return res.status(201).send(createdCat.data);
+});
+app.use('/cats', authMiddleware, getCrudController());
+
+app.listen(PORT, () => {
   console.log(`Listening on http://localhost:${PORT}`);
 });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

The express example was erroring and used soon-to-be-deprecated API. I'm bringing that up to date.

----

## Short description of the changes

Mainly just removing the usage of the old plugins API and replacing that with `registerInstrumentations`. I also added logger configuration because especially for the newcomers it will definitely be helpful to see those messages and know how to configure the logger. Other than that it's functionally the same.

----

A question for the original express instrumentation developer(@vmarchaud, I believe): **Is it expected that if HTTP layer is not instrumented, express instrumentation is a no-op? Should we document that? Error? Somehow make HTTP instrumentation a dependency for express?**

If that looks alright, I could work on others as well.

Fixes #376
