### PR TITLE
chore: add Rauno56 as the component owner of authored instrumentations

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -5,6 +5,16 @@ components:
   plugins/node/opentelemetry-instrumentation-aws-lambda:
     - NathanielRN
     - willarmiros
+  plugins/node/opentelemetry-instrumentation-restify:
+    - rauno56
+  plugins/node/opentelemetry-instrumentation-router:
+    - rauno56
+  plugins/node/opentelemetry-instrumentation-memcached:
+    - rauno56
+  plugins/node/opentelemetry-instrumentation-knex:
+    - rauno56
+  plugins/node/opentelemetry-instrumentation-generic-pool:
+    - rauno56
   propagators/opentelemetry-propagator-aws-xray:
     - NathanielRN
     - willarmiros


### PR DESCRIPTION
## Short description of the changes

Just making use of the new component owner workflow for some instrumentations I've authored.