### PR TITLE
chore: configure renovate to bump API

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,10 @@
       "groupName": "all non-major dependencies",
       "updateTypes": ["patch", "minor"],
       "groupSlug": "all-minor-patch"
+    },
+    {
+      "matchPackageNames": ["@opentelemetry/api"],
+      "rangeStrategy": "bump"
     }
   ],
   "assignees": [


### PR DESCRIPTION
Adapt renovate configuration to match core repo and bump API to ensure that peer-dependency gets updated.

Refs: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/599
