### PR TITLE
fix: don't try to shut cassandra client down if it wasn't initialized

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-cassandra/test/cassandra-driver.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-cassandra/test/cassandra-driver.test.ts
@@ -165,7 +165,7 @@ describe('CassandraDriverInstrumentation', () => {
 
   after(async function () {
     this.timeout(60000);
-    await client.shutdown();
+    await client?.shutdown?.();
     if (testCassandraLocally) {
       testUtils.cleanUpDocker('cassandra');
     }


### PR DESCRIPTION
## Which problem is this PR solving?

Tests fail if Cassandra tests which require an external service to be running are not run.

## Short description of the changes

Add conditional shut down to avoid running methods on uninitialized var.
