### PR TITLE
fix: allow react 18 in peer deps

### DIFF
--- a/plugins/web/opentelemetry-plugin-react-load/package.json
+++ b/plugins/web/opentelemetry-plugin-react-load/package.json
@@ -53,7 +53,7 @@
     "@opentelemetry/propagator-b3": "^1.3.1",
     "@types/mocha": "7.0.2",
     "@types/node": "16.11.21",
-    "@types/react": "17.0.16",
+    "@types/react": "18.0.15",
     "@types/react-addons-test-utils": "0.14.26",
     "@types/react-dom": "18.0.2",
     "@types/shimmer": "1.0.2",
@@ -71,8 +71,8 @@
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "process": "0.11.10",
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "rimraf": "3.0.2",
     "sinon": "14.0.0",
     "ts-loader": "8.3.0",
@@ -84,7 +84,7 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0",
-    "react": "^16.13.1 || ^17.0.0"
+    "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "@opentelemetry/context-zone": "^1.0.0",


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes #1098 

## Short description of the changes

- Added React 18 as a valid peerDependency version range.

## Checklist

- [x] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
