### PR TITLE
fix: restrict hashed package.json files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
             plugins/node/*/node_modules
             plugins/web/*/node_modules
             propagators/*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-${{ hashFiles('package.json', 'detectors/node/*/package.json', 'metapackages/*/package.json', 'packages/*/package.json', 'plugins/node/*/package.json', 'plugins/web/*/package.json', 'propagators/*/package.json') }}
 
       - name: Bootstrap
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,7 +39,7 @@ jobs:
             plugins/node/*/node_modules
             plugins/web/*/node_modules
             propagators/*/node_modules
-          key: release-${{ runner.os }}-${{ matrix.container }}-${{ hashFiles('**/package.json') }}
+          key: release-${{ runner.os }}-${{ matrix.container }}-${{ hashFiles('package.json', 'detectors/node/*/package.json', 'metapackages/*/package.json', 'packages/*/package.json', 'plugins/node/*/package.json', 'plugins/web/*/package.json', 'propagators/*/package.json') }}
 
       - name: Build Packages
         run: |


### PR DESCRIPTION
## Which problem is this PR solving?

Seeing the `hashFiles` taking minutes makes me think it searches the `node_modules` dirs as well.
I have experienced and debugged it for test builds as well.
The examples using `action/cache` hash package-lock.json files, which would generally make sense if we checked our package-lock files in.
Why don't we? I've forgotten, but it has been discussed multiple times.

## Short description of the changes

Restrict the globs to only hash package.json.
