### PR TITLE
fix(aws-sdk): sns span name should be with low cardinality

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sns.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sns.ts
@@ -43,9 +43,7 @@ export class SnsServiceExtension implements ServiceExtension {
       spanAttributes[SemanticAttributes.MESSAGING_DESTINATION] =
         this.extractDestinationName(TopicArn, TargetArn, PhoneNumber);
 
-      spanName = `${
-        spanAttributes[SemanticAttributes.MESSAGING_DESTINATION]
-      } send`;
+      spanName = `${PhoneNumber ? 'phone_number' : spanAttributes[SemanticAttributes.MESSAGING_DESTINATION]} send`;
     }
 
     return {

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sns.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sns.ts
@@ -43,7 +43,11 @@ export class SnsServiceExtension implements ServiceExtension {
       spanAttributes[SemanticAttributes.MESSAGING_DESTINATION] =
         this.extractDestinationName(TopicArn, TargetArn, PhoneNumber);
 
-      spanName = `${PhoneNumber ? 'phone_number' : spanAttributes[SemanticAttributes.MESSAGING_DESTINATION]} send`;
+      spanName = `${
+        PhoneNumber
+          ? 'phone_number'
+          : spanAttributes[SemanticAttributes.MESSAGING_DESTINATION]
+      } send`;
     }
 
     return {

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/sns.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/sns.test.ts
@@ -101,7 +101,7 @@ describe('SNS', () => {
         .promise();
 
       const publishSpans = getTestSpans().filter(
-        (s: ReadableSpan) => s.name === `phone_number send`
+        (s: ReadableSpan) => s.name === 'phone_number send'
       );
       expect(publishSpans.length).toBe(1);
       const publishSpan = publishSpans[0];

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/sns.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/sns.test.ts
@@ -101,7 +101,7 @@ describe('SNS', () => {
         .promise();
 
       const publishSpans = getTestSpans().filter(
-        (s: ReadableSpan) => s.name === `${PhoneNumber} send`
+        (s: ReadableSpan) => s.name === `phone_number send`
       );
       expect(publishSpans.length).toBe(1);
       const publishSpan = publishSpans[0];


### PR DESCRIPTION
## Short description of the changes

- When using SNS to publish message to a phone number, span name contain the phone number.
According messaging spec, [span name should be of low cardinality](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md#span-name)


## Short description of the changes

- Span name will be `phone_number send` when publishing SNS to a phone number. As I implemented in [ruby's instrumentation](https://github.com/open-telemetry/opentelemetry-ruby/blob/658440f2f749f151fde393ce1654803a816f1c38/instrumentation/aws_sdk/lib/opentelemetry/instrumentation/aws_sdk/messaging_helper.rb#L22-L23)
