### PR TITLE
chore: add tedious to release config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,6 +15,7 @@
     "packages/opentelemetry-host-metrics": {},
     "packages/opentelemetry-id-generator-aws-xray": {},
     "packages/opentelemetry-test-utils": {},
+    "plugins/node/instrumentation-tedious": {},
     "plugins/node/opentelemetry-instrumentation-aws-lambda": {},
     "plugins/node/opentelemetry-instrumentation-aws-sdk": {},
     "plugins/node/opentelemetry-instrumentation-bunyan": {},


### PR DESCRIPTION
#815 is currently blocked by tedious tests failing. Tedious test-utils package is not updated because it is not included in the release config. This also would prevent it from being released by the automation.