### PR TITLE
feat: add mysql2 responsehook

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-mysql2/README.md
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/README.md
@@ -43,6 +43,14 @@ registerInstrumentations({
 })
 ```
 
+### MySQL2 Instrumentation Options
+
+You can set the following instrumentation options:
+
+| Options | Type | Description |
+| ------- | ---- | ----------- |
+| `responseHook` | `MySQL2InstrumentationExecutionResponseHook` (function) | Function for adding custom attributes from db response |
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/plugins/node/opentelemetry-instrumentation-mysql2/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/src/instrumentation.ts
@@ -107,12 +107,18 @@ export class MySQL2Instrumentation extends InstrumentationBase<
             ),
           },
         });
-        const endSpan = once((err?: any) => {
+        const endSpan = once((err?: any, results?: any) => {
           if (err) {
             span.setStatus({
               code: api.SpanStatusCode.ERROR,
               message: err.message,
             });
+          } else if (results) {
+            try {
+              span.setAttribute('db.query_result', JSON.stringify(results));
+            } catch (err) {
+              // Do nothing
+            }
           }
           span.end();
         });

--- a/plugins/node/opentelemetry-instrumentation-mysql2/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/src/instrumentation.ts
@@ -119,7 +119,7 @@ export class MySQL2Instrumentation extends InstrumentationBase<
             if (typeof config.responseHook === 'function') {
               safeExecuteInTheMiddle(
                 () => {
-                  config.responseHook!(span, results);
+                  config.responseHook!(span, { queryResults: results });
                 },
                 err => {
                   if (err) {

--- a/plugins/node/opentelemetry-instrumentation-mysql2/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/src/types.ts
@@ -15,5 +15,18 @@
  */
 
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import type { Span } from '@opentelemetry/api';
 
-export type MySQL2InstrumentationConfig = InstrumentationConfig;
+export interface MySQL2InstrumentationExecutionResponseHook {
+  (span: Span, queryResults: any): void;
+}
+
+export interface MySQL2InstrumentationConfig extends InstrumentationConfig {
+  /**
+   * Hook that allows adding custom span attributes based on the data
+   * returned MySQL2 queries.
+   *
+   * @default undefined
+   */
+  responseHook?: MySQL2InstrumentationExecutionResponseHook;
+}

--- a/plugins/node/opentelemetry-instrumentation-mysql2/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/src/types.ts
@@ -17,8 +17,12 @@
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import type { Span } from '@opentelemetry/api';
 
+export interface MySQL2ResponseHookInformation {
+  queryResults: any;
+}
+
 export interface MySQL2InstrumentationExecutionResponseHook {
-  (span: Span, queryResults: any): void;
+  (span: Span, responseHookInfo: MySQL2ResponseHookInformation): void;
 }
 
 export interface MySQL2InstrumentationConfig extends InstrumentationConfig {

--- a/plugins/node/opentelemetry-instrumentation-mysql2/test/mysql.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/test/mysql.test.ts
@@ -657,7 +657,7 @@ describe('mysql@2.x', () => {
         instrumentation.disable();
         instrumentation.setTracerProvider(provider);
         const config: MySQL2InstrumentationConfig = {
-          responseHook: (span, queryResults) => {
+          responseHook: (span, responseHookInfo) => {
             throw new Error('random failure!');
           },
         };
@@ -684,10 +684,10 @@ describe('mysql@2.x', () => {
         instrumentation.disable();
         instrumentation.setTracerProvider(provider);
         const config: MySQL2InstrumentationConfig = {
-          responseHook: (span, queryResults) => {
+          responseHook: (span, responseHookInfo) => {
             span.setAttribute(
               queryResultAttribute,
-              JSON.stringify(queryResults)
+              JSON.stringify(responseHookInfo.queryResults)
             );
           },
         };

--- a/plugins/node/opentelemetry-instrumentation-mysql2/test/mysql.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/test/mysql.test.ts
@@ -26,7 +26,7 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 import * as assert from 'assert';
-import { MySQL2Instrumentation } from '../src';
+import { MySQL2Instrumentation, MySQL2InstrumentationConfig } from '../src';
 
 const LIB_VERSION = testUtils.getPackageVersion('mysql2');
 const port = Number(process.env.MYSQL_PORT) || 33306;
@@ -642,6 +642,126 @@ describe('mysql@2.x', () => {
           });
         }
       );
+    });
+  });
+
+  describe('#responseHook', () => {
+    const queryResultAttribute = 'query_result';
+
+    after(() => {
+      instrumentation.setConfig({});
+    });
+
+    describe('invalid repsonse hook', () => {
+      before(() => {
+        instrumentation.disable();
+        instrumentation.setTracerProvider(provider);
+        const config: MySQL2InstrumentationConfig = {
+          responseHook: (span, queryResults) => {
+            throw new Error('random failure!');
+          },
+        };
+        instrumentation.setConfig(config);
+        instrumentation.enable();
+      });
+
+      it('should not affect the behavior of the query', done => {
+        const span = provider.getTracer('default').startSpan('test span');
+        context.with(trace.setSpan(context.active(), span), () => {
+          const sql = 'SELECT 1+1 as solution';
+          connection.query(sql, (err, res: mysqlTypes.RowDataPacket[]) => {
+            assert.ifError(err);
+            assert.ok(res);
+            assert.strictEqual(res[0].solution, 2);
+            done();
+          });
+        });
+      });
+    });
+
+    describe('valid response hook', () => {
+      before(() => {
+        instrumentation.disable();
+        instrumentation.setTracerProvider(provider);
+        const config: MySQL2InstrumentationConfig = {
+          responseHook: (span, queryResults) => {
+            span.setAttribute(
+              queryResultAttribute,
+              JSON.stringify(queryResults)
+            );
+          },
+        };
+        instrumentation.setConfig(config);
+        instrumentation.enable();
+      });
+
+      it('should extract data from responseHook - connection', done => {
+        const span = provider.getTracer('default').startSpan('test span');
+        context.with(trace.setSpan(context.active(), span), () => {
+          const sql = 'SELECT 1+1 as solution';
+          connection.query(sql, (err, res: mysqlTypes.RowDataPacket[]) => {
+            assert.ifError(err);
+            assert.ok(res);
+            assert.strictEqual(res[0].solution, 2);
+            const spans = memoryExporter.getFinishedSpans();
+            assert.strictEqual(spans.length, 1);
+            assertSpan(spans[0], sql);
+            assert.strictEqual(
+              spans[0].attributes[queryResultAttribute],
+              JSON.stringify(res)
+            );
+            done();
+          });
+        });
+      });
+
+      it('should extract data from responseHook - pool', done => {
+        const span = provider.getTracer('default').startSpan('test span');
+        context.with(trace.setSpan(context.active(), span), () => {
+          const sql = 'SELECT 1+1 as solution';
+          pool.getConnection((err, conn) => {
+            conn.query(sql, (err, res: mysqlTypes.RowDataPacket[]) => {
+              assert.ifError(err);
+              assert.ok(res);
+              assert.strictEqual(res[0].solution, 2);
+              const spans = memoryExporter.getFinishedSpans();
+              assert.strictEqual(spans.length, 1);
+              assertSpan(spans[0], sql);
+              assert.strictEqual(
+                spans[0].attributes[queryResultAttribute],
+                JSON.stringify(res)
+              );
+              done();
+            });
+          });
+        });
+      });
+
+      it('should extract data from responseHook - poolCluster', done => {
+        poolCluster.getConnection((err, poolClusterConnection) => {
+          assert.ifError(err);
+          const span = provider.getTracer('default').startSpan('test span');
+          context.with(trace.setSpan(context.active(), span), () => {
+            const sql = 'SELECT 1+1 as solution';
+            poolClusterConnection.query(
+              sql,
+              (err, res: mysqlTypes.RowDataPacket[]) => {
+                assert.ifError(err);
+                assert.ok(res);
+                assert.strictEqual(res[0].solution, 2);
+                const spans = memoryExporter.getFinishedSpans();
+                assert.strictEqual(spans.length, 1);
+                assertSpan(spans[0], sql);
+                assert.strictEqual(
+                  spans[0].attributes[queryResultAttribute],
+                  JSON.stringify(res)
+                );
+                done();
+              }
+            );
+          });
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?

- Adding support for a `responseHook`, that enables collecting the query result.

## Short description of the changes

- Add a `responseHook` config, and add tests to verify its behavior.

## Checklist

- [ ] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
