### PR TITLE
chore(deps): update dependency @types/node to v16

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-alibaba-cloud/package.json
+++ b/detectors/node/opentelemetry-resource-detector-alibaba-cloud/package.json
@@ -47,7 +47,7 @@
     "@opentelemetry/api": "1.0.2",
     "@opentelemetry/contrib-test-utils": "^0.29.0",
     "@types/mocha": "8.2.3",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "@types/sinon": "10.0.2",
     "codecov": "3.8.3",
     "gts": "3.1.0",

--- a/detectors/node/opentelemetry-resource-detector-aws/package.json
+++ b/detectors/node/opentelemetry-resource-detector-aws/package.json
@@ -46,7 +46,7 @@
     "@opentelemetry/api": "1.0.2",
     "@opentelemetry/contrib-test-utils": "^0.29.0",
     "@types/mocha": "8.2.3",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "@types/sinon": "10.0.2",
     "codecov": "3.8.3",
     "gts": "3.1.0",

--- a/detectors/node/opentelemetry-resource-detector-gcp/package.json
+++ b/detectors/node/opentelemetry-resource-detector-gcp/package.json
@@ -47,7 +47,7 @@
     "@opentelemetry/contrib-test-utils": "^0.29.0",
     "@opentelemetry/core": "1.0.1",
     "@types/mocha": "8.2.3",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "@types/semver": "7.3.8",
     "codecov": "3.8.3",
     "gts": "3.1.0",

--- a/detectors/node/opentelemetry-resource-detector-github/package.json
+++ b/detectors/node/opentelemetry-resource-detector-github/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
     "@types/mocha": "8.2.3",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "@types/sinon": "10.0.2",
     "codecov": "3.8.3",
     "gts": "3.1.0",

--- a/metapackages/auto-instrumentations-node/package.json
+++ b/metapackages/auto-instrumentations-node/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "@types/sinon": "10.0.2",
     "codecov": "3.8.3",
     "gts": "3.1.0",

--- a/metapackages/auto-instrumentations-web/package.json
+++ b/metapackages/auto-instrumentations-web/package.json
@@ -35,7 +35,7 @@
     "@babel/core": "7.15.0",
     "@opentelemetry/api": "1.0.2",
     "@types/mocha": "8.2.3",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "@types/sinon": "10.0.2",
     "@types/webpack-env": "1.16.2",
     "babel-loader": "8.2.2",

--- a/packages/opentelemetry-host-metrics/package.json
+++ b/packages/opentelemetry-host-metrics/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
     "@types/mocha": "8.2.3",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "@types/sinon": "10.0.2",
     "codecov": "3.8.3",
     "gts": "3.1.0",

--- a/packages/opentelemetry-id-generator-aws-xray/package.json
+++ b/packages/opentelemetry-id-generator-aws-xray/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
     "@types/mocha": "8.2.3",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "@types/sinon": "10.0.2",
     "@types/webpack-env": "1.16.2",
     "codecov": "3.8.3",

--- a/packages/opentelemetry-propagation-utils/package.json
+++ b/packages/opentelemetry-propagation-utils/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.1",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "gts": "3.1.0",
     "typescript": "4.3.5"
   }

--- a/packages/opentelemetry-test-utils/package.json
+++ b/packages/opentelemetry-test-utils/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "gts": "3.1.0",
     "typescript": "4.3.5"
   },

--- a/plugins/node/instrumentation-tedious/package.json
+++ b/plugins/node/instrumentation-tedious/package.json
@@ -53,7 +53,7 @@
     "@opentelemetry/contrib-test-utils": "^0.29.0",
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "codecov": "3.8.3",
     "gts": "3.1.0",
     "mocha": "^7.2.0",

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
@@ -51,7 +51,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "codecov": "3.8.3",
     "colors": "1.4.0",
     "gts": "3.1.0",

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
@@ -60,7 +60,7 @@
     "@opentelemetry/api": "1.0.1",
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@types/mocha": "8.2.3",
-    "@types/node": "14.18.2",
+    "@types/node": "16.11.21",
     "@types/sinon": "10.0.6",
     "aws-sdk": "2.1008.0",
     "eslint": "7.32.0",

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/utils.ts
@@ -78,7 +78,10 @@ export const bindPromise = (
   rebindCount = 1
 ): Promise<any> => {
   const origThen = target.then;
-  target.then = function (onFulfilled, onRejected) {
+  target.then = function (
+    onFulfilled: (value: any) => any,
+    onRejected: (reason: any) => any
+  ) {
     const newOnFulfilled = context.bind(contextForCallbacks, onFulfilled);
     const newOnRejected = context.bind(contextForCallbacks, onRejected);
     const patchedPromise = origThen.call(this, newOnFulfilled, newOnRejected);

--- a/plugins/node/opentelemetry-instrumentation-bunyan/package.json
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/package.json
@@ -53,7 +53,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "@types/sinon": "10.0.2",
     "bunyan": "1.8.15",
     "codecov": "3.8.3",

--- a/plugins/node/opentelemetry-instrumentation-cassandra/package.json
+++ b/plugins/node/opentelemetry-instrumentation-cassandra/package.json
@@ -53,7 +53,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "@types/semver": "7.3.8",
     "@types/sinon": "10.0.2",
     "cassandra-driver": "4.6.3",

--- a/plugins/node/opentelemetry-instrumentation-connect/package.json
+++ b/plugins/node/opentelemetry-instrumentation-connect/package.json
@@ -50,7 +50,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.4",
+    "@types/node": "16.11.21",
     "codecov": "3.8.2",
     "connect": "3.7.0",
     "gts": "3.1.0",

--- a/plugins/node/opentelemetry-instrumentation-dns/package.json
+++ b/plugins/node/opentelemetry-instrumentation-dns/package.json
@@ -51,7 +51,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "@types/semver": "7.3.8",
     "@types/shimmer": "1.0.2",
     "@types/sinon": "10.0.2",

--- a/plugins/node/opentelemetry-instrumentation-express/package.json
+++ b/plugins/node/opentelemetry-instrumentation-express/package.json
@@ -52,7 +52,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "codecov": "3.8.3",
     "express": "4.17.1",
     "gts": "3.1.0",

--- a/plugins/node/opentelemetry-instrumentation-fastify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-fastify/package.json
@@ -52,7 +52,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@types/express": "4.17.13",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.4",
+    "@types/node": "16.11.21",
     "codecov": "3.8.2",
     "fastify-express": "0.3.3",
     "gts": "3.1.0",

--- a/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
+++ b/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
@@ -51,7 +51,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "@types/semver": "7.3.8",
     "codecov": "3.8.3",
     "generic-pool": "3.8.2",

--- a/plugins/node/opentelemetry-instrumentation-graphql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-graphql/package.json
@@ -51,7 +51,7 @@
     "@opentelemetry/api": "1.0.2",
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@types/mocha": "8.2.3",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "codecov": "3.8.3",
     "graphql": "15.5.1",
     "gts": "3.1.0",

--- a/plugins/node/opentelemetry-instrumentation-hapi/package.json
+++ b/plugins/node/opentelemetry-instrumentation-hapi/package.json
@@ -52,7 +52,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "codecov": "3.8.3",
     "gts": "3.1.0",
     "mocha": "7.2.0",

--- a/plugins/node/opentelemetry-instrumentation-ioredis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/package.json
@@ -57,7 +57,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "@types/sinon": "^10.0.6",
     "codecov": "3.8.3",
     "cross-env": "7.0.3",

--- a/plugins/node/opentelemetry-instrumentation-knex/package.json
+++ b/plugins/node/opentelemetry-instrumentation-knex/package.json
@@ -51,7 +51,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "codecov": "3.8.3",
     "gts": "3.1.0",
     "knex": "0.95.9",

--- a/plugins/node/opentelemetry-instrumentation-koa/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/package.json
@@ -55,7 +55,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "codecov": "3.8.3",
     "gts": "3.1.0",
     "koa": "2.13.1",

--- a/plugins/node/opentelemetry-instrumentation-memcached/package.json
+++ b/plugins/node/opentelemetry-instrumentation-memcached/package.json
@@ -54,7 +54,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "codecov": "3.8.3",
     "cross-env": "7.0.3",
     "gts": "3.1.0",

--- a/plugins/node/opentelemetry-instrumentation-mongodb/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/package.json
@@ -55,7 +55,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "codecov": "3.8.3",
     "gts": "3.1.0",
     "mocha": "7.2.0",

--- a/plugins/node/opentelemetry-instrumentation-mysql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql/package.json
@@ -51,7 +51,7 @@
     "@opentelemetry/contrib-test-utils": "^0.29.0",
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "codecov": "3.8.3",
     "gts": "3.1.0",
     "mocha": "7.2.0",

--- a/plugins/node/opentelemetry-instrumentation-mysql2/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/package.json
@@ -53,7 +53,7 @@
     "@opentelemetry/contrib-test-utils": "^0.29.0",
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "codecov": "3.8.3",
     "gts": "3.1.0",
     "mocha": "7.2.0",

--- a/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
+++ b/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
@@ -59,7 +59,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.6",
+    "@types/node": "16.11.21",
     "@types/semver": "7.3.8",
     "@types/vinyl-fs": "2.4.12",
     "codecov": "3.8.3",

--- a/plugins/node/opentelemetry-instrumentation-net/package.json
+++ b/plugins/node/opentelemetry-instrumentation-net/package.json
@@ -51,7 +51,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "@types/sinon": "10.0.2",
     "codecov": "3.8.3",
     "gts": "3.1.0",

--- a/plugins/node/opentelemetry-instrumentation-pg/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pg/package.json
@@ -60,7 +60,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "codecov": "3.8.3",
     "cross-env": "7.0.3",
     "gts": "3.1.0",

--- a/plugins/node/opentelemetry-instrumentation-pino/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pino/package.json
@@ -53,7 +53,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "@types/semver": "7.3.8",
     "@types/sinon": "10.0.2",
     "codecov": "3.8.3",

--- a/plugins/node/opentelemetry-instrumentation-redis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis/package.json
@@ -56,7 +56,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "codecov": "3.8.3",
     "cross-env": "7.0.3",
     "gts": "3.1.0",

--- a/plugins/node/opentelemetry-instrumentation-restify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-restify/package.json
@@ -51,7 +51,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "codecov": "3.8.3",
     "gts": "3.1.0",
     "mocha": "7.2.0",

--- a/plugins/node/opentelemetry-instrumentation-router/package.json
+++ b/plugins/node/opentelemetry-instrumentation-router/package.json
@@ -51,7 +51,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "codecov": "3.8.3",
     "gts": "3.1.0",
     "mocha": "7.2.0",

--- a/plugins/node/opentelemetry-instrumentation-winston/package.json
+++ b/plugins/node/opentelemetry-instrumentation-winston/package.json
@@ -53,7 +53,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@opentelemetry/sdk-trace-node": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "@types/sinon": "10.0.2",
     "codecov": "3.8.3",
     "colors": "1.4.0",

--- a/plugins/web/opentelemetry-instrumentation-document-load/package.json
+++ b/plugins/web/opentelemetry-instrumentation-document-load/package.json
@@ -54,7 +54,7 @@
     "@babel/core": "7.15.0",
     "@opentelemetry/api": "1.0.2",
     "@types/mocha": "8.2.3",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "@types/sinon": "10.0.2",
     "@types/webpack-env": "1.16.2",
     "babel-loader": "8.2.2",

--- a/plugins/web/opentelemetry-instrumentation-long-task/package.json
+++ b/plugins/web/opentelemetry-instrumentation-long-task/package.json
@@ -53,7 +53,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@types/jquery": "3.5.6",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "@types/sinon": "10.0.2",
     "@types/webpack-env": "1.16.2",
     "babel-loader": "8.2.2",

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
@@ -55,7 +55,7 @@
     "@opentelemetry/sdk-trace-base": "1.0.1",
     "@types/jquery": "3.5.6",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "@types/sinon": "10.0.2",
     "@types/webpack-env": "1.16.2",
     "babel-loader": "8.2.2",

--- a/plugins/web/opentelemetry-plugin-react-load/package.json
+++ b/plugins/web/opentelemetry-plugin-react-load/package.json
@@ -52,7 +52,7 @@
     "@opentelemetry/api": "1.0.2",
     "@opentelemetry/propagator-b3": "1.0.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "@types/react": "17.0.16",
     "@types/react-addons-test-utils": "0.14.26",
     "@types/react-dom": "17.0.9",

--- a/propagators/opentelemetry-propagator-aws-xray/package.json
+++ b/propagators/opentelemetry-propagator-aws-xray/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
     "@types/mocha": "8.2.3",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "@types/webpack-env": "1.16.2",
     "codecov": "3.8.3",
     "colors": "1.4.0",

--- a/propagators/opentelemetry-propagator-grpc-census-binary/package.json
+++ b/propagators/opentelemetry-propagator-grpc-census-binary/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
     "@types/mocha": "7.0.2",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "codecov": "3.8.3",
     "grpc": "1.24.11",
     "gts": "3.1.0",

--- a/propagators/opentelemetry-propagator-ot-trace/package.json
+++ b/propagators/opentelemetry-propagator-ot-trace/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
     "@types/mocha": "8.2.3",
-    "@types/node": "14.17.9",
+    "@types/node": "16.11.21",
     "@types/webpack-env": "1.16.2",
     "codecov": "3.8.3",
     "colors": "1.4.0",


### PR DESCRIPTION
This is the same as #718 with an attempt to fix the failing CI jobs

Changes:
- Added more types on aws-sdk's `bindPromise` function. This function will be removed once the new messaging systems semantic conventions are released (along with other refactors to the SQS instrumentation)