### PR TITLE
chore: skip peer checking on packages that look like examples

### DIFF
--- a/scripts/peer-api-check.js
+++ b/scripts/peer-api-check.js
@@ -21,6 +21,12 @@ const appRoot = process.cwd();
 const packageJsonUrl = path.resolve(`${appRoot}/package.json`);
 const pjson = require(packageJsonUrl);
 
+const isExample = pjson.private && /-example$/.test(pjson.name);
+
+if (isExample) {
+  return console.log(`Skipping checking ${pjson.name} because it's an example`);
+}
+
 if (pjson.dependencies && pjson.dependencies['@opentelemetry/api']) {
   throw new Error(`Package ${pjson.name} depends on API but it should be a peer dependency`);
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

https://github.com/open-telemetry/opentelemetry-js-contrib/pull/939 is failing because of the peer check.
It's an useful check, but should not be run on examples.

## Short description of the changes

Instead of excluding example packages one-by-one in CI scripts, created a special case in the checking script to skip enforcing this.
