### PR TITLE
test: fix ioredis tests

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-ioredis/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/.tav.yml
@@ -1,7 +1,7 @@
 ioredis:
   # Ignoring v4.19.0. Tests never ends. Caused by https://github.com/luin/ioredis/pull/1219
-  versions: ">1 < 4.19.0 || > 4.19.0 < 5"
+  versions: "^2.5.0 || ^3.2.2 || 4.14.0 || 4.14.1 || 4.16.3 || 4.17.3 || 4.18.0 || 4.19.2 || 4.19.4 || 4.22.0 || 4.24.5 || 4.26.0 || 4.27.2 || 4.27.3 || ^4.27.6"
   commands: npm run test
 
   # Fix missing `contrib-test-utils` package
-  pretest: npm run --prefix ../../../ lerna:link 
+  pretest: npm run --prefix ../../../ lerna:link

--- a/plugins/node/opentelemetry-instrumentation-ioredis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/package.json
@@ -65,6 +65,7 @@
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
+    "sinon": "^12.0.1",
     "test-all-versions": "5.0.1",
     "ts-mocha": "8.0.0",
     "typescript": "4.3.5"

--- a/plugins/node/opentelemetry-instrumentation-ioredis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/package.json
@@ -58,6 +58,7 @@
     "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/mocha": "7.0.2",
     "@types/node": "14.17.9",
+    "@types/sinon": "^10.0.6",
     "codecov": "3.8.3",
     "cross-env": "7.0.3",
     "gts": "3.1.0",

--- a/plugins/node/opentelemetry-instrumentation-ioredis/test/ioredis.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/test/ioredis.test.ts
@@ -784,7 +784,9 @@ describe('ioredis', () => {
             );
           }
         );
-        instrumentation.setConfig(<IORedisInstrumentationConfig> { requestHook });
+        instrumentation.setConfig(<IORedisInstrumentationConfig>{
+          requestHook,
+        });
 
         const span = provider.getTracer('ioredis-test').startSpan('test span');
         await context.with(trace.setSpan(context.active(), span), async () => {
@@ -818,7 +820,9 @@ describe('ioredis', () => {
             throw Error('error thrown in requestHook');
           }
         );
-        instrumentation.setConfig(<IORedisInstrumentationConfig> { requestHook });
+        instrumentation.setConfig(<IORedisInstrumentationConfig>{
+          requestHook,
+        });
 
         const span = provider.getTracer('ioredis-test').startSpan('test span');
         await context.with(trace.setSpan(context.active(), span), async () => {
@@ -848,7 +852,9 @@ describe('ioredis', () => {
             );
           }
         );
-        instrumentation.setConfig(<IORedisInstrumentationConfig> { responseHook });
+        instrumentation.setConfig(<IORedisInstrumentationConfig>{
+          responseHook,
+        });
 
         const span = provider.getTracer('ioredis-test').startSpan('test span');
         await context.with(trace.setSpan(context.active(), span), async () => {
@@ -862,7 +868,12 @@ describe('ioredis', () => {
         });
 
         sinon.assert.calledOnce(responseHook);
-        const [, cmdName, , response] = responseHook.firstCall.args as [Span, string, unknown, Buffer];
+        const [, cmdName, , response] = responseHook.firstCall.args as [
+          Span,
+          string,
+          unknown,
+          Buffer
+        ];
         assert.strictEqual(cmdName, 'set');
         assert.strictEqual(response.toString(), 'OK');
       });
@@ -878,7 +889,9 @@ describe('ioredis', () => {
             throw Error('error thrown in responseHook');
           }
         );
-        instrumentation.setConfig(<IORedisInstrumentationConfig> { responseHook });
+        instrumentation.setConfig(<IORedisInstrumentationConfig>{
+          responseHook,
+        });
 
         const span = provider.getTracer('ioredis-test').startSpan('test span');
         await context.with(trace.setSpan(context.active(), span), async () => {

--- a/plugins/node/opentelemetry-instrumentation-ioredis/test/ioredis.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/test/ioredis.test.ts
@@ -776,16 +776,15 @@ describe('ioredis', () => {
       });
 
       it('should call requestHook when set in config', async () => {
-        const requestHook = sinon.spy((
-          span: Span,
-          requestInfo: IORedisRequestHookInformation
-        ) => {
-          span.setAttribute(
-            'attribute key from request hook',
-            'custom value from request hook'
-          );
-        });
-        instrumentation.setConfig({ requestHook });
+        const requestHook = sinon.spy(
+          (span: Span, requestInfo: IORedisRequestHookInformation) => {
+            span.setAttribute(
+              'attribute key from request hook',
+              'custom value from request hook'
+            );
+          }
+        );
+        instrumentation.setConfig(<IORedisInstrumentationConfig> { requestHook });
 
         const span = provider.getTracer('ioredis-test').startSpan('test span');
         await context.with(trace.setSpan(context.active(), span), async () => {
@@ -799,7 +798,7 @@ describe('ioredis', () => {
         });
 
         sinon.assert.calledOnce(requestHook);
-        const [ , requestInfo] = requestHook.firstCall.args;
+        const [, requestInfo] = requestHook.firstCall.args;
         assert.ok(
           /\d{1,4}\.\d{1,4}\.\d{1,5}.*/.test(
             requestInfo.moduleVersion as string
@@ -810,17 +809,16 @@ describe('ioredis', () => {
       });
 
       it('should ignore requestHook which throws exception', async () => {
-        const requestHook = sinon.spy((
-          span: Span,
-          _requestInfo: IORedisRequestHookInformation
-        ) => {
-          span.setAttribute(
-            'attribute key BEFORE exception',
-            'this attribute is added to span BEFORE exception is thrown thus we can expect it'
-          );
-          throw Error('error thrown in requestHook');
-        });
-        instrumentation.setConfig({ requestHook });
+        const requestHook = sinon.spy(
+          (span: Span, _requestInfo: IORedisRequestHookInformation) => {
+            span.setAttribute(
+              'attribute key BEFORE exception',
+              'this attribute is added to span BEFORE exception is thrown thus we can expect it'
+            );
+            throw Error('error thrown in requestHook');
+          }
+        );
+        instrumentation.setConfig(<IORedisInstrumentationConfig> { requestHook });
 
         const span = provider.getTracer('ioredis-test').startSpan('test span');
         await context.with(trace.setSpan(context.active(), span), async () => {
@@ -837,18 +835,20 @@ describe('ioredis', () => {
       });
 
       it('should call responseHook when set in config', async () => {
-        const responseHook = sinon.spy((
-          span: Span,
-          cmdName: string,
-          _cmdArgs: Array<string | Buffer | number>,
-          response: unknown
-        ) => {
-          span.setAttribute(
-            'attribute key from hook',
-            'custom value from hook'
-          );
-        });
-        instrumentation.setConfig({ responseHook });
+        const responseHook = sinon.spy(
+          (
+            span: Span,
+            cmdName: string,
+            _cmdArgs: Array<string | Buffer | number>,
+            response: unknown
+          ) => {
+            span.setAttribute(
+              'attribute key from hook',
+              'custom value from hook'
+            );
+          }
+        );
+        instrumentation.setConfig(<IORedisInstrumentationConfig> { responseHook });
 
         const span = provider.getTracer('ioredis-test').startSpan('test span');
         await context.with(trace.setSpan(context.active(), span), async () => {
@@ -862,21 +862,23 @@ describe('ioredis', () => {
         });
 
         sinon.assert.calledOnce(responseHook);
-        const [ , cmdName, , response] = responseHook.firstCall.args;
+        const [, cmdName, , response] = responseHook.firstCall.args as [Span, string, unknown, Buffer];
         assert.strictEqual(cmdName, 'set');
         assert.strictEqual(response.toString(), 'OK');
       });
 
       it('should ignore responseHook which throws exception', async () => {
-        const responseHook = sinon.spy((
-          _span: Span,
-          _cmdName: string,
-          _cmdArgs: Array<string | Buffer | number>,
-          _response: unknown
-        ) => {
-          throw Error('error thrown in responseHook');
-        });
-        instrumentation.setConfig({ responseHook });
+        const responseHook = sinon.spy(
+          (
+            _span: Span,
+            _cmdName: string,
+            _cmdArgs: Array<string | Buffer | number>,
+            _response: unknown
+          ) => {
+            throw Error('error thrown in responseHook');
+          }
+        );
+        instrumentation.setConfig(<IORedisInstrumentationConfig> { responseHook });
 
         const span = provider.getTracer('ioredis-test').startSpan('test span');
         await context.with(trace.setSpan(context.active(), span), async () => {


### PR DESCRIPTION
## Which problem is this PR solving?

Some of the assertions are done in the hooks in the tests for `ioredis`.

1. The errors thrown in the hooks are eaten, so no benefit having them there,
2. Even if they aren't one of them was validating an ever-increasing counter, which can ever only be correct once,
3. Test for `scan` broke when there were more than 10 keys in the DB - not a problem when running on a clean DB every time, but happens locally when tests occasionally completely fail and the cleanup will not happen.

## Short description of the changes

- Added `sinon` to move the assertions in the hooks outside of them.
- Tweaked `scan` tests with match and count parameters
- Narrowed down the TAV version set - if we expect devs to ever run them, it better not take an hour. It currently takes 2 minutes.
