### PR TITLE
feat(pg): allow overriding command extraction

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-pg/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/instrumentation.ts
@@ -129,7 +129,12 @@ export class PgInstrumentation extends InstrumentationBase {
               params
             );
           } else {
-            span = utils.handleTextQuery.call(this, plugin.tracer, query);
+            span = utils.handleTextQuery.call(
+              this,
+              plugin.tracer,
+              plugin.getConfig() as PgInstrumentationConfig,
+              query
+            );
           }
         } else if (typeof args[0] === 'object') {
           const queryConfig = args[0] as NormalizedQueryConfig;

--- a/plugins/node/opentelemetry-instrumentation-pg/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/types.ts
@@ -40,6 +40,13 @@ export interface PgInstrumentationConfig extends InstrumentationConfig {
    * @default undefined
    */
   responseHook?: PgInstrumentationExecutionResponseHook;
+
+  /**
+   * Hook that allows overriding the extracted operation tag, for span operation generation.
+   *
+   * @default implementation takes the first "word" from the query (e.g. "SELECT")
+   */
+  getCommandFromText?: (text?: string) => string;
 }
 
 export type PostgresCallback = (err: Error, res: object) => unknown;


### PR DESCRIPTION
## Which problem is this PR solving?

Command extraction (the code which generates `pg.query:select` from `select * from foo`) fails for us, as we comment our SQL, e.g. `/* getUser@main.js:17 */ select * from user where id=?`. Currently, all of our spans are named `pg.query:/*`, which is, uh, not useful.

This PR allows us to override the implementation with one which can extract `select` in this case.

## Short description of the changes

- Config option allows specification of `getCommandFromText`.
- `getCommandFromText` defers to the config implementation, if it is set.
- Tests for before and after.