### PR TITLE
fix(opentelemetry-instrumentation-document-load): updated instrumenta…

### DIFF
--- a/plugins/web/opentelemetry-instrumentation-document-load/test/documentLoad.test.ts
+++ b/plugins/web/opentelemetry-instrumentation-document-load/test/documentLoad.test.ts
@@ -124,6 +124,32 @@ const resourcesNoSecureConnectionStart = [
     serverTiming: [],
   },
 ];
+const resourcesFetchAfterEnd = [
+  {
+    name: 'http://localhost:8090/bundle.js',
+    entryType: 'resource',
+    startTime: 20.985000010114163,
+    duration: 90.94999998342246,
+    initiatorType: 'script',
+    nextHopProtocol: 'http/1.1',
+    workerStart: 0,
+    redirectStart: 0,
+    redirectEnd: 0,
+    fetchStart: 120.985000010114163,
+    domainLookupStart: 20.985000010114163,
+    domainLookupEnd: 20.985000010114163,
+    connectStart: 20.985000010114163,
+    connectEnd: 20.985000010114163,
+    secureConnectionStart: 0,
+    requestStart: 29.28999997675419,
+    responseStart: 31.88999998383224,
+    responseEnd: 32.93499999353662,
+    transferSize: 1446645,
+    encodedBodySize: 1446396,
+    decodedBodySize: 1446396,
+    serverTiming: [],
+  },
+];
 const entries = {
   name: 'http://localhost:8090/',
   entryType: 'navigation',
@@ -316,6 +342,29 @@ describe('DocumentLoad Instrumentation', () => {
       );
       setTimeout(() => {
         assert.strictEqual(spyEntries.callCount, 3);
+        done();
+      });
+    });
+  });
+
+  describe('when navigation entries have bad timings', () => {
+    let spyEntries: sinon.SinonStub;
+    beforeEach(() => {
+      spyEntries = sandbox.stub(window.performance, 'getEntriesByType');
+      spyEntries.withArgs('navigation').returns([entries]);
+      spyEntries.withArgs('resource').returns(resourcesFetchAfterEnd);
+      spyEntries.withArgs('paint').returns(paintEntries);
+    });
+    afterEach(() => {
+      spyEntries.restore();
+    });
+
+    it('should never have negative duration', done => {
+      plugin.enable();
+
+      setTimeout(() => {
+        const fetchSpan = exporter.getFinishedSpans()[1] as ReadableSpan;
+        assert.deepEqual(fetchSpan.duration, [0,0]);
         done();
       });
     });


### PR DESCRIPTION
…tion of document load to disallow end time being set to value before start time

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Fixes #1013 Spans getting end timestamps after start timestamps occasionally.

## Short description of the changes

- Updated the explicit end span to validate that the end time is actually after the start time when the source of those timestamps are performance metrics, otherwise falling back to the start time.

## Checklist

- [x] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
