### PR TITLE
HLSP-65 add mongo hook

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-mongodb/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/src/instrumentation.ts
@@ -42,12 +42,24 @@ import { VERSION } from './version';
 
 const supportedVersions = ['>=3.3 <4'];
 
+const DEFAULT_CONFIG: MongoDBInstrumentationConfig = {
+  enhancedDatabaseReporting: false,
+};
+
 /** mongodb instrumentation plugin for OpenTelemetry */
 export class MongoDBInstrumentation extends InstrumentationBase<
   typeof mongodb
 > {
-  constructor(protected _config: MongoDBInstrumentationConfig = {}) {
-    super('@opentelemetry/instrumentation-mongodb', VERSION, _config);
+  constructor(config: MongoDBInstrumentationConfig = {}) {
+    super("@opentelemetry/instrumentation-mongodb", VERSION, Object.assign({}, DEFAULT_CONFIG, config));
+  }
+
+  private _getConfig(): MongoDBInstrumentationConfig {
+    return this._config as MongoDBInstrumentationConfig;
+  }
+
+  setConfig(config: MongoDBInstrumentationConfig) {
+    this._config = Object.assign({}, DEFAULT_CONFIG, config);
   }
 
   init() {
@@ -406,8 +418,9 @@ export class MongoDBInstrumentation extends InstrumentationBase<
 
     // capture parameters within the query as well if enhancedDatabaseReporting is enabled.
     const commandObj = command.query ?? command.q ?? command;
+    const config = this._getConfig();
     const query =
-      this._config?.enhancedDatabaseReporting === true
+      config?.enhancedDatabaseReporting === true
         ? commandObj
         : Object.keys(commandObj).reduce((obj, key) => {
             obj[key] = '?';

--- a/plugins/node/opentelemetry-instrumentation-mongodb/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/src/types.ts
@@ -15,6 +15,11 @@
  */
 
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import { Span } from '@opentelemetry/api';
+
+export interface MongoDBInstrumentationExecutionResponseHook {
+  (span: Span, result: CommandResult): void;
+}
 
 export interface MongoDBInstrumentationConfig extends InstrumentationConfig {
   /**
@@ -25,6 +30,14 @@ export interface MongoDBInstrumentationConfig extends InstrumentationConfig {
    * @default false
    */
   enhancedDatabaseReporting?: boolean;
+
+  /**
+   * Hook that allows adding custom span attributes based on the data
+   * returned from MongoDB actions.
+   *
+   * @default undefined
+   */
+  responseHook?: MongoDBInstrumentationExecutionResponseHook;
 }
 
 export type Func<T> = (...args: unknown[]) => T;
@@ -44,6 +57,13 @@ export type CursorState = { cmd: MongoInternalCommand } & Record<
   string,
   unknown
 >;
+
+// https://github.com/mongodb/node-mongodb-native/blob/3.6/lib/core/connection/command_result.js
+export type CommandResult = {
+  result?: string;
+  connection?: string;
+  message?: string;
+}
 
 // https://github.com/mongodb/node-mongodb-native/blob/3.6/lib/core/wireprotocol/index.js
 export type WireProtocolInternal = {

--- a/plugins/node/opentelemetry-instrumentation-mongodb/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/src/types.ts
@@ -21,6 +21,8 @@ export interface MongoDBInstrumentationConfig extends InstrumentationConfig {
    * If true, additional information about query parameters and
    * results will be attached (as `attributes`) to spans representing
    * database operations.
+   *
+   * @default false
    */
   enhancedDatabaseReporting?: boolean;
 }

--- a/plugins/node/opentelemetry-instrumentation-mongodb/test/mongodb.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/test/mongodb.test.ts
@@ -16,7 +16,7 @@
 
 // for testing locally "npm run docker:start"
 
-import { context, trace, SpanKind } from '@opentelemetry/api';
+import { context, trace, SpanKind, Span } from '@opentelemetry/api';
 import { BasicTracerProvider } from '@opentelemetry/tracing';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import {
@@ -24,7 +24,8 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/tracing';
 import * as assert from 'assert';
-import { MongoDBInstrumentation } from '../src';
+import { MongoDBInstrumentation, MongoDBInstrumentationConfig } from '../src';
+import { CommandResult } from '../src/types';
 
 const instrumentation = new MongoDBInstrumentation();
 instrumentation.enable();
@@ -34,6 +35,10 @@ import * as mongodb from 'mongodb';
 import { assertSpans, accessCollection } from './utils';
 
 describe('MongoDBInstrumentation', () => {
+  function create(config: MongoDBInstrumentationConfig = {}) {
+    instrumentation.setConfig(config);
+    instrumentation.enable();
+  }
   // For these tests, mongo must be running. Add RUN_MONGODB_TESTS to run
   // these tests.
   const RUN_MONGODB_TESTS = process.env.RUN_MONGODB_TESTS as string;
@@ -239,6 +244,87 @@ describe('MongoDBInstrumentation', () => {
             SpanKind.CLIENT
           );
           done();
+        });
+      });
+    });
+  });
+
+  describe('when specifying a responseHook configuration', () => {
+    const dataAttributeName = 'mongodb_data';
+    beforeEach(() => {
+      memoryExporter.reset();
+    });
+
+    describe('with a valid function and enhancedDatabaseReporting set to true', () => {
+      beforeEach(() => {
+        create({
+          enhancedDatabaseReporting: true,
+          responseHook: (span: Span, result: CommandResult) => {
+            span.setAttribute(dataAttributeName, JSON.stringify(result.result));
+          }
+        });
+      })
+
+      it('should attach response hook data to the resulting span for insert function', done => {
+        const insertData = [{ a: 1 }, { a: 2 }, { a: 3 }];
+        const span = provider.getTracer('default').startSpan('insertRootSpan');
+        context.with(trace.setSpan(context.active(), span), () => {
+          collection.insertMany(insertData, (err, result) => {
+            span.end();
+            assert.ifError(err);
+            const spans = memoryExporter.getFinishedSpans();
+            const insertSpan = spans[0];
+
+            assert.strictEqual(insertSpan.attributes[dataAttributeName], JSON.stringify(result.result, Object.keys(result.result).sort()));
+
+            memoryExporter.reset();
+            done();
+          });
+        });
+      });
+
+      it('should attach response hook data to the resulting span for find function', done => {
+        const span = provider.getTracer('default').startSpan('findRootSpan');
+        context.with(trace.setSpan(context.active(), span), () => {
+          collection.find({ a: 1 }).toArray((err, results) => {
+            span.end();
+            assert.ifError(err);
+            const spans = memoryExporter.getFinishedSpans();
+            const findSpan = spans[0];
+            const spanResult = JSON.parse(findSpan.attributes[dataAttributeName]?.toString() || '{}');
+
+            assert.strictEqual(spanResult.cursor.firstBatch[0]._id, results[0]._id.toString());
+
+            memoryExporter.reset();
+            done();
+          });
+        });
+      });
+    });
+
+    describe('with an invalid function', () => {
+      beforeEach(() => {
+        create({
+          enhancedDatabaseReporting: true,
+          responseHook: (span: Span, result: CommandResult) => {
+            throw 'some error';
+          },
+        });
+      });
+
+      it('should not do any harm when throwing an exception', done => {
+        const span = provider.getTracer('default').startSpan('findRootSpan');
+        context.with(trace.setSpan(context.active(), span), () => {
+          collection.find({ a: 1 }).toArray((err, results) => {
+            span.end();
+            const spans = memoryExporter.getFinishedSpans();
+
+            assert.ifError(err);
+            assertSpans(spans, 'mongodb.find', SpanKind.CLIENT);
+
+            memoryExporter.reset();
+            done();
+          });
         });
       });
     });

--- a/plugins/node/opentelemetry-instrumentation-pg/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/index.ts
@@ -15,3 +15,7 @@
  */
 
 export * from './instrumentation';
+export {
+  PgInstrumentationConfig,
+  PgInstrumentationExecutionResponseHook,
+} from './types';

--- a/plugins/node/opentelemetry-instrumentation-pg/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/instrumentation.ts
@@ -36,6 +36,7 @@ import {
   PostgresCallback,
   PgPoolExtended,
   PgPoolCallback,
+  PgInstrumentationConfig,
 } from './types';
 import * as utils from './utils';
 import { AttributeNames } from './enums/AttributeNames';
@@ -45,17 +46,7 @@ import {
 } from '@opentelemetry/semantic-conventions';
 import { VERSION } from './version';
 
-export interface PgInstrumentationConfig extends InstrumentationConfig {
-  /**
-   * If true, additional information about query parameters and
-   * results will be attached (as `attributes`) to spans representing
-   * database operations.
-   */
-  enhancedDatabaseReporting?: boolean;
-}
-
 const PG_POOL_COMPONENT = 'pg-pool';
-
 export class PgInstrumentation extends InstrumentationBase {
   static readonly COMPONENT = 'pg';
 
@@ -67,6 +58,14 @@ export class PgInstrumentation extends InstrumentationBase {
       VERSION,
       Object.assign({}, config)
     );
+  }
+
+  private _getConfig(): PgInstrumentationConfig {
+    return this._config as PgInstrumentationConfig & InstrumentationConfig;
+  }
+
+  setConfig(config: PgInstrumentationConfig & InstrumentationConfig = {}) {
+    this._config = Object.assign({}, config);
   }
 
   protected init() {
@@ -134,7 +133,7 @@ export class PgInstrumentation extends InstrumentationBase {
             span = utils.handleParameterizedQuery.call(
               this,
               plugin.tracer,
-              plugin._config as InstrumentationConfig & PgInstrumentationConfig,
+              plugin._getConfig(),
               query,
               params
             );
@@ -146,7 +145,7 @@ export class PgInstrumentation extends InstrumentationBase {
           span = utils.handleConfigQuery.call(
             this,
             plugin.tracer,
-            plugin._config as InstrumentationConfig & PgInstrumentationConfig,
+            plugin._getConfig(),
             queryConfig
           );
         } else {
@@ -164,6 +163,7 @@ export class PgInstrumentation extends InstrumentationBase {
           if (typeof args[args.length - 1] === 'function') {
             // Patch ParameterQuery callback
             args[args.length - 1] = utils.patchCallback(
+              plugin._getConfig(),
               span,
               args[args.length - 1] as PostgresCallback
             );
@@ -176,6 +176,7 @@ export class PgInstrumentation extends InstrumentationBase {
           ) {
             // Patch ConfigQuery callback
             let callback = utils.patchCallback(
+              plugin._getConfig(),
               span,
               (args[0] as NormalizedQueryConfig).callback!
             );
@@ -199,6 +200,7 @@ export class PgInstrumentation extends InstrumentationBase {
             .then((result: unknown) => {
               // Return a pass-along promise which ends the span and then goes to user's orig resolvers
               return new Promise(resolve => {
+                utils.handleExecutionResult(plugin._getConfig(), span, result);
                 span.end();
                 resolve(result);
               });

--- a/plugins/node/opentelemetry-instrumentation-pg/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/types.ts
@@ -16,6 +16,30 @@
 
 import * as pgTypes from 'pg';
 import * as pgPoolTypes from 'pg-pool';
+import type * as api from '@opentelemetry/api';
+import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+
+export interface PgInstrumentationExecutionResponseHook {
+  (span: api.Span, data: pgTypes.QueryResult | pgTypes.QueryArrayResult): void;
+}
+
+export interface PgInstrumentationConfig extends InstrumentationConfig {
+  /**
+   * If true, additional information about query parameters and
+   * results will be attached (as `attributes`) to spans representing
+   * database operations.
+   */
+  enhancedDatabaseReporting?: boolean;
+
+  /**
+   * Hook that allows adding custom span attributes based on the data
+   * returned from "query" Pg actions.
+   * Using this requires that the `enhancedDatabaseReporting` flag be set to true.
+   *
+   * @default undefined
+   */
+  responseHook?: PgInstrumentationExecutionResponseHook;
+}
 
 export type PostgresCallback = (err: Error, res: object) => unknown;
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Add the ability to collect the response of a mongo action (as an optional configuration). This data can be used for monitoring purposes.

## Short description of the changes

- Added get/set for the MongoDBInstrumentationConfig
- Added `responseHook` configuration member which is called at the end of each mongo action
