### PR TITLE
docs: Explicitly state that express instrumentation does not export spans without http instrumentation

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-express/README.md
+++ b/plugins/node/opentelemetry-instrumentation-express/README.md
@@ -12,7 +12,7 @@ For automatic instrumentation see the
 
 ## Installation
 
-This instrumentation relies on HTTP calls to also be instrumented. Make sure you install and enable both.
+This instrumentation relies on HTTP calls to also be instrumented. Make sure you install and enable both, otherwise you will not see any spans being exported from the instrumentation.
 
 ```bash
 npm install --save @opentelemetry/instrumentation-http @opentelemetry/instrumentation-express


### PR DESCRIPTION
As discussed in the meeting today, I think making this point clear helps enduser to understand what they _might_ be doing wrong if no spans are exported.