### PR TITLE
fix: rename lerna's --include-filtered-dependencies option

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-alibaba-cloud/package.json
+++ b/detectors/node/opentelemetry-resource-detector-alibaba-cloud/package.json
@@ -11,7 +11,7 @@
     "compile": "npm run version:update && tsc -p .",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/resource-detector-alibaba-cloud --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/resource-detector-alibaba-cloud --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",

--- a/detectors/node/opentelemetry-resource-detector-aws/package.json
+++ b/detectors/node/opentelemetry-resource-detector-aws/package.json
@@ -11,7 +11,7 @@
     "compile": "npm run version:update && tsc -p .",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/resource-detector-aws --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/resource-detector-aws --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",

--- a/detectors/node/opentelemetry-resource-detector-gcp/package.json
+++ b/detectors/node/opentelemetry-resource-detector-gcp/package.json
@@ -11,7 +11,7 @@
     "compile": "npm run version:update && tsc -p .",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/resource-detector-gcp --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/resource-detector-gcp --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",

--- a/detectors/node/opentelemetry-resource-detector-github/package.json
+++ b/detectors/node/opentelemetry-resource-detector-github/package.json
@@ -11,7 +11,7 @@
     "compile": "npm run version:update && tsc -p .",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/resource-detector-github --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/resource-detector-github --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,4 @@
 {
-  "lerna": "3.13.4",
   "npmClient": "npm",
   "packages": [
     "packages/*",

--- a/metapackages/auto-instrumentations-node/package.json
+++ b/metapackages/auto-instrumentations-node/package.json
@@ -17,7 +17,7 @@
     "compile": "tsc -p .",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/auto-instrumentations-node --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/auto-instrumentations-node --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "tdd": "yarn test -- --watch-extensions ts --watch",

--- a/metapackages/auto-instrumentations-web/package.json
+++ b/metapackages/auto-instrumentations-web/package.json
@@ -18,7 +18,7 @@
     "compile": "tsc --build tsconfig.json tsconfig.esm.json",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/auto-instrumentations-web --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/auto-instrumentations-web --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "test:browser": "nyc karma start --single-run",

--- a/packages/opentelemetry-browser-extension-autoinjection/package.json
+++ b/packages/opentelemetry-browser-extension-autoinjection/package.json
@@ -11,7 +11,7 @@
     "build:mv3": "npx webpack --mode=production --env MV=3",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/browser-extension-autoinjection --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/browser-extension-autoinjection --include-dependencies",
     "prewatch": "npm run precompile",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "tdd": "npm run test -- --watch-extensions ts --watch",

--- a/packages/opentelemetry-host-metrics/package.json
+++ b/packages/opentelemetry-host-metrics/package.json
@@ -11,7 +11,7 @@
     "compile": "npm run version:update && tsc -p .",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/host-metrics --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/host-metrics --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "tdd": "npm run test -- --watch-extensions ts --watch",

--- a/packages/opentelemetry-id-generator-aws-xray/package.json
+++ b/packages/opentelemetry-id-generator-aws-xray/package.json
@@ -15,7 +15,7 @@
   "types": "build/src/index.d.ts",
   "repository": "open-telemetry/opentelemetry-js-contrib",
   "scripts": {
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/id-generator-aws-xray --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/id-generator-aws-xray --include-dependencies",
     "prewatch": "npm run precompile",
     "compile": "tsc --build tsconfig.json tsconfig.esm.json",
     "clean": "tsc --build --clean tsconfig.json tsconfig.esm.json",

--- a/packages/opentelemetry-propagation-utils/package.json
+++ b/packages/opentelemetry-propagation-utils/package.json
@@ -12,7 +12,7 @@
     "compile": "tsc --build tsconfig.json tsconfig.esm.json",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/propagation-utils --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/propagation-utils --include-dependencies",
     "prepare": "npm run compile",
     "prewatch": "npm run precompile",
     "version": "node ../../scripts/version-update.js",

--- a/packages/opentelemetry-test-utils/package.json
+++ b/packages/opentelemetry-test-utils/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "compile": "tsc -p .",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/contrib-test-utils --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/contrib-test-utils --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "watch": "tsc -w"

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-aws-lambda --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-aws-lambda --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "version:update": "node ../../../scripts/version-update.js",

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
@@ -34,7 +34,7 @@
     "compile": "npm run version:update && tsc -p .",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope $(npm pkg get name) --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope $(npm pkg get name) --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "tdd": "npm run test -- --watch-extensions ts --watch",

--- a/plugins/node/opentelemetry-instrumentation-bunyan/package.json
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/package.json
@@ -11,7 +11,7 @@
     "compile": "npm run version:update && tsc -p .",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-bunyan --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-bunyan --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "tdd": "npm run test -- --watch-extensions ts --watch",

--- a/plugins/node/opentelemetry-instrumentation-cassandra/package.json
+++ b/plugins/node/opentelemetry-instrumentation-cassandra/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-cassandra-driver --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-cassandra-driver --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "version:update": "node ../../../scripts/version-update.js",

--- a/plugins/node/opentelemetry-instrumentation-connect/package.json
+++ b/plugins/node/opentelemetry-instrumentation-connect/package.json
@@ -11,7 +11,7 @@
     "compile": "npm run version:update && tsc -p .",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-connect --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-connect --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",

--- a/plugins/node/opentelemetry-instrumentation-dns/package.json
+++ b/plugins/node/opentelemetry-instrumentation-dns/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-dns --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-dns --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "version:update": "node ../../../scripts/version-update.js",

--- a/plugins/node/opentelemetry-instrumentation-express/package.json
+++ b/plugins/node/opentelemetry-instrumentation-express/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf build/*",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-express --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-express --include-dependencies",
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "npm run version:update && tsc -p .",

--- a/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
+++ b/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf build/*",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-generic-pool --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-generic-pool --include-dependencies",
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "npm run version:update && tsc -p .",

--- a/plugins/node/opentelemetry-instrumentation-graphql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-graphql/package.json
@@ -11,7 +11,7 @@
     "compile": "npm run version:update && tsc -p .",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-graphql --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-graphql --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",

--- a/plugins/node/opentelemetry-instrumentation-hapi/package.json
+++ b/plugins/node/opentelemetry-instrumentation-hapi/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf build/*",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-hapi --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-hapi --include-dependencies",
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "npm run version:update && tsc -p .",

--- a/plugins/node/opentelemetry-instrumentation-ioredis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/package.json
@@ -15,7 +15,7 @@
     "clean": "rimraf build/*",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-ioredis --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-ioredis --include-dependencies",
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "npm run version:update && tsc -p .",

--- a/plugins/node/opentelemetry-instrumentation-knex/package.json
+++ b/plugins/node/opentelemetry-instrumentation-knex/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf build/*",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-knex --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-knex --include-dependencies",
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "npm run version:update && tsc -p .",

--- a/plugins/node/opentelemetry-instrumentation-koa/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/package.json
@@ -13,7 +13,7 @@
     "clean": "rimraf build/*",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-koa --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-koa --include-dependencies",
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "npm run version:update && tsc -p .",

--- a/plugins/node/opentelemetry-instrumentation-memcached/package.json
+++ b/plugins/node/opentelemetry-instrumentation-memcached/package.json
@@ -11,7 +11,7 @@
     "compile": "npm run version:update && tsc -p .",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-memcached --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-memcached --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "tdd": "npm run test -- --watch-extensions ts --watch",

--- a/plugins/node/opentelemetry-instrumentation-mongodb/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/package.json
@@ -14,7 +14,7 @@
     "clean": "rimraf build/*",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-mongodb --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-mongodb --include-dependencies",
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "npm run version:update && tsc -p .",

--- a/plugins/node/opentelemetry-instrumentation-mysql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql/package.json
@@ -11,7 +11,7 @@
     "compile": "npm run version:update && tsc -p .",
     "lint:fix": "eslint . --ext .ts --fix",
     "lint": "eslint . --ext .ts",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-mysql --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-mysql --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "tdd": "npm run test -- --watch-extensions ts --watch",

--- a/plugins/node/opentelemetry-instrumentation-mysql2/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/package.json
@@ -11,7 +11,7 @@
     "compile": "npm run version:update && tsc -p .",
     "lint:fix": "eslint . --ext .ts --fix",
     "lint": "eslint . --ext .ts",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-mysql2 --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-mysql2 --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "tdd": "npm run test -- --watch-extensions ts --watch",

--- a/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
+++ b/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
@@ -12,7 +12,7 @@
     "compile:watch": "tsc -w",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-nestjs-core --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-nestjs-core --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "tdd": "npm run test -- --watch-extensions ts --watch",

--- a/plugins/node/opentelemetry-instrumentation-net/package.json
+++ b/plugins/node/opentelemetry-instrumentation-net/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-net --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-net --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "version:update": "node ../../../scripts/version-update.js",

--- a/plugins/node/opentelemetry-instrumentation-pg/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pg/package.json
@@ -11,7 +11,7 @@
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-pg --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-pg --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "tdd": "npm run test -- --watch-extensions ts --watch",

--- a/plugins/node/opentelemetry-instrumentation-pino/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pino/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-pino --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-pino --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "version:update": "node ../../../scripts/version-update.js",

--- a/plugins/node/opentelemetry-instrumentation-redis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis/package.json
@@ -15,7 +15,7 @@
     "clean": "rimraf build/*",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-redis --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-redis --include-dependencies",
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "npm run version:update && tsc -p .",

--- a/plugins/node/opentelemetry-instrumentation-restify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-restify/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf build/*",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-restify --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-restify --include-dependencies",
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "npm run version:update && tsc -p .",

--- a/plugins/node/opentelemetry-instrumentation-router/package.json
+++ b/plugins/node/opentelemetry-instrumentation-router/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf build/*",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-router --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-router --include-dependencies",
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "npm run version:update && tsc -p .",

--- a/plugins/node/opentelemetry-instrumentation-winston/package.json
+++ b/plugins/node/opentelemetry-instrumentation-winston/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-winston --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-winston --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "version:update": "node ../../../scripts/version-update.js",

--- a/plugins/web/opentelemetry-instrumentation-document-load/package.json
+++ b/plugins/web/opentelemetry-instrumentation-document-load/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "codecov:browser": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-document-load --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-document-load --include-dependencies",
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "npm run version:update && tsc --build tsconfig.json tsconfig.esm.json",

--- a/plugins/web/opentelemetry-instrumentation-long-task/package.json
+++ b/plugins/web/opentelemetry-instrumentation-long-task/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "clean": "tsc --build --clean tsconfig.json tsconfig.esm.json",
     "codecov:browser": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-user-interaction --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-user-interaction --include-dependencies",
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "npm run version:update && tsc --build tsconfig.json tsconfig.esm.json",

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
@@ -11,7 +11,7 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "clean": "tsc --build --clean tsconfig.json tsconfig.esm.json",
     "codecov:browser": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-user-interaction --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-user-interaction --include-dependencies",
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "npm run version:update && tsc --build tsconfig.json tsconfig.esm.json",

--- a/plugins/web/opentelemetry-plugin-react-load/package.json
+++ b/plugins/web/opentelemetry-plugin-react-load/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "codecov:browser": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/plugin-react-load --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/plugin-react-load --include-dependencies",
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "npm run version:update && tsc --build tsconfig.json tsconfig.esm.json",

--- a/propagators/opentelemetry-propagator-aws-xray/package.json
+++ b/propagators/opentelemetry-propagator-aws-xray/package.json
@@ -7,7 +7,7 @@
   "types": "build/src/index.d.ts",
   "repository": "open-telemetry/opentelemetry-js-contrib",
   "scripts": {
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/propagator-aws-xray --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/propagator-aws-xray --include-dependencies",
     "prewatch": "npm run precompile",
     "compile": "tsc --build tsconfig.json tsconfig.esm.json",
     "clean": "tsc --build --clean tsconfig.json tsconfig.esm.json",

--- a/propagators/opentelemetry-propagator-grpc-census-binary/package.json
+++ b/propagators/opentelemetry-propagator-grpc-census-binary/package.json
@@ -13,7 +13,7 @@
     "clean": "rimraf build/*",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/propagator-grpc-census-binary --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/propagator-grpc-census-binary --include-dependencies",
     "prewatch": "npm run precompile",
     "compile": "npm run version:update && tsc -p .",
     "prepare": "npm run compile",

--- a/propagators/opentelemetry-propagator-ot-trace/package.json
+++ b/propagators/opentelemetry-propagator-ot-trace/package.json
@@ -7,7 +7,7 @@
   "types": "build/src/index.d.ts",
   "repository": "open-telemetry/opentelemetry-js-contrib",
   "scripts": {
-    "precompile": "tsc --version && lerna run version --scope @opentelemetry/propagator-ot-trace --include-filtered-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/propagator-ot-trace --include-dependencies",
     "prewatch": "npm run precompile",
     "compile": "tsc --build tsconfig.json tsconfig.esm.json",
     "clean": "tsc --build --clean tsconfig.json tsconfig.esm.json",


### PR DESCRIPTION
## Which problem is this PR solving?

`--include-filtered-dependencies` option is deprecated:
https://github.com/lerna/lerna/commit/f2c3a92fe41b6fdc5d11269f0f2c3e27761b4c85

## Short description of the changes

Rename `--include-filtered-dependencies` -> `--include-dependencies`.
Also substituting `$(npm pkg get name)` in the `package.json` of `@opentelemetry/instrumentation-aws-sdk` - GHA logs seem to tell us it's not properly working.