### PR TITLE
feat: use Otel SDK 1.2/0.28

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-alibaba-cloud/package.json
+++ b/detectors/node/opentelemetry-resource-detector-alibaba-cloud/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/contrib-test-utils": "^0.29.0",
+    "@opentelemetry/contrib-test-utils": "0.29.0",
     "@types/mocha": "8.2.3",
     "@types/node": "16.11.21",
     "@types/sinon": "10.0.2",

--- a/detectors/node/opentelemetry-resource-detector-alibaba-cloud/package.json
+++ b/detectors/node/opentelemetry-resource-detector-alibaba-cloud/package.json
@@ -57,7 +57,7 @@
     "typescript": "4.3.5"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
     "@opentelemetry/resources": "^1.0.0",

--- a/detectors/node/opentelemetry-resource-detector-aws/package.json
+++ b/detectors/node/opentelemetry-resource-detector-aws/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/contrib-test-utils": "^0.29.0",
+    "@opentelemetry/contrib-test-utils": "0.29.0",
     "@types/mocha": "8.2.3",
     "@types/node": "16.11.21",
     "@types/sinon": "10.0.2",

--- a/detectors/node/opentelemetry-resource-detector-aws/package.json
+++ b/detectors/node/opentelemetry-resource-detector-aws/package.json
@@ -56,7 +56,7 @@
     "typescript": "4.3.5"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
     "@opentelemetry/core": "^1.0.0",

--- a/detectors/node/opentelemetry-resource-detector-docker/package.json
+++ b/detectors/node/opentelemetry-resource-detector-docker/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.4",
-    "@opentelemetry/contrib-test-utils": "^0.29.0",
+    "@opentelemetry/contrib-test-utils": "0.29.0",
     "@types/mocha": "8.2.3",
     "@types/node": "^17.0.14",
     "@types/sinon": "10.0.2",

--- a/detectors/node/opentelemetry-resource-detector-docker/package.json
+++ b/detectors/node/opentelemetry-resource-detector-docker/package.json
@@ -51,7 +51,7 @@
     "typescript": "^4.5.5"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.4"
+    "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
     "@opentelemetry/resources": "^1.0.1",

--- a/detectors/node/opentelemetry-resource-detector-gcp/package.json
+++ b/detectors/node/opentelemetry-resource-detector-gcp/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/contrib-test-utils": "^0.29.0",
+    "@opentelemetry/contrib-test-utils": "0.29.0",
     "@opentelemetry/core": "1.2.0",
     "@types/mocha": "8.2.3",
     "@types/node": "16.11.21",

--- a/detectors/node/opentelemetry-resource-detector-gcp/package.json
+++ b/detectors/node/opentelemetry-resource-detector-gcp/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
     "@opentelemetry/contrib-test-utils": "^0.29.0",
-    "@opentelemetry/core": "1.0.1",
+    "@opentelemetry/core": "1.2.0",
     "@types/mocha": "8.2.3",
     "@types/node": "16.11.21",
     "@types/semver": "7.3.8",
@@ -56,7 +56,7 @@
     "typescript": "4.3.5"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
     "@opentelemetry/resources": "^1.0.0",

--- a/detectors/node/opentelemetry-resource-detector-github/package.json
+++ b/detectors/node/opentelemetry-resource-detector-github/package.json
@@ -42,7 +42,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",

--- a/metapackages/auto-instrumentations-node/package.json
+++ b/metapackages/auto-instrumentations-node/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js-contrib/issues"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
@@ -46,7 +46,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/instrumentation-amqplib": "^0.28.0",
     "@opentelemetry/instrumentation-aws-lambda": "^0.30.0",
     "@opentelemetry/instrumentation-aws-sdk": "^0.6.0",
@@ -58,9 +58,9 @@
     "@opentelemetry/instrumentation-fastify": "^0.26.0",
     "@opentelemetry/instrumentation-generic-pool": "^0.27.2",
     "@opentelemetry/instrumentation-graphql": "^0.27.4",
-    "@opentelemetry/instrumentation-grpc": "^0.27.0",
+    "@opentelemetry/instrumentation-grpc": "^0.28.0",
     "@opentelemetry/instrumentation-hapi": "^0.27.0",
-    "@opentelemetry/instrumentation-http": "^0.27.0",
+    "@opentelemetry/instrumentation-http": "^0.28.0",
     "@opentelemetry/instrumentation-ioredis": "^0.28.0",
     "@opentelemetry/instrumentation-knex": "^0.27.0",
     "@opentelemetry/instrumentation-koa": "^0.28.1",

--- a/metapackages/auto-instrumentations-web/package.json
+++ b/metapackages/auto-instrumentations-web/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js-contrib/issues"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.15.0",
@@ -63,10 +63,10 @@
     "webpack-merge": "5.8.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/instrumentation-document-load": "^0.27.1",
-    "@opentelemetry/instrumentation-fetch": "^0.27.0",
+    "@opentelemetry/instrumentation-fetch": "^0.28.0",
     "@opentelemetry/instrumentation-user-interaction": "^0.28.1",
-    "@opentelemetry/instrumentation-xml-http-request": "^0.27.0"
+    "@opentelemetry/instrumentation-xml-http-request": "^0.28.0"
   }
 }

--- a/packages/opentelemetry-browser-extension-autoinjection/package.json
+++ b/packages/opentelemetry-browser-extension-autoinjection/package.json
@@ -26,7 +26,7 @@
     "node": ">=8.12.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
@@ -66,18 +66,18 @@
     "@material-ui/core": "4.12.3",
     "@material-ui/icons": "4.11.2",
     "@material-ui/lab": "4.0.0-alpha.60",
-    "@opentelemetry/context-zone": "1.0.1",
-    "@opentelemetry/core": "1.0.1",
-    "@opentelemetry/exporter-trace-otlp-http": "0.27.0",
-    "@opentelemetry/exporter-zipkin": "1.0.1",
-    "@opentelemetry/instrumentation": "0.27.0",
+    "@opentelemetry/context-zone": "1.2.0",
+    "@opentelemetry/core": "1.2.0",
+    "@opentelemetry/exporter-trace-otlp-http": "0.28.0",
+    "@opentelemetry/exporter-zipkin": "1.2.0",
+    "@opentelemetry/instrumentation": "0.28.0",
     "@opentelemetry/instrumentation-document-load": "^0.27.1",
-    "@opentelemetry/instrumentation-fetch": "0.27.0",
-    "@opentelemetry/instrumentation-xml-http-request": "0.27.0",
-    "@opentelemetry/resources": "1.0.1",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-web": "1.0.1",
-    "@opentelemetry/semantic-conventions": "1.0.1",
+    "@opentelemetry/instrumentation-fetch": "0.28.0",
+    "@opentelemetry/instrumentation-xml-http-request": "0.28.0",
+    "@opentelemetry/resources": "1.2.0",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/sdk-trace-web": "1.2.0",
+    "@opentelemetry/semantic-conventions": "1.2.0",
     "change-case": "4.1.2",
     "json5": "2.2.0",
     "react": "17.0.2",

--- a/packages/opentelemetry-host-metrics/package.json
+++ b/packages/opentelemetry-host-metrics/package.json
@@ -59,9 +59,9 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "^0.28.0",
+    "@opentelemetry/api-metrics": "^0.27.0",
     "@opentelemetry/core": "^1.0.0",
-    "@opentelemetry/sdk-metrics-base": "^0.28.0",
+    "@opentelemetry/sdk-metrics-base": "^0.27.0",
     "systeminformation": "^5.0.0"
   }
 }

--- a/packages/opentelemetry-host-metrics/package.json
+++ b/packages/opentelemetry-host-metrics/package.json
@@ -43,7 +43,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
@@ -59,9 +59,9 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "^0.27.0",
+    "@opentelemetry/api-metrics": "^0.28.0",
     "@opentelemetry/core": "^1.0.0",
-    "@opentelemetry/sdk-metrics-base": "^0.27.0",
+    "@opentelemetry/sdk-metrics-base": "^0.28.0",
     "systeminformation": "^5.0.0"
   }
 }

--- a/packages/opentelemetry-id-generator-aws-xray/package.json
+++ b/packages/opentelemetry-id-generator-aws-xray/package.json
@@ -51,7 +51,7 @@
     "README.md"
   ],
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",

--- a/packages/opentelemetry-propagation-utils/package.json
+++ b/packages/opentelemetry-propagation-utils/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib#readme",
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.1"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.1",

--- a/packages/opentelemetry-test-utils/package.json
+++ b/packages/opentelemetry-test-utils/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib#readme",
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
@@ -47,12 +47,12 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/core": "1.0.1",
-    "@opentelemetry/exporter-jaeger": "1.0.1",
-    "@opentelemetry/instrumentation": "0.27.0",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
-    "@opentelemetry/resources": "1.0.1",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/semantic-conventions": "1.0.1"
+    "@opentelemetry/core": "1.2.0",
+    "@opentelemetry/exporter-jaeger": "1.2.0",
+    "@opentelemetry/instrumentation": "0.28.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
+    "@opentelemetry/resources": "1.2.0",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/semantic-conventions": "1.2.0"
   }
 }

--- a/plugins/node/instrumentation-amqplib/package.json
+++ b/plugins/node/instrumentation-amqplib/package.json
@@ -43,7 +43,7 @@
     "test:docker:run": "docker run -d --hostname demo-amqplib-rabbit --name amqplib-unittests -p 22221:5672 --env RABBITMQ_DEFAULT_USER=username --env RABBITMQ_DEFAULT_PASS=password rabbitmq:3"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.1"
+    "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
     "@opentelemetry/core": "^1.0.0",

--- a/plugins/node/instrumentation-amqplib/package.json
+++ b/plugins/node/instrumentation-amqplib/package.json
@@ -64,7 +64,7 @@
     "ts-mocha": "8.0.0",
     "nyc": "15.1.0",
     "gts": "3.1.0",
-    "@opentelemetry/contrib-test-utils": "^0.28.0",
+    "@opentelemetry/contrib-test-utils": "0.29.0",
     "sinon": "13.0.1",
     "test-all-versions": "5.0.1",
     "typescript": "4.3.5"

--- a/plugins/node/instrumentation-amqplib/package.json
+++ b/plugins/node/instrumentation-amqplib/package.json
@@ -52,7 +52,7 @@
     "@types/amqplib": "^0.5.17"
   },
   "devDependencies": {
-    "@opentelemetry/api": "1.2.0",
+    "@opentelemetry/api": "1.0.1",
     "@types/lodash": "4.14.178",
     "@types/mocha": "8.2.3",
     "@types/sinon": "10.0.2",

--- a/plugins/node/instrumentation-amqplib/package.json
+++ b/plugins/node/instrumentation-amqplib/package.json
@@ -47,12 +47,12 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.0.0",
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "@types/amqplib": "^0.5.17"
   },
   "devDependencies": {
-    "@opentelemetry/api": "1.0.1",
+    "@opentelemetry/api": "1.2.0",
     "@types/lodash": "4.14.178",
     "@types/mocha": "8.2.3",
     "@types/sinon": "10.0.2",

--- a/plugins/node/instrumentation-fs/package.json
+++ b/plugins/node/instrumentation-fs/package.json
@@ -43,10 +43,10 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.4",
-    "@opentelemetry/context-async-hooks": "1.0.1",
-    "@opentelemetry/resources": "1.0.1",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
+    "@opentelemetry/context-async-hooks": "1.2.0",
+    "@opentelemetry/resources": "1.2.0",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "14.17.9",
     "@types/shimmer": "1.0.2",
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.0.1",
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.1"
   }
 }

--- a/plugins/node/instrumentation-fs/package.json
+++ b/plugins/node/instrumentation-fs/package.json
@@ -39,7 +39,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.4"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.4",

--- a/plugins/node/instrumentation-tedious/package.json
+++ b/plugins/node/instrumentation-tedious/package.json
@@ -44,13 +44,13 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/context-async-hooks": "1.0.1",
+    "@opentelemetry/context-async-hooks": "1.2.0",
     "@opentelemetry/contrib-test-utils": "^0.29.0",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
     "gts": "3.1.0",
@@ -63,7 +63,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "@types/tedious": "^4.0.6"
   }

--- a/plugins/node/instrumentation-tedious/package.json
+++ b/plugins/node/instrumentation-tedious/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
     "@opentelemetry/context-async-hooks": "1.2.0",
-    "@opentelemetry/contrib-test-utils": "^0.29.0",
+    "@opentelemetry/contrib-test-utils": "0.29.0",
     "@opentelemetry/sdk-trace-base": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
@@ -42,13 +42,13 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/core": "1.0.1",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
+    "@opentelemetry/core": "1.2.0",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
     "gts": "3.1.0",
@@ -59,7 +59,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/propagator-aws-xray": "^1.0.1",
     "@opentelemetry/resources": "^1.0.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
@@ -43,7 +43,7 @@
     "watch": "tsc -w"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.1"
+    "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
     "@opentelemetry/core": "^1.0.0",

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
@@ -58,7 +58,7 @@
     "@aws-sdk/client-sqs": "3.37.0",
     "@aws-sdk/types": "3.37.0",
     "@opentelemetry/api": "1.0.1",
-    "@opentelemetry/contrib-test-utils": "^0.29.0",
+    "@opentelemetry/contrib-test-utils": "0.29.0",
     "@opentelemetry/sdk-trace-base": "1.2.0",
     "@types/mocha": "8.2.3",
     "@types/node": "16.11.21",

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
@@ -57,7 +57,7 @@
     "@aws-sdk/client-s3": "3.37.0",
     "@aws-sdk/client-sqs": "3.37.0",
     "@aws-sdk/types": "3.37.0",
-    "@opentelemetry/api": "1.2.0",
+    "@opentelemetry/api": "1.0.1",
     "@opentelemetry/contrib-test-utils": "^0.29.0",
     "@opentelemetry/sdk-trace-base": "1.2.0",
     "@types/mocha": "8.2.3",

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.0.0",
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "@opentelemetry/propagation-utils": "^0.27.0"
   },
@@ -57,9 +57,9 @@
     "@aws-sdk/client-s3": "3.37.0",
     "@aws-sdk/client-sqs": "3.37.0",
     "@aws-sdk/types": "3.37.0",
-    "@opentelemetry/api": "1.0.1",
+    "@opentelemetry/api": "1.2.0",
     "@opentelemetry/contrib-test-utils": "^0.29.0",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
     "@types/mocha": "8.2.3",
     "@types/node": "16.11.21",
     "@types/sinon": "10.0.6",

--- a/plugins/node/opentelemetry-instrumentation-bunyan/package.json
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/package.json
@@ -44,13 +44,13 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/context-async-hooks": "1.0.1",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
+    "@opentelemetry/context-async-hooks": "1.2.0",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
     "@types/sinon": "10.0.2",
@@ -65,7 +65,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@types/bunyan": "1.8.7"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-cassandra/package.json
+++ b/plugins/node/opentelemetry-instrumentation-cassandra/package.json
@@ -43,14 +43,14 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/context-async-hooks": "1.0.1",
+    "@opentelemetry/context-async-hooks": "1.2.0",
     "@opentelemetry/contrib-test-utils": "^0.29.0",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
     "@types/semver": "7.3.8",
@@ -65,7 +65,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.0"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-cassandra/package.json
+++ b/plugins/node/opentelemetry-instrumentation-cassandra/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
     "@opentelemetry/context-async-hooks": "1.2.0",
-    "@opentelemetry/contrib-test-utils": "^0.29.0",
+    "@opentelemetry/contrib-test-utils": "0.29.0",
     "@opentelemetry/sdk-trace-base": "1.2.0",
     "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",

--- a/plugins/node/opentelemetry-instrumentation-connect/package.json
+++ b/plugins/node/opentelemetry-instrumentation-connect/package.json
@@ -41,13 +41,13 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/context-async-hooks": "1.0.1",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
+    "@opentelemetry/context-async-hooks": "1.2.0",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
     "connect": "3.7.0",
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.0.0",
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "@types/connect": "3.4.35"
   }

--- a/plugins/node/opentelemetry-instrumentation-dns/package.json
+++ b/plugins/node/opentelemetry-instrumentation-dns/package.json
@@ -42,13 +42,13 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/core": "1.0.1",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
+    "@opentelemetry/core": "1.2.0",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
     "@types/semver": "7.3.8",
@@ -63,7 +63,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "semver": "^7.3.2"
   }

--- a/plugins/node/opentelemetry-instrumentation-express/package.json
+++ b/plugins/node/opentelemetry-instrumentation-express/package.json
@@ -44,13 +44,13 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/context-async-hooks": "1.0.1",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
+    "@opentelemetry/context-async-hooks": "1.2.0",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
     "express": "4.17.1",
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.0.0",
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "@types/express": "4.17.13"
   }

--- a/plugins/node/opentelemetry-instrumentation-fastify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-fastify/package.json
@@ -42,14 +42,14 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/context-async-hooks": "1.0.1",
-    "@opentelemetry/instrumentation-http": "0.27.0",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
+    "@opentelemetry/context-async-hooks": "1.2.0",
+    "@opentelemetry/instrumentation-http": "0.28.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
     "@types/express": "4.17.13",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.0.0",
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "fastify": "^3.19.2"
   }

--- a/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
+++ b/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
@@ -42,13 +42,13 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/context-async-hooks": "1.0.1",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
+    "@opentelemetry/context-async-hooks": "1.2.0",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
     "@types/semver": "7.3.8",
@@ -62,7 +62,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "@types/generic-pool": "^3.1.9"
   }

--- a/plugins/node/opentelemetry-instrumentation-graphql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-graphql/package.json
@@ -44,11 +44,11 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
     "@types/mocha": "8.2.3",
     "@types/node": "16.11.21",
     "gts": "3.1.0",
@@ -60,7 +60,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "graphql": "^15.5.1"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-hapi/package.json
+++ b/plugins/node/opentelemetry-instrumentation-hapi/package.json
@@ -42,14 +42,14 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@hapi/hapi": "20.1.5",
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/context-async-hooks": "1.0.1",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
+    "@opentelemetry/context-async-hooks": "1.2.0",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
     "gts": "3.1.0",
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.0.0",
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "@types/hapi__hapi": "20.0.9"
   }

--- a/plugins/node/opentelemetry-instrumentation-ioredis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
     "@opentelemetry/context-async-hooks": "1.2.0",
-    "@opentelemetry/contrib-test-utils": "^0.29.0",
+    "@opentelemetry/contrib-test-utils": "0.29.0",
     "@opentelemetry/sdk-trace-base": "1.2.0",
     "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",

--- a/plugins/node/opentelemetry-instrumentation-ioredis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/package.json
@@ -47,14 +47,14 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/context-async-hooks": "1.0.1",
+    "@opentelemetry/context-async-hooks": "1.2.0",
     "@opentelemetry/contrib-test-utils": "^0.29.0",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/sinon": "10.0.9",
     "@types/node": "16.11.21",
@@ -70,7 +70,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "@types/ioredis": "4.26.6"
   }

--- a/plugins/node/opentelemetry-instrumentation-knex/package.json
+++ b/plugins/node/opentelemetry-instrumentation-knex/package.json
@@ -42,13 +42,13 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/context-async-hooks": "1.0.1",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
+    "@opentelemetry/context-async-hooks": "1.2.0",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
     "gts": "3.1.0",
@@ -61,7 +61,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.0"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-koa/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/package.json
@@ -45,14 +45,14 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@koa/router": "9.4.0",
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/context-async-hooks": "1.0.1",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
+    "@opentelemetry/context-async-hooks": "1.2.0",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
     "gts": "3.1.0",
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.0.0",
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "@types/koa": "2.13.4",
     "@types/koa__router": "8.0.7"

--- a/plugins/node/opentelemetry-instrumentation-memcached/package.json
+++ b/plugins/node/opentelemetry-instrumentation-memcached/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
     "@opentelemetry/context-async-hooks": "1.2.0",
-    "@opentelemetry/contrib-test-utils": "^0.29.0",
+    "@opentelemetry/contrib-test-utils": "0.29.0",
     "@opentelemetry/sdk-trace-base": "1.2.0",
     "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",

--- a/plugins/node/opentelemetry-instrumentation-memcached/package.json
+++ b/plugins/node/opentelemetry-instrumentation-memcached/package.json
@@ -44,14 +44,14 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/context-async-hooks": "1.0.1",
+    "@opentelemetry/context-async-hooks": "1.2.0",
     "@opentelemetry/contrib-test-utils": "^0.29.0",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
     "cross-env": "7.0.3",
@@ -64,7 +64,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "@types/memcached": "^2.2.6"
   }

--- a/plugins/node/opentelemetry-instrumentation-mongodb/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/contrib-test-utils": "^0.29.0",
+    "@opentelemetry/contrib-test-utils": "0.29.0",
     "@opentelemetry/context-async-hooks": "1.2.0",
     "@opentelemetry/sdk-trace-base": "1.2.0",
     "@opentelemetry/sdk-trace-node": "1.2.0",

--- a/plugins/node/opentelemetry-instrumentation-mongodb/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/package.json
@@ -46,14 +46,14 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
     "@opentelemetry/contrib-test-utils": "^0.29.0",
-    "@opentelemetry/context-async-hooks": "1.0.1",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
+    "@opentelemetry/context-async-hooks": "1.2.0",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
     "gts": "3.1.0",
@@ -66,7 +66,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "@types/mongodb": "3.6.20"
   }

--- a/plugins/node/opentelemetry-instrumentation-mysql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql/package.json
@@ -42,13 +42,13 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/context-async-hooks": "1.0.1",
+    "@opentelemetry/context-async-hooks": "1.2.0",
     "@opentelemetry/contrib-test-utils": "^0.29.0",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
     "gts": "3.1.0",
@@ -60,7 +60,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "@types/mysql": "2.15.19"
   }

--- a/plugins/node/opentelemetry-instrumentation-mysql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
     "@opentelemetry/context-async-hooks": "1.2.0",
-    "@opentelemetry/contrib-test-utils": "^0.29.0",
+    "@opentelemetry/contrib-test-utils": "0.29.0",
     "@opentelemetry/sdk-trace-base": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",

--- a/plugins/node/opentelemetry-instrumentation-mysql2/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
     "@opentelemetry/context-async-hooks": "1.2.0",
-    "@opentelemetry/contrib-test-utils": "^0.29.0",
+    "@opentelemetry/contrib-test-utils": "0.29.0",
     "@opentelemetry/sdk-trace-base": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/mysql2": "github:types/mysql2",

--- a/plugins/node/opentelemetry-instrumentation-mysql2/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/package.json
@@ -44,13 +44,13 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/context-async-hooks": "1.0.1",
+    "@opentelemetry/context-async-hooks": "1.2.0",
     "@opentelemetry/contrib-test-utils": "^0.29.0",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/mysql2": "github:types/mysql2",
     "@types/node": "16.11.21",
@@ -66,7 +66,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.0"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
+++ b/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
@@ -45,7 +45,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@nestjs/common": "8.2.6",
@@ -54,9 +54,9 @@
     "@nestjs/platform-express": "8.2.6",
     "@nestjs/websockets": "8.2.6",
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/context-async-hooks": "1.0.1",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
+    "@opentelemetry/context-async-hooks": "1.2.0",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
     "@types/semver": "7.3.8",
@@ -75,7 +75,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.0"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-net/package.json
+++ b/plugins/node/opentelemetry-instrumentation-net/package.json
@@ -43,12 +43,12 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
     "@types/sinon": "10.0.2",
@@ -61,7 +61,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.0"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-pg/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pg/package.json
@@ -50,14 +50,14 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/context-async-hooks": "1.0.1",
+    "@opentelemetry/context-async-hooks": "1.2.0",
     "@opentelemetry/contrib-test-utils": "^0.29.0",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
     "cross-env": "7.0.3",
@@ -72,7 +72,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "@types/pg": "8.6.1",
     "@types/pg-pool": "2.0.3"

--- a/plugins/node/opentelemetry-instrumentation-pg/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pg/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
     "@opentelemetry/context-async-hooks": "1.2.0",
-    "@opentelemetry/contrib-test-utils": "^0.29.0",
+    "@opentelemetry/contrib-test-utils": "0.29.0",
     "@opentelemetry/sdk-trace-base": "1.2.0",
     "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",

--- a/plugins/node/opentelemetry-instrumentation-pino/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pino/package.json
@@ -44,13 +44,13 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/context-async-hooks": "1.0.1",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
+    "@opentelemetry/context-async-hooks": "1.2.0",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
     "@types/semver": "7.3.8",
@@ -65,7 +65,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "pino": "7.10.0",
     "semver": "^7.3.5"
   }

--- a/plugins/node/opentelemetry-instrumentation-redis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
     "@opentelemetry/context-async-hooks": "1.2.0",
-    "@opentelemetry/contrib-test-utils": "^0.29.0",
+    "@opentelemetry/contrib-test-utils": "0.29.0",
     "@opentelemetry/sdk-trace-base": "1.2.0",
     "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",

--- a/plugins/node/opentelemetry-instrumentation-redis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis/package.json
@@ -46,14 +46,14 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/context-async-hooks": "1.0.1",
+    "@opentelemetry/context-async-hooks": "1.2.0",
     "@opentelemetry/contrib-test-utils": "^0.29.0",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
     "cross-env": "7.0.3",
@@ -67,7 +67,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "@types/redis": "2.8.31"
   }

--- a/plugins/node/opentelemetry-instrumentation-restify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-restify/package.json
@@ -42,13 +42,13 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/context-async-hooks": "1.0.1",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
+    "@opentelemetry/context-async-hooks": "1.2.0",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
     "gts": "3.1.0",
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.0.0",
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "@types/restify": "4.3.8"
   }

--- a/plugins/node/opentelemetry-instrumentation-router/package.json
+++ b/plugins/node/opentelemetry-instrumentation-router/package.json
@@ -42,13 +42,13 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/context-async-hooks": "1.0.1",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
+    "@opentelemetry/context-async-hooks": "1.2.0",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
     "gts": "3.1.0",
@@ -60,7 +60,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/semantic-conventions": "^1.0.0"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-winston/package.json
+++ b/plugins/node/opentelemetry-instrumentation-winston/package.json
@@ -44,13 +44,13 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/context-async-hooks": "1.0.1",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
-    "@opentelemetry/sdk-trace-node": "1.0.1",
+    "@opentelemetry/context-async-hooks": "1.2.0",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
+    "@opentelemetry/sdk-trace-node": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
     "@types/sinon": "10.0.2",
@@ -66,6 +66,6 @@
     "winston2": "npm:winston@2.4.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.27.0"
+    "@opentelemetry/instrumentation": "^0.28.0"
   }
 }

--- a/plugins/web/opentelemetry-instrumentation-document-load/package.json
+++ b/plugins/web/opentelemetry-instrumentation-document-load/package.json
@@ -47,7 +47,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.15.0",
@@ -81,7 +81,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.0.0",
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/sdk-trace-base": "^1.0.0",
     "@opentelemetry/sdk-trace-web": "^1.0.0",
     "@opentelemetry/semantic-conventions": "^1.0.0"

--- a/plugins/web/opentelemetry-instrumentation-long-task/package.json
+++ b/plugins/web/opentelemetry-instrumentation-long-task/package.json
@@ -50,7 +50,7 @@
     "@babel/core": "7.15.0",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
     "@types/jquery": "3.5.6",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
@@ -81,11 +81,11 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.0.0",
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/sdk-trace-web": "^1.0.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "sideEffects": false
 }

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
@@ -50,9 +50,9 @@
     "@babel/core": "7.15.0",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/context-zone-peer-dep": "1.0.1",
-    "@opentelemetry/instrumentation-xml-http-request": "0.27.0",
-    "@opentelemetry/sdk-trace-base": "1.0.1",
+    "@opentelemetry/context-zone-peer-dep": "1.2.0",
+    "@opentelemetry/instrumentation-xml-http-request": "0.28.0",
+    "@opentelemetry/sdk-trace-base": "1.2.0",
     "@types/jquery": "3.5.6",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
@@ -83,11 +83,11 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.0.0",
-    "@opentelemetry/instrumentation": "^0.27.0",
+    "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/sdk-trace-web": "^1.0.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2",
+    "@opentelemetry/api": "^1.0.0",
     "zone.js": "0.11.4"
   },
   "sideEffects": false

--- a/plugins/web/opentelemetry-plugin-react-load/package.json
+++ b/plugins/web/opentelemetry-plugin-react-load/package.json
@@ -50,7 +50,7 @@
     "@babel/core": "7.15.0",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "@opentelemetry/api": "1.0.2",
-    "@opentelemetry/propagator-b3": "1.0.1",
+    "@opentelemetry/propagator-b3": "1.2.0",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
     "@types/react": "17.0.16",
@@ -83,7 +83,7 @@
     "webpack-merge": "5.8.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2",
+    "@opentelemetry/api": "^1.0.0",
     "react": "^16.13.1 || ^17.0.0"
   },
   "dependencies": {

--- a/propagators/opentelemetry-propagator-aws-xray/package.json
+++ b/propagators/opentelemetry-propagator-aws-xray/package.json
@@ -45,7 +45,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",

--- a/propagators/opentelemetry-propagator-grpc-census-binary/package.json
+++ b/propagators/opentelemetry-propagator-grpc-census-binary/package.json
@@ -42,7 +42,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",

--- a/propagators/opentelemetry-propagator-ot-trace/package.json
+++ b/propagators/opentelemetry-propagator-ot-trace/package.json
@@ -46,7 +46,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.2"
+    "@opentelemetry/api": "^1.0.0"
   },
   "devDependencies": {
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",


### PR DESCRIPTION
## Which problem is this PR solving?

fixes #983

## Short description of the changes

use ^0.28.0 in dependencies to SDK experimental packages
use 1.2.0 in dev-dependencies

## Checklist

- [ ] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
