### PR TITLE
chore: use db.system constants from semantic-conventions package

### DIFF
--- a/plugins/node/instrumentation-tedious/test/instrumentation.test.ts
+++ b/plugins/node/instrumentation-tedious/test/instrumentation.test.ts
@@ -16,7 +16,10 @@
 
 import { context, trace, SpanStatusCode, SpanKind } from '@opentelemetry/api';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  DbSystemValues,
+  SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 import * as util from 'util';
 import * as testUtils from '@opentelemetry/contrib-test-utils';
 import {
@@ -334,7 +337,10 @@ function assertSpan(span: ReadableSpan, expected: any) {
   assert(span);
   assert.strictEqual(span.name, expected.name);
   assert.strictEqual(span.kind, SpanKind.CLIENT);
-  assert.strictEqual(span.attributes[SemanticAttributes.DB_SYSTEM], 'mssql');
+  assert.strictEqual(
+    span.attributes[SemanticAttributes.DB_SYSTEM],
+    DbSystemValues.MSSQL
+  );
   assert.strictEqual(
     span.attributes[SemanticAttributes.DB_NAME],
     expected.database ?? database

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/dynamodb.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/dynamodb.ts
@@ -15,7 +15,10 @@
  */
 import { Span, SpanKind, Tracer } from '@opentelemetry/api';
 import { RequestMetadata, ServiceExtension } from './ServiceExtension';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  DbSystemValues,
+  SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 import {
   AwsSdkInstrumentationConfig,
   NormalizedRequest,
@@ -30,7 +33,7 @@ export class DynamodbServiceExtension implements ServiceExtension {
     const operation = normalizedRequest.commandName;
 
     const spanAttributes = {
-      [SemanticAttributes.DB_SYSTEM]: 'dynamodb',
+      [SemanticAttributes.DB_SYSTEM]: DbSystemValues.DYNAMODB,
       [SemanticAttributes.DB_NAME]: normalizedRequest.commandInput?.TableName,
       [SemanticAttributes.DB_OPERATION]: operation,
       [SemanticAttributes.DB_STATEMENT]: JSON.stringify(

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/dynamodb.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/dynamodb.test.ts
@@ -23,7 +23,10 @@ import * as AWS from 'aws-sdk';
 import { AWSError } from 'aws-sdk';
 
 import { mockV2AwsSend } from './testing-utils';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  DbSystemValues,
+  SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 import * as expect from 'expect';
 import type { ConsumedCapacity as ConsumedCapacityV2 } from 'aws-sdk/clients/dynamodb';
 import type { ConsumedCapacity as ConsumedCapacityV3 } from '@aws-sdk/client-dynamodb';
@@ -73,7 +76,9 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SemanticAttributes.DB_SYSTEM]).toStrictEqual('dynamodb');
+          expect(attrs[SemanticAttributes.DB_SYSTEM]).toStrictEqual(
+            DbSystemValues.DYNAMODB
+          );
           expect(attrs[SemanticAttributes.DB_NAME]).toStrictEqual('test-table');
           expect(attrs[SemanticAttributes.DB_OPERATION]).toStrictEqual('Query');
           expect(
@@ -120,7 +125,9 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SemanticAttributes.DB_SYSTEM]).toStrictEqual('dynamodb');
+          expect(attrs[SemanticAttributes.DB_SYSTEM]).toStrictEqual(
+            DbSystemValues.DYNAMODB
+          );
           expect(attrs[SemanticAttributes.DB_OPERATION]).toStrictEqual(
             'BatchGetItem'
           );
@@ -165,7 +172,9 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SemanticAttributes.DB_SYSTEM]).toStrictEqual('dynamodb');
+          expect(attrs[SemanticAttributes.DB_SYSTEM]).toStrictEqual(
+            DbSystemValues.DYNAMODB
+          );
           expect(attrs[SemanticAttributes.DB_OPERATION]).toStrictEqual(
             'BatchGetItem'
           );

--- a/plugins/node/opentelemetry-instrumentation-ioredis/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/src/instrumentation.ts
@@ -22,7 +22,10 @@ import {
   isWrapped,
 } from '@opentelemetry/instrumentation';
 import { IORedisInstrumentationConfig, IORedisCommand } from './types';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  DbSystemValues,
+  SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 import { safeExecuteInTheMiddle } from '@opentelemetry/instrumentation';
 import { endSpan, defaultDbStatementSerializer } from './utils';
 import { VERSION } from './version';
@@ -34,8 +37,6 @@ const DEFAULT_CONFIG: IORedisInstrumentationConfig = {
 export class IORedisInstrumentation extends InstrumentationBase<
   typeof ioredisTypes
 > {
-  static readonly DB_SYSTEM = 'redis';
-
   constructor(_config: IORedisInstrumentationConfig = {}) {
     super(
       '@opentelemetry/instrumentation-ioredis',
@@ -113,7 +114,7 @@ export class IORedisInstrumentation extends InstrumentationBase<
       const span = instrumentation.tracer.startSpan(cmd.name, {
         kind: SpanKind.CLIENT,
         attributes: {
-          [SemanticAttributes.DB_SYSTEM]: IORedisInstrumentation.DB_SYSTEM,
+          [SemanticAttributes.DB_SYSTEM]: DbSystemValues.REDIS,
           [SemanticAttributes.DB_STATEMENT]: dbStatementSerializer(
             cmd.name,
             cmd.args
@@ -186,7 +187,7 @@ export class IORedisInstrumentation extends InstrumentationBase<
       const span = instrumentation.tracer.startSpan('connect', {
         kind: SpanKind.CLIENT,
         attributes: {
-          [SemanticAttributes.DB_SYSTEM]: IORedisInstrumentation.DB_SYSTEM,
+          [SemanticAttributes.DB_SYSTEM]: DbSystemValues.REDIS,
           [SemanticAttributes.DB_STATEMENT]: 'connect',
         },
       });

--- a/plugins/node/opentelemetry-instrumentation-ioredis/test/ioredis.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/test/ioredis.test.ts
@@ -39,7 +39,10 @@ import {
   DbStatementSerializer,
   IORedisRequestHookInformation,
 } from '../src/types';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  DbSystemValues,
+  SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 
 const memoryExporter = new InMemorySpanExporter();
 
@@ -51,7 +54,7 @@ const CONFIG = {
 const URL = `redis://${CONFIG.host}:${CONFIG.port}`;
 
 const DEFAULT_ATTRIBUTES = {
-  [SemanticAttributes.DB_SYSTEM]: IORedisInstrumentation.DB_SYSTEM,
+  [SemanticAttributes.DB_SYSTEM]: DbSystemValues.REDIS,
   [SemanticAttributes.NET_PEER_NAME]: CONFIG.host,
   [SemanticAttributes.NET_PEER_PORT]: CONFIG.port,
   [SemanticAttributes.NET_PEER_IP]: URL,

--- a/plugins/node/opentelemetry-instrumentation-knex/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-knex/src/utils.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { DbSystemValues } from '@opentelemetry/semantic-conventions';
+
 type Exception = {
   new (message: string): Exception;
   constructor: Exception;
@@ -50,8 +52,8 @@ export const cloneErrorWithNewMessage = (err: Exception, message: string) => {
 };
 
 const systemMap = new Map([
-  ['sqlite3', 'sqlite'],
-  ['pg', 'postgresql'],
+  ['sqlite3', DbSystemValues.SQLITE],
+  ['pg', DbSystemValues.POSTGRESQL],
 ]);
 export const mapSystem = (knexSystem: string) => {
   return systemMap.get(knexSystem) || knexSystem;

--- a/plugins/node/opentelemetry-instrumentation-memcached/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-memcached/src/instrumentation.ts
@@ -21,7 +21,10 @@ import {
   InstrumentationNodeModuleDefinition,
 } from '@opentelemetry/instrumentation';
 import type * as Memcached from 'memcached';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  DbSystemValues,
+  SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 import * as utils from './utils';
 import { InstrumentationConfig } from './types';
 import { VERSION } from './version';
@@ -29,7 +32,7 @@ import { VERSION } from './version';
 export class Instrumentation extends InstrumentationBase<typeof Memcached> {
   static readonly COMPONENT = 'memcached';
   static readonly COMMON_ATTRIBUTES = {
-    [SemanticAttributes.DB_SYSTEM]: Instrumentation.COMPONENT,
+    [SemanticAttributes.DB_SYSTEM]: DbSystemValues.MEMCACHED,
   };
   static readonly DEFAULT_CONFIG: InstrumentationConfig = {
     enhancedDatabaseReporting: false,

--- a/plugins/node/opentelemetry-instrumentation-memcached/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-memcached/test/index.test.ts
@@ -25,7 +25,10 @@ import {
 import type * as Memcached from 'memcached';
 import * as assert from 'assert';
 import Instrumentation from '../src';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  DbSystemValues,
+  SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 import * as util from 'util';
 
 const instrumentation = new Instrumentation();
@@ -37,7 +40,7 @@ const CONFIG = {
 };
 
 const DEFAULT_ATTRIBUTES = {
-  [SemanticAttributes.DB_SYSTEM]: Instrumentation.COMPONENT,
+  [SemanticAttributes.DB_SYSTEM]: DbSystemValues.MEMCACHED,
   [SemanticAttributes.NET_PEER_NAME]: CONFIG.host,
   [SemanticAttributes.NET_PEER_PORT]: CONFIG.port,
 };

--- a/plugins/node/opentelemetry-instrumentation-mongodb/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/src/instrumentation.ts
@@ -29,7 +29,10 @@ import {
   isWrapped,
   safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  DbSystemValues,
+  SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 import type * as mongodb from 'mongodb';
 import {
   CursorState,
@@ -563,7 +566,7 @@ export class MongoDBInstrumentation extends InstrumentationBase<
   ) {
     // add database related attributes
     span.setAttributes({
-      [SemanticAttributes.DB_SYSTEM]: 'mongodb',
+      [SemanticAttributes.DB_SYSTEM]: DbSystemValues.MONGODB,
       [SemanticAttributes.DB_NAME]: dbName,
       [SemanticAttributes.DB_MONGODB_COLLECTION]: dbCollection,
     });

--- a/plugins/node/opentelemetry-instrumentation-mysql/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql/src/instrumentation.ts
@@ -26,7 +26,10 @@ import {
   InstrumentationNodeModuleDefinition,
   isWrapped,
 } from '@opentelemetry/instrumentation';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  DbSystemValues,
+  SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 import type * as mysqlTypes from 'mysql';
 import { MySQLInstrumentationConfig } from './types';
 import { getConnectionAttributes, getDbStatement, getSpanName } from './utils';
@@ -44,7 +47,7 @@ export class MySQLInstrumentation extends InstrumentationBase<
 > {
   static readonly COMPONENT = 'mysql';
   static readonly COMMON_ATTRIBUTES = {
-    [SemanticAttributes.DB_SYSTEM]: MySQLInstrumentation.COMPONENT,
+    [SemanticAttributes.DB_SYSTEM]: DbSystemValues.MYSQL,
   };
 
   constructor(config?: MySQLInstrumentationConfig) {

--- a/plugins/node/opentelemetry-instrumentation-mysql/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql/src/instrumentation.ts
@@ -45,7 +45,6 @@ type getConnectionCallbackType = (
 export class MySQLInstrumentation extends InstrumentationBase<
   typeof mysqlTypes
 > {
-  static readonly COMPONENT = 'mysql';
   static readonly COMMON_ATTRIBUTES = {
     [SemanticAttributes.DB_SYSTEM]: DbSystemValues.MYSQL,
   };

--- a/plugins/node/opentelemetry-instrumentation-mysql/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql/test/index.test.ts
@@ -16,7 +16,10 @@
 
 import { context, trace, SpanStatusCode } from '@opentelemetry/api';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  DbSystemValues,
+  SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 import * as testUtils from '@opentelemetry/contrib-test-utils';
 import {
   BasicTracerProvider,
@@ -716,7 +719,10 @@ function assertSpan(
   values?: any,
   errorMessage?: string
 ) {
-  assert.strictEqual(span.attributes[SemanticAttributes.DB_SYSTEM], 'mysql');
+  assert.strictEqual(
+    span.attributes[SemanticAttributes.DB_SYSTEM],
+    DbSystemValues.MYSQL
+  );
   assert.strictEqual(span.attributes[SemanticAttributes.DB_NAME], database);
   assert.strictEqual(span.attributes[SemanticAttributes.NET_PEER_PORT], port);
   assert.strictEqual(span.attributes[SemanticAttributes.NET_PEER_NAME], host);

--- a/plugins/node/opentelemetry-instrumentation-mysql2/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/src/instrumentation.ts
@@ -39,7 +39,6 @@ type formatType = typeof mysqlTypes.format;
 export class MySQL2Instrumentation extends InstrumentationBase<
   typeof mysqlTypes
 > {
-  static readonly COMPONENT = 'mysql';
   static readonly COMMON_ATTRIBUTES = {
     [SemanticAttributes.DB_SYSTEM]: DbSystemValues.MYSQL,
   };

--- a/plugins/node/opentelemetry-instrumentation-mysql2/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/src/instrumentation.ts
@@ -20,7 +20,10 @@ import {
   InstrumentationNodeModuleDefinition,
   isWrapped,
 } from '@opentelemetry/instrumentation';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  DbSystemValues,
+  SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 import type * as mysqlTypes from 'mysql2';
 import { MySQL2InstrumentationConfig } from './types';
 import {
@@ -38,7 +41,7 @@ export class MySQL2Instrumentation extends InstrumentationBase<
 > {
   static readonly COMPONENT = 'mysql';
   static readonly COMMON_ATTRIBUTES = {
-    [SemanticAttributes.DB_SYSTEM]: MySQL2Instrumentation.COMPONENT,
+    [SemanticAttributes.DB_SYSTEM]: DbSystemValues.MYSQL,
   };
 
   constructor(config?: MySQL2InstrumentationConfig) {

--- a/plugins/node/opentelemetry-instrumentation-mysql2/test/mysql.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/test/mysql.test.ts
@@ -17,7 +17,10 @@
 import * as semver from 'semver';
 import { context, trace, SpanStatusCode } from '@opentelemetry/api';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  DbSystemValues,
+  SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 import * as testUtils from '@opentelemetry/contrib-test-utils';
 import {
   BasicTracerProvider,
@@ -652,7 +655,10 @@ function assertSpan(
   values?: any,
   errorMessage?: string
 ) {
-  assert.strictEqual(span.attributes[SemanticAttributes.DB_SYSTEM], 'mysql');
+  assert.strictEqual(
+    span.attributes[SemanticAttributes.DB_SYSTEM],
+    DbSystemValues.MYSQL
+  );
   assert.strictEqual(span.attributes[SemanticAttributes.DB_NAME], database);
   assert.strictEqual(span.attributes[SemanticAttributes.NET_PEER_PORT], port);
   assert.strictEqual(span.attributes[SemanticAttributes.NET_PEER_NAME], host);

--- a/plugins/node/opentelemetry-instrumentation-redis/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-redis/src/utils.ts
@@ -32,7 +32,10 @@ import {
 } from './types';
 import { EventEmitter } from 'events';
 import { RedisInstrumentation } from './';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  DbSystemValues,
+  SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 import { safeExecuteInTheMiddle } from '@opentelemetry/instrumentation';
 
 const endSpan = (span: Span, err?: Error | null) => {
@@ -102,7 +105,7 @@ export const getTracedInternalSendCommand = (
       {
         kind: SpanKind.CLIENT,
         attributes: {
-          [SemanticAttributes.DB_SYSTEM]: RedisInstrumentation.COMPONENT,
+          [SemanticAttributes.DB_SYSTEM]: DbSystemValues.REDIS,
           [SemanticAttributes.DB_STATEMENT]: dbStatementSerializer(
             cmd.command,
             cmd.args

--- a/plugins/node/opentelemetry-instrumentation-redis/test/redis.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-redis/test/redis.test.ts
@@ -31,7 +31,10 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 import * as assert from 'assert';
 import { RedisInstrumentation } from '../src';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  DbSystemValues,
+  SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 
 const instrumentation = new RedisInstrumentation();
 instrumentation.enable();
@@ -50,7 +53,7 @@ const CONFIG = {
 const URL = `redis://${CONFIG.host}:${CONFIG.port}`;
 
 const DEFAULT_ATTRIBUTES = {
-  [SemanticAttributes.DB_SYSTEM]: RedisInstrumentation.COMPONENT,
+  [SemanticAttributes.DB_SYSTEM]: DbSystemValues.REDIS,
   [SemanticAttributes.NET_PEER_NAME]: CONFIG.host,
   [SemanticAttributes.NET_PEER_PORT]: CONFIG.port,
   [SemanticAttributes.NET_PEER_IP]: URL,


### PR DESCRIPTION
## Which problem is this PR solving?

- DbSystemValues constants were used in some places but not in others

## Short description of the changes

- use DbSystemValues everywhere for `db.system` attribute values
