### PR TITLE
refactor(net): remove hardcoded values, use semantic conventions

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-net/package.json
+++ b/plugins/node/opentelemetry-instrumentation-net/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^0.18.0",
-    "@opentelemetry/instrumentation": "^0.18.2",
-    "@opentelemetry/semantic-conventions": "^0.18.2"
+    "@opentelemetry/instrumentation": "^0.18.0",
+    "@opentelemetry/semantic-conventions": "^0.18.0"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-net/package.json
+++ b/plugins/node/opentelemetry-instrumentation-net/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^0.18.0",
-    "@opentelemetry/instrumentation": "^0.18.0",
-    "@opentelemetry/semantic-conventions": "^0.18.0"
+    "@opentelemetry/instrumentation": "^0.18.2",
+    "@opentelemetry/semantic-conventions": "^0.18.2"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-net/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-net/src/utils.ts
@@ -15,12 +15,11 @@
  */
 
 import { NormalizedOptions } from './types';
+import { GeneralAttribute } from '@opentelemetry/semantic-conventions';
 import { platform } from 'os';
 
-// @TODO Can be replaced with constants from the semantic conventions package once released.
-export const IPC_PIPE = 'pipe';
-export const IPC_UNIX = 'Unix';
-export const IPC_TRANSPORT = platform() === 'win32' ? IPC_PIPE : IPC_UNIX;
+export const IPC_TRANSPORT =
+  platform() === 'win32' ? GeneralAttribute.PIPE : GeneralAttribute.UNIX;
 
 export function getNormalizedArgs(
   args: unknown[]


### PR DESCRIPTION
## Short description of the changes

Use semantic-conventions package to bring in `PIPE` and `UNIX` attributes.
