### PR TITLE
chore: enable running TAV on PRs

### DIFF
--- a/.github/workflows/test-all-versions.pr.yml
+++ b/.github/workflows/test-all-versions.pr.yml
@@ -1,0 +1,37 @@
+name: TAV for PR
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+  parse-labels:
+    runs-on: ubuntu-latest
+    container:
+      image: node:16
+    env:
+      PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+    outputs:
+      args: ${{ steps.lerna-args.outputs.args }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        # Need lerna to list all packages
+      - name: Install lerna
+        run: npm install -g lerna
+      - name: Parse labels into lerna scope arguments
+        id: lerna-args
+        run: |
+          OUTPUT=`node scripts/parse-lerna-scopes.mjs "$PR_LABELS"`
+          echo "::set-output name=args::$OUTPUT"
+
+  tav:
+    uses: ./.github/workflows/test-all-versions.yml
+    needs: parse-labels
+    with:
+      lerna-args: ${{ needs.parse-labels.outputs.args }}
+    if: ${{ needs.parse-labels.outputs.args != '' }}

--- a/.github/workflows/test-all-versions.push.yml
+++ b/.github/workflows/test-all-versions.push.yml
@@ -1,0 +1,13 @@
+name: TAV for Push
+on:
+  push:
+    branches:
+      - "main"
+      - "release/**"
+      - "release-please/**"
+
+jobs:
+  tav:
+    uses: ./.github/workflows/test-all-versions.yml
+    with:
+      lerna-args: ""

--- a/.github/workflows/test-all-versions.yml
+++ b/.github/workflows/test-all-versions.yml
@@ -16,6 +16,12 @@ jobs:
       fail-fast: false
       matrix:
         node: ["14", "16", "18"]
+        include:
+          - node: "18"
+            lerna-extra-args: >-
+              --ignore @opentelemetry/instrumentation-fastify
+              --ignore @opentelemetry/instrumentation-restify
+              --ignore @opentelemetry/resource-detector-alibaba-cloud
     runs-on: ubuntu-latest
     services:
       memcached:

--- a/.github/workflows/test-all-versions.yml
+++ b/.github/workflows/test-all-versions.yml
@@ -1,13 +1,16 @@
 name: Test All Versions
 on:
-  push:
-    branches:
-      - "main"
-      - "release/**"
-      - "release-please/**"
   schedule:
     - cron: "30 4 * * *"
   workflow_dispatch:
+    inputs:
+      lerna-args:
+        type: string
+  workflow_call:
+    inputs:
+      lerna-args:
+        required: true
+        type: string
 
 jobs:
   tav:
@@ -153,4 +156,4 @@ jobs:
       - name: Bootstrap Dependencies
         run: lerna bootstrap --no-ci --hoist --nohoist='zone.js' --nohoist='mocha' --nohoist='ts-mocha'
       - name: Run test-all-versions
-        run: lerna run test-all-versions ${{ matrix.lerna-extra-args }} --stream --concurrency 1
+        run: lerna run test-all-versions ${{ inputs.lerna-args }} ${{ matrix.lerna-extra-args }} --stream --concurrency 1

--- a/scripts/parse-lerna-scopes.mjs
+++ b/scripts/parse-lerna-scopes.mjs
@@ -1,0 +1,39 @@
+import * as childProcess from 'child_process';
+
+/*
+	Formats `--scope` arguments for lerna from "pkg:"-prefixed labels.
+	Takes a JSON string as an argument and returns the formatted args in stdout.
+
+	arg: '["pkg:404", "pkg:", "pkg:instrumentation-dns", "pkg:instrumentation-fs", "urgent", "pkg:instrumentation-fs"]'
+	stdout: '--scope @opentelemetry/instrumentation-dns --scope @opentelemetry/instrumentation-fs'
+*/
+
+const labels = JSON.parse(process.argv[2]);
+const packageList = new Set(
+	childProcess.spawnSync('lerna', ['list']).stdout
+		.toString('utf8')
+		.split('\n')
+);
+
+console.error('Labels:', labels);
+console.error('Packages:', [...packageList]);
+
+const scopes = labels
+		.filter((l) => {
+			return l.startsWith('pkg:');
+		})
+		.map((l) => {
+			return l.replace(/^pkg:/, '@opentelemetry/');
+		})
+		.filter((pkgName) => {
+			return packageList.has(pkgName);
+		})
+
+console.error('Scopes:', scopes);
+
+console.log(
+	scopes.map((scope) => {
+		return `--scope ${scope}`;
+	})
+	.join(' ')
+);


### PR DESCRIPTION
## Which problem is this PR solving?

Since running TAV for all packages takes ages we cannot really afford running it on every commit in PRs.
However, it's very important do run TAV at least for the changed pacakge because this is the only way to avoid breaking old versions of instrumented packages.

#### TODO

- [ ] Make sure adding the label for a package that lacks TAV setup doesn't fail the build
- [ ] Remove the "checklist" section from PR template

## Short description of the changes

1. Turned TAV workflow into a generic workflow that takes lerna scope arguments.
1. Added a script to parse "pkg:"-prefixed labels into lerna scopes and pass them to TAV workflow.

The previous behavior(checking on release PRs and pushes) was refactored but left unchanged.

## Checklist

- [ ] Ran `npm run test-all-versions` for the edited package(s) on the latest commit if applicable.
