### PR TITLE
fix: move @opentelemetry/core to dependencies

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-gcp/package.json
+++ b/detectors/node/opentelemetry-resource-detector-gcp/package.json
@@ -43,7 +43,6 @@
   "devDependencies": {
     "@opentelemetry/api": "1.0.2",
     "@opentelemetry/contrib-test-utils": "0.29.0",
-    "@opentelemetry/core": "1.2.0",
     "@types/mocha": "8.2.3",
     "@types/node": "16.11.21",
     "@types/semver": "7.3.8",
@@ -59,6 +58,7 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
+    "@opentelemetry/core": "^1.0.0",
     "@opentelemetry/resources": "^1.0.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "gcp-metadata": "^4.1.4",


### PR DESCRIPTION
## Which problem is this PR solving?

https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1000

## Short description of the changes

Move @opentelemetry/core to dependencies

## Checklist

- [ ] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
