### PR TITLE
fix: adding nested input variables in graphql plugin

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-graphql/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/src/instrumentation.ts
@@ -43,6 +43,7 @@ import {
   Maybe,
 } from './types';
 import {
+  addInputVariableAttributes,
   addSpanSource,
   endSpan,
   getOperation,
@@ -419,9 +420,7 @@ export class GraphQLInstrumentation extends InstrumentationBase {
     }
 
     if (processedArgs.variableValues && config.allowValues) {
-      Object.entries(processedArgs.variableValues).forEach(([key, value]) => {
-        span.setAttribute(`${AttributeNames.VARIABLES}${String(key)}`, value);
-      });
+      addInputVariableAttributes(span, processedArgs.variableValues);
     }
 
     return span;

--- a/plugins/node/opentelemetry-instrumentation-graphql/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/src/utils.ts
@@ -32,6 +32,31 @@ import {
 
 const OPERATION_VALUES = Object.values(AllowedOperationTypes);
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function addInputVariableAttribute(span: api.Span, key: string, variable: any) {
+  if (Array.isArray(variable)) {
+    variable.forEach((value, idx) => {
+      addInputVariableAttribute(span, `${key}.${idx}`, value);
+    });
+  } else if (variable instanceof Object) {
+    Object.entries(variable).forEach(([nestedKey, value]) => {
+      addInputVariableAttribute(span, `${key}.${nestedKey}`, value);
+    });
+  } else {
+    span.setAttribute(`${AttributeNames.VARIABLES}${String(key)}`, variable);
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function addInputVariableAttributes(
+  span: api.Span,
+  variableValues: { [key: string]: any }
+) {
+  Object.entries(variableValues).forEach(([key, value]) => {
+    addInputVariableAttribute(span, key, value);
+  });
+}
+
 export function addSpanSource(
   span: api.Span,
   loc?: graphqlTypes.Location,


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

GraphQL inputs are frequently nested like:
```
{
  "input": {
    "value1": 1,
    "value2": 2
  }
}
```
Currently this would result the following call:
```
span.setAttribute("graphql.variables.input", Object({ value1: 1, value2: 2}))
```
But since `SpanAttribute` doesn't accept an `Object` type it silently fails
and doesn't add the attribute at all.


## Short description of the changes

This PR goes depth-first into the nested structure and adds each
variable with the appropriate path like:
```
span.setAttribute("graphql.variables.input.value1", 1)
span.setAttribute("graphql.variables.input.value2", 2)
```

