### PR TITLE
chore: bumped aws components to 1.0

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-aws/package.json
+++ b/detectors/node/opentelemetry-resource-detector-aws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/resource-detector-aws",
-  "version": "0.24.0",
+  "version": "1.0.0",
   "description": "OpenTelemetry SDK resource detector for AWS",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/packages/opentelemetry-id-generator-aws-xray/package.json
+++ b/packages/opentelemetry-id-generator-aws-xray/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/id-generator-aws-xray",
-  "version": "0.24.0",
+  "version": "1.0.0",
   "description": "AWS X-Ray ID generator for OpenTelemetry",
   "main": "build/src/index.js",
   "publishConfig": {

--- a/propagators/opentelemetry-propagator-aws-xray/package.json
+++ b/propagators/opentelemetry-propagator-aws-xray/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/propagator-aws-xray",
-  "version": "0.24.0",
+  "version": "1.0.0",
   "description": "OpenTelemetry AWS Xray propagator provides context propagation for systems that are using AWS X-Ray format.",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",


### PR DESCRIPTION
## Short description of the changes

- Bumps AWS X-Ray ID generator, propagator, and resource detector packages to 1.0 since no breaking changes are anticipated.
- Will leave in draft until core SDK reaches 1.0 first.
