### PR TITLE
fix: lint failure in ci due to hoisting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,6 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           npm install --only=dev --ignore-scripts
-          npx lerna bootstrap --no-ci --hoist --nohoist='zone.js' --ignore-scripts -- --only=dev
+          npx lerna bootstrap --no-ci --hoist --nohoist='zone.js' --nohoist='gts' --ignore-scripts -- --only=dev
       - name: Lint
         run: npm run lint


### PR DESCRIPTION
## Which problem is this PR solving?

- After #648 lint started failing in CI due to "ESLint couldn't find the config "./node_modules/gts" to extend from".
Looks like `eslint.config.js` is [referencing a file in `node_modules`](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/eslint.config.js#L7) which is now not accessible.

## Short description of the changes

- add `gts` to the `no-hoist` list only for linting workflow. this should fix the workflow I believe.

This PR is only for fixing the current CI issue, but for the long run, I suggest executing the linting from the repo root and not per package. This has the following advantages:
1. less configuration and setup per package in the monorepo (no need to install `gts`, repeated the lint scripts in package.json, and include `.eslintignore` and `.eslintrc.js` for each package again and again)
2. guarantee to have the same linting behavior for the entire codebase. This has the side effect of not allowing any specific package to override lint rules.
3. even faster linting CI time, as there is no need to install the dependencies of each package or build it. only install root package.json dependencies and execute `eslint` once from root. As lint failure in CI is very common, the project can benefit from speeding up feedback on this specific workflow IMO.

We can discuss improvements on the SIG.