### PR TITLE
feat: add requireParentSpan option to pg instrumentation

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-pg/README.md
+++ b/plugins/node/opentelemetry-instrumentation-pg/README.md
@@ -48,6 +48,7 @@ PostgreSQL instrumentation has few options available to choose from. You can set
 | ------- | ---- | ----------- |
 | [`enhancedDatabaseReporting`](./src/types.ts#L30) | `boolean` | If true, additional information about query parameters and results will be attached (as `attributes`) to spans representing database operations |
 | `responseHook` | `PgInstrumentationExecutionResponseHook` (function) | Function for adding custom attributes from db response |
+| `requireParentSpan` | `boolean` | If true, spans are created only if there is an active span to act as the parent (default false) |
 
 ## Useful links
 

--- a/plugins/node/opentelemetry-instrumentation-pg/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/types.ts
@@ -40,6 +40,13 @@ export interface PgInstrumentationConfig extends InstrumentationConfig {
    * @default undefined
    */
   responseHook?: PgInstrumentationExecutionResponseHook;
+
+  /**
+   * Whether the instrumentation requires a parent span, if set to true
+   * and there is no parent span, no additional spans are created
+   * (default: false)
+   */
+  requireParentSpan?: boolean;
 }
 
 export type PostgresCallback = (err: Error, res: object) => unknown;

--- a/plugins/node/opentelemetry-instrumentation-pg/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/utils.ts
@@ -20,6 +20,8 @@ import {
   Tracer,
   SpanKind,
   diag,
+  trace,
+  context,
 } from '@opentelemetry/api';
 import { AttributeNames } from './enums/AttributeNames';
 import {
@@ -72,6 +74,16 @@ function pgStartSpan(tracer: Tracer, client: PgClientExtended, name: string) {
       [SemanticAttributes.DB_USER]: client.connectionParameters.user,
     },
   });
+}
+
+// Helper for determining whether a span should be started
+export function shouldStartSpan(
+  instrumentationConfig: PgInstrumentationConfig
+) {
+  const parentSpan = trace.getSpan(context.active());
+  return (
+    parentSpan !== undefined || instrumentationConfig.requireParentSpan !== true
+  );
 }
 
 // Queries where args[0] is a QueryConfig


### PR DESCRIPTION
## Which problem is this PR solving?

pg instrumentation currently lacks the option to require a parent span, which can produce quite a bit of noise, especially in situations where there are things like health-checks being done against DBs etc.

## Short description of the changes

Adds a new option (keeping the default to false so that this change does not alter existing deployments) `requireParentSpan` to the config of pg instrumentation. If set to true, it does not create spans unless there is a parent span that it can attach to