### PR TITLE
fix: avoid type imports of the aws-sdk package in the built assets

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.ts
@@ -105,29 +105,28 @@ export class AwsInstrumentation extends InstrumentationBase<any> {
     // as for aws-sdk v3.13.1, constructStack is exported from @aws-sdk/middleware-stack as
     // getter instead of function, which fails shimmer.
     // so we are patching the MiddlewareStack.js file directly to get around it.
-    const v3MiddlewareStack = new InstrumentationNodeModuleDefinition<any>(
-      '@aws-sdk/middleware-stack',
-      ['^3.1.0'],
-      undefined,
-      undefined,
-      [v3MiddlewareStackFileOldVersions, v3MiddlewareStackFileNewVersions]
-    );
+    const v3MiddlewareStack = new InstrumentationNodeModuleDefinition<
+      typeof AWS
+    >('@aws-sdk/middleware-stack', ['^3.1.0'], undefined, undefined, [
+      v3MiddlewareStackFileOldVersions,
+      v3MiddlewareStackFileNewVersions,
+    ]);
 
-    const v3SmithyClient = new InstrumentationNodeModuleDefinition<any>(
+    const v3SmithyClient = new InstrumentationNodeModuleDefinition<typeof AWS>(
       '@aws-sdk/smithy-client',
       ['^3.1.0'],
       this.patchV3SmithyClient.bind(this),
       this.unpatchV3SmithyClient.bind(this)
     );
 
-    const v2Request = new InstrumentationNodeModuleFile<any>(
+    const v2Request = new InstrumentationNodeModuleFile<typeof AWS>(
       'aws-sdk/lib/core.js',
       ['^2.308.0'],
       this.patchV2.bind(this),
       this.unpatchV2.bind(this)
     );
 
-    const v2Module = new InstrumentationNodeModuleDefinition<any>(
+    const v2Module = new InstrumentationNodeModuleDefinition<typeof AWS>(
       'aws-sdk',
       ['^2.308.0'],
       undefined,

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.ts
@@ -71,7 +71,7 @@ type V2PluginRequest = AWS.Request<any, any> & {
   [REQUEST_SPAN_KEY]?: Span;
 };
 
-export class AwsInstrumentation extends InstrumentationBase<typeof AWS> {
+export class AwsInstrumentation extends InstrumentationBase<any> {
   static readonly component = 'aws-sdk';
   protected override _config!: AwsSdkInstrumentationConfig;
   private servicesExtensions: ServicesExtensions = new ServicesExtensions();
@@ -105,28 +105,29 @@ export class AwsInstrumentation extends InstrumentationBase<typeof AWS> {
     // as for aws-sdk v3.13.1, constructStack is exported from @aws-sdk/middleware-stack as
     // getter instead of function, which fails shimmer.
     // so we are patching the MiddlewareStack.js file directly to get around it.
-    const v3MiddlewareStack = new InstrumentationNodeModuleDefinition<
-      typeof AWS
-    >('@aws-sdk/middleware-stack', ['^3.1.0'], undefined, undefined, [
-      v3MiddlewareStackFileOldVersions,
-      v3MiddlewareStackFileNewVersions,
-    ]);
+    const v3MiddlewareStack = new InstrumentationNodeModuleDefinition<any>(
+      '@aws-sdk/middleware-stack',
+      ['^3.1.0'],
+      undefined,
+      undefined,
+      [v3MiddlewareStackFileOldVersions, v3MiddlewareStackFileNewVersions]
+    );
 
-    const v3SmithyClient = new InstrumentationNodeModuleDefinition<typeof AWS>(
+    const v3SmithyClient = new InstrumentationNodeModuleDefinition<any>(
       '@aws-sdk/smithy-client',
       ['^3.1.0'],
       this.patchV3SmithyClient.bind(this),
       this.unpatchV3SmithyClient.bind(this)
     );
 
-    const v2Request = new InstrumentationNodeModuleFile<typeof AWS>(
+    const v2Request = new InstrumentationNodeModuleFile<any>(
       'aws-sdk/lib/core.js',
       ['^2.308.0'],
       this.patchV2.bind(this),
       this.unpatchV2.bind(this)
     );
 
-    const v2Module = new InstrumentationNodeModuleDefinition<typeof AWS>(
+    const v2Module = new InstrumentationNodeModuleDefinition<any>(
       'aws-sdk',
       ['^2.308.0'],
       undefined,
@@ -177,7 +178,7 @@ export class AwsInstrumentation extends InstrumentationBase<typeof AWS> {
     return moduleExports;
   }
 
-  protected patchV2(moduleExports: typeof AWS, moduleVersion?: string) {
+  protected patchV2(moduleExports: any, moduleVersion?: string) {
     diag.debug(
       `aws-sdk instrumentation: applying patch to ${AwsInstrumentation.component}`
     );
@@ -196,7 +197,7 @@ export class AwsInstrumentation extends InstrumentationBase<typeof AWS> {
     return moduleExports;
   }
 
-  protected unpatchV2(moduleExports?: typeof AWS) {
+  protected unpatchV2(moduleExports?: any) {
     if (isWrapped(moduleExports?.Request.prototype.send)) {
       this._unwrap(moduleExports!.Request.prototype, 'send');
     }

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.types.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.types.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+  These are slightly modified and simplified versions of the actual SQS types included
+  in the official distribution:
+  https://github.com/aws/aws-sdk-js/blob/master/clients/sqs.d.ts
+  These are brought here to avoid having users install the `aws-sdk` whenever they
+  require this instrumentation.
+*/
+
+interface Blob {}
+type Binary = Buffer | Uint8Array | Blob | string;
+
+export namespace SNS {
+  interface MessageAttributeValue {
+    /**
+     * Amazon SNS supports the following logical data types: String, String.Array, Number, and Binary. For more information, see Message Attribute Data Types.
+     */
+    DataType: string;
+    /**
+     * Strings are Unicode with UTF8 binary encoding. For a list of code values, see ASCII Printable Characters.
+     */
+    StringValue?: string;
+    /**
+     * Binary type attributes can store any binary data, for example, compressed data, encrypted data, or images.
+     */
+    BinaryValue?: Binary;
+  }
+
+  export type MessageAttributeMap = { [key: string]: MessageAttributeValue };
+}
+
+export namespace SQS {
+  type StringList = string[];
+  type BinaryList = Binary[];
+  interface MessageAttributeValue {
+    /**
+     * Strings are Unicode with UTF-8 binary encoding. For a list of code values, see ASCII Printable Characters.
+     */
+    StringValue?: string;
+    /**
+     * Binary type attributes can store any binary data, such as compressed data, encrypted data, or images.
+     */
+    BinaryValue?: Binary;
+    /**
+     * Not implemented. Reserved for future use.
+     */
+    StringListValues?: StringList;
+    /**
+     * Not implemented. Reserved for future use.
+     */
+    BinaryListValues?: BinaryList;
+    /**
+     * Amazon SQS supports the following logical data types: String, Number, and Binary. For the Number data type, you must use StringValue. You can also append custom labels. For more information, see Amazon SQS Message Attributes in the Amazon SQS Developer Guide.
+     */
+    DataType: string;
+  }
+
+  export type MessageBodyAttributeMap = {
+    [key: string]: MessageAttributeValue;
+  };
+
+  type MessageSystemAttributeMap = { [key: string]: string };
+
+  export interface Message {
+    /**
+     * A unique identifier for the message. A MessageIdis considered unique across all accounts for an extended period of time.
+     */
+    MessageId?: string;
+    /**
+     * An identifier associated with the act of receiving the message. A new receipt handle is returned every time you receive a message. When deleting a message, you provide the last received receipt handle to delete the message.
+     */
+    ReceiptHandle?: string;
+    /**
+     * An MD5 digest of the non-URL-encoded message body string.
+     */
+    MD5OfBody?: string;
+    /**
+     * The message's contents (not URL-encoded).
+     */
+    Body?: string;
+    /**
+     * A map of the attributes requested in  ReceiveMessage  to their respective values. Supported attributes:    ApproximateReceiveCount     ApproximateFirstReceiveTimestamp     MessageDeduplicationId     MessageGroupId     SenderId     SentTimestamp     SequenceNumber     ApproximateFirstReceiveTimestamp and SentTimestamp are each returned as an integer representing the epoch time in milliseconds.
+     */
+    Attributes?: MessageSystemAttributeMap;
+    /**
+     * An MD5 digest of the non-URL-encoded message attribute string. You can use this attribute to verify that Amazon SQS received the message correctly. Amazon SQS URL-decodes the message before creating the MD5 digest. For information about MD5, see RFC1321.
+     */
+    MD5OfMessageAttributes?: string;
+    /**
+     * Each message attribute consists of a Name, Type, and Value. For more information, see Amazon SQS message attributes in the Amazon SQS Developer Guide.
+     */
+    MessageAttributes?: MessageBodyAttributeMap;
+  }
+}

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.types.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.types.ts
@@ -22,9 +22,11 @@
   require this instrumentation.
 */
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface -- Our lint doesn't like it, but we prefer to keep it the way original source code has it
 interface Blob {}
 type Binary = Buffer | Uint8Array | Blob | string;
 
+// eslint-disable-next-line @typescript-eslint/no-namespace -- Prefer to contain the types copied over in one location
 export namespace SNS {
   interface MessageAttributeValue {
     /**
@@ -44,6 +46,7 @@ export namespace SNS {
   export type MessageAttributeMap = { [key: string]: MessageAttributeValue };
 }
 
+// eslint-disable-next-line @typescript-eslint/no-namespace -- Prefer to contain the types copied over in one location
 export namespace SQS {
   type StringList = string[];
   type BinaryList = Binary[];

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/MessageAttributes.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/MessageAttributes.ts
@@ -20,7 +20,7 @@ import {
   propagation,
   diag,
 } from '@opentelemetry/api';
-import type { SQS, SNS } from 'aws-sdk';
+import type { SQS, SNS } from '../aws-sdk.types';
 
 // https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-quotas.html
 export const MAX_MESSAGE_ATTRIBUTES = 10;

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/types.ts
@@ -15,7 +15,7 @@
  */
 import { Span } from '@opentelemetry/api';
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
-import type * as AWS from 'aws-sdk';
+import { SQS } from './aws-sdk.types';
 
 /**
  * These are normalized request and response, which are used by both sdk v2 and v3.
@@ -56,7 +56,7 @@ export interface AwsSdkResponseCustomAttributeFunction {
 }
 
 export interface AwsSdkSqsProcessHookInformation {
-  message: AWS.SQS.Message;
+  message: SQS.Message;
 }
 export interface AwsSdkSqsProcessCustomAttributeFunction {
   (span: Span, sqsProcessInfo: AwsSdkSqsProcessHookInformation): void;

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/utils.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import { NormalizedRequest } from './types';
-import type { Request } from 'aws-sdk';
 import { Context, SpanAttributes, context } from '@opentelemetry/api';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { AttributeNames } from './enums';
@@ -32,14 +31,12 @@ export const removeSuffixFromStringIfExists = (
     : str;
 };
 
-export const normalizeV2Request = (
-  awsV2Request: Request<any, any>
-): NormalizedRequest => {
-  const service = (awsV2Request as any)?.service;
+export const normalizeV2Request = (awsV2Request: any): NormalizedRequest => {
+  const service = awsV2Request?.service;
   return {
     serviceName: service?.api?.serviceId?.replace(/\s+/g, ''),
-    commandName: toPascalCase((awsV2Request as any)?.operation),
-    commandInput: (awsV2Request as any).params,
+    commandName: toPascalCase(awsV2Request?.operation),
+    commandInput: awsV2Request.params,
     region: service?.config?.region,
   };
 };


### PR DESCRIPTION
## Which problem is this PR solving?

This is a subset of #1017 that touches `aws-sdk` types because of the legal discussion holding merging those back.

## Short description of the changes

See #1017

## Checklist

- [ ] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
