### PR TITLE
Fix sample

### DIFF
--- a/examples/express/tracer.js
+++ b/examples/express/tracer.js
@@ -54,7 +54,7 @@ function filterSampler(filterFn, parent) {
       if (!filterFn(spanName, spanKind, attr)) {
         return { decision: opentelemetry.SamplingDecision.NOT_RECORD };
       }
-      return parent.shouldSample(ctx, tid, name, kind, attr, links);
+      return parent.shouldSample(ctx, tid, spanName, spanKind, attr, links);
     },
     toString() {
       return `FilterSampler(${parent.toString()})`;


### PR DESCRIPTION
I fix sample.
name and kind hasn't correct variables.
I change it to spanName and spanKind.

Before
```js
return parent.shouldSample(ctx, tid, name, kind, attr, links);
```

After
```js
return parent.shouldSample(ctx, tid, spanName, spanKind, attr, links);
```
