### PR TITLE
fix(mysql): bind get connection callback to active context

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-mysql/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql/src/instrumentation.ts
@@ -34,7 +34,10 @@ import { VERSION } from './version';
 
 type formatType = typeof mysqlTypes.format;
 
-type getConnectionCallbackType = (err: mysqlTypes.MysqlError, connection: mysqlTypes.PoolConnection) => void;
+type getConnectionCallbackType = (
+  err: mysqlTypes.MysqlError,
+  connection: mysqlTypes.PoolConnection
+) => void;
 
 export class MySQLInstrumentation extends InstrumentationBase<
   typeof mysqlTypes
@@ -209,10 +212,17 @@ export class MySQLInstrumentation extends InstrumentationBase<
     };
   }
 
-  private _getConnectionCallbackPatchFn(cb: getConnectionCallbackType, format: formatType) {
+  private _getConnectionCallbackPatchFn(
+    cb: getConnectionCallbackType,
+    format: formatType
+  ) {
     const thisPlugin = this;
     const activeContext = context.active();
-    return function (this: any, err: mysqlTypes.MysqlError, connection: mysqlTypes.PoolConnection) {
+    return function (
+      this: any,
+      err: mysqlTypes.MysqlError,
+      connection: mysqlTypes.PoolConnection
+    ) {
       if (connection) {
         // this is the callback passed into a query
         // no need to unwrap

--- a/plugins/node/opentelemetry-instrumentation-mysql/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql/src/instrumentation.ts
@@ -34,6 +34,8 @@ import { VERSION } from './version';
 
 type formatType = typeof mysqlTypes.format;
 
+type getConnectionCallbackType = (err: mysqlTypes.MysqlError, connection: mysqlTypes.PoolConnection) => void;
+
 export class MySQLInstrumentation extends InstrumentationBase<
   typeof mysqlTypes
 > {
@@ -182,21 +184,21 @@ export class MySQLInstrumentation extends InstrumentationBase<
 
         if (arguments.length === 1 && typeof arg1 === 'function') {
           const patchFn = thisPlugin._getConnectionCallbackPatchFn(
-            arg1,
+            arg1 as getConnectionCallbackType,
             format
           );
           return originalGetConnection.call(pool, patchFn);
         }
         if (arguments.length === 2 && typeof arg2 === 'function') {
           const patchFn = thisPlugin._getConnectionCallbackPatchFn(
-            arg2,
+            arg2 as getConnectionCallbackType,
             format
           );
           return originalGetConnection.call(pool, arg1, patchFn);
         }
         if (arguments.length === 3 && typeof arg3 === 'function') {
           const patchFn = thisPlugin._getConnectionCallbackPatchFn(
-            arg3,
+            arg3 as getConnectionCallbackType,
             format
           );
           return originalGetConnection.call(pool, arg1, arg2, patchFn);
@@ -207,25 +209,23 @@ export class MySQLInstrumentation extends InstrumentationBase<
     };
   }
 
-  private _getConnectionCallbackPatchFn(cb: Function, format: formatType) {
+  private _getConnectionCallbackPatchFn(cb: getConnectionCallbackType, format: formatType) {
     const thisPlugin = this;
     const activeContext = context.active();
-    return function () {
-      if (arguments[1]) {
+    return function (this: any, err: mysqlTypes.MysqlError, connection: mysqlTypes.PoolConnection) {
+      if (connection) {
         // this is the callback passed into a query
         // no need to unwrap
-        if (!isWrapped(arguments[1].query)) {
+        if (!isWrapped(connection.query)) {
           thisPlugin._wrap(
-            arguments[1],
+            connection,
             'query',
-            thisPlugin._patchQuery(arguments[1], format)
+            thisPlugin._patchQuery(connection, format)
           );
         }
       }
       if (typeof cb === 'function') {
-        context.with(activeContext, () => {
-          cb(...arguments);
-        });
+        context.with(activeContext, cb, this, err, connection);
       }
     };
   }

--- a/plugins/node/opentelemetry-instrumentation-mysql/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql/src/instrumentation.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { diag, Span, SpanKind, SpanStatusCode } from '@opentelemetry/api';
+import {
+  context,
+  diag,
+  Span,
+  SpanKind,
+  SpanStatusCode,
+} from '@opentelemetry/api';
 import {
   InstrumentationBase,
   InstrumentationNodeModuleDefinition,
@@ -203,6 +209,7 @@ export class MySQLInstrumentation extends InstrumentationBase<
 
   private _getConnectionCallbackPatchFn(cb: Function, format: formatType) {
     const thisPlugin = this;
+    const activeContext = context.active();
     return function () {
       if (arguments[1]) {
         // this is the callback passed into a query
@@ -216,7 +223,9 @@ export class MySQLInstrumentation extends InstrumentationBase<
         }
       }
       if (typeof cb === 'function') {
-        cb(...arguments);
+        context.with(activeContext, () => {
+          cb(...arguments);
+        });
       }
     };
   }

--- a/plugins/node/opentelemetry-instrumentation-mysql/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql/test/index.test.ts
@@ -426,6 +426,30 @@ describe('mysql@2.x', () => {
         });
       });
     });
+
+    it('should propagate active context to callback', done => {
+      const parentSpan = provider.getTracer('default').startSpan('test span');
+      context.with(trace.setSpan(context.active(), parentSpan), () => {
+        pool.getConnection((err, connection) => {
+          assert.ifError(err);
+          assert.ok(connection);
+          const sql = 'SELECT ? as solution';
+          connection.query(sql, 1, (err, res) => {
+            assert.ifError(err);
+            assert.ok(res);
+            assert.strictEqual(res[0].solution, 1);
+            const spans = memoryExporter.getFinishedSpans();
+            assert.strictEqual(spans.length, 1);
+            const querySpan = spans[0];
+            assert.strictEqual(
+              querySpan.parentSpanId,
+              parentSpan.spanContext().spanId
+            );
+            done();
+          });
+        });
+      });
+    });
   });
 
   describe('#PoolCluster', () => {
@@ -599,6 +623,30 @@ describe('mysql@2.x', () => {
           });
         }
       );
+    });
+
+    it('should propagate active context to callback', done => {
+      const parentSpan = provider.getTracer('default').startSpan('test span');
+      context.with(trace.setSpan(context.active(), parentSpan), () => {
+        poolCluster.getConnection((err, connection) => {
+          assert.ifError(err);
+          assert.ok(connection);
+          const sql = 'SELECT ? as solution';
+          connection.query(sql, 1, (err, res) => {
+            assert.ifError(err);
+            assert.ok(res);
+            assert.strictEqual(res[0].solution, 1);
+            const spans = memoryExporter.getFinishedSpans();
+            assert.strictEqual(spans.length, 1);
+            const querySpan = spans[0];
+            assert.strictEqual(
+              querySpan.parentSpanId,
+              parentSpan.spanContext().spanId
+            );
+            done();
+          });
+        });
+      });
     });
   });
 });

--- a/plugins/node/opentelemetry-instrumentation-mysql/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql/test/index.test.ts
@@ -438,13 +438,8 @@ describe('mysql@2.x', () => {
             assert.ifError(err);
             assert.ok(res);
             assert.strictEqual(res[0].solution, 1);
-            const spans = memoryExporter.getFinishedSpans();
-            assert.strictEqual(spans.length, 1);
-            const querySpan = spans[0];
-            assert.strictEqual(
-              querySpan.parentSpanId,
-              parentSpan.spanContext().spanId
-            );
+            const actualSpan = trace.getSpan(context.active());
+            assert.strictEqual(actualSpan, parentSpan);
             done();
           });
         });
@@ -636,13 +631,8 @@ describe('mysql@2.x', () => {
             assert.ifError(err);
             assert.ok(res);
             assert.strictEqual(res[0].solution, 1);
-            const spans = memoryExporter.getFinishedSpans();
-            assert.strictEqual(spans.length, 1);
-            const querySpan = spans[0];
-            assert.strictEqual(
-              querySpan.parentSpanId,
-              parentSpan.spanContext().spanId
-            );
+            const actualSpan = trace.getSpan(context.active());
+            assert.strictEqual(actualSpan, parentSpan);
             done();
           });
         });


### PR DESCRIPTION
Signed-off-by: Simon Stone <simonstone1@gmail.com>

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- The problem described in issue #561 

## Short description of the changes

- The callback for `getConnection` is now bound to the active context before it is passed into the instrumented `mysql` code
