### PR TITLE
fix: mongodb types fails to compile with latest tsc v4.8

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-docker/package.json
+++ b/detectors/node/opentelemetry-resource-detector-docker/package.json
@@ -48,7 +48,7 @@
     "rimraf": "3.0.2",
     "sinon": "14.0.0",
     "ts-mocha": "10.0.0",
-    "typescript": "^4.5.5"
+    "typescript": "4.3.5"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/plugins/node/opentelemetry-instrumentation-express/examples/package.json
+++ b/plugins/node/opentelemetry-instrumentation-express/examples/package.json
@@ -47,6 +47,6 @@
   "devDependencies": {
     "@types/express": "^4.17.13",
     "ts-node": "^10.6.0",
-    "typescript": "4.3.5",
+    "typescript": "4.3.5"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-express/examples/package.json
+++ b/plugins/node/opentelemetry-instrumentation-express/examples/package.json
@@ -47,6 +47,6 @@
   "devDependencies": {
     "@types/express": "^4.17.13",
     "ts-node": "^10.6.0",
-    "typescript": "^4.6.2"
+    "typescript": "4.3.5",
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-koa/examples/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/examples/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "cross-env": "^6.0.0",
     "ts-node": "^10.6.0",
-    "typescript": "^4.6.2",
+    "typescript": "4.3.5",
     "@types/koa": "^2.13.5"
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-mongodb/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/package.json
@@ -67,8 +67,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.31.0",
-    "@opentelemetry/semantic-conventions": "^1.0.0",
-    "@types/mongodb": "3.6.20"
+    "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-mongodb#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-mongodb/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/package.json
@@ -59,6 +59,7 @@
     "gts": "3.1.0",
     "mocha": "7.2.0",
     "mongodb": "3.6.11",
+    "@types/mongodb": "3.6.20",
     "nyc": "15.1.0",
     "rimraf": "3.0.2",
     "test-all-versions": "5.0.1",

--- a/plugins/node/opentelemetry-instrumentation-mongodb/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/src/instrumentation.ts
@@ -33,7 +33,6 @@ import {
   DbSystemValues,
   SemanticAttributes,
 } from '@opentelemetry/semantic-conventions';
-import type * as mongodb from 'mongodb';
 import {
   CursorState,
   MongodbCommandType,
@@ -47,9 +46,7 @@ import {
 import { VERSION } from './version';
 
 /** mongodb instrumentation plugin for OpenTelemetry */
-export class MongoDBInstrumentation extends InstrumentationBase<
-  typeof mongodb
-> {
+export class MongoDBInstrumentation extends InstrumentationBase {
   constructor(protected override _config: MongoDBInstrumentationConfig = {}) {
     super('@opentelemetry/instrumentation-mongodb', VERSION, _config);
   }
@@ -59,7 +56,7 @@ export class MongoDBInstrumentation extends InstrumentationBase<
     const { v4Patch, v4Unpatch } = this._getV4Patches();
 
     return [
-      new InstrumentationNodeModuleDefinition<typeof mongodb>(
+      new InstrumentationNodeModuleDefinition<any>(
         'mongodb',
         ['>=3.3 <4'],
         undefined,
@@ -73,7 +70,7 @@ export class MongoDBInstrumentation extends InstrumentationBase<
           ),
         ]
       ),
-      new InstrumentationNodeModuleDefinition<typeof mongodb>(
+      new InstrumentationNodeModuleDefinition<any>(
         'mongodb',
         ['4.*'],
         undefined,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,8 +17,7 @@
     "strictNullChecks": true,
     "target": "es2017",
     "incremental": true,
-    "newLine": "LF",
-    "skipLibCheck": true
+    "newLine": "LF"
   },
   "exclude": [
     "node_modules"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,7 +17,8 @@
     "strictNullChecks": true,
     "target": "es2017",
     "incremental": true,
-    "newLine": "LF"
+    "newLine": "LF",
+    "skipLibCheck": true
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

There were some sub-packages that used the latest typescript version and caused errors against the deprecated @types/mongodb: 3.6.20 dependency.


## Short description of the changes

1. Moved the deprecated MongoDB dependency to a devDependency:
    * The use of `@types/mongodb` in the instrumentation itself was minor. 
       All the places that used the MongoDB types were replaced with `any` as it applied in many other instrumentations,
       in order to avoid the use of deprecated dependencies.

2. Aligned all typescript versions in the project to 4.3.5:
    There were three packages that were used latest typescript version (duo to "^version):
    * "koa-example"
    * express-example
    * @opentelemetry/resource-detector-docker

Also, we have to think about how to restrict those typescript version update changes.


## Checklist

- [x] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
