### PR TITLE
chore(release-please): issue GitHub API requests sequencially

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
     "node-workspace"
   ],
   "bump-minor-pre-major": true,
+  "sequential-calls": true,
   "packages": {
     "detectors/node/opentelemetry-resource-detector-alibaba-cloud": {},
     "detectors/node/opentelemetry-resource-detector-aws": {},


### PR DESCRIPTION
## Which problem is this PR solving?

Our release step is failing. Don't know for a fact that it's because of the rate-limiting, but there are glues. Release Please could output rate limiting errors as "Server Errors".

## Short description of the changes

Enabled [an option](https://github.com/googleapis/release-please/blob/d7d525f283f931dd999ca69228e71dd6adf9e0c3/docs/manifest-releaser.md) to slow API calls down.
