### PR TITLE
feat(pino): add support for version 7

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-pino/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pino/package.json
@@ -59,7 +59,7 @@
     "gts": "3.1.0",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
-    "pino": "6.13.0",
+    "pino": "7.2.0",
     "rimraf": "3.0.2",
     "sinon": "11.1.2",
     "ts-mocha": "8.0.0",
@@ -67,7 +67,6 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.26.0",
-    "@types/pino": "6.3.11",
     "semver": "^7.3.5"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-pino/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-pino/src/instrumentation.ts
@@ -28,9 +28,9 @@ import {
 } from '@opentelemetry/instrumentation';
 import { Pino, PinoInstrumentationConfig } from './types';
 import { VERSION } from './version';
-import type * as pino from 'pino';
+import type { pino } from 'pino';
 
-const pinoVersions = ['>=5.14.0 <7'];
+const pinoVersions = ['>=5.14.0 <8'];
 
 export class PinoInstrumentation extends InstrumentationBase {
   constructor(config: PinoInstrumentationConfig = {}) {

--- a/plugins/node/opentelemetry-instrumentation-pino/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-pino/src/types.ts
@@ -16,7 +16,7 @@
 
 import { Span } from '@opentelemetry/api';
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
-import type * as pino from 'pino';
+import type { pino } from 'pino';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type LogHookFunction = (span: Span, record: Record<string, any>) => void;

--- a/plugins/node/opentelemetry-instrumentation-pino/test/pino.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pino/test/pino.test.ts
@@ -24,7 +24,7 @@ import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import { Writable } from 'stream';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import type * as Pino from 'pino';
+import type { pino as Pino } from 'pino';
 
 import { PinoInstrumentation } from '../src';
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Pino released version 7 which is not covered by current instrumentation.
- https://github.com/pinojs/pino/releases/tag/v7.0.0

## Short description of the changes

- Check for version changed from `<7` to `<8`
- Removed `@types/pino` dependency as typescript types are now provided by `pino` package.
- Fix imports to match the correct exports for version 8
