### PR TITLE
feat: support using lambda context in the aws lambda context extractor

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/README.md
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/README.md
@@ -51,7 +51,7 @@ In your Lambda function configuration, add or update the `NODE_OPTIONS` environm
 | `requestHook` | `RequestHook` (function) | Hook for adding custom attributes before lambda starts handling the request. Receives params: `span, { event, context }` |
 | `responseHook` | `ResponseHook` (function) | Hook for adding custom attributes before lambda returns the response. Receives params: `span, { err?, res? }` |
 | `disableAwsContextPropagation` | `boolean` | By default, this instrumentation will try to read the context from the `_X_AMZN_TRACE_ID` environment variable set by Lambda, set this to `true` to disable this behavior |
-| `eventContextExtractor` | `EventContextExtractor` (function) | Function for providing custom context extractor in order to support different event types that are handled by AWS Lambda (e.g., SQS, CloudWatch, Kinesis, API Gateway). Applied only when `disableAwsContextPropagation` is set to `true`. Receives params: `event` |
+| `eventContextExtractor` | `EventContextExtractor` (function) | Function for providing custom context extractor in order to support different event types that are handled by AWS Lambda (e.g., SQS, CloudWatch, Kinesis, API Gateway). Applied only when `disableAwsContextPropagation` is set to `true`. Receives params: `event, context` |
 
 ### Hooks Usage Example
 

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -156,6 +156,7 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
       const config = plugin._config;
       const parent = AwsLambdaInstrumentation._determineParent(
         event,
+        context,
         config.disableAwsContextPropagation === true,
         config.eventContextExtractor ||
           AwsLambdaInstrumentation._defaultEventContextExtractor
@@ -331,6 +332,7 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
 
   private static _determineParent(
     event: any,
+    context: Context,
     disableAwsContextPropagation: boolean,
     eventContextExtractor: EventContextExtractor
   ): OtelContext {
@@ -358,7 +360,7 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
       }
     }
     const extractedContext = safeExecuteInTheMiddle(
-      () => eventContextExtractor(event),
+      () => eventContextExtractor(event, context),
       e => {
         if (e)
           diag.error(

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/types.ts
@@ -33,7 +33,10 @@ export type ResponseHook = (
   }
 ) => void;
 
-export type EventContextExtractor = (event: any) => OtelContext;
+export type EventContextExtractor = (
+  event: any,
+  context: Context
+) => OtelContext;
 export interface AwsLambdaInstrumentationConfig extends InstrumentationConfig {
   requestHook?: RequestHook;
   responseHook?: ResponseHook;


### PR DESCRIPTION
## Which problem is this PR solving?
Implements feat #855 - it exposes the lambda context object to the custom event extractor to allow this to carry context.

## Short description of the changes

- Changes the signature of the eventContextExtractor to add context as a second argument
- Passes this through in via _determineParent
- Updates tests and README

## Checklist
- [x ] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
