### PR TITLE
[WIP] feat(user-interaction): create one span per interaction

### DIFF
--- a/plugins/web/opentelemetry-instrumentation-user-interaction/src/UserInteractionZoneSpec.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/src/UserInteractionZoneSpec.ts
@@ -1,0 +1,185 @@
+import type { Span } from '@opentelemetry/api';
+import type { UserInteractionAggregates, UserInteractionEvents } from './types';
+
+type OnCompleteCallback = (
+  attributes: UserInteractionAggregates,
+  events: UserInteractionEvents
+) => void;
+type OnErrorCallback = (error: Error) => void;
+
+export class UserInteractionZoneSpec implements ZoneSpec {
+  name = 'UserInteractionZone';
+  properties: { span: Span };
+
+  // interaction state
+  private completed = false;
+  private count = 0;
+  private unresolvedCount = 0;
+
+  // interaction metrics
+  //// span attributes
+  private attributes: UserInteractionAggregates = {
+    listenerCount: 0,
+    scheduledTaskCount: 0,
+    cancelledTaskCount: 0,
+    ranTaskCount: 0,
+  };
+
+  //// span events
+  private events: UserInteractionEvents = {
+    processingStart: 0, // the time when the browser is able to begin processing event handlers
+    processingEnd: 0, // the time when the browser finishes exeucting all sync code initiated from event handlers
+  };
+
+  constructor(
+    span: Span,
+    onComplete: OnCompleteCallback,
+    onError: OnErrorCallback
+  ) {
+    this.properties = { span };
+    this.onComplete = onComplete;
+    this.onError = onError;
+  }
+
+  /**
+   * Callback passed into UserInteractionZun.run(), and will be inherited by child zones
+   * in terms of this instrumentation, that is when an event listener callback fires.
+   *
+   * Intercepts when a new zone is entered.
+   */
+  onInvoke(
+    parentZoneDelegate: ZoneDelegate,
+    current: Zone,
+    target: Zone,
+    delegate: Function,
+    applyThis: any,
+    applyArgs?: any[],
+    source?: string
+  ) {
+    // current === target is true only when intercepting "root" UserInteractionZone
+    if (current === target) {
+      try {
+        // this.printDebugInfo('root::onInvoke');
+        this.attributes.listenerCount++;
+        // if executing in the UserInteractionZone, capture earliest processingStart for sync work timing
+        if (!this.events.processingStart)
+          this.events.processingStart = performance.now();
+        return parentZoneDelegate.invoke(
+          target,
+          delegate,
+          applyThis,
+          applyArgs
+        );
+      } finally {
+        // continually update processingEnd (in case of multiple listeners) with latest timestamp to record end of sync work
+        this.events.processingEnd = performance.now();
+      }
+    }
+
+    // if a child zone is invoking a Promise.then callback and there are pending unresolved promises, decrease unresolvedCount
+    // TODO: compare by reference rather than naively assuming the promises resolve
+    const task = Zone.currentTask;
+    if (
+      task?.source === 'Promise.then' &&
+      task?.state === 'running' &&
+      this.unresolvedCount > 0
+    ) {
+      this.unresolvedCount--;
+    }
+
+    const ret = parentZoneDelegate.invoke(
+      target,
+      delegate,
+      applyThis,
+      applyArgs
+    );
+
+    // Increase unresolvedCount if any child zone.run() callback returns a Promise ("thenable").
+    // This is necessary to capture unresolved promise chains within event listeners,
+    // since the next macro task will be scheduled once all sync work is complete.
+    // This enables capture of async work that occurs within event handlers, such as data fetches or timers.
+    if (ret && ret.then) this.unresolvedCount++;
+    return ret;
+  }
+
+  // setTimeout
+  onScheduleTask(
+    delegate: ZoneDelegate,
+    current: Zone,
+    target: Zone,
+    task: Task
+  ) {
+    if (task.type === 'eventTask' || task.data?.isPeriodic || this.completed) {
+      return delegate.scheduleTask(target, task);
+    }
+
+    this.count++;
+    this.attributes.scheduledTaskCount++;
+    return delegate.scheduleTask(target, task);
+  }
+
+  // clearTimeout, when setTimeout finishes
+  onInvokeTask(
+    delegate: ZoneDelegate,
+    current: Zone,
+    target: Zone,
+    task: Task,
+    applyThis: any,
+    applyArgs: any
+  ) {
+    if (task.type === 'eventTask' || task.data?.isPeriodic || this.completed) {
+      return delegate.invokeTask(target, task, applyThis, applyArgs);
+    }
+
+    this.count--;
+    this.attributes.ranTaskCount++;
+    return delegate.invokeTask(target, task, applyThis, applyArgs);
+  }
+
+  onCancelTask(
+    delegate: ZoneDelegate,
+    current: Zone,
+    target: Zone,
+    task: Task
+  ) {
+    this.attributes.cancelledTaskCount++;
+    console.log('onCancelTask', this.count, this.unresolvedCount);
+    return delegate.cancelTask(target, task);
+  }
+
+  onHasTask(
+    delegate: ZoneDelegate,
+    current: Zone,
+    target: Zone,
+    hasTaskState: HasTaskState
+  ) {
+    delegate.hasTask(target, hasTaskState);
+
+    // skip onHasTask for child zones to prevent double checking
+    if (current !== target) {
+      return;
+    }
+
+    if (this.count === 0 && this.unresolvedCount === 0 && !this.completed) {
+      target.run(() => {
+        this.completed = true;
+        this.onComplete(this.attributes, this.events);
+      });
+    }
+  }
+
+  onHandleError(
+    delegate: ZoneDelegate,
+    current: Zone,
+    target: Zone,
+    error: any
+  ) {
+    target.run(() => this.onError(error));
+    return delegate.handleError(target, error);
+  }
+  // hook for when interaction completes
+  public onComplete(_attributes: any, _events: any) {}
+
+  // hook for when error occurs during interaction
+  public onError(_error: Error) {}
+}

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/src/enums/AttributeNames.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/src/enums/AttributeNames.ts
@@ -15,11 +15,18 @@
  */
 
 export enum AttributeNames {
-  COMPONENT = 'component',
+  // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions
+  INSTRUMENTATION_NAME = 'otel.scope.version',
+  INSTRUMENTATION_VERSION = 'otel.scope.version',
+  HTTP_URL = 'http.url',
+  HTTP_USER_AGENT = 'http.user_agent',
+
+  // NOT ON OFFICIAL SPEC
   EVENT_TYPE = 'event_type',
   TARGET_ELEMENT = 'target_element',
   TARGET_XPATH = 'target_xpath',
-  HTTP_URL = 'http.url',
-  // NOT ON OFFICIAL SPEC
-  HTTP_USER_AGENT = 'http.user_agent',
+  LISTENERS_COUNT = 'listeners.count',
+  TASKS_SCHEDULED_COUNT = 'tasks.scheduled.count',
+  TASKS_RAN_COUNT = 'tasks.ran.count',
+  TASKS_CANCELLED_COUNT = 'tasks.cancelled.count',
 }

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/src/enums/AttributeNames.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/src/enums/AttributeNames.ts
@@ -16,7 +16,7 @@
 
 export enum AttributeNames {
   // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions
-  INSTRUMENTATION_NAME = 'otel.scope.version',
+  INSTRUMENTATION_NAME = 'otel.scope.name',
   INSTRUMENTATION_VERSION = 'otel.scope.version',
   HTTP_URL = 'http.url',
   HTTP_USER_AGENT = 'http.user_agent',

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/src/instrumentation.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/src/instrumentation.ts
@@ -17,194 +17,218 @@
 import { isWrapped, InstrumentationBase } from '@opentelemetry/instrumentation';
 
 import * as api from '@opentelemetry/api';
-import { hrTime } from '@opentelemetry/core';
+import { isTracingSuppressed } from '@opentelemetry/core';
 import { getElementXPath } from '@opentelemetry/sdk-trace-web';
+import { UserInteractionZoneSpec } from './UserInteractionZoneSpec';
 import { AttributeNames } from './enums/AttributeNames';
-import {
-  AsyncTask,
-  EventName,
-  RunTaskFunction,
-  ShouldPreventSpanCreation,
-  SpanData,
-  UserInteractionInstrumentationConfig,
-  WindowWithZone,
-  ZoneTypeWithPrototype,
-} from './types';
+import { EventName, UserInteractionInstrumentationConfig } from './types';
 import { VERSION } from './version';
 
-const ZONE_CONTEXT_KEY = 'OT_ZONE_CONTEXT';
 const EVENT_NAVIGATION_NAME = 'Navigation:';
 const DEFAULT_EVENT_NAMES: EventName[] = ['click'];
-
-function defaultShouldPreventSpanCreation() {
-  return false;
-}
 
 /**
  * This class represents a UserInteraction plugin for auto instrumentation.
  * If zone.js is available then it patches the zone otherwise it patches
  * addEventListener of HTMLElement
  */
-export class UserInteractionInstrumentation extends InstrumentationBase<unknown> {
-  readonly component: string = 'user-interaction';
-  readonly version = VERSION;
-  moduleName = this.component;
-  private _spansData = new WeakMap<api.Span, SpanData>();
+export class UserInteractionInstrumentation extends InstrumentationBase<typeof window.addEventListener> {
+  static readonly component: string = 'user-interaction';
+
   private _zonePatched?: boolean;
+  private _eventNames: Set<EventName>;
+
   // for addEventListener/removeEventListener state
   private _wrappedListeners = new WeakMap<
     Function | EventListenerObject,
     Map<string, Map<HTMLElement, Function>>
   >();
-  // for event bubbling
-  private _eventsSpanMap: WeakMap<Event, api.Span> = new WeakMap<
-    Event,
-    api.Span
-  >();
-  private _eventNames: Set<EventName>;
-  private _shouldPreventSpanCreation: ShouldPreventSpanCreation;
 
-  constructor(config?: UserInteractionInstrumentationConfig) {
-    super('@opentelemetry/instrumentation-user-interaction', VERSION, config);
-    this._eventNames = new Set(config?.eventNames ?? DEFAULT_EVENT_NAMES);
-    this._shouldPreventSpanCreation =
-      typeof config?.shouldPreventSpanCreation === 'function'
-        ? config.shouldPreventSpanCreation
-        : defaultShouldPreventSpanCreation;
+  // stores reference to active Zone if in use, and the active Span otherwise
+  private _activeInteractionContexts: WeakMap<Event, Zone | api.Span> =
+    new WeakMap();
+
+  constructor(config: UserInteractionInstrumentationConfig = {}) {
+    super('@opentelemetry/instrumentation-user-interaction', VERSION, { ...config });
+    this._eventNames = new Set(config.eventNames ?? DEFAULT_EVENT_NAMES);
   }
 
   init() {}
 
   /**
-   * This will check if last task was timeout and will save the time to
-   * fix the user interaction when nothing happens
-   * This timeout comes from xhr plugin which is needed to collect information
-   * about last xhr main request from observer
-   * @param task
-   * @param span
-   */
-  private _checkForTimeout(task: AsyncTask, span: api.Span) {
-    const spanData = this._spansData.get(span);
-    if (spanData) {
-      if (task.source === 'setTimeout') {
-        spanData.hrTimeLastTimeout = hrTime();
-      } else if (
-        task.source !== 'Promise.then' &&
-        task.source !== 'setTimeout'
-      ) {
-        spanData.hrTimeLastTimeout = undefined;
-      }
-    }
-  }
-
-  /**
    * Controls whether or not to create a span, based on the event type.
    */
-  protected _allowEventName(eventName: EventName): boolean {
+  private _allowEventName(eventName: EventName): boolean {
     return this._eventNames.has(eventName);
   }
 
-  /**
-   * Creates a new span
-   * @param element
-   * @param eventName
-   */
-  private _createSpan(
-    element: EventTarget | null | undefined,
-    eventName: EventName,
-    parentSpan?: api.Span | undefined
-  ): api.Span | undefined {
-    if (!(element instanceof HTMLElement)) {
-      return undefined;
-    }
-    if (!element.getAttribute) {
-      return undefined;
-    }
-    if (element.hasAttribute('disabled')) {
-      return undefined;
-    }
-    if (!this._allowEventName(eventName)) {
-      return undefined;
-    }
-    const xpath = getElementXPath(element, true);
-    try {
-      const span = this.tracer.startSpan(
-        eventName,
-        {
-          attributes: {
-            [AttributeNames.COMPONENT]: this.component,
-            [AttributeNames.EVENT_TYPE]: eventName,
-            [AttributeNames.TARGET_ELEMENT]: element.tagName,
-            [AttributeNames.TARGET_XPATH]: xpath,
-            [AttributeNames.HTTP_URL]: window.location.href,
-            [AttributeNames.HTTP_USER_AGENT]: navigator.userAgent,
-          },
-        },
-        parentSpan
-          ? api.trace.setSpan(api.context.active(), parentSpan)
-          : undefined
-      );
-
-      if (this._shouldPreventSpanCreation(eventName, element, span) === true) {
-        return undefined;
-      }
-
-      this._spansData.set(span, {
-        taskCount: 0,
-      });
-
-      return span;
-    } catch (e) {
-      api.diag.error(this.component, e);
-    }
-    return undefined;
-  }
-
-  /**
-   * Decrement number of tasks that left in zone,
-   * This is needed to be able to end span when no more tasks left
-   * @param span
-   */
-  private _decrementTask(span: api.Span) {
-    const spanData = this._spansData.get(span);
-    if (spanData) {
-      spanData.taskCount--;
-      if (spanData.taskCount === 0) {
-        this._tryToEndSpan(span, spanData.hrTimeLastTimeout);
-      }
+  // utility method to deal with the Function|EventListener nature of addEventListener
+  private _invokeListener(
+    listener: EventListener | EventListenerObject,
+    target: EventTarget,
+    event: Event
+  ): any {
+    if (typeof listener === 'function') {
+      return listener.call(target, event);
+    } else {
+      return listener.handleEvent.call(target, event);
     }
   }
 
   /**
-   * Return the current span
-   * @param zone
-   * @private
+   * This patches the addEventListener of HTMLElement to be able to
+   * auto instrument the click events
    */
-  private _getCurrentSpan(zone: Zone): api.Span | undefined {
-    const context: api.Context | undefined = zone.get(ZONE_CONTEXT_KEY);
-    if (context) {
-      return api.trace.getSpan(context);
-    }
-    return context;
+  private _patchAddEventListener() {
+    const plugin = this;
+    return (original: EventTarget['addEventListener']) => {
+      return function addEventListenerPatched(
+        this: HTMLElement,
+        type: keyof HTMLElementEventMap,
+        listener: EventListenerOrEventListenerObject | null,
+        options?: boolean | AddEventListenerOptions
+      ) {
+        if (
+          !listener ||
+          !plugin._allowEventName(type) ||
+          isTracingSuppressed(api.context.active())
+        ) {
+          return original.call(this, type, listener, options);
+        }
+
+        const element = this;
+        const patchedListener = function (event: Event) {
+          let span: api.Span;
+          let activeInteractionContext =
+            plugin._activeInteractionContexts.get(event);
+
+          if (!activeInteractionContext) {
+            // create active listener span
+            span = plugin.tracer.startSpan(type, {
+              startTime: event.timeStamp,
+              attributes: {
+                [AttributeNames.INSTRUMENTATION_NAME]: plugin.instrumentationName,
+                [AttributeNames.INSTRUMENTATION_VERSION]: plugin.instrumentationVersion,
+                [AttributeNames.EVENT_TYPE]: type,
+                [AttributeNames.TARGET_ELEMENT]: element.tagName,
+                [AttributeNames.TARGET_XPATH]: getElementXPath(element, true),
+                [AttributeNames.HTTP_URL]: window.location.href,
+                [AttributeNames.HTTP_USER_AGENT]: navigator.userAgent,
+              },
+            });
+
+            if (plugin._zonePatched) {
+              // create a new zone for listener for given target
+              activeInteractionContext = Zone.current.fork(
+                new UserInteractionZoneSpec(
+                  span,
+                  function onComplete(attributes, events) {
+                    console.log('onComplete', event);
+                    span.setAttributes({
+                      [AttributeNames.LISTENERS_COUNT]: attributes.listenerCount,
+                      [AttributeNames.TASKS_SCHEDULED_COUNT]: attributes.scheduledTaskCount,
+                      [AttributeNames.TASKS_RAN_COUNT]: attributes.ranTaskCount,
+                      [AttributeNames.TASKS_CANCELLED_COUNT]: attributes.cancelledTaskCount,
+                    });
+                    span.addEvent('processingStart', events.processingStart);
+                    span.addEvent('processingEnd', events.processingEnd);
+                    span.end();
+                    plugin._activeInteractionContexts.delete(event);
+                  },
+                  function onError(error) {
+                    span.recordException(error);
+                    span.setStatus({
+                      code: api.SpanStatusCode.ERROR,
+                      message: error?.message ?? error,
+                    });
+                  }
+                )
+              );
+            } else {
+              // if not using zones, set span as activeInteractionContext
+              activeInteractionContext = span;
+            }
+
+            plugin._activeInteractionContexts.set(
+              event,
+              activeInteractionContext
+            );
+          }
+
+          if (plugin._zonePatched) {
+            const activeInteractionZone = activeInteractionContext as Zone;
+            const span = activeInteractionZone.get('span');
+            return activeInteractionZone.runGuarded(() => {
+              return api.context.with(
+                api.trace.setSpan(api.context.active(), span),
+                () => plugin._invokeListener(listener, element, event)
+              );
+            });
+          } else {
+            const span = activeInteractionContext as api.Span;
+            return api.context.with(
+              api.trace.setSpan(api.context.active(), span),
+              () => {
+                try {
+                  return plugin._invokeListener(listener, element, event);
+                } catch (error: unknown) {
+                  if (error instanceof Error) {
+                    span.recordException(error);
+                    span.setStatus({
+                      code: api.SpanStatusCode.ERROR,
+                      message: error.message,
+                    });
+                  } else {
+                    span.setStatus({
+                      code: api.SpanStatusCode.ERROR,
+                      message: error as any,
+                    });
+                  }
+                  throw error;
+                } finally {
+                  // TODO: figure out how to end span for multiple event targets without Zone
+                  span.end();
+                }
+              }
+            );
+          }
+        };
+
+        if (plugin._addPatchedListener(this, type, listener, patchedListener)) {
+          return original.call(this, type, patchedListener, options);
+        }
+      };
+    };
   }
 
-  /**
-   * Increment number of tasks that are run within the same zone.
-   *     This is needed to be able to end span when no more tasks left
-   * @param span
-   */
-  private _incrementTask(span: api.Span) {
-    const spanData = this._spansData.get(span);
-    if (spanData) {
-      spanData.taskCount++;
-    }
+  private _patchRemoveEventListener() {
+    const plugin = this;
+    return (original: Function) => {
+      return function removeEventListenerPatched(
+        this: HTMLElement,
+        type: any,
+        listener: any,
+        options: boolean | AddEventListenerOptions
+      ) {
+        const wrappedListener = plugin._removePatchedListener(
+          this,
+          type,
+          listener
+        );
+        if (wrappedListener) {
+          return original.call(this, type, wrappedListener, options);
+        } else {
+          return original.call(this, type, listener, options);
+        }
+      };
+    };
   }
 
   /**
    * Returns true iff we should use the patched callback; false if it's already been patched
    */
-  private addPatchedListener(
-    on: HTMLElement,
+  private _addPatchedListener(
+    element: HTMLElement,
     type: string,
     listener: Function | EventListenerObject,
     wrappedListener: Function
@@ -219,17 +243,17 @@ export class UserInteractionInstrumentation extends InstrumentationBase<unknown>
       element2patched = new Map();
       listener2Type.set(type, element2patched);
     }
-    if (element2patched.has(on)) {
+    if (element2patched.has(element)) {
       return false;
     }
-    element2patched.set(on, wrappedListener);
+    element2patched.set(element, wrappedListener);
     return true;
   }
 
   /**
    * Returns the patched version of the callback (or undefined)
    */
-  private removePatchedListener(
+  private _removePatchedListener(
     on: HTMLElement,
     type: string,
     listener: Function | EventListenerObject
@@ -255,102 +279,6 @@ export class UserInteractionInstrumentation extends InstrumentationBase<unknown>
     return patched;
   }
 
-  // utility method to deal with the Function|EventListener nature of addEventListener
-  private _invokeListener(
-    listener: Function | EventListenerObject,
-    target: any,
-    args: any[]
-  ): any {
-    if (typeof listener === 'function') {
-      return listener.apply(target, args);
-    } else {
-      return listener.handleEvent(args[0]);
-    }
-  }
-
-  /**
-   * This patches the addEventListener of HTMLElement to be able to
-   * auto instrument the click events
-   * This is done when zone is not available
-   */
-  private _patchAddEventListener() {
-    const plugin = this;
-    return (original: EventTarget['addEventListener']) => {
-      return function addEventListenerPatched(
-        this: HTMLElement,
-        type: keyof HTMLElementEventMap,
-        listener: EventListenerOrEventListenerObject | null,
-        useCapture?: boolean | AddEventListenerOptions
-      ) {
-        // Forward calls with listener = null
-        if (!listener) {
-          return original.call(this, type, listener, useCapture);
-        }
-
-        const once = typeof useCapture === 'object' && useCapture.once;
-        const patchedListener = function (this: HTMLElement, ...args: any[]) {
-          let parentSpan: api.Span | undefined;
-          const event: Event | undefined = args[0];
-          const target = event?.target;
-          if (event) {
-            parentSpan = plugin._eventsSpanMap.get(event);
-          }
-          if (once) {
-            plugin.removePatchedListener(this, type, listener);
-          }
-          const span = plugin._createSpan(target, type, parentSpan);
-          if (span) {
-            if (event) {
-              plugin._eventsSpanMap.set(event, span);
-            }
-            return api.context.with(
-              api.trace.setSpan(api.context.active(), span),
-              () => {
-                const result = plugin._invokeListener(listener, this, args);
-                // no zone so end span immediately
-                span.end();
-                return result;
-              }
-            );
-          } else {
-            return plugin._invokeListener(listener, this, args);
-          }
-        };
-        if (plugin.addPatchedListener(this, type, listener, patchedListener)) {
-          return original.call(this, type, patchedListener, useCapture);
-        }
-      };
-    };
-  }
-
-  /**
-   * This patches the removeEventListener of HTMLElement to handle the fact that
-   * we patched the original callbacks
-   * This is done when zone is not available
-   */
-  private _patchRemoveEventListener() {
-    const plugin = this;
-    return (original: Function) => {
-      return function removeEventListenerPatched(
-        this: HTMLElement,
-        type: any,
-        listener: any,
-        useCapture: any
-      ) {
-        const wrappedListener = plugin.removePatchedListener(
-          this,
-          type,
-          listener
-        );
-        if (wrappedListener) {
-          return original.call(this, type, wrappedListener, useCapture);
-        } else {
-          return original.call(this, type, listener, useCapture);
-        }
-      };
-    };
-  }
-
   /**
    * Most browser provide event listener api via EventTarget in prototype chain.
    * Exception to this is IE 11 which has it on the prototypes closest to EventTarget:
@@ -370,22 +298,34 @@ export class UserInteractionInstrumentation extends InstrumentationBase<unknown>
   }
 
   /**
+   * Updates interaction span name
+   * @param url
+   */
+   _updateInteractionName(url: string) {
+    const span: api.Span | undefined = api.trace.getSpan(api.context.active());
+    if (span && typeof span.updateName === 'function') {
+      span.updateName(`${EVENT_NAVIGATION_NAME} ${url}`);
+    }
+  }
+
+  /**
    * Patches the history api
    */
-  _patchHistoryApi() {
+  private _patchHistoryApi() {
     this._unpatchHistoryApi();
 
-    this._wrap(history, 'replaceState', this._patchHistoryMethod());
-    this._wrap(history, 'pushState', this._patchHistoryMethod());
-    this._wrap(history, 'back', this._patchHistoryMethod());
-    this._wrap(history, 'forward', this._patchHistoryMethod());
-    this._wrap(history, 'go', this._patchHistoryMethod());
+    const historyMethods: (keyof History)[] = ['replaceState', 'pushState', 'back', 'forward', 'go'];
+    this._massWrap(
+      historyMethods.map(() => history),
+      historyMethods,
+      this._patchHistoryMethod()
+    );
   }
 
   /**
    * Patches the certain history api method
    */
-  _patchHistoryMethod() {
+  private _patchHistoryMethod() {
     const plugin = this;
     return (original: any) => {
       return function patchHistoryMethod(this: History, ...args: unknown[]) {
@@ -393,6 +333,7 @@ export class UserInteractionInstrumentation extends InstrumentationBase<unknown>
         const result = original.apply(this, args);
         const urlAfter = `${location.pathname}${location.hash}${location.search}`;
         if (url !== urlAfter) {
+          // TODO: parameterize
           plugin._updateInteractionName(urlAfter);
         }
         return result;
@@ -403,235 +344,48 @@ export class UserInteractionInstrumentation extends InstrumentationBase<unknown>
   /**
    * unpatch the history api methods
    */
-  _unpatchHistoryApi() {
-    if (isWrapped(history.replaceState)) this._unwrap(history, 'replaceState');
-    if (isWrapped(history.pushState)) this._unwrap(history, 'pushState');
-    if (isWrapped(history.back)) this._unwrap(history, 'back');
-    if (isWrapped(history.forward)) this._unwrap(history, 'forward');
-    if (isWrapped(history.go)) this._unwrap(history, 'go');
-  }
-
-  /**
-   * Updates interaction span name
-   * @param url
-   */
-  _updateInteractionName(url: string) {
-    const span: api.Span | undefined = api.trace.getSpan(api.context.active());
-    if (span && typeof span.updateName === 'function') {
-      span.updateName(`${EVENT_NAVIGATION_NAME} ${url}`);
-    }
-  }
-
-  /**
-   * Patches zone cancel task - this is done to be able to correctly
-   * decrement the number of remaining tasks
-   */
-  private _patchZoneCancelTask() {
-    const plugin = this;
-    return (original: any) => {
-      return function patchCancelTask<T extends Task>(
-        this: Zone,
-        task: AsyncTask
-      ) {
-        const currentZone = Zone.current;
-        const currentSpan = plugin._getCurrentSpan(currentZone);
-        if (currentSpan && plugin._shouldCountTask(task, currentZone)) {
-          plugin._decrementTask(currentSpan);
-        }
-        return original.call(this, task) as T;
-      };
-    };
-  }
-
-  /**
-   * Patches zone schedule task - this is done to be able to correctly
-   * increment the number of tasks running within current zone but also to
-   * save time in case of timeout running from xhr plugin when waiting for
-   * main request from PerformanceResourceTiming
-   */
-  private _patchZoneScheduleTask() {
-    const plugin = this;
-    return (original: any) => {
-      return function patchScheduleTask<T extends Task>(
-        this: Zone,
-        task: AsyncTask
-      ) {
-        const currentZone = Zone.current;
-        const currentSpan = plugin._getCurrentSpan(currentZone);
-        if (currentSpan && plugin._shouldCountTask(task, currentZone)) {
-          plugin._incrementTask(currentSpan);
-          plugin._checkForTimeout(task, currentSpan);
-        }
-        return original.call(this, task) as T;
-      };
-    };
-  }
-
-  /**
-   * Patches zone run task - this is done to be able to create a span when
-   * user interaction starts
-   * @private
-   */
-  private _patchZoneRunTask() {
-    const plugin = this;
-    return (original: RunTaskFunction): RunTaskFunction => {
-      return function patchRunTask(
-        this: Zone,
-        task: AsyncTask,
-        applyThis?: any,
-        applyArgs?: any
-      ): Zone {
-        const event =
-          Array.isArray(applyArgs) && applyArgs[0] instanceof Event
-            ? applyArgs[0]
-            : undefined;
-        const target = event?.target;
-        let span: api.Span | undefined;
-        const activeZone = this;
-        if (target) {
-          span = plugin._createSpan(target, task.eventName);
-          if (span) {
-            plugin._incrementTask(span);
-            return activeZone.run(() => {
-              try {
-                return api.context.with(
-                  api.trace.setSpan(api.context.active(), span!),
-                  () => {
-                    const currentZone = Zone.current;
-                    task._zone = currentZone;
-                    return original.call(
-                      currentZone,
-                      task,
-                      applyThis,
-                      applyArgs
-                    );
-                  }
-                );
-              } finally {
-                plugin._decrementTask(span as api.Span);
-              }
-            });
-          }
-        } else {
-          span = plugin._getCurrentSpan(activeZone);
-        }
-
-        try {
-          return original.call(activeZone, task, applyThis, applyArgs);
-        } finally {
-          if (span && plugin._shouldCountTask(task, activeZone)) {
-            plugin._decrementTask(span);
-          }
-        }
-      };
-    };
-  }
-
-  /**
-   * Decides if task should be counted.
-   * @param task
-   * @param currentZone
-   * @private
-   */
-  private _shouldCountTask(task: AsyncTask, currentZone: Zone): boolean {
-    if (task._zone) {
-      currentZone = task._zone;
-    }
-    if (!currentZone || !task.data || task.data.isPeriodic) {
-      return false;
-    }
-    const currentSpan = this._getCurrentSpan(currentZone);
-    if (!currentSpan) {
-      return false;
-    }
-    if (!this._spansData.get(currentSpan)) {
-      return false;
-    }
-    return task.type === 'macroTask' || task.type === 'microTask';
-  }
-
-  /**
-   * Will try to end span when such span still exists.
-   * @param span
-   * @param endTime
-   * @private
-   */
-  private _tryToEndSpan(span: api.Span, endTime?: api.HrTime) {
-    if (span) {
-      const spanData = this._spansData.get(span);
-      if (spanData) {
-        span.end(endTime);
-        this._spansData.delete(span);
+   private _unpatchHistoryApi() {
+    const historyMethods: (keyof History)[] = [
+      'replaceState',
+      'pushState',
+      'back',
+      'forward',
+      'go',
+    ];
+    historyMethods.forEach((methodName) => {
+      if (isWrapped(history[methodName])) {
+        this._unwrap(history, methodName);
       }
-    }
+    });
   }
 
   /**
    * implements enable function
    */
   override enable() {
-    const ZoneWithPrototype = this.getZoneWithPrototype();
-    api.diag.debug(
-      'applying patch to',
-      this.moduleName,
-      this.version,
-      'zone:',
-      !!ZoneWithPrototype
-    );
-    if (ZoneWithPrototype) {
-      if (isWrapped(ZoneWithPrototype.prototype.runTask)) {
-        this._unwrap(ZoneWithPrototype.prototype, 'runTask');
-        api.diag.debug('removing previous patch from method runTask');
-      }
-      if (isWrapped(ZoneWithPrototype.prototype.scheduleTask)) {
-        this._unwrap(ZoneWithPrototype.prototype, 'scheduleTask');
-        api.diag.debug('removing previous patch from method scheduleTask');
-      }
-      if (isWrapped(ZoneWithPrototype.prototype.cancelTask)) {
-        this._unwrap(ZoneWithPrototype.prototype, 'cancelTask');
-        api.diag.debug('removing previous patch from method cancelTask');
+    const targets = this._getPatchableEventTargets();
+    this._zonePatched = !!(window as any).Zone;
+
+    targets.forEach((target) => {
+      if (isWrapped(target.addEventListener)) {
+        this._unwrap(target, 'addEventListener');
+        api.diag.debug('removing previous patch from method addEventListener');
       }
 
-      this._zonePatched = true;
-      this._wrap(
-        ZoneWithPrototype.prototype,
-        'runTask',
-        this._patchZoneRunTask()
-      );
-      this._wrap(
-        ZoneWithPrototype.prototype,
-        'scheduleTask',
-        this._patchZoneScheduleTask()
-      );
-      this._wrap(
-        ZoneWithPrototype.prototype,
-        'cancelTask',
-        this._patchZoneCancelTask()
-      );
-    } else {
-      this._zonePatched = false;
-      const targets = this._getPatchableEventTargets();
-      targets.forEach(target => {
-        if (isWrapped(target.addEventListener)) {
-          this._unwrap(target, 'addEventListener');
-          api.diag.debug(
-            'removing previous patch from method addEventListener'
-          );
-        }
-        if (isWrapped(target.removeEventListener)) {
-          this._unwrap(target, 'removeEventListener');
-          api.diag.debug(
-            'removing previous patch from method removeEventListener'
-          );
-        }
-        this._wrap(target, 'addEventListener', this._patchAddEventListener());
-        this._wrap(
-          target,
-          'removeEventListener',
-          this._patchRemoveEventListener()
+      if (isWrapped(target.removeEventListener)) {
+        this._unwrap(target, 'removeEventListener');
+        api.diag.debug(
+          'removing previous patch from method removeEventListener'
         );
-      });
-    }
+      }
+
+      this._wrap(target, 'addEventListener', this._patchAddEventListener());
+      this._wrap(
+        target,
+        'removeEventListener',
+        this._patchRemoveEventListener()
+      );
+    });
 
     this._patchHistoryApi();
   }
@@ -640,43 +394,17 @@ export class UserInteractionInstrumentation extends InstrumentationBase<unknown>
    * implements unpatch function
    */
   override disable() {
-    const ZoneWithPrototype = this.getZoneWithPrototype();
-    api.diag.debug(
-      'removing patch from',
-      this.moduleName,
-      this.version,
-      'zone:',
-      !!ZoneWithPrototype
-    );
-    if (ZoneWithPrototype && this._zonePatched) {
-      if (isWrapped(ZoneWithPrototype.prototype.runTask)) {
-        this._unwrap(ZoneWithPrototype.prototype, 'runTask');
+    const targets = this._getPatchableEventTargets();
+    targets.forEach((target) => {
+      if (isWrapped(target.addEventListener)) {
+        this._unwrap(target, 'addEventListener');
       }
-      if (isWrapped(ZoneWithPrototype.prototype.scheduleTask)) {
-        this._unwrap(ZoneWithPrototype.prototype, 'scheduleTask');
-      }
-      if (isWrapped(ZoneWithPrototype.prototype.cancelTask)) {
-        this._unwrap(ZoneWithPrototype.prototype, 'cancelTask');
-      }
-    } else {
-      const targets = this._getPatchableEventTargets();
-      targets.forEach(target => {
-        if (isWrapped(target.addEventListener)) {
-          this._unwrap(target, 'addEventListener');
-        }
-        if (isWrapped(target.removeEventListener)) {
-          this._unwrap(target, 'removeEventListener');
-        }
-      });
-    }
-    this._unpatchHistoryApi();
-  }
 
-  /**
-   * returns Zone
-   */
-  getZoneWithPrototype(): ZoneTypeWithPrototype | undefined {
-    const _window: WindowWithZone = window as unknown as WindowWithZone;
-    return _window.Zone;
+      if (isWrapped(target.removeEventListener)) {
+        this._unwrap(target, 'removeEventListener');
+      }
+    });
+
+    this._unpatchHistoryApi();
   }
 }

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/src/types.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/src/types.ts
@@ -86,3 +86,15 @@ interface ZonePrototype {
  * type to be  able to use prototype on Zone
  */
 export type ZoneTypeWithPrototype = ZonePrototype & Zone;
+
+export interface UserInteractionAggregates {
+  listenerCount: number;
+  scheduledTaskCount: number;
+  cancelledTaskCount: number;
+  ranTaskCount: number;
+}
+
+export interface UserInteractionEvents {
+  processingStart: number;
+  processingEnd: number;
+}

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.nozone.test.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.nozone.test.ts
@@ -57,12 +57,6 @@ describe('UserInteractionInstrumentation', () => {
         ...config,
       });
 
-      sandbox
-        .stub(userInteractionInstrumentation, 'getZoneWithPrototype')
-        .callsFake(() => {
-          return false as any;
-        });
-
       registerInstrumentations({
         tracerProvider: webTracerProvider,
         instrumentations: [


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Fixes #548

This a WIP solution that replaces #548, and should account for some of the debate around the approach in that PR regarding heuristics. However, this solution is a much larger diff (albeit less code/simpler than existing solution by avoiding Zone patches).

[See StackBlitz for example](https://stackblitz.com/edit/opentelemetry-js-interaction-with-gtm-akeucp)

- Deduplicates user interaction spans per event target, rather than create one span per listener callback. Contrary to #743, this implementation does not rely on heuristics and accurately captures the execution context across multiple event handlers.
- Further aligns the instrumentation with the [upcoming Responsiveness CWV metric](https://web.dev/better-responsiveness-metric/). This will be baked in the PerformanceObserver in the future where we can get increased accuracy on span timestamps. However, the metrics they record will not account for async tasks due to the difficult implementation, [even though they would prefer that](https://web.dev/better-responsiveness-metric/#capture-the-full-event-duration). Because this solution is leveraging Zone.js, we are capable of capturing this powerful data today.

## Short description of the changes

- Refactors Zone patching logic to a ZoneSpec implementation that performs async task tracking across all listeners for an event target, and provides onComplete/onError callbacks consumable from the instrumentation.
- Changes span duration characteristics. It now starts from the first `event.timeStamp`, and ends after all async tasks have been performed within all listener callbacks. Starting from `event.timeStamp` improves the recording accuracy as it now accounts for the input delay (aka First Input Delay but for all interactions)
- Calculates additional aggregates and events that may be useful when analyzing interactions, such as `processingStart` (when the browser is able to start executing), `processingEnd` (when all synchronous work is complete), `listenerCount` (total count of listeners that executed for the interaction), and detailed task counts (number of async tasks executed). The `processingStart` and `processingEnd` metrics are the same values found on the [spec'd PerformanceEventTiming interface](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEventTiming#properties).
- Silently records errors/exceptions on the interaction span without disrupting user-land error handling

## Checklist

- [ ] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
- [ ] Add several new test cases (but having difficulty getting Karma to work right now)
- [ ] Explore additional aggregates such as longest event handler within interaction, total interaction latency over time, average interaction latency over time, high quantile aggregates
- [ ] Explore grouping `up` and `down` metrics (e.g. `mousedown` + `mouseup`, `keydown` + `keyup`) to further align with Responsiveness metric, since both events are guaranteed to occur and count as a single "interaction"
- [ ] Check if ZoneContextManager is being used rather assume it is being used by checking window.Zone 
- [ ] Verify accuracy by comparing with PerformanceTimeline values
