### PR TITLE
chore: removing usage of timed event from api

### DIFF
--- a/packages/opentelemetry-test-utils/testUtils.ts
+++ b/packages/opentelemetry-test-utils/testUtils.ts
@@ -16,11 +16,11 @@
 
 import * as childProcess from 'child_process';
 import {
-  SpanKind,
-  SpanAttributes,
+  HrTime,
   Span,
+  SpanAttributes,
+  SpanKind,
   SpanStatus,
-  TimedEvent,
 } from '@opentelemetry/api';
 import * as assert from 'assert';
 import { ReadableSpan } from '@opentelemetry/tracing';
@@ -126,3 +126,15 @@ export const assertPropagation = (
   );
   assert.notStrictEqual(targetSpanContext.spanId, sourceSpanContext.spanId);
 };
+
+/**
+ * Represents a timed event.
+ * A timed event is an event with a timestamp.
+ */
+export interface TimedEvent {
+  time: HrTime;
+  /** The name of the event. */
+  name: string;
+  /** The attributes of the event. */
+  attributes?: SpanAttributes;
+}

--- a/plugins/node/opentelemetry-instrumentation-pg/test/pg-pool.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/test/pg-pool.test.ts
@@ -21,7 +21,6 @@ import {
   Span,
   SpanKind,
   SpanStatus,
-  TimedEvent,
   setSpan,
 } from '@opentelemetry/api';
 import { BasicTracerProvider } from '@opentelemetry/tracing';
@@ -36,6 +35,7 @@ import * as assert from 'assert';
 import * as pg from 'pg';
 import * as pgPool from 'pg-pool';
 import { AttributeNames } from '../src/enums';
+import { TimedEvent } from './types';
 
 const memoryExporter = new InMemorySpanExporter();
 

--- a/plugins/node/opentelemetry-instrumentation-pg/test/pg.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/test/pg.test.ts
@@ -21,7 +21,6 @@ import {
   Span,
   SpanKind,
   SpanStatus,
-  TimedEvent,
   setSpan,
   getSpan,
 } from '@opentelemetry/api';
@@ -36,6 +35,7 @@ import * as assert from 'assert';
 import type * as pg from 'pg';
 import { PgInstrumentation } from '../src';
 import { AttributeNames } from '../src/enums';
+import { TimedEvent } from './types';
 
 const memoryExporter = new InMemorySpanExporter();
 

--- a/plugins/node/opentelemetry-instrumentation-pg/test/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/test/types.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HrTime, SpanAttributes } from '@opentelemetry/api';
+
+/**
+ * Represents a timed event.
+ * A timed event is an event with a timestamp.
+ */
+export interface TimedEvent {
+  time: HrTime;
+  /** The name of the event. */
+  name: string;
+  /** The attributes of the event. */
+  attributes?: SpanAttributes;
+}

--- a/plugins/web/opentelemetry-instrumentation-document-load/test/documentLoad.test.ts
+++ b/plugins/web/opentelemetry-instrumentation-document-load/test/documentLoad.test.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { context, propagation, TimedEvent } from '@opentelemetry/api';
+import {
+  context,
+  HrTime,
+  propagation,
+  SpanAttributes,
+} from '@opentelemetry/api';
 import { HttpTraceContext, TRACE_PARENT_HEADER } from '@opentelemetry/core';
 import {
   BasicTracerProvider,
@@ -597,3 +602,15 @@ describe('DocumentLoad Instrumentation', () => {
     shouldExportCorrectSpan();
   });
 });
+
+/**
+ * Represents a timed event.
+ * A timed event is an event with a timestamp.
+ */
+interface TimedEvent {
+  time: HrTime;
+  /** The name of the event. */
+  name: string;
+  /** The attributes of the event. */
+  attributes?: SpanAttributes;
+}


### PR DESCRIPTION
## Which problem is this PR solving?

- Removing dependency on TimedEvent from api

## Short description of the changes

- Fixes https://github.com/open-telemetry/opentelemetry-js-api/issues/37
