### PR TITLE
refactor: renamed ResourceAttributes to SemanticResourceAttributes (#574)

### DIFF
--- a/examples/memcached/tracer.js
+++ b/examples/memcached/tracer.js
@@ -9,14 +9,14 @@ const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 const { NodeTracerProvider } = require('@opentelemetry/node');
 const { SimpleSpanProcessor, ConsoleSpanExporter } = require('@opentelemetry/tracing');
 const { Resource } = require('@opentelemetry/resources');
-const { ResourceAttributes } = require('@opentelemetry/semantic-conventions');
+const { SemanticResourceAttributes } = require('@opentelemetry/semantic-conventions');
 
 const { MemcachedInstrumentation } = require('@opentelemetry/instrumentation-memcached');
 
 module.exports = (serviceName) => {
   const provider = new NodeTracerProvider({
     resource: new Resource({
-      [ResourceAttributes.SERVICE_NAME]: serviceName,
+      [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
     }),
   });
   registerInstrumentations({

--- a/metapackages/auto-instrumentations-node/README.md
+++ b/metapackages/auto-instrumentations-node/README.md
@@ -23,14 +23,14 @@ const { NodeTracerProvider } = require('@opentelemetry/node');
 const { getNodeAutoInstrumentations } = require('@opentelemetry/auto-instrumentations-node');
 const { CollectorTraceExporter } = require('@opentelemetry/exporter-collector');
 const { Resource } = require('@opentelemetry/resources');
-const { ResourceAttributes } = require('@opentelemetry/semantic-conventions');
+const { SemanticResourceAttributes } = require('@opentelemetry/semantic-conventions');
 const { SimpleSpanProcessor } = require('@opentelemetry/tracing');
 const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 
 const exporter = new CollectorTraceExporter();
 const provider = new NodeTracerProvider({
   resource: new Resource({
-    [ResourceAttributes.SERVICE_NAME]: 'basic-service',
+    [SemanticResourceAttributes.SERVICE_NAME]: 'basic-service',
   }),
 });
 provider.addSpanProcessor(new SimpleSpanProcessor(exporter));

--- a/packages/opentelemetry-browser-extension-autoinjection/src/instrumentation/index.ts
+++ b/packages/opentelemetry-browser-extension-autoinjection/src/instrumentation/index.ts
@@ -23,7 +23,7 @@ import {
 } from '../types';
 import { WebInstrumentation } from './WebInstrumentation';
 import { Resource } from '@opentelemetry/resources';
-import { ResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 
 const configTag = document.getElementById(DomElements['CONFIG_TAG']);
 const { exporters }: Settings = configTag
@@ -48,7 +48,7 @@ new WebInstrumentation(
   },
   new WebTracerProvider({
     resource: new Resource({
-      [ResourceAttributes.SERVICE_NAME]: window.location.hostname,
+      [SemanticResourceAttributes.SERVICE_NAME]: window.location.hostname,
     }),
   })
 ).register();

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -42,7 +42,7 @@ import {
 } from '@opentelemetry/propagator-aws-xray';
 import {
   SemanticAttributes,
-  ResourceAttributes,
+  SemanticResourceAttributes,
 } from '@opentelemetry/semantic-conventions';
 import { BasicTracerProvider } from '@opentelemetry/tracing';
 
@@ -168,8 +168,8 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
           kind: SpanKind.SERVER,
           attributes: {
             [SemanticAttributes.FAAS_EXECUTION]: context.awsRequestId,
-            [ResourceAttributes.FAAS_ID]: context.invokedFunctionArn,
-            [ResourceAttributes.CLOUD_ACCOUNT_ID]:
+            [SemanticResourceAttributes.FAAS_ID]: context.invokedFunctionArn,
+            [SemanticResourceAttributes.CLOUD_ACCOUNT_ID]:
               AwsLambdaInstrumentation._extractAccountId(
                 context.invokedFunctionArn
               ),

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler.test.ts
@@ -34,7 +34,7 @@ import { Context } from 'aws-lambda';
 import * as assert from 'assert';
 import {
   SemanticAttributes,
-  ResourceAttributes,
+  SemanticResourceAttributes,
 } from '@opentelemetry/semantic-conventions';
 import {
   Context as OtelContext,
@@ -632,7 +632,7 @@ describe('lambda handler', () => {
         initializeHandler('lambda-test/async.handler', {
           requestHook: (span, { context }) => {
             span.setAttribute(
-              ResourceAttributes.FAAS_NAME,
+              SemanticResourceAttributes.FAAS_NAME,
               context.functionName
             );
           },
@@ -643,7 +643,7 @@ describe('lambda handler', () => {
         const [span] = spans;
         assert.strictEqual(spans.length, 1);
         assert.strictEqual(
-          span.attributes[ResourceAttributes.FAAS_NAME],
+          span.attributes[SemanticResourceAttributes.FAAS_NAME],
           ctx.functionName
         );
         assertSpanSuccess(span);


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Closes #574 

## Short description of the changes

- I've renamed every usage of `ResourceAttributes` to `SemanticResourceAttributes` in order to follow v1.5.0 of [@opentelemetry/semantic-conventions](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-semantic-conventions)

Blocked by https://github.com/open-telemetry/opentelemetry-js/pull/2345
