### PR TITLE
chore: use MessagingOperationValues constants

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sqs.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sqs.ts
@@ -32,6 +32,7 @@ import {
 } from '../types';
 import {
   MessagingDestinationKindValues,
+  MessagingOperationValues,
   SemanticAttributes,
 } from '@opentelemetry/semantic-conventions';
 import {
@@ -63,7 +64,8 @@ export class SqsServiceExtension implements ServiceExtension {
           isIncoming = true;
           spanKind = SpanKind.CONSUMER;
           spanName = `${queueName} receive`;
-          spanAttributes[SemanticAttributes.MESSAGING_OPERATION] = 'receive';
+          spanAttributes[SemanticAttributes.MESSAGING_OPERATION] =
+            MessagingOperationValues.RECEIVE;
 
           request.commandInput.MessageAttributeNames = (
             request.commandInput.MessageAttributeNames ?? []
@@ -145,7 +147,8 @@ export class SqsServiceExtension implements ServiceExtension {
               MessagingDestinationKindValues.QUEUE,
             [SemanticAttributes.MESSAGING_MESSAGE_ID]: message.MessageId,
             [SemanticAttributes.MESSAGING_URL]: queueUrl,
-            [SemanticAttributes.MESSAGING_OPERATION]: 'process',
+            [SemanticAttributes.MESSAGING_OPERATION]:
+              MessagingOperationValues.PROCESS,
           },
         }),
         processHook: (span: Span, message: SQS.Message) =>

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/sqs.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/sqs.test.ts
@@ -24,7 +24,10 @@ const instrumentation = registerInstrumentationTesting(
 import * as AWS from 'aws-sdk';
 import { AWSError } from 'aws-sdk';
 
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  MessagingOperationValues,
+  SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
 import {
   context,
   SpanKind,
@@ -171,12 +174,16 @@ describe('SQS', () => {
       numChildPerProcessSpan: number
     ) => {
       const awsReceiveSpan = spans.filter(
-        s => s.attributes[SemanticAttributes.MESSAGING_OPERATION] === 'receive'
+        s =>
+          s.attributes[SemanticAttributes.MESSAGING_OPERATION] ===
+          MessagingOperationValues.RECEIVE
       );
       expect(awsReceiveSpan.length).toBe(1);
 
       const processSpans = spans.filter(
-        s => s.attributes[SemanticAttributes.MESSAGING_OPERATION] === 'process'
+        s =>
+          s.attributes[SemanticAttributes.MESSAGING_OPERATION] ===
+          MessagingOperationValues.PROCESS
       );
       expect(processSpans.length).toBe(2);
       expect(processSpans[0].parentSpanId).toStrictEqual(
@@ -380,7 +387,9 @@ describe('SQS', () => {
       );
 
       const processSpans = getTestSpans().filter(
-        s => s.attributes[SemanticAttributes.MESSAGING_OPERATION] === 'process'
+        s =>
+          s.attributes[SemanticAttributes.MESSAGING_OPERATION] ===
+          MessagingOperationValues.PROCESS
       );
       expect(processSpans.length).toBe(2);
       expect(
@@ -402,7 +411,9 @@ describe('SQS', () => {
         message => 'some mapping to create child process spans'
       );
       const processSpans = getTestSpans().filter(
-        s => s.attributes[SemanticAttributes.MESSAGING_OPERATION] === 'process'
+        s =>
+          s.attributes[SemanticAttributes.MESSAGING_OPERATION] ===
+          MessagingOperationValues.PROCESS
       );
       expect(processSpans.length).toBe(2);
     });
@@ -429,7 +440,9 @@ describe('SQS', () => {
       );
 
       const processSpans = getTestSpans().filter(
-        s => s.attributes[SemanticAttributes.MESSAGING_OPERATION] === 'process'
+        s =>
+          s.attributes[SemanticAttributes.MESSAGING_OPERATION] ===
+          MessagingOperationValues.PROCESS
       );
       expect(processSpans.length).toBe(2);
       expect(processSpans[0].status.code).toStrictEqual(SpanStatusCode.UNSET);


### PR DESCRIPTION
## Which problem is this PR solving?

- `messaging.operation` attribute values were not taking advantage of the constants defined in the semantic-conventions package

## Short description of the changes

- use MessagingOperationValues constants everywhere for `messaging.operation` attribute values