### PR TITLE
fix: update eslint-plugin-import to resolve conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint": "8.7.0",
     "eslint-config-airbnb-base": "15.0.0",
     "eslint-plugin-header": "3.1.1",
-    "eslint-plugin-import": "2.23.4",
+    "eslint-plugin-import": "2.25.4",
     "gts": "3.1.0",
     "husky": "7.0.4",
     "lerna": "3.22.1",

--- a/packages/opentelemetry-browser-extension-autoinjection/package.json
+++ b/packages/opentelemetry-browser-extension-autoinjection/package.json
@@ -42,7 +42,7 @@
     "eslint": "8.7.0",
     "eslint-config-airbnb-base": "15.0.0",
     "eslint-plugin-header": "3.1.1",
-    "eslint-plugin-import": "2.23.4",
+    "eslint-plugin-import": "2.25.4",
     "eslint-plugin-json5": "0.1.3",
     "gts": "3.1.0",
     "html-webpack-plugin": "5.3.2",


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- When installing dependencies using `yarn` from the root folder, I got the following error:
```
lerna ERR! npm install exited 1 in '@opentelemetry/browser-extension-autoinjection'
lerna ERR! npm install stderr:
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: @opentelemetry/browser-extension-autoinjection@0.27.2
npm ERR! Found: eslint@8.7.0
npm ERR! node_modules/eslint
npm ERR!   dev eslint@"8.7.0" from the root project
npm ERR!   peer eslint@"^7.32.0 || ^8.2.0" from eslint-config-airbnb-base@15.0.0
npm ERR!   node_modules/eslint-config-airbnb-base
npm ERR!     dev eslint-config-airbnb-base@"15.0.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer eslint@"^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0" from eslint-plugin-import@2.23.4
npm ERR! node_modules/eslint-plugin-import
npm ERR!   dev eslint-plugin-import@"2.23.4" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /Users/yaniv/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/yaniv/.npm/_logs/2022-02-01T10_39_56_013Z-debug.log

lerna ERR! npm install exited 1 in '@opentelemetry/browser-extension-autoinjection'
lerna WARN complete Waiting for 7 child processes to exit. CTRL-C to exit immediately.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

Env:
```
yarn v1.22.17
node v16.13.1
npm v8.1.2
```

- In this PR, I updated `eslint-plugin-import` package to version `2.25.4`, which resolve the issue.

