### PR TITLE
feat: send log level to pino hook

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-pino/README.md
+++ b/plugins/node/opentelemetry-instrumentation-pino/README.md
@@ -27,7 +27,7 @@ registerInstrumentations({
   instrumentations: [
     new PinoInstrumentation({
       // Optional hook to insert additional context to log object.
-      logHook: (span, record) => {
+      logHook: (span, record, level) => {
         record['resource.service.name'] = provider.resource.attributes['service.name'];
       },
     }),

--- a/plugins/node/opentelemetry-instrumentation-pino/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pino/package.json
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.27.0",
-    "pino": "7.2.0",
+    "pino": "7.10.0",
     "semver": "^7.3.5"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-pino/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-pino/src/types.ts
@@ -19,7 +19,11 @@ import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import type { pino } from 'pino';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type LogHookFunction = (span: Span, record: Record<string, any>) => void;
+export type LogHookFunction = (
+  span: Span,
+  record: Record<string, any>,
+  level?: number
+) => void;
 
 export interface PinoInstrumentationConfig extends InstrumentationConfig {
   logHook?: LogHookFunction;

--- a/plugins/node/opentelemetry-instrumentation-pino/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-pino/src/types.ts
@@ -22,7 +22,7 @@ import type { pino } from 'pino';
 export type LogHookFunction = (
   span: Span,
   record: Record<string, any>,
-  level?: number
+  level?: number // Available in pino >= 7.9.0
 ) => void;
 
 export interface PinoInstrumentationConfig extends InstrumentationConfig {

--- a/plugins/node/opentelemetry-instrumentation-pino/test/pino.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pino/test/pino.test.ts
@@ -24,6 +24,7 @@ import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import { Writable } from 'stream';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
+import * as semver from 'semver';
 import type { pino as Pino } from 'pino';
 
 import { PinoInstrumentation } from '../src';
@@ -112,8 +113,11 @@ describe('PinoInstrumentation', () => {
       const span = tracer.startSpan('abc');
       instrumentation.setConfig({
         enabled: true,
-        logHook: (_span, record) => {
+        logHook: (_span, record, level) => {
           record['resource.service.name'] = 'test-service';
+          if (semver.compare(pino.version, '7.9.0') >= 0) {
+            assert.strictEqual(level, 30);
+          }
         },
       });
       context.with(trace.setSpan(context.active(), span), () => {

--- a/plugins/node/opentelemetry-instrumentation-pino/test/pino.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pino/test/pino.test.ts
@@ -115,7 +115,7 @@ describe('PinoInstrumentation', () => {
         enabled: true,
         logHook: (_span, record, level) => {
           record['resource.service.name'] = 'test-service';
-          if (semver.compare(pino.version, '7.9.0') >= 0) {
+          if (semver.satisfies(pino.version, '>= 7.9.0')) {
             assert.strictEqual(level, 30);
           }
         },


### PR DESCRIPTION
## Which problem is this PR solving?

- The log level isn't available in the config hook (it was added to the mixin function since v7.9.0)

## Short description of the changes

- Propagate the log level to the hook

## Checklist

- [x] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
