### PR TITLE
chore: add component owners to redis and ioredis

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -17,6 +17,7 @@ components:
     - rauno56
   plugins/node/opentelemetry-instrumentation-ioredis:
     - blumamir
+    - naseemkullah
   plugins/node/opentelemetry-instrumentation-redis:
     - blumamir
   propagators/opentelemetry-propagator-aws-xray:

--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -15,6 +15,10 @@ components:
     - rauno56
   plugins/node/opentelemetry-instrumentation-generic-pool:
     - rauno56
+  plugins/node/opentelemetry-instrumentation-ioredis:
+    - blumamir
+  plugins/node/opentelemetry-instrumentation-redis:
+    - blumamir
   propagators/opentelemetry-propagator-aws-xray:
     - NathanielRN
     - willarmiros


### PR DESCRIPTION
I would like to suggest myself as component owner for the `ioredis` and `redis` instrumentations.
Been using them for quite some time, and also created a few PRs with fixes in the past.

Not sure who originally wrote them. Happy to share ownership with whoever wants to join, or close this PR if the ownership should be set on someone else.
