### PR TITLE
chore: unpin fetch instrumentation

### DIFF
--- a/packages/opentelemetry-browser-extension-autoinjection/package.json
+++ b/packages/opentelemetry-browser-extension-autoinjection/package.json
@@ -72,7 +72,7 @@
     "@opentelemetry/exporter-zipkin": "^1.0.0",
     "@opentelemetry/instrumentation": "^0.28.0",
     "@opentelemetry/instrumentation-document-load": "^0.28.0",
-    "@opentelemetry/instrumentation-fetch": "0.28.0",
+    "@opentelemetry/instrumentation-fetch": "^0.28.0",
     "@opentelemetry/instrumentation-xml-http-request": "^0.28.0",
     "@opentelemetry/resources": "^1.0.0",
     "@opentelemetry/sdk-trace-base": "^1.0.0",


### PR DESCRIPTION
## Which problem is this PR solving?

resolved [this comment](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1020#discussion_r872958284)

## Short description of the changes

Instrumentation fetch is in core repo and therefore it shouldn't be pinned here.


## Checklist

- [ ] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
