### PR TITLE
fix(browser-extension-autoinjection): update eslint-plugin-json5 version to 0.1.4 

### DIFF
--- a/packages/opentelemetry-browser-extension-autoinjection/package.json
+++ b/packages/opentelemetry-browser-extension-autoinjection/package.json
@@ -43,7 +43,7 @@
     "eslint-config-airbnb-base": "15.0.0",
     "eslint-plugin-header": "3.1.1",
     "eslint-plugin-import": "2.25.4",
-    "eslint-plugin-json5": "0.1.3",
+    "eslint-plugin-json5": "0.1.4",
     "gts": "3.1.0",
     "html-webpack-plugin": "5.3.2",
     "jimp": "0.16.1",


### PR DESCRIPTION
update eslint-plugin-json5 to 0.1.4 which support eslint v8
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

This problem: which happened when I 'npm install' from root


lerna info versioning independent
lerna info Bootstrapping 45 packages
lerna info Installing external dependencies
lerna ERR! npm install exited 1 in '@opentelemetry/browser-extension-autoinjection'
lerna ERR! npm install stderr:
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: @opentelemetry/browser-extension-autoinjection@0.27.3
npm ERR! Found: eslint@8.7.0
npm ERR! node_modules/eslint
npm ERR!   dev eslint@"8.7.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer eslint@"^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" from eslint-plugin-json5@0.1.3
npm ERR! node_modules/eslint-plugin-json5
npm ERR!   dev eslint-plugin-json5@"0.1.3" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.


## Short description of the changes

I updated the 'eslint-plugin-json5' version to be 0.1.4
This version supports eslint v8.

## Checklist

- [ ] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
