### PR TITLE
fix: handle string ports for Socket.connect

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-net/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-net/src/utils.ts
@@ -21,6 +21,10 @@ import { platform } from 'os';
 export const IPC_TRANSPORT =
   platform() === 'win32' ? NetTransportValues.PIPE : NetTransportValues.UNIX;
 
+function getHost(args: unknown[]) {
+  return typeof args[1] === 'string' ? args[1] : 'localhost';
+}
+
 export function getNormalizedArgs(
   args: unknown[]
 ): NormalizedOptions | null | undefined {
@@ -33,17 +37,26 @@ export function getNormalizedArgs(
     case 'number':
       return {
         port: opt,
-        host: typeof args[1] === 'string' ? args[1] : 'localhost',
+        host: getHost(args),
       };
     case 'object':
       if (Array.isArray(opt)) {
         return getNormalizedArgs(opt);
       }
       return opt;
-    case 'string':
+    case 'string': {
+      const maybePort = Number(opt);
+      if (maybePort >= 0) {
+        return {
+          port: maybePort,
+          host: getHost(args),
+        };
+      }
+
       return {
         path: opt,
       };
+    }
     default:
       return;
   }

--- a/plugins/node/opentelemetry-instrumentation-net/test/connect.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-net/test/connect.test.ts
@@ -148,6 +148,13 @@ describe('NetInstrumentation', () => {
       });
     });
 
+    it('should create a tcp span when port is given as string', done => {
+      socket = socket.connect(String(PORT) as unknown as number, HOST, () => {
+        assertTcpSpan(getSpan(), socket);
+        done();
+      });
+    });
+
     it('should produce a span given options', done => {
       socket.connect(
         {


### PR DESCRIPTION
`Socket.connect` with a string port (e.g. `socket.connect('4317', 'localhost', () => {})`) was previously creating an IPC span while it should have been creating a TCP span.

For example `cassandra-driver` is a package that uses this form of `Socket.connect`.