### PR TITLE
fix: remove link to browser extension to external repo.

### DIFF
--- a/packages/opentelemetry-browser-extension-autoinjection/README.md
+++ b/packages/opentelemetry-browser-extension-autoinjection/README.md
@@ -14,14 +14,6 @@ Compatible with OpenTelemetry JS API and SDK `1.0+`.
 
 ## Installation
 
-### from Download
-
-* Go to [Releases](https://github.com/svrnm/opentelemetry-browser-extension/releases) and download the latest opentelemetry-browser-extension-<version>-<mv2|mv3>.zip from Assets.
-* Unzip that file locally
-* Open a new browser window and go to chrome://extensions
-* Turn on "Developer Mode"
-* Click on "Load unpacked" and the select the folder, where the unzipped extension lives.
-
 ### from Source
 
 Run the following in your shell to download and build the extension from source:


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes #905, this removes a link to my repository that contains old versions of the extension

## Short description of the changes
Remove a section from README.md

## Checklist
Only a change for a md file, no code changes

## Additional comments
There are releases of the extension at [Releases](https://github.com/open-telemetry/opentelemetry-js-contrib/releases?q=browser-extension-autoinjection&expanded=true), however they only contain the source code, what changes do I need to apply to have the extension build and put there similar to [here](https://github.com/svrnm/opentelemetry-browser-extension/releases), i.e. the two builds for manifest version 1 & 2 as zip files for people to use.

Side Note: there is also the option to publish those extension on https://chrome.google.com/webstore/category/extensions and https://addons.mozilla.org/de/firefox/, making it easy for people to install the extension (and quickly get started with OpenTelemetry where ever they are)