### PR TITLE
feat(peer-api-check): error differently if devDep not pinned

### DIFF
--- a/scripts/peer-api-check.js
+++ b/scripts/peer-api-check.js
@@ -26,6 +26,12 @@ if (pjson.dependencies && pjson.dependencies['@opentelemetry/api']) {
 const peerVersion = pjson.peerDependencies && pjson.peerDependencies['@opentelemetry/api'];
 const devVersion = pjson.devDependencies && pjson.devDependencies['@opentelemetry/api'];
 if (peerVersion) {
+	// error if not pinned
+	if (!/^[0-9]/.test(devVersion)) {
+		throw new Error(
+			`Package ${pjson.name} does't have API version pinned in dev dependencies: ${devVersion}`
+		);
+	}
 	if (peerVersion !== `^${devVersion}`) {
 		throw new Error(
 			`Package ${pjson.name} depends on peer API version ${peerVersion} ` +

--- a/scripts/peer-api-check.js
+++ b/scripts/peer-api-check.js
@@ -14,23 +14,23 @@
  * limitations under the License.
  */
 
-const fs = require('fs');
-const os = require('os');
 const path = require('path');
-
 const appRoot = process.cwd();
-
 const packageJsonUrl = path.resolve(`${appRoot}/package.json`);
 const pjson = require(packageJsonUrl);
 
-if (pjson.dependencies && pjson.dependencies["@opentelemetry/api"]) 
-    throw new Error(`Package ${pjson.name} depends on API but it should be a peer dependency`);
+if (pjson.dependencies && pjson.dependencies['@opentelemetry/api']) {
+	throw new Error(`Package ${pjson.name} depends on API but it should be a peer dependency`);
+}
 
-const peerVersion = pjson.peerDependencies && pjson.peerDependencies["@opentelemetry/api"]
-const devVersion = pjson.devDependencies && pjson.devDependencies["@opentelemetry/api"]
+const peerVersion = pjson.peerDependencies && pjson.peerDependencies['@opentelemetry/api'];
+const devVersion = pjson.devDependencies && pjson.devDependencies['@opentelemetry/api'];
 if (peerVersion) {
-    if (peerVersion !== `^${devVersion}`) {
-        throw new Error(`Package ${pjson.name} depends on peer API version ${peerVersion} but version ${devVersion} in development`);
-    }
-    console.log(`${pjson.name} OK`);
+	if (peerVersion !== `^${devVersion}`) {
+		throw new Error(
+			`Package ${pjson.name} depends on peer API version ${peerVersion} ` +
+			`but version ${devVersion} in development`
+		);
+	}
+	console.log(`${pjson.name} OK`);
 }


### PR DESCRIPTION
I bumped into this in my PRs when I had both(devDep and peerDep) versions with `^`.