### PR TITLE
fixes redis instrumentation startup stream check

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-redis/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-redis/src/utils.ts
@@ -57,7 +57,7 @@ export const getTracedCreateStreamTrace = (
   original: Function
 ) => {
   return function create_stream_trace(this: redisTypes.RedisClient) {
-    if (!this.hasOwnProperty('stream')) {
+    if (!this.stream) {
       Object.defineProperty(this, 'stream', {
         get() {
           return this._patched_redis_stream;

--- a/plugins/node/opentelemetry-instrumentation-redis/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-redis/src/utils.ts
@@ -57,7 +57,7 @@ export const getTracedCreateStreamTrace = (
   original: Function
 ) => {
   return function create_stream_trace(this: redisTypes.RedisClient) {
-    if (!this.stream) {
+    if (!this.hasOwnProperty('stream')) {
       Object.defineProperty(this, 'stream', {
         get() {
           return this._patched_redis_stream;


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- When instrumenting Redis I get the error that the stream property already exists and the current check doesn't find it. Switching to `hasOwnProperty` finds the property and properly stops the duplicate addition.

## Short description of the changes

- change `if(!this.stream){` to `if(!this.hasOwnProperty('stream'){`
