### PR TITLE
docs(redis): update readme supported versions

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-redis/README.md
+++ b/plugins/node/opentelemetry-instrumentation-redis/README.md
@@ -20,7 +20,7 @@ npm install --save @opentelemetry/instrumentation-redis
 
 ### Supported Versions
 
-- `>=2.6.0`
+- `^2.6.0 || ^3.0.0` (version `4` is not yet supported)
 
 ## Usage
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- The readme states redis instrumentation support versions `>=2.6.0` which includes version 4. But in the code version 4 is not supported, not patched and not tested. 

## Short description of the changes

- redis instrumentation - updated supported versions. documented v4 is not supported yet.

## Checklist

- [ ] ~~Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.~~
