### PR TITLE
feat(instrumentation-pino): bump supported pino version to v7.x

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -14,6 +14,10 @@ jobs:
           - container: "node:8"
             lerna-extra-args: >-
               --ignore @opentelemetry/instrumentation-aws-sdk
+              --ignore @opentelemetry/instrumentation-pino
+          - container: "node:10"
+            lerna-extra-args: >-
+              --ignore @opentelemetry/instrumentation-pino
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.container }}

--- a/plugins/node/opentelemetry-instrumentation-pino/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-pino/.tav.yml
@@ -1,0 +1,6 @@
+pino:
+  versions: ">=5.14.0 < 8"
+  commands: npm run test
+
+  # Fix missing `contrib-test-utils` package
+  pretest: npm run --prefix ../../../ lerna:link

--- a/plugins/node/opentelemetry-instrumentation-pino/README.md
+++ b/plugins/node/opentelemetry-instrumentation-pino/README.md
@@ -55,7 +55,7 @@ When no span context is active or the span context is invalid, injection is skip
 
 ### Supported versions
 
-`>5.14.0` and `6.x`
+`>5.14.0` and `7.x`
 
 ## Useful links
 

--- a/plugins/node/opentelemetry-instrumentation-pino/README.md
+++ b/plugins/node/opentelemetry-instrumentation-pino/README.md
@@ -55,7 +55,7 @@ When no span context is active or the span context is invalid, injection is skip
 
 ### Supported versions
 
-`>5.14.0` and `7.x`
+`>=5.14.0 <8`
 
 ## Useful links
 

--- a/plugins/node/opentelemetry-instrumentation-pino/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pino/package.json
@@ -60,7 +60,7 @@
     "gts": "3.1.0",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
-    "pino": "6.13.3",
+    "pino": "7.1.0",
     "rimraf": "3.0.2",
     "sinon": "11.1.2",
     "test-all-versions": "5.0.1",
@@ -69,7 +69,6 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.26.0",
-    "@types/pino": "6.3.12",
     "semver": "^7.3.5"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-pino/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pino/package.json
@@ -7,6 +7,7 @@
   "repository": "open-telemetry/opentelemetry-js-contrib",
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
+    "test-all-versions": "tav",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "clean": "rimraf build/*",
     "lint": "eslint . --ext .ts",
@@ -59,15 +60,16 @@
     "gts": "3.1.0",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
-    "pino": "6.13.0",
+    "pino": "6.13.3",
     "rimraf": "3.0.2",
     "sinon": "11.1.2",
+    "test-all-versions": "5.0.1",
     "ts-mocha": "8.0.0",
     "typescript": "4.3.5"
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.26.0",
-    "@types/pino": "6.3.11",
+    "@types/pino": "6.3.12",
     "semver": "^7.3.5"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-pino/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pino/package.json
@@ -60,7 +60,6 @@
     "gts": "3.1.0",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
-    "pino": "6.13.3",
     "rimraf": "3.0.2",
     "sinon": "11.1.2",
     "test-all-versions": "5.0.1",
@@ -69,7 +68,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.26.0",
-    "@types/pino": "6.3.12",
+    "pino": "7.2.0",
     "semver": "^7.3.5"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-pino/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pino/package.json
@@ -60,7 +60,7 @@
     "gts": "3.1.0",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
-    "pino": "7.1.0",
+    "pino": "6.13.3",
     "rimraf": "3.0.2",
     "sinon": "11.1.2",
     "test-all-versions": "5.0.1",
@@ -69,6 +69,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.26.0",
+    "@types/pino": "6.3.12",
     "semver": "^7.3.5"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-pino/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-pino/src/instrumentation.ts
@@ -28,7 +28,7 @@ import {
 } from '@opentelemetry/instrumentation';
 import { Pino, PinoInstrumentationConfig } from './types';
 import { VERSION } from './version';
-import type * as pino from 'pino';
+import type pino from 'pino';
 
 const pinoVersions = ['>=5.14.0 <8'];
 

--- a/plugins/node/opentelemetry-instrumentation-pino/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-pino/src/instrumentation.ts
@@ -28,7 +28,7 @@ import {
 } from '@opentelemetry/instrumentation';
 import { Pino, PinoInstrumentationConfig } from './types';
 import { VERSION } from './version';
-import type * as pino from 'pino';
+import type { pino } from 'pino';
 
 const pinoVersions = ['>=5.14.0 <8'];
 

--- a/plugins/node/opentelemetry-instrumentation-pino/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-pino/src/instrumentation.ts
@@ -30,7 +30,7 @@ import { Pino, PinoInstrumentationConfig } from './types';
 import { VERSION } from './version';
 import type * as pino from 'pino';
 
-const pinoVersions = ['>=5.14.0 <7'];
+const pinoVersions = ['>=5.14.0 <8'];
 
 export class PinoInstrumentation extends InstrumentationBase {
   constructor(config: PinoInstrumentationConfig = {}) {

--- a/plugins/node/opentelemetry-instrumentation-pino/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-pino/src/instrumentation.ts
@@ -28,7 +28,7 @@ import {
 } from '@opentelemetry/instrumentation';
 import { Pino, PinoInstrumentationConfig } from './types';
 import { VERSION } from './version';
-import type pino from 'pino';
+import type * as pino from 'pino';
 
 const pinoVersions = ['>=5.14.0 <8'];
 

--- a/plugins/node/opentelemetry-instrumentation-pino/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-pino/src/types.ts
@@ -16,7 +16,6 @@
 
 import { Span } from '@opentelemetry/api';
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
-import type * as pino from 'pino';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type LogHookFunction = (span: Span, record: Record<string, any>) => void;
@@ -25,4 +24,4 @@ export interface PinoInstrumentationConfig extends InstrumentationConfig {
   logHook?: LogHookFunction;
 }
 
-export type Pino = typeof pino;
+export type Pino = any;

--- a/plugins/node/opentelemetry-instrumentation-pino/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-pino/src/types.ts
@@ -16,7 +16,7 @@
 
 import { Span } from '@opentelemetry/api';
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
-import type * as pino from 'pino';
+import type { pino } from 'pino';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type LogHookFunction = (span: Span, record: Record<string, any>) => void;

--- a/plugins/node/opentelemetry-instrumentation-pino/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-pino/src/types.ts
@@ -16,6 +16,7 @@
 
 import { Span } from '@opentelemetry/api';
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import type * as pino from 'pino';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type LogHookFunction = (span: Span, record: Record<string, any>) => void;
@@ -24,4 +25,4 @@ export interface PinoInstrumentationConfig extends InstrumentationConfig {
   logHook?: LogHookFunction;
 }
 
-export type Pino = any;
+export type Pino = typeof pino;

--- a/plugins/node/opentelemetry-instrumentation-pino/test/pino.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pino/test/pino.test.ts
@@ -24,7 +24,7 @@ import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import { Writable } from 'stream';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import type * as Pino from 'pino';
+import type Pino from 'pino';
 
 import { PinoInstrumentation } from '../src';
 

--- a/plugins/node/opentelemetry-instrumentation-pino/test/pino.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pino/test/pino.test.ts
@@ -24,7 +24,7 @@ import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import { Writable } from 'stream';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import type * as Pino from 'pino';
+import type { pino as Pino } from 'pino';
 
 import { PinoInstrumentation } from '../src';
 

--- a/plugins/node/opentelemetry-instrumentation-pino/test/pino.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pino/test/pino.test.ts
@@ -24,7 +24,7 @@ import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import { Writable } from 'stream';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import type Pino from 'pino';
+import type * as Pino from 'pino';
 
 import { PinoInstrumentation } from '../src';
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- When upgrading to the latest version of Pino (v7.x), the OpenTelemetry instrumentation doesn't work anymore

## Short description of the changes

- There is a hard check on the Pino version in use to prevent errors in case of major upgrades. I tested with the latest Pino version and bumped that number.
