### PR TITLE
feat(mysql2): support Connection.execute

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-mysql2/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/src/instrumentation.ts
@@ -68,6 +68,15 @@ export class MySQL2Instrumentation extends InstrumentationBase<
             this._patchQuery(moduleExports.format) as any
           );
 
+          if (isWrapped(ConnectionPrototype.execute)) {
+            this._unwrap(ConnectionPrototype, 'execute');
+          }
+          this._wrap(
+            ConnectionPrototype,
+            'execute',
+            this._patchQuery(moduleExports.format) as any
+          );
+
           return moduleExports;
         },
         (moduleExports: any) => {
@@ -75,6 +84,7 @@ export class MySQL2Instrumentation extends InstrumentationBase<
           const ConnectionPrototype: mysqlTypes.Connection =
             moduleExports.Connection.prototype;
           this._unwrap(ConnectionPrototype, 'query');
+          this._unwrap(ConnectionPrototype, 'execute');
         }
       ),
     ];
@@ -83,7 +93,7 @@ export class MySQL2Instrumentation extends InstrumentationBase<
   private _patchQuery(format: formatType) {
     return (originalQuery: Function): Function => {
       const thisPlugin = this;
-      api.diag.debug('MySQL2Instrumentation: patched mysql query');
+      api.diag.debug('MySQL2Instrumentation: patched mysql query/execute');
 
       return function query(
         this: mysqlTypes.Connection,


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

The current instrumentation for mysql2 does not track queries made with [`Connection.execute`](https://www.npmjs.com/package/mysql2#using-prepared-statements), which is the helper method for preparing and executing a statement.

## Short description of the changes

Since `Connection.query` and `Connection.execute` have the same signature and response formats (where it matters), all the existing wrapper code can simply be reused.

Tests for `Connection.query` and `Pool.query` have been mirrored for `.execute`.

## Checklist

- [x] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
