### PR TITLE
fix(memcached): low cardinality span name

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-memcached/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-memcached/src/instrumentation.ts
@@ -138,7 +138,7 @@ export class Instrumentation extends InstrumentationBase<typeof Memcached> {
       const query = original.apply(this, arguments as any);
       const callback = query.callback;
 
-      span.updateName(`${query.type} ${query.key}`);
+      span.updateName(`memcached ${query.type}`);
       span.setAttributes({
         'db.memcached.key': query.key,
         'db.memcached.lifetime': query.lifetime,

--- a/plugins/node/opentelemetry-instrumentation-memcached/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-memcached/test/index.test.ts
@@ -280,7 +280,7 @@ const assertSpans = (actualSpans: any[], expectedSpans: any[]) => {
       assert.notStrictEqual(span, undefined);
       assert.notStrictEqual(expected, undefined);
       assertMatch(span.name, new RegExp(expected.op));
-      assertMatch(span.name, new RegExp(expected.key));
+      assertMatch(span.name, new RegExp('memcached'));
       assert.strictEqual(span.kind, SpanKind.CLIENT);
       assert.strictEqual(span.attributes['db.statement'], expected.statement);
       for (const attr in DEFAULT_ATTRIBUTES) {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Fixes https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1102

We have addressed the problem above by making the changes necessary and we can get the memcached value from the span attributes itself. 

## Short description of the changes

- Removed query.type from the span name as it creates a high cardinality of span names.
- The span name will be memcached get or memcached set. (Open to change this span name)

## Checklist

- [x] Ran `npm test` for the edited package(s) on the latest commit if applicable.
