### PR TITLE
docs: remove obsolete instruction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,6 @@ The `opentelemetry-js-contrib` project is written in TypeScript.
 
 - `npm install` to install dependencies.
 - `npm run compile` compiles the code, checking for type errors.
-- `npm run bootstrap` Bootstrap the packages in the current Lerna repo. Installs all of their dependencies and links any cross-dependencies.
 - `npm test` tests code the same way that our CI will test it.
 - `npm run lint:fix` lint (and maybe fix) any changes.
 


### PR DESCRIPTION
## Which problem is this PR solving?

`npm run bootstrap` is ran as a `postinstall` lifecycle hook during `npm
install`, thus executing it as a separate step is not necessary.

See https://github.com/open-telemetry/opentelemetry-js-contrib/blob/8786cbe7163e552a4d9fc39609188236fd66c780/package.json#L16

## Checklist

- [x] Not applicable -- ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
