### PR TITLE
fix: use localhost for services in CI

### DIFF
--- a/.github/workflows/test-all-versions.yml
+++ b/.github/workflows/test-all-versions.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   tav:
+    # skip the workflow for now #816
+    if: false
     name: run test-all-version (tav)
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -74,24 +74,24 @@ jobs:
       RUN_MYSQL_TESTS: 1
       RUN_POSTGRES_TESTS: 1
       RUN_REDIS_TESTS: 1
-      OPENTELEMETRY_MEMCACHED_HOST: memcached
+      OPENTELEMETRY_MEMCACHED_HOST: localhost
       OPENTELEMETRY_MEMCACHED_PORT: 11211
       POSTGRES_USER: postgres
       POSTGRES_DB: circle_database
-      POSTGRES_HOST: postgres
+      POSTGRES_HOST: localhost
       POSTGRES_PORT: 5432
-      OPENTELEMETRY_REDIS_HOST: redis
+      OPENTELEMETRY_REDIS_HOST: localhost
       OPENTELEMETRY_REDIS_PORT: 6379
       MONGODB_DB: opentelemetry-tests
-      MONGODB_HOST: mongo
+      MONGODB_HOST: localhost
       MONGODB_PORT: 27017
       MYSQL_USER: otel
       MYSQL_PASSWORD: secret
       MYSQL_DATABASE: circle_database
-      MYSQL_HOST: mysql
+      MYSQL_HOST: localhost
       MYSQL_PORT: 3306
       NPM_CONFIG_UNSAFE_PERM: true
-      CASSANDRA_HOST: cassandra
+      CASSANDRA_HOST: localhost
       CASSANDRA_PORT: 9042
     steps:
       - name: Checkout

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -92,7 +92,6 @@ jobs:
       MYSQL_PORT: 3306
       NPM_CONFIG_UNSAFE_PERM: true
       CASSANDRA_HOST: localhost
-      CASSANDRA_PORT: 9042
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
@@ -19,12 +19,12 @@
     "compile": "npm run version:update && tsc -p ."
   },
   "keywords": [
-    "opentelemetry",
     "aws-lambda",
+    "instrumentation",
     "nodejs",
-    "tracing",
+    "opentelemetry",
     "profiling",
-    "instrumentation"
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
@@ -1,82 +1,83 @@
 {
-    "name": "@opentelemetry/instrumentation-aws-sdk",
-    "version": "0.4.0",
-    "description": "OpenTelemetry automatic instrumentation for the `aws-sdk` package",
-    "keywords": [
-        "aws",
-        "opentelemetry",
-        "aws-sdk"
-    ],
-    "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib#readme",
-    "license": "Apache-2.0",
-    "author": "OpenTelemetry Authors",
-    "bugs": {
-        "url": "https://github.com/open-telemetry/opentelemetry-js-contrib/issues"
-    },
-    "main": "build/src/index.js",
-    "types": "build/src/index.d.ts",
-    "files": [
-        "build/src/**/*.js",
-        "build/src/**/*.js.map",
-        "build/src/**/*.d.ts",
-        "doc",
-        "LICENSE",
-        "README.md"
-    ],
-    "publishConfig": {
-        "access": "public"
-    },
-    "repository": "open-telemetry/opentelemetry-js-contrib",
-    "scripts": {
-        "clean": "rimraf build/*",
-        "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
-        "compile": "npm run version:update && tsc -p .",
-        "lint": "eslint . --ext .ts",
-        "lint:fix": "eslint . --ext .ts --fix",
-        "precompile": "tsc --version && lerna run version --scope $(npm pkg get name) --include-filtered-dependencies",
-        "prewatch": "npm run precompile",
-        "prepare": "npm run compile",
-        "tdd": "npm run test -- --watch-extensions ts --watch",
-        "test": "nyc ts-mocha -p tsconfig.json --require '@opentelemetry/contrib-test-utils' 'test/**/*.test.ts'",
-        "test-all-versions": "tav",
-        "version:update": "node ../../../scripts/version-update.js",
-        "watch": "tsc -w"
-    },
-    "peerDependencies": {
-        "@opentelemetry/api": "^1.0.1"
-    },
-    "dependencies": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation": "^0.27.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@opentelemetry/propagation-utils": "^0.26.0"
-    },
-    "devDependencies": {
-        "@aws-sdk/client-dynamodb": "3.37.0",
-        "@aws-sdk/client-s3": "3.37.0",
-        "@aws-sdk/client-sqs": "3.37.0",
-        "@aws-sdk/types": "3.37.0",
-        "@opentelemetry/api": "1.0.1",
-        "@opentelemetry/sdk-trace-base": "1.0.1",
-        "@types/mocha": "8.2.3",
-        "@types/node": "14.18.2",
-        "@types/sinon": "10.0.6",
-        "aws-sdk": "2.1008.0",
-        "eslint": "7.32.0",
-        "expect": "27.4.2",
-        "mocha": "7.2.0",
-        "nock": "13.2.1",
-        "nyc": "15.1.0",
-        "rimraf": "3.0.2",
-        "sinon": "12.0.1",
-        "gts": "3.1.0",
-        "@opentelemetry/contrib-test-utils": "^0.28.0",
-        "test-all-versions": "5.0.1",
-        "ts-mocha": "8.0.0",
-        "ts-node": "9.1.1",
-        "typescript": "4.3.4"
-    },
-    "engines": {
-        "node": ">=8.5.0"
-    }
+  "name": "@opentelemetry/instrumentation-aws-sdk",
+  "version": "0.4.0",
+  "description": "OpenTelemetry automatic instrumentation for the `aws-sdk` package",
+  "keywords": [
+    "aws",
+    "aws-sdk",
+    "nodejs",
+    "opentelemetry"
+  ],
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib#readme",
+  "license": "Apache-2.0",
+  "author": "OpenTelemetry Authors",
+  "bugs": {
+    "url": "https://github.com/open-telemetry/opentelemetry-js-contrib/issues"
+  },
+  "main": "build/src/index.js",
+  "types": "build/src/index.d.ts",
+  "files": [
+    "build/src/**/*.js",
+    "build/src/**/*.js.map",
+    "build/src/**/*.d.ts",
+    "doc",
+    "LICENSE",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": "open-telemetry/opentelemetry-js-contrib",
+  "scripts": {
+    "clean": "rimraf build/*",
+    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
+    "compile": "npm run version:update && tsc -p .",
+    "lint": "eslint . --ext .ts",
+    "lint:fix": "eslint . --ext .ts --fix",
+    "precompile": "tsc --version && lerna run version --scope $(npm pkg get name) --include-filtered-dependencies",
+    "prewatch": "npm run precompile",
+    "prepare": "npm run compile",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
+    "test": "nyc ts-mocha -p tsconfig.json --require '@opentelemetry/contrib-test-utils' 'test/**/*.test.ts'",
+    "test-all-versions": "tav",
+    "version:update": "node ../../../scripts/version-update.js",
+    "watch": "tsc -w"
+  },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.1"
+  },
+  "dependencies": {
+    "@opentelemetry/core": "^1.0.0",
+    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/semantic-conventions": "^1.0.0",
+    "@opentelemetry/propagation-utils": "^0.26.0"
+  },
+  "devDependencies": {
+    "@aws-sdk/client-dynamodb": "3.37.0",
+    "@aws-sdk/client-s3": "3.37.0",
+    "@aws-sdk/client-sqs": "3.37.0",
+    "@aws-sdk/types": "3.37.0",
+    "@opentelemetry/api": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.0.1",
+    "@types/mocha": "8.2.3",
+    "@types/node": "14.18.2",
+    "@types/sinon": "10.0.6",
+    "aws-sdk": "2.1008.0",
+    "eslint": "7.32.0",
+    "expect": "27.4.2",
+    "mocha": "7.2.0",
+    "nock": "13.2.1",
+    "nyc": "15.1.0",
+    "rimraf": "3.0.2",
+    "sinon": "12.0.1",
+    "gts": "3.1.0",
+    "@opentelemetry/contrib-test-utils": "^0.28.0",
+    "test-all-versions": "5.0.1",
+    "ts-mocha": "8.0.0",
+    "ts-node": "9.1.1",
+    "typescript": "4.3.4"
+  },
+  "engines": {
+    "node": ">=8.5.0"
+  }
 }

--- a/plugins/node/opentelemetry-instrumentation-bunyan/package.json
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/package.json
@@ -20,13 +20,13 @@
     "version:update": "node ../../../scripts/version-update.js"
   },
   "keywords": [
-    "opentelemetry",
+    "bunyan",
+    "instrumentation",
     "logging",
     "nodejs",
-    "tracing",
+    "opentelemetry",
     "profiling",
-    "instrumentation",
-    "bunyan"
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-cassandra/package.json
+++ b/plugins/node/opentelemetry-instrumentation-cassandra/package.json
@@ -19,13 +19,13 @@
     "compile": "npm run version:update && tsc -p ."
   },
   "keywords": [
-    "opentelemetry",
+    "cassandra-driver",
+    "instrumentation",
     "logging",
     "nodejs",
-    "tracing",
+    "opentelemetry",
     "profiling",
-    "instrumentation",
-    "cassandra-driver"
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-cassandra/test/cassandra-driver.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-cassandra/test/cassandra-driver.test.ts
@@ -134,7 +134,10 @@ describe('CassandraDriverInstrumentation', () => {
     instrumentation.setTracerProvider(provider);
 
     const cassandra = require('cassandra-driver');
-    const endpoint = testCassandraLocally ? '127.0.0.1' : 'cassandra';
+    const endpoint =
+      process.env.CASSANDRA_HOST ?? testCassandraLocally
+        ? '127.0.0.1'
+        : 'cassandra';
     client = new cassandra.Client({
       contactPoints: [endpoint],
       localDataCenter: 'datacenter1',

--- a/plugins/node/opentelemetry-instrumentation-connect/package.json
+++ b/plugins/node/opentelemetry-instrumentation-connect/package.json
@@ -19,12 +19,12 @@
     "watch": "tsc -w"
   },
   "keywords": [
-    "opentelemetry",
     "connect",
+    "instrumentation",
     "nodejs",
-    "tracing",
+    "opentelemetry",
     "profiling",
-    "instrumentation"
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-dns/package.json
+++ b/plugins/node/opentelemetry-instrumentation-dns/package.json
@@ -19,12 +19,12 @@
     "compile": "npm run version:update && tsc -p ."
   },
   "keywords": [
-    "opentelemetry",
     "dns",
+    "instrumentation",
     "nodejs",
-    "tracing",
+    "opentelemetry",
     "profiling",
-    "instrumentation"
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-express/package.json
+++ b/plugins/node/opentelemetry-instrumentation-express/package.json
@@ -20,12 +20,12 @@
     "watch": "tsc -w"
   },
   "keywords": [
-    "opentelemetry",
     "express",
+    "instrumentation",
     "nodejs",
-    "tracing",
+    "opentelemetry",
     "profiling",
-    "instrumentation"
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-fastify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-fastify/package.json
@@ -18,12 +18,12 @@
     "watch": "tsc -w"
   },
   "keywords": [
-    "opentelemetry",
     "fastify",
+    "instrumentation",
     "nodejs",
-    "tracing",
+    "opentelemetry",
     "profiling",
-    "instrumentation"
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
+++ b/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
@@ -20,11 +20,11 @@
     "watch": "tsc -w"
   },
   "keywords": [
-    "opentelemetry",
     "generic-pool",
+    "instrumentation",
     "nodejs",
-    "tracing",
-    "instrumentation"
+    "opentelemetry",
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-graphql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-graphql/package.json
@@ -21,12 +21,12 @@
     "watch": "tsc -w"
   },
   "keywords": [
-    "opentelemetry",
-    "nodejs",
-    "tracing",
+    "graphql",
     "metrics",
+    "nodejs",
+    "opentelemetry",
     "stats",
-    "graphql"
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-hapi/package.json
+++ b/plugins/node/opentelemetry-instrumentation-hapi/package.json
@@ -19,12 +19,12 @@
     "prepare": "npm run compile"
   },
   "keywords": [
-    "opentelemetry",
     "hapi",
+    "instrumentation",
     "nodejs",
-    "tracing",
+    "opentelemetry",
     "profiling",
-    "instrumentation"
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-ioredis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/package.json
@@ -23,13 +23,13 @@
     "prepare": "npm run compile"
   },
   "keywords": [
-    "opentelemetry",
+    "instrumentation",
     "ioredis",
-    "redis",
     "nodejs",
-    "tracing",
+    "opentelemetry",
     "profiling",
-    "instrumentation"
+    "redis",
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-knex/package.json
+++ b/plugins/node/opentelemetry-instrumentation-knex/package.json
@@ -20,11 +20,11 @@
     "watch": "tsc -w"
   },
   "keywords": [
-    "opentelemetry",
+    "instrumentation",
     "knex",
     "nodejs",
-    "tracing",
-    "instrumentation"
+    "opentelemetry",
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-koa/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/package.json
@@ -21,13 +21,13 @@
     "watch": "tsc -w"
   },
   "keywords": [
-    "opentelemetry",
+    "instrumentation",
     "koa",
     "nodejs",
-    "tracing",
-    "profiling",
+    "opentelemetry",
     "plugin",
-    "instrumentation"
+    "profiling",
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-memcached/package.json
+++ b/plugins/node/opentelemetry-instrumentation-memcached/package.json
@@ -21,12 +21,12 @@
     "version:update": "node ../../../scripts/version-update.js"
   },
   "keywords": [
-    "opentelemetry",
+    "instrumentation",
     "memcached",
     "nodejs",
-    "tracing",
+    "opentelemetry",
     "profiling",
-    "instrumentation"
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-mongodb/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/package.json
@@ -22,12 +22,12 @@
     "watch": "tsc -w"
   },
   "keywords": [
-    "opentelemetry",
     "mongodb",
     "nodejs",
-    "tracing",
+    "opentelemetry",
+    "plugin",
     "profiling",
-    "plugin"
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-mysql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql/package.json
@@ -19,12 +19,12 @@
     "version:update": "node ../../../scripts/version-update.js"
   },
   "keywords": [
-    "opentelemetry",
+    "instrumentation",
     "mysql",
     "nodejs",
-    "tracing",
+    "opentelemetry",
     "profiling",
-    "instrumentation"
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-mysql2/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/package.json
@@ -20,13 +20,13 @@
     "version:update": "node ../../../scripts/version-update.js"
   },
   "keywords": [
-    "opentelemetry",
+    "instrumentation",
     "mysql",
     "mysql2",
     "nodejs",
-    "tracing",
+    "opentelemetry",
     "profiling",
-    "instrumentation"
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
+++ b/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
@@ -20,12 +20,13 @@
     "version:update": "node ../../../scripts/version-update.js"
   },
   "keywords": [
-    "opentelemetry",
+    "instrumentation",
     "nestjs",
+    "nestjs-core",
     "nodejs",
-    "tracing",
+    "opentelemetry",
     "profiling",
-    "instrumentation"
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-net/package.json
+++ b/plugins/node/opentelemetry-instrumentation-net/package.json
@@ -19,13 +19,13 @@
     "compile": "npm run version:update && tsc -p ."
   },
   "keywords": [
-    "opentelemetry",
-    "net",
     "connect",
+    "instrumentation",
+    "net",
     "nodejs",
-    "tracing",
+    "opentelemetry",
     "profiling",
-    "instrumentation"
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-pg/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pg/package.json
@@ -24,15 +24,15 @@
     "watch": "tsc -w"
   },
   "keywords": [
-    "opentelemetry",
-    "postgres",
-    "pg",
-    "postgresql",
+    "instrumentation",
     "nodejs",
-    "tracing",
-    "profiling",
+    "opentelemetry",
+    "pg",
     "plugin",
-    "instrumentation"
+    "postgres",
+    "postgresql",
+    "profiling",
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-pino/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pino/package.json
@@ -20,13 +20,13 @@
     "compile": "npm run version:update && tsc -p ."
   },
   "keywords": [
-    "opentelemetry",
+    "instrumentation",
     "logging",
     "nodejs",
-    "tracing",
+    "opentelemetry",
+    "pino",
     "profiling",
-    "instrumentation",
-    "pino"
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-redis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis/package.json
@@ -23,12 +23,12 @@
     "prepare": "npm run compile"
   },
   "keywords": [
-    "opentelemetry",
-    "redis",
+    "instrumentation",
     "nodejs",
-    "tracing",
+    "opentelemetry",
     "profiling",
-    "instrumentation"
+    "redis",
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-restify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-restify/package.json
@@ -20,11 +20,11 @@
     "watch": "tsc -w"
   },
   "keywords": [
+    "instrumentation",
+    "nodejs",
     "opentelemetry",
     "restify",
-    "nodejs",
-    "tracing",
-    "instrumentation"
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-router/package.json
+++ b/plugins/node/opentelemetry-instrumentation-router/package.json
@@ -20,11 +20,11 @@
     "watch": "tsc -w"
   },
   "keywords": [
+    "instrumentation",
+    "nodejs",
     "opentelemetry",
     "router",
-    "nodejs",
-    "tracing",
-    "instrumentation"
+    "tracing"
   ],
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/opentelemetry-instrumentation-winston/package.json
+++ b/plugins/node/opentelemetry-instrumentation-winston/package.json
@@ -20,12 +20,12 @@
     "compile": "npm run version:update && tsc -p ."
   },
   "keywords": [
-    "opentelemetry",
+    "instrumentation",
     "logging",
     "nodejs",
-    "tracing",
+    "opentelemetry",
     "profiling",
-    "instrumentation",
+    "tracing",
     "winston"
   ],
   "author": "OpenTelemetry Authors",


### PR DESCRIPTION
## Which problem is this PR solving?

The services in CI are not currently accessible.
The hostnames do not resolve because the step execution was recently moved from containers(which belong to the bridge network where the service names resolve) to the runner machine.
See c69c202a - @dyladan

The [docs](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idservices):

> If you configure the job to run directly on the runner machine and your step doesn't use a container action, you must map any required Docker service container ports to the Docker host (the runner machine). You can access the service container using localhost and the mapped port.

The above section from the docs makes total sense, however, I'm personally not clear on why is [`actions/setup-node@v2`](https://github.com/actions/setup-node) the recommended way to run node - it pollutes the runner machine and comes with an additional layer of caching.

## Short description of the changes

Since just swapping back to running in a container, results in some FS permission issues, I'm just changing the hostnames to use to localhost.

**That means the TAV setup is broken as well. I'd make the same change to it, but seeing that it doesn't set up node, I cannot see how it could work even with the services being accessible. I'll disable it for now.**

Sorted the keywords in the packages mainly to trigger a change for Lerna for all the packages.