### PR TITLE
Fix usage of renamed enum `SpanStatusCode`.

### DIFF
--- a/examples/postgres/server.js
+++ b/examples/postgres/server.js
@@ -3,7 +3,7 @@
 const api = require('@opentelemetry/api');
 // eslint-disable-next-line import/order
 const tracer = require('./tracer')('postgres-server-service');
-const { SpanKind, StatusCode } = require('@opentelemetry/api');
+const { SpanKind, SpanStatusCode } = require('@opentelemetry/api');
 const express = require('express');
 const setupPg = require('./setupPsql');
 
@@ -41,7 +41,7 @@ app.get('/:cmd', (req, res) => {
       });
     } catch (e) {
       res.status(400).send({ message: e.message });
-      span.setStatus(StatusCode.ERROR);
+      span.setStatus(SpanStatusCode.ERROR);
     }
     span.end();
   });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Usage of enum `StatusCode` results in an error.

## Short description of the changes

- Use updated name `SpanStatusCode`.
