### PR TITLE
chore(ci): fix lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: node:14
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Github Actions team updated their base ubuntu to ship with Node 16 instead of 14 like before, so we got an npm update that obviously broke the dependency resolution and resulted in broken deps install. I didn't have the time to (nor the will ahah)  to make it work with node 16 so i just downgraded to 14 :)