### PR TITLE
docs: document node v10 EOL & v16 supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Currently, OpenTelemetry supports automatic collection for following environment
 
 Platform Version | Supported
 ---------------- | ---------
+Node.JS `v16`    | ✅
 Node.JS `v14`    | ✅
 Node.JS `v12`    | ✅
 Node.JS `v10`    | ✅
@@ -120,7 +121,7 @@ Web Browsers     | ✅ See [Browser Support](#browser-support) below
 ### Node Support
 
 Automated tests are run using the latest release of each currently active version of Node.JS.
-While Node.JS v8 is no longer supported by the Node.JS team, the latest version of Node.JS v8 is still included in our testing suite.
+While Node.JS v8 and v10 are no longer supported by the Node.JS team, the latest versions of Node.JS v8 and v10 are still included in our testing suite.
 Please note that versions of Node.JS v8 prior to `v8.5.0` will NOT work, because OpenTelemetry Node depends on the `perf_hooks` module introduced in `v8.5.0`
 
 ### Browser Support


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Short description of the changes
- Document node v16 is supported by OTEL
- Document node v10 is no longer supported by Node.js team


