### PR TITLE
fix(mongo): added missing exported types

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-mongodb/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/src/index.ts
@@ -15,4 +15,8 @@
  */
 
 export * from './instrumentation';
-export { MongoDBInstrumentationConfig } from './types';
+export {
+  MongoDBInstrumentationConfig,
+  MongoDBInstrumentationExecutionResponseHook,
+  MongoResponseHookInformation,
+} from './types';


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- New types were introduced in this https://github.com/open-telemetry/opentelemetry-js-contrib/pull/533 but were not exported as part of the plugin. This PR exposes them on `index.ts`

## Short description of the changes

- Added the new types `MongoDBInstrumentationExecutionResponseHook` and `MongoResponseHookInformation` to the export clause on `index.ts`
