### PR TITLE
feat(instrumentation.dns): Add option to include name as attribute in dns lookup

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-dns/src/enums/AttributeNames.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/src/enums/AttributeNames.ts
@@ -18,4 +18,5 @@ export enum AttributeNames {
   DNS_ERROR_CODE = 'dns.error_code',
   DNS_ERROR_NAME = 'dns.error_name',
   DNS_ERROR_MESSAGE = 'dns.error_message',
+  DNS_HOSTNAME = 'dns.hostname',
 }

--- a/plugins/node/opentelemetry-instrumentation-dns/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/src/instrumentation.ts
@@ -32,6 +32,7 @@ import {
 } from './types';
 import * as utils from './utils';
 import { VERSION } from './version';
+import { AttributeNames } from './enums/AttributeNames';
 
 /**
  * Dns instrumentation for Opentelemetry
@@ -110,9 +111,23 @@ export class DnsInstrumentation extends InstrumentationBase<Dns> {
       const argsCount = args.length;
       diag.debug('wrap lookup callback function and starts span');
       const name = utils.getOperationName('lookup');
-      const span = plugin.tracer.startSpan(name, {
-        kind: SpanKind.CLIENT,
-      });
+      let opts = null;
+      if (plugin._config?.addHostnameAttribute) {
+        opts = {
+          attributes: {
+            [AttributeNames.DNS_HOSTNAME]: hostname,
+          },
+        };
+      }
+      const span = plugin.tracer.startSpan(
+        name,
+        Object.assign(
+          {
+            kind: SpanKind.CLIENT,
+          },
+          opts
+        )
+      );
 
       const originalCallback = args[argsCount - 1];
       if (typeof originalCallback === 'function') {

--- a/plugins/node/opentelemetry-instrumentation-dns/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/src/instrumentation.ts
@@ -112,7 +112,7 @@ export class DnsInstrumentation extends InstrumentationBase<Dns> {
       diag.debug('wrap lookup callback function and starts span');
       const name = utils.getOperationName('lookup');
       let opts = null;
-      if (plugin._config?.addHostnameAttribute) {
+      if (plugin._config?.includeHostname) {
         opts = {
           attributes: {
             [AttributeNames.DNS_HOSTNAME]: hostname,

--- a/plugins/node/opentelemetry-instrumentation-dns/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/src/types.ts
@@ -100,5 +100,5 @@ export interface DnsInstrumentationConfig extends InstrumentationConfig {
   ignoreHostnames?: IgnoreMatcher[];
 
   /** Add target of dns lookup as span attribute in dns.lookup, default is false */
-  addHostnameAttribute?: boolean;
+  includeHostname?: boolean;
 }

--- a/plugins/node/opentelemetry-instrumentation-dns/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/src/types.ts
@@ -96,5 +96,9 @@ export type LookupCallbackSignature = LookupSimpleCallback &
   ) => void);
 
 export interface DnsInstrumentationConfig extends InstrumentationConfig {
+  /** List of hostname matchers used to decide whether to skip creating a span */
   ignoreHostnames?: IgnoreMatcher[];
+
+  /** Add target of dns lookup as span attribute in dns.lookup, default is false */
+  addHostnameAttribute?: boolean;
 }

--- a/plugins/node/opentelemetry-instrumentation-dns/test/integrations/dns-lookup.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/test/integrations/dns-lookup.test.ts
@@ -185,7 +185,7 @@ describe('dns.lookup()', () => {
     it('should include dns.hostname attribute if requested', done => {
       const hostname = 'google.com';
       const config: DnsInstrumentationConfig = {
-        addHostnameAttribute: true,
+        includeHostname: true,
       };
       instrumentation.setConfig(config);
 

--- a/plugins/node/opentelemetry-instrumentation-dns/test/integrations/dnspromise-lookup.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/test/integrations/dnspromise-lookup.test.ts
@@ -201,7 +201,7 @@ describe('dns.promises.lookup()', () => {
     it('should include dns.hostname attribute if configured', async () => {
       const hostname = 'google.com';
       const config: DnsInstrumentationConfig = {
-        addHostnameAttribute: true,
+        includeHostname: true,
       };
       instrumentation.setConfig(config);
 

--- a/plugins/node/opentelemetry-instrumentation-dns/test/utils/assertSpan.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/test/utils/assertSpan.ts
@@ -26,7 +26,7 @@ export const assertSpan = (
   span: ReadableSpan,
   validations: {
     addresses: LookupAddress[];
-    hostname: string;
+    hostname?: string;
     forceStatus?: SpanStatus;
   }
 ) => {
@@ -50,6 +50,13 @@ export const assertSpan = (
       _.address
     );
   });
+
+  if (validations.hostname !== undefined) {
+    assert.strictEqual(
+      span.attributes[AttributeNames.DNS_HOSTNAME],
+      validations.hostname
+    );
+  }
 
   assert.ok(span.endTime);
   assert.strictEqual(span.links.length, 0);


### PR DESCRIPTION
## Which problem is this PR solving?

fixes #1165 

## Short description of the changes

Adds an option in the plugin configuration to include "hostname" parameter used in `dns.lookup()` calls. Defaults to `false`.

## Checklist

- [ ] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
