### PR TITLE
fix(propagator-ot-trace): read sampled flag correctly from span context

### DIFF
--- a/propagators/opentelemetry-propagator-ot-trace/src/OTTracePropagator.ts
+++ b/propagators/opentelemetry-propagator-ot-trace/src/OTTracePropagator.ts
@@ -72,7 +72,9 @@ export class OTTracePropagator implements TextMapPropagator {
     setter.set(
       carrier,
       OT_SAMPLED_HEADER,
-      spanContext.traceFlags === TraceFlags.SAMPLED ? 'true' : 'false'
+      (spanContext.traceFlags & TraceFlags.SAMPLED) === TraceFlags.SAMPLED
+        ? 'true'
+        : 'false'
     );
 
     const baggage = propagation.getBaggage(context);

--- a/propagators/opentelemetry-propagator-ot-trace/test/OTTracePropagator.test.ts
+++ b/propagators/opentelemetry-propagator-ot-trace/test/OTTracePropagator.test.ts
@@ -78,6 +78,25 @@ describe('OTTracePropagator', () => {
       assert.strictEqual(carrier[OT_SAMPLED_HEADER], 'true');
     });
 
+    it('correctly reads the sampled flag even if other flags are set', () => {
+      const spanContext: SpanContext = {
+        traceId: '80f198ee56343ba864fe8b2a57d3eff7',
+        spanId: 'e457b5a2e4d86bd1',
+        // 81 = 1000 0001, so this sets the sampled flag (rightmost bit) and one other flag (leftmost bit, semantics unspecified at the time of writing)
+        traceFlags: 81,
+      };
+
+      propagator.inject(
+        trace.setSpan(ROOT_CONTEXT, trace.wrapSpanContext(spanContext)),
+        carrier,
+        defaultTextMapSetter
+      );
+
+      assert.strictEqual(carrier[OT_TRACE_ID_HEADER], '64fe8b2a57d3eff7');
+      assert.strictEqual(carrier[OT_SPAN_ID_HEADER], 'e457b5a2e4d86bd1');
+      assert.strictEqual(carrier[OT_SAMPLED_HEADER], 'true');
+    });
+
     it('injects context with unspecified trace flags', () => {
       const spanContext: SpanContext = {
         traceId: '80f198ee56343ba864fe8b2a57d3eff7',


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes the way the `sampled` flag is read from the span context. The way it
is currently read will break when more flags are introduced. This is even
mentioned explicitly in the
[specification](https://www.w3.org/TR/trace-context/#trace-flags).

## Short description of the changes

- check the flag bit independently instead of comparing the whole flags byte value with the SAMPLED_FLAG constant.
- add a unit test that show cases the issue (and breaks without the change in production code)

## Checklist

- [x] Ran `npm run test` for the edited package(s) on the latest commit if applicable.