### PR TITLE
feat(mongo instrumentation): added response hook option

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-mongodb/README.md
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/README.md
@@ -50,6 +50,7 @@ Mongodb instrumentation has few options available to choose from. You can set th
 | Options | Type | Description |
 | ------- | ---- | ----------- |
 | [`enhancedDatabaseReporting`](https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-api/src/trace/instrumentation/instrumentation.ts#L91) | `string` | If true, additional information about query parameters and results will be attached (as `attributes`) to spans representing database operations |
+| `responseHook` | `MongoDBInstrumentationExecutionResponseHook` (function) | Function for adding custom attributes from db response |
 
 ## Useful links
 

--- a/plugins/node/opentelemetry-instrumentation-mongodb/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/src/types.ts
@@ -15,6 +15,11 @@
  */
 
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import { Span } from '@opentelemetry/api';
+
+export interface MongoDBInstrumentationExecutionResponseHook {
+  (span: Span, responseInfo: MongoResponseHookInformation): void;
+}
 
 export interface MongoDBInstrumentationConfig extends InstrumentationConfig {
   /**
@@ -23,6 +28,14 @@ export interface MongoDBInstrumentationConfig extends InstrumentationConfig {
    * database operations.
    */
   enhancedDatabaseReporting?: boolean;
+
+  /**
+   * Hook that allows adding custom span attributes based on the data
+   * returned from MongoDB actions.
+   *
+   * @default undefined
+   */
+  responseHook?: MongoDBInstrumentationExecutionResponseHook;
 }
 
 export type Func<T> = (...args: unknown[]) => T;
@@ -42,6 +55,17 @@ export type CursorState = { cmd: MongoInternalCommand } & Record<
   string,
   unknown
 >;
+
+export interface MongoResponseHookInformation {
+  data: CommandResult;
+}
+
+// https://github.com/mongodb/node-mongodb-native/blob/3.6/lib/core/connection/command_result.js
+export type CommandResult = {
+  result?: unknown;
+  connection?: unknown;
+  message?: unknown;
+};
 
 // https://github.com/mongodb/node-mongodb-native/blob/3.6/lib/core/wireprotocol/index.js
 export type WireProtocolInternal = {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Add the ability to collect the response of a mongo action (as an optional configuration). This data can be used for monitoring purposes.

## Short description of the changes

- Added `responseHook` configuration member which is called at the end of each mongo action
