### PR TITLE
feat(aws-sdk): add http status code attribute to aws sdk span

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.ts
@@ -57,6 +57,7 @@ import {
   removeSuffixFromStringIfExists,
 } from './utils';
 import { RequestMetadata } from './services/ServiceExtension';
+import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 
 const V3_CLIENT_CONFIG_KEY = Symbol(
   'opentelemetry.instrumentation.aws-sdk.client.config'
@@ -328,6 +329,14 @@ export class AwsInstrumentation extends InstrumentationBase<typeof AWS> {
         }
 
         span.setAttribute(AttributeNames.AWS_REQUEST_ID, response.requestId);
+
+        const httpStatusCode = response.httpResponse?.statusCode;
+        if (httpStatusCode) {
+          span.setAttribute(
+            SemanticAttributes.HTTP_STATUS_CODE,
+            httpStatusCode
+          );
+        }
         span.end();
       });
     });
@@ -469,9 +478,18 @@ export class AwsInstrumentation extends InstrumentationBase<typeof AWS> {
               const promiseWithResponseLogic = resultPromise
                 .then(response => {
                   const requestId = response.output?.$metadata?.requestId;
+                  const httpStatusCode =
+                    response.output?.$metadata?.httpStatusCode;
                   if (requestId) {
                     span.setAttribute(AttributeNames.AWS_REQUEST_ID, requestId);
                   }
+                  if (httpStatusCode) {
+                    span.setAttribute(
+                      SemanticAttributes.HTTP_STATUS_CODE,
+                      httpStatusCode
+                    );
+                  }
+
                   const extendedRequestId =
                     response.output?.$metadata?.extendedRequestId;
                   if (extendedRequestId) {

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.ts
@@ -478,11 +478,12 @@ export class AwsInstrumentation extends InstrumentationBase<typeof AWS> {
               const promiseWithResponseLogic = resultPromise
                 .then(response => {
                   const requestId = response.output?.$metadata?.requestId;
-                  const httpStatusCode =
-                    response.output?.$metadata?.httpStatusCode;
                   if (requestId) {
                     span.setAttribute(AttributeNames.AWS_REQUEST_ID, requestId);
                   }
+
+                  const httpStatusCode =
+                    response.output?.$metadata?.httpStatusCode;
                   if (httpStatusCode) {
                     span.setAttribute(
                       SemanticAttributes.HTTP_STATUS_CODE,

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/aws-sdk-v2.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/aws-sdk-v2.test.ts
@@ -32,16 +32,23 @@ import { SpanStatusCode, Span } from '@opentelemetry/api';
 import { AttributeNames } from '../src/enums';
 import { mockV2AwsSend } from './testing-utils';
 import * as expect from 'expect';
+import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 
 describe('instrumentation-aws-sdk-v2', () => {
   const responseMockSuccess = {
     requestId: '0000000000000',
     error: null,
+    httpResponse: {
+      statusCode: 200,
+    },
   };
 
   const responseMockWithError = {
     requestId: '0000000000000',
     error: 'something went wrong',
+    httpResponse: {
+      statusCode: 400,
+    },
   };
 
   const getAwsSpans = (): ReadableSpan[] => {
@@ -111,6 +118,9 @@ describe('instrumentation-aws-sdk-v2', () => {
         expect(spanCreateBucket.attributes[AttributeNames.AWS_REGION]).toBe(
           'us-east-1'
         );
+        expect(
+          spanCreateBucket.attributes[SemanticAttributes.HTTP_STATUS_CODE]
+        ).toBe(200);
 
         expect(spanCreateBucket.name).toBe('S3.CreateBucket');
 
@@ -136,6 +146,9 @@ describe('instrumentation-aws-sdk-v2', () => {
           'us-east-1'
         );
         expect(spanPutObject.name).toBe('S3.PutObject');
+        expect(
+          spanPutObject.attributes[SemanticAttributes.HTTP_STATUS_CODE]
+        ).toBe(200);
       });
 
       it('adds proper number of spans with correct attributes if both, promise and callback were used', async () => {
@@ -184,6 +197,9 @@ describe('instrumentation-aws-sdk-v2', () => {
         expect(spanPutObjectCb.attributes[AttributeNames.AWS_REGION]).toBe(
           'us-east-1'
         );
+        expect(
+          spanPutObjectCb.attributes[SemanticAttributes.HTTP_STATUS_CODE]
+        ).toBe(200);
       });
 
       it('adds proper number of spans with correct attributes if only promise was used', async () => {
@@ -219,6 +235,9 @@ describe('instrumentation-aws-sdk-v2', () => {
         expect(spanPutObjectCb.attributes[AttributeNames.AWS_REGION]).toBe(
           'us-east-1'
         );
+        expect(
+          spanPutObjectCb.attributes[SemanticAttributes.HTTP_STATUS_CODE]
+        ).toBe(200);
       });
 
       it('should create span if no callback is supplied', done => {
@@ -259,6 +278,9 @@ describe('instrumentation-aws-sdk-v2', () => {
         expect(spanCreateBucket.attributes[AttributeNames.AWS_ERROR]).toBe(
           responseMockWithError.error
         );
+        expect(
+          spanCreateBucket.attributes[SemanticAttributes.HTTP_STATUS_CODE]
+        ).toBe(400);
       });
     });
   });

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/aws-sdk-v3.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/aws-sdk-v3.test.ts
@@ -78,6 +78,7 @@ describe('instrumentation-aws-sdk-v3', () => {
       expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual('S3');
       expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
       expect(span.name).toEqual('S3.PutObject');
+      expect(span.attributes[SemanticAttributes.HTTP_STATUS_CODE]).toEqual(200);
     });
 
     it('callback interface', done => {
@@ -104,6 +105,9 @@ describe('instrumentation-aws-sdk-v3', () => {
         expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual('S3');
         expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
         expect(span.name).toEqual('S3.PutObject');
+        expect(span.attributes[SemanticAttributes.HTTP_STATUS_CODE]).toEqual(
+          200
+        );
         done();
       });
     });
@@ -131,6 +135,7 @@ describe('instrumentation-aws-sdk-v3', () => {
       expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual('S3');
       expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
       expect(span.name).toEqual('S3.PutObject');
+      expect(span.attributes[SemanticAttributes.HTTP_STATUS_CODE]).toEqual(200);
     });
 
     it('aws error', async () => {
@@ -315,6 +320,9 @@ describe('instrumentation-aws-sdk-v3', () => {
         expect(span.attributes[SemanticAttributes.MESSAGING_URL]).toEqual(
           params.QueueUrl
         );
+        expect(span.attributes[SemanticAttributes.HTTP_STATUS_CODE]).toEqual(
+          200
+        );
       });
 
       it('sqs receive add messaging attributes and context', done => {
@@ -352,6 +360,9 @@ describe('instrumentation-aws-sdk-v3', () => {
             .attributes;
           expect(attributes[SemanticAttributes.MESSAGING_OPERATION]).toMatch(
             MessagingOperationValues.RECEIVE
+          );
+          expect(span.attributes[SemanticAttributes.HTTP_STATUS_CODE]).toEqual(
+            200
           );
           done();
         });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->



## Short description of the changes

- Add `http.status_code` attribute, as discussed in Ruby repo
https://github.com/open-telemetry/opentelemetry-ruby/issues/1094
 
## Checklist

- [x] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
