### PR TITLE
fix(graphql): move graphql to dependencies

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-graphql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-graphql/package.json
@@ -53,7 +53,6 @@
     "@types/mocha": "8.2.3",
     "@types/node": "14.17.9",
     "codecov": "3.8.3",
-    "graphql": "15.5.1",
     "gts": "3.1.0",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
@@ -63,6 +62,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.27.0"
+    "@opentelemetry/instrumentation": "^0.27.0",
+    "graphql": "^15.5.1"
   }
 }


### PR DESCRIPTION
Fixes #802

Move graphql to dependencies in order to avoid a compilation failure during lib check (instrumentation imports graphql when it is not installed). This is affecting all users of the metapackage which installs the instrumentation but does not install graphql which it depends on.