### PR TITLE
chore: fix lint workflow by running in container

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: node:16
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
GHA updated their base configuration and our lint task stopped working. Until we can make a more permanent fix, this should fix the lint step.