### PR TITLE
chore: set publishConfig for test utils

### DIFF
--- a/packages/opentelemetry-test-utils/package.json
+++ b/packages/opentelemetry-test-utils/package.json
@@ -3,6 +3,9 @@
   "version": "0.25.0",
   "description": "Test utilities for opentelemetry components",
   "main": "build/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",


### PR DESCRIPTION
When the test util was made public its publish config was not set