### PR TITLE
test: update TAV versions for aws-sdk instrumentation package

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/.tav.yml
@@ -1,21 +1,21 @@
 "aws-sdk":
   # there are so many version to test, it can take forever.
   # we will just sample few of them
-  versions: ">=2.1004.0 || 2.1002.0 || 2.950.0 || 2.903.0 || 2.880.0 || 2.706.0 || 2.608.0 || 2.518.0 || 2.422.0 || 2.308.0"
+  versions: ">=2.1130.0 || 2.1048.0 || 2.1012.0 || 2.647.0 || 2.308.0"
   commands:
     - npm run test
   # Fix missing `contrib-test-utils` package
   pretest: npm run --prefix ../../../ lerna:link
 
 "@aws-sdk/client-s3":
-  versions: ">=3.33.0 || 3.27.0 || 3.18.0 || 3.6.1 || 3.3.0"
+  versions: ">=3.83.0 || 3.58.0 || 3.54.0 || 3.6.1"
   commands:
     - npm run test
   # Fix missing `contrib-test-utils` package
   pretest: npm run --prefix ../../../ lerna:link
 
 "@aws-sdk/client-sqs":
-  versions: ">=3.33.0 || 3.24.0 || 3.19.0 || 3.1.0"
+  versions: ">=3.85.0 || 3.82.0 || 3.58.0 || 3.54.0 || 3.43.0 || 3.24.0"
   commands:
     - npm run test
   # Fix missing `contrib-test-utils` package


### PR DESCRIPTION
## Which problem is this PR solving?

TAV runs take approximatelys 3 hours. Half of it is spent on testing different `aws-sdk` versions. Not a huge problem, but still quite out of balance and a realy problem since we expect devs to actually run TAV locally.

## Short description of the changes

Update version ranges for TAV runs for `aws-sdk` instrumentation.

## Checklist

- [x] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
