### PR TITLE
ci: [Bug] DNS Lookup and Promise Lookup test for error NOT_FOUND failing #1136

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-dns/test/integrations/dns-lookup.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/test/integrations/dns-lookup.test.ts
@@ -98,24 +98,30 @@ describe('dns.lookup()', () => {
       });
     });
 
-    it('should export a valid span with error NOT_FOUND', done => {
-      const hostname = 'ᚕ';
-      dns.lookup(hostname, (err, address, family) => {
-        assert.ok(err);
+    describe("extended timeout", function () {
+      // Extending the default timeout as some environments are taking longer than 2 seconds to fail
+      // So rather than fail the test -- just take a little longer
+      this.timeout(10000);
 
-        const spans = memoryExporter.getFinishedSpans();
-        const [span] = spans;
+      it('should export a valid span with error NOT_FOUND', done => {
+        const hostname = 'ᚕ';
+        dns.lookup(hostname, (err, address, family) => {
+          assert.ok(err);
 
-        assert.strictEqual(spans.length, 1);
-        assertSpan(span, {
-          addresses: [{ address, family }],
-          hostname,
-          forceStatus: {
-            code: SpanStatusCode.ERROR,
-            message: err!.message,
-          },
+          const spans = memoryExporter.getFinishedSpans();
+          const [span] = spans;
+
+          assert.strictEqual(spans.length, 1);
+          assertSpan(span, {
+            addresses: [{ address, family }],
+            hostname,
+            forceStatus: {
+              code: SpanStatusCode.ERROR,
+              message: err!.message,
+            },
+          });
+          done();
         });
-        done();
       });
     });
 

--- a/plugins/node/opentelemetry-instrumentation-dns/test/integrations/dns-lookup.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/test/integrations/dns-lookup.test.ts
@@ -98,7 +98,7 @@ describe('dns.lookup()', () => {
       });
     });
 
-    describe("extended timeout", function () {
+    describe('extended timeout', function () {
       // Extending the default timeout as some environments are taking longer than 2 seconds to fail
       // So rather than fail the test -- just take a little longer
       this.timeout(10000);

--- a/plugins/node/opentelemetry-instrumentation-dns/test/integrations/dnspromise-lookup.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/test/integrations/dnspromise-lookup.test.ts
@@ -111,7 +111,7 @@ describe('dns.promises.lookup()', () => {
       assertSpan(span, { addresses: [{ address, family }], hostname });
     });
 
-    describe("extended timeout", function () {
+    describe('extended timeout', function () {
       // Extending the default timeout as some environments are taking longer than 2 seconds to fail
       // So rather than fail the test -- just take a little longer
       this.timeout(10000);

--- a/plugins/node/opentelemetry-instrumentation-dns/test/integrations/dnspromise-lookup.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/test/integrations/dnspromise-lookup.test.ts
@@ -111,25 +111,31 @@ describe('dns.promises.lookup()', () => {
       assertSpan(span, { addresses: [{ address, family }], hostname });
     });
 
-    it('should export a valid span with error NOT_FOUND', async () => {
-      const hostname = 'ᚕ';
-      try {
-        await lookupPromise(hostname);
-        assert.fail();
-      } catch (error) {
-        const spans = memoryExporter.getFinishedSpans();
-        const [span] = spans;
+    describe("extended timeout", function () {
+      // Extending the default timeout as some environments are taking longer than 2 seconds to fail
+      // So rather than fail the test -- just take a little longer
+      this.timeout(10000);
 
-        assert.strictEqual(spans.length, 1);
-        assertSpan(span, {
-          addresses: [],
-          hostname,
-          forceStatus: {
-            code: SpanStatusCode.ERROR,
-            message: error!.message,
-          },
-        });
-      }
+      it('should export a valid span with error NOT_FOUND', async () => {
+        const hostname = 'ᚕ';
+        try {
+          await lookupPromise(hostname);
+          assert.fail();
+        } catch (error) {
+          const spans = memoryExporter.getFinishedSpans();
+          const [span] = spans;
+
+          assert.strictEqual(spans.length, 1);
+          assertSpan(span, {
+            addresses: [],
+            hostname,
+            forceStatus: {
+              code: SpanStatusCode.ERROR,
+              message: error!.message,
+            },
+          });
+        }
+      });
     });
 
     it('should export a valid span with error INVALID_ARGUMENT when "family" param is equal to -1', async () => {


### PR DESCRIPTION
## Which problem is this PR solving?

[Bug] DNS Lookup and Promise Lookup test for error NOT_FOUND failing #1136 

## Short description of the changes

DNS resolution in local environment is exceeding 2 seconds (due to lots of fallback DNS servers) for invalid URL this is causing these 2 tests to timeout with the default 2 second delay.

Resolution:
Extend the timeout for these 2 tests so for environments where DNS resolution can take longer than expected the tests still pass.
