### PR TITLE
chore: remove tslint dependencies

### DIFF
--- a/metapackages/auto-instrumentations-node/package.json
+++ b/metapackages/auto-instrumentations-node/package.json
@@ -37,8 +37,6 @@
     "rimraf": "3.0.2",
     "sinon": "10.0.0",
     "ts-mocha": "8.0.0",
-    "tslint-consistent-codestyle": "1.16.0",
-    "tslint-microsoft-contrib": "6.2.0",
     "typescript": "4.2.4"
   },
   "dependencies": {

--- a/packages/opentelemetry-test-utils/package.json
+++ b/packages/opentelemetry-test-utils/package.json
@@ -26,8 +26,6 @@
   "devDependencies": {
     "@types/node": "14.14.43",
     "gts": "3.1.0",
-    "tslint-consistent-codestyle": "1.16.0",
-    "tslint-microsoft-contrib": "6.2.0",
     "typescript": "4.2.4"
   },
   "dependencies": {

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
@@ -51,8 +51,6 @@
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
     "ts-mocha": "8.0.0",
-    "tslint-consistent-codestyle": "1.16.0",
-    "tslint-microsoft-contrib": "6.2.0",
     "typescript": "4.2.4"
   },
   "dependencies": {

--- a/plugins/node/opentelemetry-instrumentation-bunyan/package.json
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/package.json
@@ -57,8 +57,6 @@
     "rimraf": "3.0.2",
     "sinon": "9.2.4",
     "ts-mocha": "8.0.0",
-    "tslint-consistent-codestyle": "1.16.0",
-    "tslint-microsoft-contrib": "6.2.0",
     "typescript": "4.2.4"
   },
   "dependencies": {

--- a/plugins/node/opentelemetry-instrumentation-dns/package.json
+++ b/plugins/node/opentelemetry-instrumentation-dns/package.json
@@ -56,8 +56,6 @@
     "rimraf": "3.0.2",
     "sinon": "10.0.0",
     "ts-mocha": "8.0.0",
-    "tslint-consistent-codestyle": "1.16.0",
-    "tslint-microsoft-contrib": "6.2.0",
     "typescript": "4.2.4"
   },
   "dependencies": {

--- a/plugins/node/opentelemetry-instrumentation-express/package.json
+++ b/plugins/node/opentelemetry-instrumentation-express/package.json
@@ -55,8 +55,6 @@
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
     "ts-mocha": "8.0.0",
-    "tslint-consistent-codestyle": "1.16.0",
-    "tslint-microsoft-contrib": "6.2.0",
     "typescript": "4.2.4"
   },
   "dependencies": {

--- a/plugins/node/opentelemetry-instrumentation-hapi/package.json
+++ b/plugins/node/opentelemetry-instrumentation-hapi/package.json
@@ -55,8 +55,6 @@
     "rimraf": "3.0.2",
     "semver": "7.3.5",
     "ts-mocha": "8.0.0",
-    "tslint-consistent-codestyle": "1.16.0",
-    "tslint-microsoft-contrib": "6.2.0",
     "typescript": "4.2.4"
   },
   "dependencies": {

--- a/plugins/node/opentelemetry-instrumentation-ioredis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/package.json
@@ -60,8 +60,6 @@
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
     "ts-mocha": "8.0.0",
-    "tslint-consistent-codestyle": "1.16.0",
-    "tslint-microsoft-contrib": "6.2.0",
     "typescript": "4.2.4"
   },
   "dependencies": {

--- a/plugins/node/opentelemetry-instrumentation-koa/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/package.json
@@ -58,8 +58,6 @@
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
     "ts-mocha": "8.0.0",
-    "tslint-consistent-codestyle": "1.16.0",
-    "tslint-microsoft-contrib": "6.2.0",
     "typescript": "4.2.4"
   },
   "dependencies": {

--- a/plugins/node/opentelemetry-instrumentation-mongodb/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/package.json
@@ -56,8 +56,6 @@
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
     "ts-mocha": "8.0.0",
-    "tslint-consistent-codestyle": "1.16.0",
-    "tslint-microsoft-contrib": "6.2.0",
     "typescript": "4.2.4"
   },
   "dependencies": {

--- a/plugins/node/opentelemetry-instrumentation-mysql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql/package.json
@@ -54,8 +54,6 @@
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
     "ts-mocha": "8.0.0",
-    "tslint-consistent-codestyle": "1.16.0",
-    "tslint-microsoft-contrib": "6.2.0",
     "typescript": "4.2.4"
   },
   "dependencies": {

--- a/plugins/node/opentelemetry-instrumentation-net/package.json
+++ b/plugins/node/opentelemetry-instrumentation-net/package.json
@@ -54,8 +54,6 @@
     "rimraf": "3.0.2",
     "sinon": "10.0.0",
     "ts-mocha": "8.0.0",
-    "tslint-consistent-codestyle": "1.16.0",
-    "tslint-microsoft-contrib": "6.2.0",
     "typescript": "4.2.4"
   },
   "dependencies": {

--- a/plugins/node/opentelemetry-instrumentation-pg/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pg/package.json
@@ -64,8 +64,6 @@
     "pg-pool": "3.3.0",
     "rimraf": "3.0.2",
     "ts-mocha": "8.0.0",
-    "tslint-consistent-codestyle": "1.16.0",
-    "tslint-microsoft-contrib": "6.2.0",
     "typescript": "4.2.4"
   },
   "dependencies": {

--- a/plugins/node/opentelemetry-instrumentation-pino/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pino/package.json
@@ -59,8 +59,6 @@
     "sinon": "9.2.4",
     "ts-mocha": "8.0.0",
     "ts-node": "9.1.1",
-    "tslint-consistent-codestyle": "1.16.0",
-    "tslint-microsoft-contrib": "6.2.0",
     "typescript": "4.2.4"
   },
   "dependencies": {

--- a/plugins/node/opentelemetry-instrumentation-redis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis/package.json
@@ -58,8 +58,6 @@
     "redis": "3.1.2",
     "rimraf": "3.0.2",
     "ts-mocha": "8.0.0",
-    "tslint-consistent-codestyle": "1.16.0",
-    "tslint-microsoft-contrib": "6.2.0",
     "typescript": "4.2.4"
   },
   "dependencies": {

--- a/plugins/node/opentelemetry-instrumentation-restify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-restify/package.json
@@ -54,8 +54,6 @@
     "restify": "4.3.4",
     "rimraf": "3.0.2",
     "ts-mocha": "8.0.0",
-    "tslint-consistent-codestyle": "1.16.0",
-    "tslint-microsoft-contrib": "6.2.0",
     "typescript": "4.2.4"
   },
   "dependencies": {

--- a/plugins/node/opentelemetry-instrumentation-winston/package.json
+++ b/plugins/node/opentelemetry-instrumentation-winston/package.json
@@ -55,8 +55,6 @@
     "rimraf": "3.0.2",
     "sinon": "9.2.4",
     "ts-mocha": "8.0.0",
-    "tslint-consistent-codestyle": "1.16.0",
-    "tslint-microsoft-contrib": "6.2.0",
     "typescript": "4.2.4",
     "winston": "3.3.3",
     "winston2": "npm:winston@2.4.5"

--- a/plugins/web/opentelemetry-instrumentation-document-load/package.json
+++ b/plugins/web/opentelemetry-instrumentation-document-load/package.json
@@ -68,8 +68,6 @@
     "sinon": "10.0.0",
     "ts-loader": "8.2.0",
     "ts-mocha": "8.0.0",
-    "tslint-consistent-codestyle": "1.16.0",
-    "tslint-microsoft-contrib": "6.2.0",
     "typescript": "4.2.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.6.0",

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
@@ -74,8 +74,6 @@
     "sinon": "10.0.0",
     "ts-loader": "8.2.0",
     "ts-mocha": "8.0.0",
-    "tslint-consistent-codestyle": "1.16.0",
-    "tslint-microsoft-contrib": "6.2.0",
     "typescript": "4.2.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.6.0",

--- a/plugins/web/opentelemetry-plugin-react-load/package.json
+++ b/plugins/web/opentelemetry-plugin-react-load/package.json
@@ -75,8 +75,6 @@
     "sinon": "10.0.0",
     "ts-loader": "8.2.0",
     "ts-mocha": "8.0.0",
-    "tslint-consistent-codestyle": "1.16.0",
-    "tslint-microsoft-contrib": "6.2.0",
     "typescript": "4.2.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.6.0",

--- a/propagators/opentelemetry-propagator-grpc-census-binary/package.json
+++ b/propagators/opentelemetry-propagator-grpc-census-binary/package.json
@@ -52,8 +52,6 @@
     "rimraf": "3.0.2",
     "ts-loader": "8.2.0",
     "ts-mocha": "8.0.0",
-    "tslint-consistent-codestyle": "1.16.0",
-    "tslint-microsoft-contrib": "6.2.0",
     "typescript": "4.2.4"
   },
   "dependencies": {


### PR DESCRIPTION
## Short description of the changes

we move to eslint recently therefore it seems time to remove some tslint plugins/extensions from dev-dependencies.
