### PR TITLE
ci: always release packages when a release is merged

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,20 +17,17 @@ jobs:
 
       # The logic below handles the npm publication:
       - name: Checkout Repository
-        if: ${{ steps.release.outputs.releases_created }}
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v3
-        if: ${{ steps.release.outputs.releases_created }}
         with:
           node-version: 14
           registry-url: 'https://registry.npmjs.org'
 
       - name: Cache Dependencies
-        if: ${{ steps.release.outputs.releases_created }}
         uses: actions/cache@v3
         with:
           path: |
@@ -45,7 +42,6 @@ jobs:
           key: release-${{ runner.os }}-${{ matrix.container }}-${{ hashFiles('**/package.json') }}
 
       - name: Build Packages
-        if: ${{ steps.release.outputs.releases_created }}
         run: |
           npm install
           npx lerna bootstrap --no-ci
@@ -54,7 +50,6 @@ jobs:
       # need to publish all unpublished versions to npm here
       # See: https://github.com/lerna/lerna/tree/main/commands/publish#bump-from-package
       - name: Publish to npm
-        if: ${{ steps.release.outputs.releases_created }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         run: npx lerna publish from-package --no-push --no-private --no-git-tag-version --no-verify-access --yes


### PR DESCRIPTION
The check `if: ${{ steps.release.outputs.releases_created }}` does not seem to be working. Fortunately, `lerna publish from-package` already only releases packages which have had their versions updated. As a result, we should be able to release on any merge to main.