### PR TITLE
test: use `127.0.0.1` in mongo tests as the default host

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-mongodb/test/mongodb.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/test/mongodb.test.ts
@@ -32,7 +32,7 @@ const instrumentation = registerInstrumentationTesting(
 );
 
 import * as mongodb from 'mongodb';
-import { assertSpans, accessCollection } from './utils';
+import { assertSpans, accessCollection, DEFAULT_MONGO_HOST } from './utils';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 
 describe('MongoDBInstrumentation', () => {
@@ -49,7 +49,7 @@ describe('MongoDBInstrumentation', () => {
   }
   // shouldTest = true
 
-  const URL = `mongodb://${process.env.MONGODB_HOST || 'localhost'}:${
+  const URL = `mongodb://${process.env.MONGODB_HOST || DEFAULT_MONGO_HOST}:${
     process.env.MONGODB_PORT || '27017'
   }`;
   const DB_NAME = process.env.MONGODB_DB || 'opentelemetry-tests';
@@ -437,7 +437,7 @@ describe('MongoDBInstrumentation', () => {
           span.end();
           const [mongoSpan] = getTestSpans();
           assert.ifError(err);
-          lookup(process.env.MONGODB_HOST || 'localhost', (err, address) => {
+          lookup(process.env.MONGODB_HOST || DEFAULT_MONGO_HOST, (err, address) => {
             if (err) return done(err);
             assert.strictEqual(
               mongoSpan.attributes[SemanticAttributes.NET_HOST_NAME],

--- a/plugins/node/opentelemetry-instrumentation-mongodb/test/mongodb.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/test/mongodb.test.ts
@@ -437,18 +437,21 @@ describe('MongoDBInstrumentation', () => {
           span.end();
           const [mongoSpan] = getTestSpans();
           assert.ifError(err);
-          lookup(process.env.MONGODB_HOST || DEFAULT_MONGO_HOST, (err, address) => {
-            if (err) return done(err);
-            assert.strictEqual(
-              mongoSpan.attributes[SemanticAttributes.NET_HOST_NAME],
-              address
-            );
-            assert.strictEqual(
-              mongoSpan.attributes[SemanticAttributes.NET_HOST_PORT],
-              process.env.MONGODB_PORT || '27017'
-            );
-            done();
-          });
+          lookup(
+            process.env.MONGODB_HOST || DEFAULT_MONGO_HOST,
+            (err, address) => {
+              if (err) return done(err);
+              assert.strictEqual(
+                mongoSpan.attributes[SemanticAttributes.NET_HOST_NAME],
+                address
+              );
+              assert.strictEqual(
+                mongoSpan.attributes[SemanticAttributes.NET_HOST_PORT],
+                process.env.MONGODB_PORT || '27017'
+              );
+              done();
+            }
+          );
         });
       });
     });

--- a/plugins/node/opentelemetry-instrumentation-mongodb/test/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/test/utils.ts
@@ -20,6 +20,8 @@ import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import * as assert from 'assert';
 import * as mongodb from 'mongodb';
 
+export const DEFAULT_MONGO_HOST = '127.0.0.1';
+
 export interface MongoDBAccess {
   client: mongodb.MongoClient;
   collection: mongodb.Collection;
@@ -82,7 +84,7 @@ export function assertSpans(
   );
   assert.strictEqual(
     mongoSpan.attributes[SemanticAttributes.NET_HOST_NAME],
-    process.env.MONGODB_HOST || 'localhost'
+    process.env.MONGODB_HOST || DEFAULT_MONGO_HOST
   );
   assert.strictEqual(mongoSpan.status.code, SpanStatusCode.UNSET);
 


### PR DESCRIPTION
## Which problem is this PR solving?

This fixes tests for mongodb versions 3.3 - 3.4.

## Short description of the changes

We're currently running TAV tests for 37 versions, 8 of which do not pass because versions before 3.5 do not resolve the DNS name. This bypasses that and makes the tests pass on all of the supported versions