### PR TITLE
chore: moving dev dependency to main dependency due to upgrade to ts 4

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
@@ -42,7 +42,6 @@
   },
   "devDependencies": {
     "@opentelemetry/node": "0.19.0",
-    "@types/aws-lambda": "8.10.76",
     "@types/mocha": "7.0.2",
     "@types/node": "14.14.41",
     "codecov": "3.8.1",
@@ -60,6 +59,7 @@
     "@opentelemetry/instrumentation": "^0.19.0",
     "@opentelemetry/resources": "^0.19.0",
     "@opentelemetry/semantic-conventions": "^0.19.0",
-    "@opentelemetry/tracing": "^0.19.0"
+    "@opentelemetry/tracing": "^0.19.0",
+    "@types/aws-lambda": "8.10.76"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-bunyan/package.json
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/package.json
@@ -45,7 +45,6 @@
     "@opentelemetry/context-async-hooks": "0.19.0",
     "@opentelemetry/node": "0.19.0",
     "@opentelemetry/tracing": "0.19.0",
-    "@types/bunyan": "1.8.6",
     "@types/mocha": "7.0.2",
     "@types/node": "14.14.41",
     "@types/sinon": "9.0.11",
@@ -63,6 +62,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0-rc.0",
-    "@opentelemetry/instrumentation": "^0.19.0"
+    "@opentelemetry/instrumentation": "^0.19.0",
+    "@types/bunyan": "1.8.6"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-express/package.json
+++ b/plugins/node/opentelemetry-instrumentation-express/package.json
@@ -45,7 +45,6 @@
     "@opentelemetry/context-async-hooks": "0.19.0",
     "@opentelemetry/node": "0.19.0",
     "@opentelemetry/tracing": "0.19.0",
-    "@types/express": "4.17.11",
     "@types/mocha": "7.0.2",
     "@types/node": "14.14.41",
     "codecov": "3.8.1",
@@ -63,6 +62,7 @@
     "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/core": "^0.19.0",
     "@opentelemetry/instrumentation": "^0.19.0",
-    "@opentelemetry/semantic-conventions": "^0.19.0"
+    "@opentelemetry/semantic-conventions": "^0.19.0",
+    "@types/express": "4.17.11"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-graphql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-graphql/package.json
@@ -44,7 +44,6 @@
   },
   "devDependencies": {
     "@opentelemetry/tracing": "0.19.0",
-    "@types/graphql": "14.5.0",
     "@types/mocha": "8.2.2",
     "@types/node": "14.14.41",
     "codecov": "3.8.1",
@@ -58,6 +57,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0-rc.0",
-    "@opentelemetry/instrumentation": "^0.19.0"
+    "@opentelemetry/instrumentation": "^0.19.0",
+    "@types/graphql": "14.5.0"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-hapi/package.json
+++ b/plugins/node/opentelemetry-instrumentation-hapi/package.json
@@ -45,7 +45,6 @@
     "@opentelemetry/context-async-hooks": "0.19.0",
     "@opentelemetry/node": "0.19.0",
     "@opentelemetry/tracing": "0.19.0",
-    "@types/hapi__hapi": "20.0.8",
     "@types/mocha": "7.0.2",
     "@types/node": "12.20.10",
     "codecov": "3.8.1",
@@ -62,6 +61,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/instrumentation": "^0.19.0",
-    "@opentelemetry/semantic-conventions": "^0.19.0"
+    "@opentelemetry/semantic-conventions": "^0.19.0",
+    "@types/hapi__hapi": "20.0.8"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-ioredis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/package.json
@@ -48,10 +48,8 @@
     "@opentelemetry/node": "0.19.0",
     "@opentelemetry/test-utils": "^0.16.0",
     "@opentelemetry/tracing": "0.19.0",
-    "@types/ioredis": "4.26.0",
     "@types/mocha": "7.0.2",
     "@types/node": "14.14.41",
-    "@types/shimmer": "1.0.1",
     "codecov": "3.8.1",
     "cross-env": "7.0.3",
     "gts": "3.1.0",
@@ -67,6 +65,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/instrumentation": "^0.19.0",
-    "@opentelemetry/semantic-conventions": "^0.19.0"
+    "@opentelemetry/semantic-conventions": "^0.19.0",
+    "@types/ioredis": "4.26.0"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-koa/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/package.json
@@ -47,8 +47,6 @@
     "@opentelemetry/context-async-hooks": "0.19.0",
     "@opentelemetry/node": "0.19.0",
     "@opentelemetry/tracing": "0.19.0",
-    "@types/koa": "2.13.1",
-    "@types/koa__router": "8.0.4",
     "@types/mocha": "7.0.2",
     "@types/node": "12.20.10",
     "codecov": "3.8.1",
@@ -65,6 +63,8 @@
   "dependencies": {
     "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/instrumentation": "^0.19.0",
-    "@opentelemetry/semantic-conventions": "^0.19.0"
+    "@opentelemetry/semantic-conventions": "^0.19.0",
+    "@types/koa": "2.13.1",
+    "@types/koa__router": "8.0.4"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-mongodb/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/package.json
@@ -47,7 +47,6 @@
     "@opentelemetry/node": "0.19.0",
     "@opentelemetry/tracing": "0.19.0",
     "@types/mocha": "7.0.2",
-    "@types/mongodb": "3.6.12",
     "@types/node": "14.14.41",
     "codecov": "3.8.1",
     "gts": "3.1.0",
@@ -63,6 +62,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/instrumentation": "^0.19.0",
-    "@opentelemetry/semantic-conventions": "^0.19.0"
+    "@opentelemetry/semantic-conventions": "^0.19.0",
+    "@types/mongodb": "3.6.12"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-mysql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql/package.json
@@ -45,7 +45,6 @@
     "@opentelemetry/test-utils": "^0.16.0",
     "@opentelemetry/tracing": "0.19.0",
     "@types/mocha": "7.0.2",
-    "@types/mysql": "2.15.18",
     "@types/node": "14.14.41",
     "codecov": "3.8.1",
     "gts": "3.1.0",
@@ -61,6 +60,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/instrumentation": "^0.19.0",
-    "@opentelemetry/semantic-conventions": "^0.19.0"
+    "@opentelemetry/semantic-conventions": "^0.19.0",
+    "@types/mysql": "2.15.18"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-pg/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pg/package.json
@@ -53,8 +53,6 @@
     "@opentelemetry/tracing": "0.19.0",
     "@types/mocha": "7.0.2",
     "@types/node": "14.14.41",
-    "@types/pg": "7.14.11",
-    "@types/pg-pool": "2.0.2",
     "codecov": "3.8.1",
     "cross-env": "7.0.3",
     "gts": "3.1.0",
@@ -70,6 +68,8 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.0.0-rc.0",
-    "@opentelemetry/instrumentation": "^0.19.0"
+    "@opentelemetry/instrumentation": "^0.19.0",
+    "@types/pg": "7.14.11",
+    "@types/pg-pool": "2.0.2"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-pino/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pino/package.json
@@ -47,7 +47,6 @@
     "@opentelemetry/tracing": "0.19.0",
     "@types/mocha": "7.0.2",
     "@types/node": "14.14.41",
-    "@types/pino": "6.3.8",
     "@types/semver": "7.3.5",
     "@types/sinon": "9.0.11",
     "codecov": "3.8.1",
@@ -66,6 +65,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/instrumentation": "^0.19.0",
-    "semver": "^7.3.5"
+    "semver": "^7.3.5",
+    "@types/pino": "6.3.8"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-redis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis/package.json
@@ -49,7 +49,6 @@
     "@opentelemetry/tracing": "0.19.0",
     "@types/mocha": "7.0.2",
     "@types/node": "14.14.41",
-    "@types/redis": "2.8.28",
     "codecov": "3.8.1",
     "cross-env": "7.0.3",
     "gts": "3.1.0",
@@ -65,6 +64,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/instrumentation": "^0.19.0",
-    "@opentelemetry/semantic-conventions": "^0.19.0"
+    "@opentelemetry/semantic-conventions": "^0.19.0",
+    "@types/redis": "2.8.28"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-restify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-restify/package.json
@@ -46,7 +46,6 @@
     "@opentelemetry/tracing": "0.19.0",
     "@types/mocha": "7.0.2",
     "@types/node": "14.14.41",
-    "@types/restify": "4.3.7",
     "codecov": "3.8.1",
     "gts": "3.1.0",
     "mocha": "7.2.0",
@@ -61,6 +60,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.0.0-rc.0",
     "@opentelemetry/instrumentation": "^0.19.0",
-    "@opentelemetry/semantic-conventions": "^0.19.0"
+    "@opentelemetry/semantic-conventions": "^0.19.0",
+    "@types/restify": "4.3.7"
   }
 }

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
@@ -49,7 +49,6 @@
     "@types/jquery": "3.5.5",
     "@types/mocha": "7.0.2",
     "@types/node": "14.14.41",
-    "@types/shimmer": "1.0.1",
     "@types/sinon": "9.0.11",
     "@types/webpack-env": "1.16.0",
     "babel-loader": "8.2.2",


### PR DESCRIPTION
Because of upgrading to ts v4 the types dependency needs to be now a part of main dependency, otherwise there is an error during installation for example
```
node_modules/@opentelemetry/instrumentation-pg/build/src/pg.d.ts:2:26 - error TS2307: Cannot find module 'pg' or its corresponding type declarations.

2 import * as pgTypes from 'pg';
```

We need to make a patch release asap