### PR TITLE
docs(graphql): corrected optional param in Usage section of Readme in opentelemetry-instrumentation-graphql

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-graphql/README.md
+++ b/plugins/node/opentelemetry-instrumentation-graphql/README.md
@@ -33,7 +33,7 @@ registerInstrumentations({
   instrumentations: [
     new GraphQLInstrumentation({
     // optional params
-      // allowAttributes: true,
+      // allowValues: true,
       // depth: 2,
       // mergeItems: true,
     }),


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Usage section of Readme.md in `opentelemetry-instrumentation-graphql` has incorrect optional param `allowAttributes`. It needs to be `allowValues`.

## Short description of the changes

- Corrected Usage section of Readme.md in `opentelemetry-instrumentation-graphql` to include `allowValues` instead of `allowAttributes`.
