### PR TITLE
fix(pino): removed the tav for versions ^8

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-pino/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-pino/.tav.yml
@@ -1,5 +1,5 @@
 pino:
-  versions: "^8 || ^7.11.0 || 7.8.0 || 7.2.0 || ^6.13.1 || 5.17.0 || 5.14.0"
+  versions: "^7.11.0 || 7.8.0 || 7.2.0 || ^6.13.1 || 5.17.0 || 5.14.0"
   commands: npm run test
 
   # Fix missing `contrib-test-utils` package


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Pinto test-all-versions for versions <8 fail the test-all versions.
Also, according to the documentation, the instrumentation does not support versions that are greater than ^7.11.

-

## Short description of the changes

Remove the testing for version <8 and open a new issue to support versions <8
-


The failed Ci:
https://github.com/open-telemetry/opentelemetry-js-contrib/runs/8117913889?check_suite_focus=true


## Checklist

- [x] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
