### PR TITLE
feat: Compile metapackages/auto-instrumentations-web to es5

### DIFF
--- a/metapackages/auto-instrumentations-web/tsconfig.json
+++ b/metapackages/auto-instrumentations-web/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base",
+  "extends": "../../tsconfig.es5",
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "build",


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?
- [autoinstrumentations-web does not work in IE10 or IE11](https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1186)

## Short description of the changes
- Change tsconfig compilerOptions.target to es5 


## Checklist

- [x] Ran `npm run test:browser` for the edited package(s) on the latest commit if applicable.
