### PR TITLE
chore: add fs to release config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,6 +16,7 @@
     "packages/opentelemetry-id-generator-aws-xray": {},
     "packages/opentelemetry-propagation-utils": {},
     "packages/opentelemetry-test-utils": {},
+    "plugins/node/instrumentation-fs": {},
     "plugins/node/instrumentation-tedious": {},
     "plugins/node/opentelemetry-instrumentation-aws-lambda": {},
     "plugins/node/opentelemetry-instrumentation-aws-sdk": {},


### PR DESCRIPTION
fs instrumentation release is skipped in #929 because it is missing from the config