### PR TITLE
fix: avoid leaking winston types

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-winston/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-winston/src/instrumentation.ts
@@ -29,13 +29,13 @@ import {
   isWrapped,
   safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
-import {
-  WinstonInstrumentationConfig,
+import type { WinstonInstrumentationConfig } from './types';
+import type {
   Winston2LogMethod,
   Winston2LoggerModule,
   Winston3LogMethod,
   Winston3Logger,
-} from './types';
+} from './internal-types';
 import { VERSION } from './version';
 
 const winston3Versions = ['>=3 <4'];

--- a/plugins/node/opentelemetry-instrumentation-winston/src/internal-types.ts
+++ b/plugins/node/opentelemetry-instrumentation-winston/src/internal-types.ts
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-import { Span } from '@opentelemetry/api';
-import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import type { Logger as Winston3Logger } from 'winston';
+import type {
+  LoggerInstance as Winston2Logger,
+  LogMethod as Winston2LogMethod,
+} from 'winston2';
+export type Winston3LogMethod = Winston3Logger['write'];
+export type { Winston3Logger };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type LogHookFunction = (span: Span, record: Record<string, any>) => void;
-
-export interface WinstonInstrumentationConfig extends InstrumentationConfig {
-  logHook?: LogHookFunction;
-}
+export type { Winston2LogMethod };
+export type Winston2LoggerModule = {
+  Logger: Winston2Logger & { prototype: { log: Winston2LogMethod } };
+};
+export type { Winston2Logger };

--- a/plugins/node/opentelemetry-instrumentation-winston/test/winston.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-winston/test/winston.test.ts
@@ -25,7 +25,7 @@ import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { Writable } from 'stream';
-import type { Winston2Logger, Winston3Logger } from '../src/types';
+import type { Winston2Logger, Winston3Logger } from '../src/internal-types';
 import { WinstonInstrumentation } from '../src';
 
 const memoryExporter = new InMemorySpanExporter();


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #925

## Short description of the changes

The winston instrumentation needs the winston types only internaly.
Move them into an internal file to avoid leaking it to end user.

## Checklist

- [x] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
