### PR TITLE
test: test multiple versions of `koa`

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-koa/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-koa/.tav.yml
@@ -1,0 +1,4 @@
+koa:
+  # Testing ^2.7.0 covers at least 97% of the downloaded koa versions
+  versions: "^2.7.0"
+  commands: npm run test

--- a/plugins/node/opentelemetry-instrumentation-koa/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/package.json
@@ -7,6 +7,7 @@
   "repository": "open-telemetry/opentelemetry-js-contrib",
   "scripts": {
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.ts'",
+    "test-all-versions": "tav",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
     "tdd": "yarn test -- --watch-extensions ts --watch",
     "clean": "rimraf build/*",
@@ -61,6 +62,7 @@
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
+    "test-all-versions": "^5.0.1",
     "ts-mocha": "8.0.0",
     "typescript": "4.3.5"
   },


### PR DESCRIPTION
## Which problem is this PR solving?

We claim support for `koa@^2.0.0`, but only test for one fixed version.

## Short description of the changes

I'm adding TAV setup for `^2.7.0`(13 versions, 97.23% of the downloads) rather than the whole supported range `^2.0.0`(26 versions 99.12% of the downloads) because the older versions are released a while ago and seldom installed anymore. Testing 13 versions took just under a minute.

<details>
  <summary>Stats</summary>
  
  ```
❯ nvds koa ^2.0.0 
Loading stats for koa
┌─────────┬──────────┬───────────┬──────────────────────────┬──────────────┬──────────┐
│ (index) │ version  │ downloads │           time           │     tags     │ ratio(%) │
├─────────┼──────────┼───────────┼──────────────────────────┼──────────────┼──────────┤
│    0    │ '2.13.1' │  536865   │ 2021-01-04T15:12:12.283Z │      []      │   40.7   │
│    1    │ '2.13.4' │  388044   │ 2021-10-19T06:11:33.980Z │ [ 'latest' ] │   29.4   │
│    2    │ '2.11.0' │  142574   │ 2019-10-28T03:06:59.281Z │      []      │   10.8   │
│    3    │ '2.13.0' │  105654   │ 2020-06-21T15:58:06.393Z │      []      │    8     │
│    4    │ '2.13.3' │   56858   │ 2021-09-24T07:24:17.139Z │      []      │   4.3    │
│    5    │ '2.7.0'  │   20447   │ 2019-01-28T08:51:48.546Z │      []      │   1.5    │
│    6    │ '2.12.0' │   11525   │ 2020-05-17T16:02:30.378Z │      []      │   0.9    │
│    7    │ '2.8.2'  │   8078    │ 2019-09-28T04:51:26.573Z │      []      │   0.6    │
│    8    │ '2.8.1'  │   7884    │ 2019-08-19T04:36:34.141Z │      []      │   0.6    │
│    9    │ '2.5.3'  │   5626    │ 2018-09-11T15:25:07.982Z │      []      │   0.4    │
│   10    │ '2.6.2'  │   5203    │ 2018-11-09T17:43:27.005Z │      []      │   0.4    │
│   11    │ '2.5.1'  │   4001    │ 2018-04-26T17:11:18.698Z │      []      │   0.3    │
│   12    │ '2.12.1' │   3794    │ 2020-06-13T15:11:20.115Z │      []      │   0.3    │
│   13    │ '2.3.0'  │   3103    │ 2017-06-20T17:01:21.187Z │      []      │   0.2    │
│   14    │ '2.5.2'  │   1551    │ 2018-07-12T06:17:20.282Z │      []      │   0.1    │
│   15    │ '2.5.0'  │   1510    │ 2018-02-11T09:49:20.942Z │      []      │   0.1    │
│   16    │ '2.4.1'  │   1407    │ 2017-11-06T14:31:37.351Z │      []      │   0.1    │
│   17    │ '2.10.0' │   1321    │ 2019-10-12T08:22:36.668Z │      []      │   0.1    │
│   18    │ '2.9.0'  │    936    │ 2019-10-12T05:48:08.849Z │  [ 'next' ]  │   0.1    │
│   19    │ '2.0.1'  │    698    │ 2017-02-25T06:48:01.144Z │      []      │   0.1    │
│   20    │ '2.6.1'  │    668    │ 2018-10-23T07:21:19.085Z │      []      │   0.1    │
│   21    │ '2.0.0'  │    580    │ 2016-03-23T18:16:30.024Z │      []      │    0     │
│   22    │ '2.2.0'  │    528    │ 2017-03-14T08:58:02.323Z │      []      │    0     │
│   23    │ '2.13.2' │    96     │ 2021-09-24T03:40:26.593Z │      []      │    0     │
│   24    │ '2.1.0'  │    34     │ 2017-03-08T07:10:31.835Z │      []      │    0     │
│   25    │ '2.6.0'  │    16     │ 2018-10-23T05:23:05.803Z │      []      │    0     │
│   26    │ '2.8.0'  │    12     │ 2019-08-19T02:47:40.920Z │      []      │    0     │
└─────────┴──────────┴───────────┴──────────────────────────┴──────────────┴──────────┘
Ratio of downloads through versions shown in the table: 99.12%
Total weekly downloads: 1,320,652
  ```
</details>