### PR TITLE
feat(instrumentation-graphql): change execute and parse span names and attributes

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-graphql/src/enum.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/src/enum.ts
@@ -53,3 +53,20 @@ export enum SpanNames {
   SCHEMA_VALIDATE = 'graphql.validateSchema',
   SCHEMA_PARSE = 'graphql.parseSchema',
 }
+
+export const createResolveSpanName = (fieldName: string): string => {
+  return `${SpanNames.RESOLVE}.${fieldName}`;
+};
+
+export const createExecuteSpanName = (
+  operationType?: string,
+  operationName?: string
+): string => {
+  if (operationType) {
+    return `${SpanNames.EXECUTE}.${operationType}`;
+  }
+  if (operationType && operationName) {
+    return `${SpanNames.EXECUTE}.${operationType}.${operationName}`;
+  }
+  return `${SpanNames.EXECUTE}`;
+};

--- a/plugins/node/opentelemetry-instrumentation-graphql/src/enum.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/src/enum.ts
@@ -53,20 +53,3 @@ export enum SpanNames {
   SCHEMA_VALIDATE = 'graphql.validateSchema',
   SCHEMA_PARSE = 'graphql.parseSchema',
 }
-
-export const createResolveSpanName = (fieldName: string): string => {
-  return `${SpanNames.RESOLVE}.${fieldName}`;
-};
-
-export const createExecuteSpanName = (
-  operationType?: string,
-  operationName?: string
-): string => {
-  if (operationType) {
-    return `${SpanNames.EXECUTE}.${operationType}`;
-  }
-  if (operationType && operationName) {
-    return `${SpanNames.EXECUTE}.${operationType}.${operationName}`;
-  }
-  return `${SpanNames.EXECUTE}`;
-};

--- a/plugins/node/opentelemetry-instrumentation-graphql/src/enums/AttributeNames.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/src/enums/AttributeNames.ts
@@ -19,7 +19,8 @@ export enum AttributeNames {
   FIELD_NAME = 'graphql.field.name',
   FIELD_PATH = 'graphql.field.path',
   FIELD_TYPE = 'graphql.field.type',
-  OPERATION = 'graphql.operation.name',
+  OPERATION_TYPE = 'graphql.operation.type',
+  OPERATION_NAME = 'graphql.operation.name',
   VARIABLES = 'graphql.variables.',
   ERROR_VALIDATION_NAME = 'graphql.validation.error',
 }

--- a/plugins/node/opentelemetry-instrumentation-graphql/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/src/instrumentation.ts
@@ -393,7 +393,7 @@ export class GraphQLInstrumentation extends InstrumentationBase {
   private getOperationType(
     operation: graphqlTypes.DefinitionNode | undefined
   ): string | undefined {
-    if (operation && operation.kind == 'OperationDefinition') {
+    if (operation?.kind === 'OperationDefinition') {
       return operation.operation;
     }
 
@@ -404,15 +404,13 @@ export class GraphQLInstrumentation extends InstrumentationBase {
     operation: graphqlTypes.DefinitionNode | undefined,
     processedArgs: graphqlTypes.ExecutionArgs
   ): string | undefined {
-    if operation?.kind === 'OperationDefinition') {
+    if (operation?.kind === 'OperationDefinition') {
       if (operation.name) {
         return operation.name.value;
       }
     }
-    if (processedArgs.operationName) {
-      return processedArgs.operationName;
-    }
-    return undefined;
+
+    return processedArgs.operationName ?? undefined;
   }
 
   private _createExecuteSpan(

--- a/plugins/node/opentelemetry-instrumentation-graphql/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/src/instrumentation.ts
@@ -404,7 +404,7 @@ export class GraphQLInstrumentation extends InstrumentationBase {
     operation: graphqlTypes.DefinitionNode | undefined,
     processedArgs: graphqlTypes.ExecutionArgs
   ): string | undefined {
-    if (operation && operation.kind == 'OperationDefinition') {
+    if operation?.kind === 'OperationDefinition') {
       if (operation.name) {
         return operation.name.value;
       }

--- a/plugins/node/opentelemetry-instrumentation-graphql/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/src/types.ts
@@ -26,9 +26,6 @@ import {
 import { GraphQLSchema } from 'graphql/type/schema';
 import { OTEL_GRAPHQL_DATA_SYMBOL, OTEL_PATCHED_SYMBOL } from './symbols';
 
-export const OPERATION_NOT_SUPPORTED =
-  'Operation$operationName$not' + ' supported';
-
 export interface GraphQLInstrumentationExecutionResponseHook {
   (span: api.Span, data: graphqlTypes.ExecutionResult): void;
 }

--- a/plugins/node/opentelemetry-instrumentation-graphql/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/src/utils.ts
@@ -17,7 +17,12 @@
 import type * as graphqlTypes from 'graphql';
 import * as api from '@opentelemetry/api';
 import { GraphQLObjectType } from 'graphql/type/definition';
-import { AllowedOperationTypes, SpanNames, TokenKind } from './enum';
+import {
+  AllowedOperationTypes,
+  createResolveSpanName,
+  SpanNames,
+  TokenKind,
+} from './enum';
 import { AttributeNames } from './enums/AttributeNames';
 import { OTEL_GRAPHQL_DATA_SYMBOL, OTEL_PATCHED_SYMBOL } from './symbols';
 import {
@@ -120,7 +125,7 @@ function createResolverSpan(
   };
 
   const span = tracer.startSpan(
-    SpanNames.RESOLVE,
+    createResolveSpanName(info.fieldName),
     {
       attributes,
     },

--- a/plugins/node/opentelemetry-instrumentation-graphql/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/src/utils.ts
@@ -17,12 +17,7 @@
 import type * as graphqlTypes from 'graphql';
 import * as api from '@opentelemetry/api';
 import { GraphQLObjectType } from 'graphql/type/definition';
-import {
-  AllowedOperationTypes,
-  createResolveSpanName,
-  SpanNames,
-  TokenKind,
-} from './enum';
+import { AllowedOperationTypes, SpanNames, TokenKind } from './enum';
 import { AttributeNames } from './enums/AttributeNames';
 import { OTEL_GRAPHQL_DATA_SYMBOL, OTEL_PATCHED_SYMBOL } from './symbols';
 import {
@@ -438,3 +433,16 @@ async function safeExecuteInTheMiddleAsync<T>(
     return result as T;
   }
 }
+
+export const createResolveSpanName = (fieldName: string): string => {
+  return `${SpanNames.RESOLVE}.${fieldName}`;
+};
+
+export const createExecuteSpanName = (
+  operationType: string | undefined
+): string => {
+  if (operationType) {
+    return `${SpanNames.EXECUTE}.${operationType}`;
+  }
+  return `${SpanNames.EXECUTE}`;
+};

--- a/plugins/node/opentelemetry-instrumentation-graphql/test/graphql.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/test/graphql.test.ts
@@ -24,13 +24,13 @@ import { Span } from '@opentelemetry/api';
 import * as assert from 'assert';
 import type * as graphqlTypes from 'graphql';
 import { GraphQLInstrumentation } from '../src';
-import { SpanNames } from '../src/enum';
+import { createExecuteSpanName, SpanNames } from '../src/enum';
 import { AttributeNames } from '../src/enums/AttributeNames';
 import {
   GraphQLInstrumentationConfig,
   GraphQLInstrumentationExecutionResponseHook,
 } from '../src/types';
-import { assertResolveSpan } from './helper';
+import { assertExecuteSpan, assertResolveSpan } from './helper';
 
 const defaultConfig: GraphQLInstrumentationConfig = {};
 const graphQLInstrumentation = new GraphQLInstrumentation(defaultConfig);
@@ -145,21 +145,16 @@ describe('graphql', () => {
       it('should instrument execute', () => {
         const executeSpan = spans[2];
 
-        assert.deepStrictEqual(
-          executeSpan.attributes[AttributeNames.SOURCE],
+        assertExecuteSpan(
+          executeSpan,
           '\n' +
             '  query {\n' +
             '    books {\n' +
             '      name\n' +
             '    }\n' +
-            '  }\n'
-        );
-        assert.deepStrictEqual(
-          executeSpan.attributes[AttributeNames.OPERATION],
+            '  }\n',
           'query'
         );
-        assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
-        assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
       });
 
       it('should instrument resolvers', () => {
@@ -247,21 +242,16 @@ describe('graphql', () => {
       it('should instrument execute', () => {
         const executeSpan = spans[2];
 
-        assert.deepStrictEqual(
-          executeSpan.attributes[AttributeNames.SOURCE],
+        assertExecuteSpan(
+          executeSpan,
           '\n' +
             '  query {\n' +
             '    book(id: *) {\n' +
             '      name\n' +
             '    }\n' +
-            '  }\n'
-        );
-        assert.deepStrictEqual(
-          executeSpan.attributes[AttributeNames.OPERATION],
+            '  }\n',
           'query'
         );
-        assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
-        assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
       });
 
       it('should instrument resolvers', () => {
@@ -333,25 +323,21 @@ describe('graphql', () => {
       it('should instrument execute', () => {
         const executeSpan = spans[2];
 
-        assert.deepStrictEqual(
-          executeSpan.attributes[AttributeNames.SOURCE],
+        assertExecuteSpan(
+          executeSpan,
           '\n' +
             '  query Query1 ($id: Int!) {\n' +
             '    book(id: $id) {\n' +
             '      name\n' +
             '    }\n' +
-            '  }\n'
-        );
-        assert.deepStrictEqual(
-          executeSpan.attributes[AttributeNames.OPERATION],
-          'query'
+            '  }\n',
+          'query',
+          'Query1'
         );
         assert.deepStrictEqual(
           executeSpan.attributes[`${AttributeNames.VARIABLES}id`],
           undefined
         );
-        assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
-        assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
       });
 
       it('should instrument resolvers', () => {
@@ -425,21 +411,16 @@ describe('graphql', () => {
       it('should instrument execute', () => {
         const executeSpan = spans[2];
 
-        assert.deepStrictEqual(
-          executeSpan.attributes[AttributeNames.SOURCE],
+        assertExecuteSpan(
+          executeSpan,
           '\n' +
             '  query {\n' +
             '    books {\n' +
             '      name\n' +
             '    }\n' +
-            '  }\n'
-        );
-        assert.deepStrictEqual(
-          executeSpan.attributes[AttributeNames.OPERATION],
+            '  }\n',
           'query'
         );
-        assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
-        assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
       });
     });
   });
@@ -489,21 +470,16 @@ describe('graphql', () => {
       it('should instrument execute', () => {
         const executeSpan = spans[2];
 
-        assert.deepStrictEqual(
-          executeSpan.attributes[AttributeNames.SOURCE],
+        assertExecuteSpan(
+          executeSpan,
           '\n' +
             '  query {\n' +
             '    books {\n' +
             '      name\n' +
             '    }\n' +
-            '  }\n'
-        );
-        assert.deepStrictEqual(
-          executeSpan.attributes[AttributeNames.OPERATION],
+            '  }\n',
           'query'
         );
-        assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
-        assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
       });
     });
 
@@ -576,21 +552,16 @@ describe('graphql', () => {
       it('should instrument execute', () => {
         const executeSpan = spans[2];
 
-        assert.deepStrictEqual(
-          executeSpan.attributes[AttributeNames.SOURCE],
+        assertExecuteSpan(
+          executeSpan,
           '\n' +
             '  query {\n' +
             '    book(id: 0) {\n' +
             '      name\n' +
             '    }\n' +
-            '  }\n'
-        );
-        assert.deepStrictEqual(
-          executeSpan.attributes[AttributeNames.OPERATION],
+            '  }\n',
           'query'
         );
-        assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
-        assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
       });
 
       it('should instrument resolvers', () => {
@@ -665,8 +636,8 @@ describe('graphql', () => {
       it('should instrument execute', () => {
         const executeSpan = spans[2];
 
-        assert.deepStrictEqual(
-          executeSpan.attributes[AttributeNames.SOURCE],
+        assertExecuteSpan(
+          executeSpan,
           '\n' +
             '  mutation {\n' +
             '    addBook(\n' +
@@ -675,14 +646,9 @@ describe('graphql', () => {
             '    ) {\n' +
             '      id\n' +
             '    }\n' +
-            '  }\n'
-        );
-        assert.deepStrictEqual(
-          executeSpan.attributes[AttributeNames.OPERATION],
+            '  }\n',
           'mutation'
         );
-        assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
-        assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
       });
 
       it('should instrument resolvers', () => {
@@ -754,25 +720,21 @@ describe('graphql', () => {
       it('should instrument execute', () => {
         const executeSpan = spans[2];
 
-        assert.deepStrictEqual(
-          executeSpan.attributes[AttributeNames.SOURCE],
+        assertExecuteSpan(
+          executeSpan,
           '\n' +
             '  query Query1 ($id: Int!) {\n' +
             '    book(id: $id) {\n' +
             '      name\n' +
             '    }\n' +
-            '  }\n'
-        );
-        assert.deepStrictEqual(
-          executeSpan.attributes[AttributeNames.OPERATION],
-          'query'
+            '  }\n',
+          'query',
+          'Query1'
         );
         assert.deepStrictEqual(
           executeSpan.attributes[`${AttributeNames.VARIABLES}id`],
           2
         );
-        assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
-        assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
       });
 
       it('should instrument resolvers', () => {
@@ -849,8 +811,8 @@ describe('graphql', () => {
     it('should instrument execute', () => {
       const executeSpan = spans[2];
 
-      assert.deepStrictEqual(
-        executeSpan.attributes[AttributeNames.SOURCE],
+      assertExecuteSpan(
+        executeSpan,
         '\n' +
           '  mutation {\n' +
           '    addBook(\n' +
@@ -859,14 +821,9 @@ describe('graphql', () => {
           '    ) {\n' +
           '      id\n' +
           '    }\n' +
-          '  }\n'
-      );
-      assert.deepStrictEqual(
-        executeSpan.attributes[AttributeNames.OPERATION],
+          '  }\n',
         'mutation'
       );
-      assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
-      assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
     });
 
     it('should instrument resolvers', () => {
@@ -1000,7 +957,7 @@ describe('graphql', () => {
 
       it('should attach response hook data to the resulting spans', () => {
         const querySpan = spans.find(
-          span => span.attributes['graphql.operation.name'] == 'query'
+          span => span.attributes['graphql.operation.type'] == 'query'
         );
         const instrumentationResult = querySpan?.attributes[dataAttributeName];
         assert.deepStrictEqual(
@@ -1094,21 +1051,17 @@ describe('graphql', () => {
     it('should instrument execute', () => {
       const executeSpan = spans[2];
 
-      assert.deepStrictEqual(
-        executeSpan.attributes[AttributeNames.SOURCE],
+      assertExecuteSpan(
+        executeSpan,
         '\n' +
           '  query {\n' +
           '    book(id: *) {\n' +
           '      name\n' +
           '    }\n' +
-          '  }\n'
+          '  }\n',
+        undefined,
+        'foo'
       );
-      assert.deepStrictEqual(
-        executeSpan.attributes[AttributeNames.OPERATION],
-        'Operation "foo" not supported'
-      );
-      assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
-      assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
     });
   });
 });

--- a/plugins/node/opentelemetry-instrumentation-graphql/test/graphql.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/test/graphql.test.ts
@@ -24,7 +24,7 @@ import { Span } from '@opentelemetry/api';
 import * as assert from 'assert';
 import type * as graphqlTypes from 'graphql';
 import { GraphQLInstrumentation } from '../src';
-import { createExecuteSpanName, SpanNames } from '../src/enum';
+import { SpanNames } from '../src/enum';
 import { AttributeNames } from '../src/enums/AttributeNames';
 import {
   GraphQLInstrumentationConfig,

--- a/plugins/node/opentelemetry-instrumentation-graphql/test/helper.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/test/helper.ts
@@ -16,7 +16,7 @@
 
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import * as assert from 'assert';
-import { SpanNames } from '../src/enum';
+import { createExecuteSpanName, createResolveSpanName } from '../src/enum';
 import { AttributeNames } from '../src/enums/AttributeNames';
 
 export function assertResolveSpan(
@@ -28,11 +28,31 @@ export function assertResolveSpan(
   parentSpanId?: string
 ) {
   const attrs = span.attributes;
-  assert.deepStrictEqual(span.name, SpanNames.RESOLVE);
+  assert.deepStrictEqual(span.name, createResolveSpanName(fieldName));
   assert.deepStrictEqual(attrs[AttributeNames.FIELD_NAME], fieldName);
   assert.deepStrictEqual(attrs[AttributeNames.FIELD_PATH], fieldPath);
   assert.deepStrictEqual(attrs[AttributeNames.FIELD_TYPE], fieldType);
   assert.deepStrictEqual(attrs[AttributeNames.SOURCE], source);
+  if (parentSpanId) {
+    assert.deepStrictEqual(span.parentSpanId, parentSpanId);
+  }
+}
+
+export function assertExecuteSpan(
+  span: ReadableSpan,
+  source: string,
+  operationType?: string,
+  operationName?: string,
+  parentSpanId?: string
+) {
+  const attrs = span.attributes;
+  assert.deepStrictEqual(
+    span.name,
+    createExecuteSpanName(operationType, operationName)
+  );
+  assert.deepStrictEqual(attrs[AttributeNames.SOURCE], source);
+  assert.deepStrictEqual(attrs[AttributeNames.OPERATION_NAME], operationName);
+  assert.deepStrictEqual(attrs[AttributeNames.OPERATION_TYPE], operationType);
   if (parentSpanId) {
     assert.deepStrictEqual(span.parentSpanId, parentSpanId);
   }

--- a/plugins/node/opentelemetry-instrumentation-graphql/test/helper.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/test/helper.ts
@@ -16,7 +16,7 @@
 
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import * as assert from 'assert';
-import { createExecuteSpanName, createResolveSpanName } from '../src/enum';
+import { createExecuteSpanName, createResolveSpanName } from '../src/utils';
 import { AttributeNames } from '../src/enums/AttributeNames';
 
 export function assertResolveSpan(
@@ -46,10 +46,7 @@ export function assertExecuteSpan(
   parentSpanId?: string
 ) {
   const attrs = span.attributes;
-  assert.deepStrictEqual(
-    span.name,
-    createExecuteSpanName(operationType, operationName)
-  );
+  assert.deepStrictEqual(span.name, createExecuteSpanName(operationType));
   assert.deepStrictEqual(attrs[AttributeNames.SOURCE], source);
   assert.deepStrictEqual(attrs[AttributeNames.OPERATION_NAME], operationName);
   assert.deepStrictEqual(attrs[AttributeNames.OPERATION_TYPE], operationType);


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Fixes partially #705 (without the `hash` request)
- Fixes #534

## Short description of the changes

- Execute span names changed from `graphq.execute` to `graphql.execute.query`, where `query` represents an operation type.
- Prepare span names changed from `graphql.prepare` to `graphql.prepare.user` wher `user` is field name.
- Renamed `graphql.operation.name` to `graphql.operation.type` which represents `mutation`,`query` or `subscription`.
- Added `graphql.operation.name` which representes `Query1` as operation name.
