### PR TITLE
fix: remove types of the instrumented libs form public apis

### DIFF
--- a/plugins/node/instrumentation-dataloader/src/instrumentation.ts
+++ b/plugins/node/instrumentation-dataloader/src/instrumentation.ts
@@ -70,7 +70,8 @@ export class DataloaderInstrumentation extends InstrumentationBase {
             this._unwrap(dataloader.prototype, 'loadMany');
           }
         }
-      ),
+        // cast it to module definition of unknown type to avoid exposing Dataloader types on public APIs
+      ) as InstrumentationNodeModuleDefinition<unknown>,
     ];
   }
 

--- a/plugins/node/instrumentation-mongoose/src/mongoose.ts
+++ b/plugins/node/instrumentation-mongoose/src/mongoose.ts
@@ -84,7 +84,7 @@ export class MongooseInstrumentation extends InstrumentationBase<any> {
     return module;
   }
 
-  protected patch(
+  private patch(
     moduleExports: typeof mongoose,
     moduleVersion: string | undefined
   ) {
@@ -127,7 +127,7 @@ export class MongooseInstrumentation extends InstrumentationBase<any> {
     return moduleExports;
   }
 
-  protected unpatch(moduleExports: typeof mongoose): void {
+  private unpatch(moduleExports: typeof mongoose): void {
     this._diag.debug('mongoose instrumentation: unpatch mongoose');
     this._unwrap(moduleExports.Model.prototype, 'save');
     // revert the patch for $save which we applyed by aliasing it to patched `save`

--- a/plugins/node/instrumentation-mongoose/src/utils.ts
+++ b/plugins/node/instrumentation-mongoose/src/utils.ts
@@ -20,10 +20,8 @@ import { safeExecuteInTheMiddle } from '@opentelemetry/instrumentation';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 
 export function getAttributesFromCollection(
-  _collection: unknown
+  collection: Collection
 ): SpanAttributes {
-  // Cast to avoid using mongoose types in the public API
-  const collection = _collection as Collection;
   return {
     [SemanticAttributes.DB_MONGODB_COLLECTION]: collection.name,
     [SemanticAttributes.DB_NAME]: collection.conn.name,

--- a/plugins/node/instrumentation-mongoose/src/utils.ts
+++ b/plugins/node/instrumentation-mongoose/src/utils.ts
@@ -20,8 +20,10 @@ import { safeExecuteInTheMiddle } from '@opentelemetry/instrumentation';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 
 export function getAttributesFromCollection(
-  collection: Collection
+  _collection: unknown
 ): SpanAttributes {
+  // Cast to avoid using mongoose types in the public API
+  const collection = _collection as Collection;
   return {
     [SemanticAttributes.DB_MONGODB_COLLECTION]: collection.name,
     [SemanticAttributes.DB_NAME]: collection.conn.name,


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #1217
Fixes #1218

## Short description of the changes

- Cast Dataloaders module definitions to `InstrumentationNodeModuleDefinition<unknown>`
- Turned `patch` and `unpatch` methods on mongoose instrumentation private
- Cast the Collection argument in mongoose untils inside the function as opposed to having the type on the signature
