### PR TITLE
fix(opentelemetry-resource-detector-aws): add missing attribute to la…

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsLambdaDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsLambdaDetector.ts
@@ -21,6 +21,7 @@ import {
 } from '@opentelemetry/resources';
 import {
   CloudProviderValues,
+  CloudPlatformValues,
   SemanticResourceAttributes,
 } from '@opentelemetry/semantic-conventions';
 
@@ -42,6 +43,9 @@ export class AwsLambdaDetector implements Detector {
     const attributes = {
       [SemanticResourceAttributes.CLOUD_PROVIDER]: String(
         CloudProviderValues.AWS
+      ),
+      [SemanticResourceAttributes.CLOUD_PLATFORM]: String(
+        CloudPlatformValues.AWS_LAMBDA
       ),
     };
     if (region) {


### PR DESCRIPTION
Signed-off-by: Anupam Dalmia <anupamdalmia10@users.noreply.github.com>

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Cloud Platform value in AWS Lambda detector was missing, it is there for other detectors.

## Short description of the changes

- Added the Cloud Platform value for AWS Lambda from semantic-conventions package.
