### PR TITLE
test: fix mongo test skip logic when there's no DB instance running

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-mongodb/test/mongodb.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/test/mongodb.test.ts
@@ -62,6 +62,7 @@ describe('MongoDBInstrumentation', () => {
     instrumentation.setTracerProvider(provider);
     provider.addSpanProcessor(spanProcessor);
     context.setGlobalContextManager(contextManager);
+    shouldTest = true;
     accessCollection(URL, DB_NAME, COLLECTION_NAME)
       .then(result => {
         client = result.client;
@@ -97,8 +98,11 @@ describe('MongoDBInstrumentation', () => {
   });
 
   afterEach(done => {
-    collection.deleteMany({}, done);
     memoryExporter.reset();
+    if (shouldTest) {
+      return collection.deleteMany({}, done);
+    }
+    done();
   });
 
   after(() => {


### PR DESCRIPTION
## Which problem is this PR solving?

The logic to skip MongoDB tests if there's no MongoDB instance running currently fails the tests if there isn't.
