### PR TITLE
fix: remove forcing RUN_MSSQL_TESTS to be true in tests

### DIFF
--- a/plugins/node/instrumentation-tedious/test/instrumentation.test.ts
+++ b/plugins/node/instrumentation-tedious/test/instrumentation.test.ts
@@ -33,8 +33,6 @@ import { TediousInstrumentation } from '../src';
 import makeApi from './api';
 import type { Connection, ConnectionConfig } from 'tedious';
 
-process.env.RUN_MSSQL_TESTS = 'true';
-
 const port = Number(process.env.MSSQL_PORT) || 1433;
 const database = process.env.MSSQL_DATABASE || 'master';
 const host = process.env.MSSQL_HOST || '127.0.0.1';


### PR DESCRIPTION
## Which problem is this PR solving?

Someone(khm...) has left a typo into the tests forcing MSSQL test always to be run.
