### PR TITLE
fix: drop running amqplib tests on node 8 and add rabbit service for TAV

### DIFF
--- a/.github/workflows/test-all-versions.yml
+++ b/.github/workflows/test-all-versions.yml
@@ -22,6 +22,7 @@ jobs:
               --ignore @opentelemetry/instrumentation-aws-sdk
               --ignore @opentelemetry/instrumentation-pino
               --ignore @opentelemetry/instrumentation-tedious
+              --ignore @opentelemetry/instrumentation-amqplib
           - node: "10"
             lerna-extra-args: >-
               --ignore @opentelemetry/instrumentation-pino


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

CI is failing because of TAV runs of amqplib.

## Short description of the changes

- skip on node 8
- add rabbitmq service
