### PR TITLE
fix(documentation): mixed up winston readme for hook

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-winston/README.md
+++ b/plugins/node/opentelemetry-instrumentation-winston/README.md
@@ -30,7 +30,7 @@ registerInstrumentations({
     new WinstonInstrumentation({
       // Optional hook to insert additional context to log metadata.
       // Called after trace context is injected to metadata.
-      logHook: (record, span) => {
+      logHook: (span, record) => {
         record['resource.service.name'] = provider.resource.attributes['service.name'];
       },
     }),


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #870 

## Short description of the changes

Updates README to flip in the example for the log hook. The source code has it as a span and then record for args. 

## Checklist

- [:heavy_check_mark:  ] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
