### PR TITLE
docs(instrumentation-redis): add instrumentation options

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-redis/README.md
+++ b/plugins/node/opentelemetry-instrumentation-redis/README.md
@@ -43,6 +43,37 @@ registerInstrumentations({
 
 See [examples/redis](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/examples/redis) for a short example.
 
+### Redis Instrumentation Options
+
+Redis instrumentation has a few options available to choose from. You can set the following:
+
+| Options                 | Type                                              | Description                                                                                                    |
+| ----------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `dbStatementSerializer` | `DbStatementSerializer` (function)                | Redis instrumentation will serialize the command to the `db.statement` attribute using the specified function. |
+| `responseHook`          | `RedisResponseCustomAttributeFunction` (function) | Function for adding custom attributes on db response. Receives params: `span, moduleVersion, cmdName, cmdArgs` |
+| `requireParentSpan`     | `boolean`                                         | Require parent to create redis span, default when unset is false.                                              |
+
+#### Custom `db.statement` Serializer
+
+The instrumentation serializes the command into a Span attribute called
+`db.statement`. The default serialization sets the attribute to the command
+name, without the command arguments.
+
+It is also possible to define a custom serialization function. The function
+will receive the command name and arguments and must return a string.
+
+Here is a simple example to serialize the command name and arguments:
+
+```javascript
+const { RedisInstrumentation } = require('@opentelemetry/instrumentation-redis');
+
+const redisInstrumentation = new RedisInstrumentation({
+  dbStatementSerializer: function (cmdName, cmdArgs) {
+    return [cmdName, ...cmdArgs].join(" ");
+  },
+});
+```
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

The Redis instrumentation already accepts several options on initialisation, in a similar manner to the IORedis instrumentation. Unlike in the IORedis instrumentation, however, these options are undocumented for the Redis instrumentation. This PR copies the relevant documentation about initialisation options from the IORedis instrumentation's README to the Redis one, tweaking it where the instrumentation libraries differ.

## Short description of the changes

- Copy documentation on IORedis instrumentation's initialisation options to the Redis instrumentation's README.
- Do not copy any documentation relating to the `requestHook` option, as it is not supported by the Redis instrumentation.
- Amend the documentation to document differences in default values:
  - In the IORedis instrumentation, the default `db.statement` serialiser returns the command name and arguments concatenated by spaces. The Redis instrumentation returns only the command name. The examples given for custom `db.statement` serialiser functions on each library's README correspond to the other library's default `db.statement` serialiser.
  - In the IORedis instrumentation, the default value for `requireParentSpan` is true. In the Redis instrumentation, it is false.