### PR TITLE
feat(user-interaction): deduplicate interaction spans by grouping them

### DIFF
--- a/plugins/web/opentelemetry-instrumentation-user-interaction/src/instrumentation.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/src/instrumentation.ts
@@ -486,9 +486,9 @@ export class UserInteractionInstrumentation extends InstrumentationBase<unknown>
         applyArgs?: any
       ): Zone {
         const event =
-        Array.isArray(applyArgs) && applyArgs[0] instanceof Event
-        ? applyArgs[0]
-        : undefined;
+          Array.isArray(applyArgs) && applyArgs[0] instanceof Event
+            ? applyArgs[0]
+            : undefined;
 
         const target = plugin._allowEventType(task.eventName) && event?.target;
         let span: api.Span | undefined;
@@ -499,9 +499,12 @@ export class UserInteractionInstrumentation extends InstrumentationBase<unknown>
             span = plugin._createSpan(target, task.eventName);
 
             if (span) {
-              api.context.with(api.trace.setSpan(api.context.active(), span), () => {
-                plugin._currentInteractionZone = Zone.current;
-              });
+              api.context.with(
+                api.trace.setSpan(api.context.active(), span),
+                () => {
+                  plugin._currentInteractionZone = Zone.current;
+                }
+              );
 
               // Reset the current interaction zone after 50ms
               // This allows new clicks to create spans when the previous interaction is still not complete
@@ -570,7 +573,7 @@ export class UserInteractionInstrumentation extends InstrumentationBase<unknown>
    * @param endTime
    * @private
    */
-  private _tryToEndSpan(span: api.Span, endTime?: api.HrTime) {
+  private _tryToEndSpan(span: api.Span) {
     if (!span) {
       return;
     }

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/src/instrumentation.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/src/instrumentation.ts
@@ -466,7 +466,7 @@ export class UserInteractionInstrumentation extends InstrumentationBase<unknown>
         this: Zone,
         task: AsyncTask
       ) {
-        let currentZone = Zone.current;
+        const currentZone = Zone.current;
         const currentSpan = plugin._getCurrentSpan(currentZone);
 
         if (currentSpan) {
@@ -510,9 +510,12 @@ export class UserInteractionInstrumentation extends InstrumentationBase<unknown>
             // create new span for interaction from current task zone
             span = plugin._createSpan(target, task.eventName);
             if (span) {
-              api.context.with(api.trace.setSpan(api.context.active(), span), function () {
-                plugin._currentEventZone = Zone.current;
-              });
+              api.context.with(
+                api.trace.setSpan(api.context.active(), span),
+                () => {
+                  plugin._currentEventZone = Zone.current;
+                }
+              );
             }
           }
 

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/src/types.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/src/types.ts
@@ -41,7 +41,9 @@ export type RunTaskFunction = (
 export interface SpanData {
   hrTimeLastTimeout?: types.HrTime;
   taskCount: number;
-  completionTimeout?: number;
+  interactionTarget?: EventTarget;
+  interactionCompleteTimeout?: number;
+  taskCompleteTimeout?: number;
 }
 
 /**

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/src/types.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/src/types.ts
@@ -41,9 +41,8 @@ export type RunTaskFunction = (
 export interface SpanData {
   hrTimeLastTimeout?: types.HrTime;
   taskCount: number;
-  interactionTarget?: EventTarget;
   interactionCompleteTimeout?: number;
-  taskCompleteTimeout?: number;
+  interactionResetTimeout?: number;
 }
 
 /**

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/src/types.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/src/types.ts
@@ -41,6 +41,7 @@ export type RunTaskFunction = (
 export interface SpanData {
   hrTimeLastTimeout?: types.HrTime;
   taskCount: number;
+  completionTimeout?: number;
 }
 
 /**

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.nozone.test.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.nozone.test.ts
@@ -15,7 +15,7 @@
  */
 const originalSetTimeout = window.setTimeout;
 
-import { trace } from '@opentelemetry/api';
+import { context, trace } from '@opentelemetry/api';
 import { isWrapped } from '@opentelemetry/core';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
@@ -92,6 +92,7 @@ describe('UserInteractionInstrumentation', () => {
       requests = [];
       sandbox.restore();
       exportSpy.restore();
+      context.disable();
       trace.disable();
     });
 

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.test.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.test.ts
@@ -107,7 +107,7 @@ describe('UserInteractionInstrumentation', () => {
     it('should handle task without async operation', () => {
       fakeInteraction();
       sandbox.clock.next();
-      assert.equal(exportSpy.args.length, 1, 'should export one span');
+      assert.strictEqual(exportSpy.args.length, 1, 'should export one span');
       const spanClick = exportSpy.args[0][0][0];
       assertClickSpan(spanClick);
     });
@@ -117,7 +117,7 @@ describe('UserInteractionInstrumentation', () => {
         originalSetTimeout(() => {
           const spanClick: tracing.ReadableSpan = exportSpy.args[0][0][0];
 
-          assert.equal(exportSpy.args.length, 1, 'should export one span');
+          assert.strictEqual(exportSpy.args.length, 1, 'should export one span');
           assertClickSpan(spanClick);
           done();
         });
@@ -129,7 +129,7 @@ describe('UserInteractionInstrumentation', () => {
       fakeInteraction(() => {
         const interval = setInterval(() => {}, 1);
         originalSetTimeout(() => {
-          assert.equal(
+          assert.strictEqual(
             exportSpy.args.length,
             1,
             'should not export more then one span'
@@ -156,25 +156,25 @@ describe('UserInteractionInstrumentation', () => {
           sandbox.clock.tick(1000);
         }).then(() => {
           originalSetTimeout(() => {
-            assert.equal(exportSpy.args.length, 2, 'should export 2 spans');
+            assert.strictEqual(exportSpy.args.length, 2, 'should export 2 spans');
 
             const spanXhr: tracing.ReadableSpan = exportSpy.args[0][0][0];
             const spanClick: tracing.ReadableSpan = exportSpy.args[1][0][0];
-            assert.equal(
+            assert.strictEqual(
               spanXhr.parentSpanId,
               spanClick.spanContext().spanId,
               'xhr span has wrong parent'
             );
-            assert.equal(
+            assert.strictEqual(
               spanClick.name,
               `Navigation: ${location.pathname}#foo=bar1`
             );
 
             const attributes = spanClick.attributes;
-            assert.equal(attributes.component, 'user-interaction');
-            assert.equal(attributes.event_type, 'click');
-            assert.equal(attributes.target_element, 'BUTTON');
-            assert.equal(attributes.target_xpath, '//*[@id="testBtn"]');
+            assert.strictEqual(attributes.component, 'user-interaction');
+            assert.strictEqual(attributes.event_type, 'click');
+            assert.strictEqual(attributes.target_element, 'BUTTON');
+            assert.strictEqual(attributes.target_xpath, '//*[@id="testBtn"]');
 
             done();
           });
@@ -189,11 +189,11 @@ describe('UserInteractionInstrumentation', () => {
           sandbox.clock.tick(1000);
         }).then(() => {
           originalSetTimeout(() => {
-            assert.equal(exportSpy.args.length, 2, 'should export 2 spans');
+            assert.strictEqual(exportSpy.args.length, 2, 'should export 2 spans');
 
             const spanXhr: tracing.ReadableSpan = exportSpy.args[0][0][0];
             const spanClick: tracing.ReadableSpan = exportSpy.args[1][0][0];
-            assert.equal(
+            assert.strictEqual(
               spanXhr.parentSpanId,
               spanClick.spanContext().spanId,
               'xhr span has wrong parent'
@@ -201,7 +201,7 @@ describe('UserInteractionInstrumentation', () => {
             assertClickSpan(spanClick);
 
             const attributes = spanXhr.attributes;
-            assert.equal(
+            assert.strictEqual(
               attributes['http.url'],
               'https://raw.githubusercontent.com/open-telemetry/opentelemetry-js/main/package.json'
             );
@@ -237,7 +237,7 @@ describe('UserInteractionInstrumentation', () => {
         );
         assert.ok(
           Zone.current.parent?.parent === rootZone,
-          'Parent of Parent Zone for 2nd listener click is wrong'
+          'Parent of parent Zone for 2nd listener click is wrong'
         );
       });
 
@@ -265,7 +265,7 @@ describe('UserInteractionInstrumentation', () => {
       fakeInteraction(callback, btn);
       sandbox.clock.next();
       originalSetTimeout(() => {
-        assert.equal(called, false, 'callback should not be called');
+        assert.strictEqual(called, false, 'callback should not be called');
         done();
       });
     });
@@ -282,13 +282,11 @@ describe('UserInteractionInstrumentation', () => {
           sandbox.clock.tick(1);
         }).then(() => {});
       }, btn1);
-      sandbox.clock.next(); // flush macro task
       fakeInteraction(() => {
         getData(FILE_URL, () => {
           sandbox.clock.tick(1);
         }).then(() => {});
       }, btn2);
-      sandbox.clock.next(); // flush macro task
       fakeInteraction(() => {
         getData(FILE_URL, () => {
           sandbox.clock.tick(1);
@@ -353,7 +351,6 @@ describe('UserInteractionInstrumentation', () => {
 
       try {
         btn1.click();
-        sandbox.clock.next(); // flush macro task
         btn2.click();
       } finally {
         // remove added listener so we don't pollute other tests
@@ -362,7 +359,7 @@ describe('UserInteractionInstrumentation', () => {
 
       sandbox.clock.tick(1000);
       originalSetTimeout(() => {
-        assert.equal(exportSpy.args.length, 4, 'should export 4 spans');
+        assert.strictEqual(exportSpy.args.length, 4, 'should export 4 spans');
 
         const span1: tracing.ReadableSpan = exportSpy.args[0][0][0];
         const span2: tracing.ReadableSpan = exportSpy.args[1][0][0];
@@ -414,12 +411,11 @@ describe('UserInteractionInstrumentation', () => {
       });
 
       btn1.click();
-      sandbox.clock.next(); // flush macro tasks
       btn2.click();
 
       sandbox.clock.tick(1000);
       originalSetTimeout(() => {
-        assert.equal(exportSpy.args.length, 4, 'should export 4 spans');
+        assert.strictEqual(exportSpy.args.length, 4, 'should export 4 spans');
 
         const span1: tracing.ReadableSpan = exportSpy.args[0][0][0];
         const span2: tracing.ReadableSpan = exportSpy.args[1][0][0];

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.test.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.test.ts
@@ -228,9 +228,15 @@ describe('UserInteractionInstrumentation', () => {
           Zone.current !== newZone,
           'Current zone for 2nd listener click is wrong'
         );
+        console.log(Zone.current.parent?.name, Zone.current.name, rootZone.name);
         assert.ok(
-          Zone.current.parent === rootZone,
+          Zone.current.parent === newZone,
           'Parent Zone for 2nd listener click is wrong'
+        );
+
+        assert.ok(
+          Zone.current.parent?.parent === rootZone,
+          'Parent Zone for new zone that click handlers run through is wrong'
         );
       });
 

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.test.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.test.ts
@@ -117,7 +117,11 @@ describe('UserInteractionInstrumentation', () => {
         originalSetTimeout(() => {
           const spanClick: tracing.ReadableSpan = exportSpy.args[0][0][0];
 
-          assert.strictEqual(exportSpy.args.length, 1, 'should export one span');
+          assert.strictEqual(
+            exportSpy.args.length,
+            1,
+            'should export one span'
+          );
           assertClickSpan(spanClick);
           done();
         });
@@ -156,7 +160,11 @@ describe('UserInteractionInstrumentation', () => {
           sandbox.clock.tick(1000);
         }).then(() => {
           originalSetTimeout(() => {
-            assert.strictEqual(exportSpy.args.length, 2, 'should export 2 spans');
+            assert.strictEqual(
+              exportSpy.args.length,
+              2,
+              'should export 2 spans'
+            );
 
             const spanXhr: tracing.ReadableSpan = exportSpy.args[0][0][0];
             const spanClick: tracing.ReadableSpan = exportSpy.args[1][0][0];
@@ -189,7 +197,11 @@ describe('UserInteractionInstrumentation', () => {
           sandbox.clock.tick(1000);
         }).then(() => {
           originalSetTimeout(() => {
-            assert.strictEqual(exportSpy.args.length, 2, 'should export 2 spans');
+            assert.strictEqual(
+              exportSpy.args.length,
+              2,
+              'should export 2 spans'
+            );
 
             const spanXhr: tracing.ReadableSpan = exportSpy.args[0][0][0];
             const spanClick: tracing.ReadableSpan = exportSpy.args[1][0][0];
@@ -491,7 +503,11 @@ describe('UserInteractionInstrumentation', () => {
       btn.click();
       btn.click();
       sandbox.clock.runAll();
-      assert.strictEqual(exportSpy.args.length, 1, 'should export 1 span when clicks occur on same target less than 50ms apart');
+      assert.strictEqual(
+        exportSpy.args.length,
+        1,
+        'should export 1 span when clicks occur on same target less than 50ms apart'
+      );
 
       const span: tracing.ReadableSpan = exportSpy.args[0][0][0];
       assertClickSpan(span);
@@ -510,7 +526,11 @@ describe('UserInteractionInstrumentation', () => {
       sandbox.clock.tick(50);
       btn.click();
       sandbox.clock.runAll();
-      assert.strictEqual(exportSpy.args.length, 2, 'should export 2 spans when clicks occur on same target more than 50ms apart');
+      assert.strictEqual(
+        exportSpy.args.length,
+        2,
+        'should export 2 spans when clicks occur on same target more than 50ms apart'
+      );
 
       const span1: tracing.ReadableSpan = exportSpy.args[0][0][0];
       const span2: tracing.ReadableSpan = exportSpy.args[1][0][0];

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.test.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.test.ts
@@ -282,11 +282,13 @@ describe('UserInteractionInstrumentation', () => {
           sandbox.clock.tick(1);
         }).then(() => {});
       }, btn1);
+      sandbox.clock.next();
       fakeInteraction(() => {
         getData(FILE_URL, () => {
           sandbox.clock.tick(1);
         }).then(() => {});
       }, btn2);
+      sandbox.clock.next();
       fakeInteraction(() => {
         getData(FILE_URL, () => {
           sandbox.clock.tick(1);
@@ -351,6 +353,7 @@ describe('UserInteractionInstrumentation', () => {
 
       try {
         btn1.click();
+        sandbox.clock.next();
         btn2.click();
       } finally {
         // remove added listener so we don't pollute other tests
@@ -411,6 +414,7 @@ describe('UserInteractionInstrumentation', () => {
       });
 
       btn1.click();
+      sandbox.clock.next();
       btn2.click();
 
       sandbox.clock.tick(1000);


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Fixes #548 

- Deduplicate interaction spans when there are multiple event listeners for a single target

## Short description of the changes

- Create a new zone that a single interaction will share with other handlers
- Capture all handlers in a 50ms window
- Fix task tracking logic for this case
- Update tests to flush macro tasks when necessary instead of a ticking a specific time
