### PR TITLE
chore: introduce no-extraneous-dependencies

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,8 @@
 module.exports = {
   plugins: [
     "@typescript-eslint",
-    "header"
+    "header",
+    "import"
   ],
   extends: [
       "./node_modules/gts",
@@ -32,7 +33,8 @@ module.exports = {
         pattern: / \* Copyright The OpenTelemetry Authors[\r\n]+ \*[\r\n]+ \* Licensed under the Apache License, Version 2\.0 \(the \"License\"\);[\r\n]+ \* you may not use this file except in compliance with the License\.[\r\n]+ \* You may obtain a copy of the License at[\r\n]+ \*[\r\n]+ \*      https:\/\/www\.apache\.org\/licenses\/LICENSE-2\.0[\r\n]+ \*[\r\n]+ \* Unless required by applicable law or agreed to in writing, software[\r\n]+ \* distributed under the License is distributed on an \"AS IS\" BASIS,[\r\n]+ \* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.[\r\n]+ \* See the License for the specific language governing permissions and[\r\n]+ \* limitations under the License\./gm,
         template:
         `\n * Copyright The OpenTelemetry Authors\n *\n * Licensed under the Apache License, Version 2.0 (the "License");\n * you may not use this file except in compliance with the License.\n * You may obtain a copy of the License at\n *\n *      https://www.apache.org/licenses/LICENSE-2.0\n *\n * Unless required by applicable law or agreed to in writing, software\n * distributed under the License is distributed on an "AS IS" BASIS,\n * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n * See the License for the specific language governing permissions and\n * limitations under the License.\n `
-    }]]
+    }]],
+    "import/no-extraneous-dependencies": ["error", { devDependencies: ["test/**/*.ts"] }]
   },
   overrides: [
     {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

This should prevent https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1003 from happening again.

## Short description of the changes

The glob is used to specify locations where the rule should not apply, we should there be safe in importing devDependencies in tests.

## Question

It _seems_[^1] to have caught some problems already, though I am not sure if we want to also address the problems in this PR.

[^1]: The error could actually be intended behaviour, as we seem to need only the typings [here](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/7510757aeeee47a7f0c4bb31de45be3a71bb673e/plugins/node/opentelemetry-instrumentation-express/src/types.ts#L18) for example. I am not confident with the codebase enough to add an exception right off the bat, a couple of more expert eyes on this would be appreciated.

## Checklist

- [x] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
