### PR TITLE
fix: make `graphql` a peer dependency

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-graphql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-graphql/package.json
@@ -44,13 +44,15 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.0"
+    "@opentelemetry/api": "^1.0.0",
+    "graphql": "^15.5.1 || ^16.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
     "@opentelemetry/sdk-trace-base": "1.2.0",
     "@types/mocha": "8.2.3",
     "@types/node": "16.11.21",
+    "graphql": "^15.5.1",
     "gts": "3.1.0",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
@@ -60,7 +62,6 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.28.0",
-    "graphql": "^15.5.1"
+    "@opentelemetry/instrumentation": "^0.28.0"
   }
 }


### PR DESCRIPTION
The `graphql` library should always be a peer dependency so that the
application can elect which version of the `graphql` library it wishes
to use.

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

-

## Short description of the changes

-

## Checklist

- [ ] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
