### PR TITLE
feat: use Koa router name as span name if available

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-koa/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/src/instrumentation.ts
@@ -175,6 +175,9 @@ export class KoaInstrumentation extends InstrumentationBase<typeof koa> {
           span.recordException(err);
           throw err;
         } finally {
+          if (context._matchedRouteName) {
+            span.updateName(context._matchedRouteName);
+          }
           span.end();
         }
       });

--- a/plugins/node/opentelemetry-instrumentation-koa/test/koa.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/test/koa.test.ts
@@ -135,7 +135,7 @@ describe('Koa Instrumentation', () => {
       );
 
       const router = new KoaRouter();
-      router.get('/post/:id', ctx => {
+      router.get('insertOperation', '/post/:id', ctx => {
         ctx.body = `Post id: ${ctx.params.id}`;
       });
 
@@ -150,7 +150,7 @@ describe('Koa Instrumentation', () => {
           assert.deepStrictEqual(memoryExporter.getFinishedSpans().length, 2);
           const requestHandlerSpan = memoryExporter
             .getFinishedSpans()
-            .find(span => span.name.includes('router - /post/:id'));
+            .find(span => span.name === 'insertOperation');
           assert.notStrictEqual(requestHandlerSpan, undefined);
 
           assert.strictEqual(


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- This allows to use the Koa router name (if available) as the span name. Usually this name is more meaningful than "method + path". In particular if the route name is the same as the OpenAPI's `operationId` for that route then it will be easier to associate spans with the OpenAPI spec.  

## Short description of the changes

- Koa will store the route name in `_matchedRouteName`. Note that I'm not using the format `router - xxx` as I'd rather have the span name clean.

## Checklist

- [ ] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
NPM failed to compile on the untouched `main` branch (some type errors related to React)