### PR TITLE
chore(aws-sdk): fix npm install on windows

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
@@ -33,7 +33,7 @@
     "compile": "npm run version:update && tsc -p .",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope $(npm pkg get name) --include-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-aws-sdk --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "tdd": "npm run test -- --watch-extensions ts --watch",


### PR DESCRIPTION
## Which problem is this PR solving?

- `npm install` fails on windows

## Short description of the changes

- follow convention that is used in the other modules to hardcode the scope instead of using `$(npm pkg get name)`
