### PR TITLE
fix(express): use the same clock for span start and end

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-express/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-express/src/instrumentation.ts
@@ -15,7 +15,6 @@
  */
 
 import {
-  hrTime,
   setRPCMetadata,
   getRPCMetadata,
   RPCType,

--- a/plugins/node/opentelemetry-instrumentation-express/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-express/src/instrumentation.ts
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  setRPCMetadata,
-  getRPCMetadata,
-  RPCType,
-} from '@opentelemetry/core';
+import { setRPCMetadata, getRPCMetadata, RPCType } from '@opentelemetry/core';
 import { trace, context, diag, SpanAttributes } from '@opentelemetry/api';
 import type * as express from 'express';
 import {

--- a/plugins/node/opentelemetry-instrumentation-express/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-express/src/instrumentation.ts
@@ -263,22 +263,19 @@ export class ExpressInstrumentation extends InstrumentationBase<
           );
         }
 
-        const startTime = hrTime();
         let spanHasEnded = false;
-        // If we found anything that isnt a middleware, there no point of measuring
-        // their time since they dont have callback.
         if (
           metadata.attributes[AttributeNames.EXPRESS_TYPE] !==
           ExpressLayerType.MIDDLEWARE
         ) {
-          span.end(startTime);
+          span.end();
           spanHasEnded = true;
         }
         // listener for response.on('finish')
         const onResponseFinish = () => {
           if (spanHasEnded === false) {
             spanHasEnded = true;
-            span.end(startTime);
+            span.end();
           }
         };
         // verify we have a callback


### PR DESCRIPTION
Fixes #1193 
Fixes #1209 

Express instrumentation does not pass a time to span start but does pass a time to span.end, which results in undefined behavior. Previous to https://github.com/open-telemetry/opentelemetry-js/pull/3134 this was not a problem as the span always used the same hrTimer that we expose in core. Now that we anchor clocks, it is possible for these clocks to be out of sync.