### PR TITLE
fix(amqplib): add missing rabbit service to CI daily run

### DIFF
--- a/.github/workflows/test-all-versions.yml
+++ b/.github/workflows/test-all-versions.yml
@@ -87,6 +87,13 @@ jobs:
         image: bitnami/cassandra:3
         ports:
         - 9042:9042
+      rabbitmq:
+        image: rabbitmq:3
+        ports:
+        - 22221:5672
+        env:
+          RABBITMQ_DEFAULT_USER: username
+          RABBITMQ_DEFAULT_PASS: password
     env:
       RUN_CASSANDRA_TESTS: 1
       RUN_MEMCACHED_TESTS: 1

--- a/.github/workflows/test-all-versions.yml
+++ b/.github/workflows/test-all-versions.yml
@@ -22,6 +22,7 @@ jobs:
               --ignore @opentelemetry/instrumentation-aws-sdk
               --ignore @opentelemetry/instrumentation-pino
               --ignore @opentelemetry/instrumentation-tedious
+              --ignore @opentelemetry/instrumentation-amqplib
           - node: "10"
             lerna-extra-args: >-
               --ignore @opentelemetry/instrumentation-pino

--- a/plugins/node/instrumentation-amqplib/package.json
+++ b/plugins/node/instrumentation-amqplib/package.json
@@ -32,7 +32,7 @@
     "compile": "npm run version:update && tsc -p .",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "precompile": "tsc --version && lerna run version --scope $(npm pkg get name) --include-dependencies",
+    "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-amqplib --include-dependencies",
     "prewatch": "npm run precompile",
     "prepare": "npm run compile",
     "tdd": "npm run test -- --watch-extensions ts --watch",


### PR DESCRIPTION

## Which problem is this PR solving?

- after amqplib is merged, the daily run of `test-all-versions` fails because I added the service only to `unit-test.yml` and forgot to add it to `test-all-versions.yml`.

## Short description of the changes

- add the required rabbitmq service also to `test-all-versions.yml`. This should fix the CI.

## Checklist

- [x] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
