### PR TITLE
chore(mongodb): add mongodb instrumentation component owner

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -42,6 +42,8 @@ components:
     - blumamir
   plugins/node/opentelemetry-instrumentation-memcached:
     - rauno56
+  plugins/node/opentelemetry-instrumentation-mongodb:
+    - osherv
   plugins/node/opentelemetry-instrumentation-nestjs-core:
     - rauno56
   plugins/node/opentelemetry-instrumentation-redis:


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Short description of the changes

Added me to be the owner of the MongoDB instrumentation.
I am willing to take component owner responsibilities for this component.

List of my contribution to MongoDB instrumentation:
* https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1141
* https://github.com/open-telemetry/opentelemetry-js-contrib/pull/869