### PR TITLE
test: test multiple versions of `graphql`

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-graphql/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-graphql/.tav.yml
@@ -1,0 +1,4 @@
+graphql:
+  # Taking a sample from the most downloaded versions in the range "14 || 15"
+  versions: "^15.8.0 || 15.7.2 || 15.6.1 || 15.6.0 || 15.5.3 || 15.5.1 || 15.5.0 || 15.4.0 || 15.3.0 || 14.6.0 || 14.5.8 || 14.5.0 || 14.0.0"
+  commands: npm run test

--- a/plugins/node/opentelemetry-instrumentation-graphql/README.md
+++ b/plugins/node/opentelemetry-instrumentation-graphql/README.md
@@ -9,8 +9,6 @@ This module provides *automated instrumentation and tracing* for GraphQL in Node
 
 *Note*: graphql plugin instruments graphql directly. it should work with any package that wraps the graphql package (e.g apollo).
 
-Minimum required graphql version is `v14`
-
 Compatible with OpenTelemetry JS API and SDK `1.0+`.
 
 ## Installation
@@ -18,6 +16,10 @@ Compatible with OpenTelemetry JS API and SDK `1.0+`.
 ```shell script
 npm install @opentelemetry/instrumentation-graphql
 ```
+
+### Supported Versions
+
+`>=14 <16`
 
 ## Usage
 

--- a/plugins/node/opentelemetry-instrumentation-graphql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-graphql/package.json
@@ -15,6 +15,7 @@
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
+    "test-all-versions": "tav",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "version:update": "node ../../../scripts/version-update.js",
     "watch": "tsc -w"
@@ -57,6 +58,7 @@
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
+    "test-all-versions": "^5.0.1",
     "ts-mocha": "8.0.0",
     "typescript": "4.3.5"
   },


### PR DESCRIPTION
## Which problem is this PR solving?

We claim support for `graphql@14+`, but only test for one fixed version. GraphQL v16 released this October is not supported - tests fail. Issue [here](https://github.com/open-telemetry/opentelemetry-js-contrib/issues/784).

## Short description of the changes

I'm adding TAV setup for a sample of versions in the range(13 versions, 78.87% of the downloads):

- `^15.8.0`,
- `15.7.2`,
- `15.6.1`,
- `15.6.0`,
- `15.5.3`,
- `15.5.1`,
- `15.5.0`,
- `15.4.0`,
- `15.3.0`,
- `14.6.0`,
- `14.5.8`,
- `14.5.0`,
- `14.0.0`,

rather than the whole supported range `>=14 || <16`(38 versions, 86.14% of the downloads).
Testing 13 versions took around a minute.

<details>
  <summary>Stats</summary>
  
  ```
❯ nvds graphql "^15.8.0 || 15.7.2 || 15.6.1 || 15.6.0 || 15.5.3 || 15.5.1 || 15.5.0 || 15.4.0 || 15.3.0 || 14.6.0 || 14.5.8 || 14.5.0 || 14.0.0"
Loading stats for graphql
┌─────────┬──────────┬───────────┬──────────────────────────┬──────────────┬──────────┐
│ (index) │ version  │ downloads │           time           │     tags     │ ratio(%) │
├─────────┼──────────┼───────────┼──────────────────────────┼──────────────┼──────────┤
│    0    │ '15.7.2' │  915585   │ 2021-10-28T14:46:29.317Z │      []      │    16    │
│    1    │ '15.5.1' │  635531   │ 2021-06-20T14:23:09.468Z │      []      │   11.1   │
│    2    │ '15.5.0' │  570690   │ 2021-01-26T17:25:50.170Z │      []      │    10    │
│    3    │ '14.0.0' │  339019   │ 2018-08-30T17:22:47.147Z │      []      │   5.9    │
│    4    │ '15.6.1' │  338509   │ 2021-10-05T12:04:20.092Z │      []      │   5.9    │
│    5    │ '15.4.0' │  338065   │ 2020-10-26T16:37:31.242Z │      []      │   5.9    │
│    6    │ '15.8.0' │  331857   │ 2021-12-07T12:17:43.375Z │ [ '15.x.x' ] │   5.8    │
│    7    │ '14.6.0' │  212217   │ 2020-01-26T16:25:06.191Z │      []      │   3.7    │
│    8    │ '15.5.3' │  205711   │ 2021-09-06T04:21:30.101Z │      []      │   3.6    │
│    9    │ '15.3.0' │  203979   │ 2020-07-05T19:15:20.148Z │      []      │   3.6    │
│   10    │ '15.6.0' │  173246   │ 2021-09-20T16:44:21.816Z │      []      │    3     │
│   11    │ '14.5.8' │  133403   │ 2019-09-25T14:02:37.883Z │      []      │   2.3    │
│   12    │ '14.5.0' │  107472   │ 2019-08-22T11:59:18.044Z │      []      │   1.9    │
└─────────┴──────────┴───────────┴──────────────────────────┴──────────────┴──────────┘
Ratio of downloads through versions shown in the table: 78.87%
Total weekly downloads: 5,712,587

❯ nvds graphql "14 || 15"
Loading stats for graphql
┌─────────┬──────────┬───────────┬──────────────────────────┬──────────────┬──────────┐
│ (index) │ version  │ downloads │           time           │     tags     │ ratio(%) │
├─────────┼──────────┼───────────┼──────────────────────────┼──────────────┼──────────┤
│    0    │ '15.7.2' │  915585   │ 2021-10-28T14:46:29.317Z │      []      │    16    │
│    1    │ '15.5.1' │  635531   │ 2021-06-20T14:23:09.468Z │      []      │   11.1   │
│    2    │ '15.5.0' │  570690   │ 2021-01-26T17:25:50.170Z │      []      │    10    │
│    3    │ '14.0.0' │  339019   │ 2018-08-30T17:22:47.147Z │      []      │   5.9    │
│    4    │ '15.6.1' │  338509   │ 2021-10-05T12:04:20.092Z │      []      │   5.9    │
│    5    │ '15.4.0' │  338065   │ 2020-10-26T16:37:31.242Z │      []      │   5.9    │
│    6    │ '15.8.0' │  331857   │ 2021-12-07T12:17:43.375Z │ [ '15.x.x' ] │   5.8    │
│    7    │ '14.6.0' │  212217   │ 2020-01-26T16:25:06.191Z │      []      │   3.7    │
│    8    │ '15.5.3' │  205711   │ 2021-09-06T04:21:30.101Z │      []      │   3.6    │
│    9    │ '15.3.0' │  203979   │ 2020-07-05T19:15:20.148Z │      []      │   3.6    │
│   10    │ '15.6.0' │  173246   │ 2021-09-20T16:44:21.816Z │      []      │    3     │
│   11    │ '14.5.8' │  133403   │ 2019-09-25T14:02:37.883Z │      []      │   2.3    │
│   12    │ '14.5.0' │  107472   │ 2019-08-22T11:59:18.044Z │      []      │   1.9    │
│   13    │ '15.7.1' │   56525   │ 2021-10-27T15:38:51.158Z │      []      │    1     │
│   14    │ '15.5.2' │   51370   │ 2021-08-30T15:19:45.108Z │      []      │   0.9    │
│   15    │ '14.2.1' │   51081   │ 2019-03-31T12:14:36.906Z │      []      │   0.9    │
│   16    │ '14.5.4' │   42938   │ 2019-08-29T12:44:16.302Z │      []      │   0.8    │
│   17    │ '15.0.0' │   40604   │ 2020-04-02T15:14:24.856Z │      []      │   0.7    │
│   18    │ '14.0.2' │   26434   │ 2018-09-06T21:11:47.089Z │      []      │   0.5    │
│   19    │ '14.1.1' │   25985   │ 2019-01-16T19:18:36.465Z │      []      │   0.5    │
│   20    │ '14.4.2' │   25289   │ 2019-07-03T15:00:19.793Z │      []      │   0.4    │
│   21    │ '14.3.1' │   20942   │ 2019-05-23T17:11:27.199Z │      []      │   0.4    │
│   22    │ '15.1.0' │   20199   │ 2020-06-07T16:42:53.015Z │      []      │   0.4    │
│   23    │ '15.7.0' │   18384   │ 2021-10-26T20:03:09.841Z │      []      │   0.3    │
│   24    │ '14.5.6' │   8044    │ 2019-09-15T16:50:25.043Z │      []      │   0.1    │
│   25    │ '14.3.0' │   5199    │ 2019-05-07T10:17:27.006Z │      []      │   0.1    │
│   26    │ '14.5.7' │   4923    │ 2019-09-20T18:06:13.535Z │      []      │   0.1    │
│   27    │ '14.2.0' │   4346    │ 2019-03-26T19:15:52.625Z │      []      │   0.1    │
│   28    │ '14.5.3' │   3380    │ 2019-08-24T00:43:05.809Z │      []      │   0.1    │
│   29    │ '14.1.0' │   3114    │ 2019-01-15T23:24:22.420Z │      []      │   0.1    │
│   30    │ '15.2.0' │   2160    │ 2020-06-29T12:06:55.932Z │      []      │    0     │
│   31    │ '14.4.1' │   1303    │ 2019-06-28T22:36:38.783Z │      []      │    0     │
│   32    │ '14.7.0' │   1194    │ 2020-07-06T16:56:10.444Z │      []      │    0     │
│   33    │ '14.4.0' │    988    │ 2019-06-26T18:30:52.519Z │      []      │    0     │
│   34    │ '14.5.5' │    664    │ 2019-09-13T15:23:48.925Z │      []      │    0     │
│   35    │ '14.5.1' │    366    │ 2019-08-23T16:25:18.890Z │      []      │    0     │
│   36    │ '14.5.2' │    87     │ 2019-08-23T22:53:41.260Z │      []      │    0     │
│   37    │ '14.0.1' │    44     │ 2018-09-06T21:01:45.725Z │      []      │    0     │
└─────────┴──────────┴───────────┴──────────────────────────┴──────────────┴──────────┘
Ratio of downloads through versions shown in the table: 86.14%
Total weekly downloads: 5,712,587
  ```
</details>
