### PR TITLE
fix(instrumentation-fs): fix `fs.exists` when it's util.promisified

### DIFF
--- a/plugins/node/instrumentation-fs/src/constants.ts
+++ b/plugins/node/instrumentation-fs/src/constants.ts
@@ -54,7 +54,7 @@ export const CALLBACK_FUNCTIONS: FMember[] = [
   'chown',
   'copyFile',
   'cp' as FMember, // added in v16
-  'exists', // deprecated, inconsistent cb signature
+  'exists', // deprecated, inconsistent cb signature, handling separately when patching
   'lchown',
   'link',
   'lstat',

--- a/plugins/node/instrumentation-fs/src/instrumentation.ts
+++ b/plugins/node/instrumentation-fs/src/instrumentation.ts
@@ -35,6 +35,7 @@ import type {
   EndHook,
   FsInstrumentationConfig,
 } from './types';
+import { promisify } from 'util';
 
 type FS = typeof fs;
 
@@ -63,6 +64,19 @@ export default class FsInstrumentation extends InstrumentationBase<FS> {
             );
           }
           for (const fName of CALLBACK_FUNCTIONS) {
+            if (fName === 'exists') {
+              // handling separately because of the inconsistent cb style:
+              // `exists` doesn't have error as the first argument, but the result
+              if (isWrapped(fs[fName])) {
+                this._unwrap(fs, fName);
+              }
+              this._wrap(
+                fs,
+                fName,
+                <any>this._patchExistsCallbackFunction.bind(this, fName)
+              );
+              continue;
+            }
             if (isWrapped(fs[fName])) {
               this._unwrap(fs, fName);
             }
@@ -242,6 +256,89 @@ export default class FsInstrumentation extends InstrumentationBase<FS> {
         return original.apply(this, args);
       }
     };
+  }
+
+  protected _patchExistsCallbackFunction<T extends (...args: any[]) => ReturnType<T>>(
+    functionName: FMember,
+    original: T
+  ): T {
+    const instrumentation = this;
+    const patchedFunction = <any>function (this: any, ...args: any[]) {
+      if (isTracingSuppressed(api.context.active())) {
+        // Performance optimization. Avoid creating additional contexts and spans
+        // if we already know that the tracing is being suppressed.
+        return original.apply(this, args);
+      }
+      if (
+        instrumentation._runCreateHook(functionName, {
+          args: args,
+        }) === false
+      ) {
+        return api.context.with(
+          suppressTracing(api.context.active()),
+          original,
+          this,
+          ...args
+        );
+      }
+
+      const lastIdx = args.length - 1;
+      const cb = args[lastIdx];
+      if (typeof cb === 'function') {
+        const span = instrumentation.tracer.startSpan(
+          `fs ${functionName}`
+        ) as api.Span;
+
+        // Return to the context active during the call in the callback
+        args[lastIdx] = api.context.bind(
+          api.context.active(),
+          function (this: unknown) {
+            // `exists` never calls the callback with an error
+            instrumentation._runEndHook(functionName, {
+              args: args,
+              span,
+            });
+            span.end();
+            return cb.apply(this, arguments);
+          }
+        );
+
+        try {
+          // Suppress tracing for internal fs calls
+          return api.context.with(
+            suppressTracing(api.trace.setSpan(api.context.active(), span)),
+            original,
+            this,
+            ...args
+          );
+        } catch (error) {
+          span.recordException(error);
+          span.setStatus({
+            message: error.message,
+            code: api.SpanStatusCode.ERROR,
+          });
+          instrumentation._runEndHook(functionName, {
+            args: args,
+            span,
+            error,
+          });
+          span.end();
+          throw error;
+        }
+      } else {
+        return original.apply(this, args);
+      }
+    };
+
+    // `exists` has a custom promisify function because of the inconsistent signature
+    // replicating that on the patched function
+    const promisified = function (path: unknown) {
+      return new Promise((resolve) => patchedFunction(path, resolve));
+    };
+    Object.defineProperty(promisified, 'name', { value: functionName });
+    Object.defineProperty(patchedFunction, promisify.custom, { value: promisified });
+
+    return patchedFunction;
   }
 
   protected _patchPromiseFunction<T extends (...args: any[]) => ReturnType<T>>(

--- a/plugins/node/instrumentation-fs/src/instrumentation.ts
+++ b/plugins/node/instrumentation-fs/src/instrumentation.ts
@@ -64,21 +64,18 @@ export default class FsInstrumentation extends InstrumentationBase<FS> {
             );
           }
           for (const fName of CALLBACK_FUNCTIONS) {
+            if (isWrapped(fs[fName])) {
+              this._unwrap(fs, fName);
+            }
             if (fName === 'exists') {
               // handling separately because of the inconsistent cb style:
               // `exists` doesn't have error as the first argument, but the result
-              if (isWrapped(fs[fName])) {
-                this._unwrap(fs, fName);
-              }
               this._wrap(
                 fs,
                 fName,
                 <any>this._patchExistsCallbackFunction.bind(this, fName)
               );
               continue;
-            }
-            if (isWrapped(fs[fName])) {
-              this._unwrap(fs, fName);
             }
             this._wrap(
               fs,

--- a/plugins/node/instrumentation-fs/src/instrumentation.ts
+++ b/plugins/node/instrumentation-fs/src/instrumentation.ts
@@ -258,10 +258,9 @@ export default class FsInstrumentation extends InstrumentationBase<FS> {
     };
   }
 
-  protected _patchExistsCallbackFunction<T extends (...args: any[]) => ReturnType<T>>(
-    functionName: FMember,
-    original: T
-  ): T {
+  protected _patchExistsCallbackFunction<
+    T extends (...args: any[]) => ReturnType<T>
+  >(functionName: FMember, original: T): T {
     const instrumentation = this;
     const patchedFunction = <any>function (this: any, ...args: any[]) {
       if (isTracingSuppressed(api.context.active())) {
@@ -333,10 +332,12 @@ export default class FsInstrumentation extends InstrumentationBase<FS> {
     // `exists` has a custom promisify function because of the inconsistent signature
     // replicating that on the patched function
     const promisified = function (path: unknown) {
-      return new Promise((resolve) => patchedFunction(path, resolve));
+      return new Promise(resolve => patchedFunction(path, resolve));
     };
     Object.defineProperty(promisified, 'name', { value: functionName });
-    Object.defineProperty(patchedFunction, promisify.custom, { value: promisified });
+    Object.defineProperty(patchedFunction, promisify.custom, {
+      value: promisified,
+    });
 
     return patchedFunction;
   }

--- a/plugins/node/instrumentation-fs/test/definitions.ts
+++ b/plugins/node/instrumentation-fs/test/definitions.ts
@@ -66,18 +66,16 @@ const tests: TestCase[] = [
     [{ name: 'fs %NAME' }],
   ],
   [
-    'exists' as FsFunction, // turning off testing async functions
+    'exists' as FsFunction, // we are defining promisified version of exists in the tests, so this is OK
     ['./test/fixtures/exists-404'],
     { resultAsError: false },
     [{ name: 'fs %NAME' }],
-    { promise: false }
   ],
   [
-    'exists' as FsFunction, // turning off testing async functions
+    'exists' as FsFunction, // we are defining promisified version of exists in the tests, so this is OK
     ['./test/fixtures/readtest'],
     { resultAsError: true },
     [{ name: 'fs %NAME' }],
-    { promise: false }
   ],
 ];
 

--- a/plugins/node/instrumentation-fs/test/definitions.ts
+++ b/plugins/node/instrumentation-fs/test/definitions.ts
@@ -23,7 +23,7 @@ export type Opts = {
   callback?: boolean;
   promise?: boolean;
 };
-export type Result = { error?: RegExp; result?: any, resultAsError?: any };
+export type Result = { error?: RegExp; result?: any; resultAsError?: any };
 export type TestCase = [FsFunction, any[], Result, any[], Opts?];
 export type TestCreator = (
   name: FsFunction,

--- a/plugins/node/instrumentation-fs/test/definitions.ts
+++ b/plugins/node/instrumentation-fs/test/definitions.ts
@@ -23,7 +23,7 @@ export type Opts = {
   callback?: boolean;
   promise?: boolean;
 };
-export type Result = { error?: RegExp; result?: any };
+export type Result = { error?: RegExp; result?: any, resultAsError?: any };
 export type TestCase = [FsFunction, any[], Result, any[], Opts?];
 export type TestCreator = (
   name: FsFunction,
@@ -64,6 +64,20 @@ const tests: TestCase[] = [
     ['./test/fixtures/writetest', TEST_CONTENTS],
     { result: undefined },
     [{ name: 'fs %NAME' }],
+  ],
+  [
+    'exists' as FsFunction, // turning off testing async functions
+    ['./test/fixtures/exists-404'],
+    { resultAsError: false },
+    [{ name: 'fs %NAME' }],
+    { promise: false }
+  ],
+  [
+    'exists' as FsFunction, // turning off testing async functions
+    ['./test/fixtures/readtest'],
+    { resultAsError: true },
+    [{ name: 'fs %NAME' }],
+    { promise: false }
   ],
 ];
 

--- a/plugins/node/instrumentation-fs/test/index.test.ts
+++ b/plugins/node/instrumentation-fs/test/index.test.ts
@@ -71,9 +71,12 @@ describe('fs instrumentation', () => {
     plugin.setTracerProvider(provider);
     plugin.enable();
     fs = require('fs');
-    Object.defineProperty(fs.promises, 'exists', { value: (...args: any[]) => {
-      return Reflect.apply(promisify(fs.exists), fs, args);
-    }, configurable: true });
+    Object.defineProperty(fs.promises, 'exists', {
+      value: (...args: any[]) => {
+        return Reflect.apply(promisify(fs.exists), fs, args);
+      },
+      configurable: true,
+    });
     assert.strictEqual(memoryExporter.getFinishedSpans().length, 0);
   });
 
@@ -100,7 +103,10 @@ describe('fs instrumentation', () => {
         if (error) {
           assert.throws(() => Reflect.apply(fs[syncName], fs, args), error);
         } else {
-          assert.deepEqual(Reflect.apply(fs[syncName], fs, args), result ?? resultAsError);
+          assert.deepEqual(
+            Reflect.apply(fs[syncName], fs, args),
+            result ?? resultAsError
+          );
         }
       });
       rootSpan.end();
@@ -157,7 +163,11 @@ describe('fs instrumentation', () => {
                     if (actualError instanceof Error) {
                       return done(actualError);
                     } else {
-                      return done(new Error(`Expected callback to be called without an error got: ${actualError}`));
+                      return done(
+                        new Error(
+                          `Expected callback to be called without an error got: ${actualError}`
+                        )
+                      );
                     }
                   }
                 }
@@ -203,7 +213,10 @@ describe('fs instrumentation', () => {
       await context
         .with(trace.setSpan(context.active(), rootSpan), () => {
           // eslint-disable-next-line node/no-unsupported-features/node-builtins
-          assert(typeof fs.promises[name] === 'function', `Expected fs.promises.${name} to be a function`);
+          assert(
+            typeof fs.promises[name] === 'function',
+            `Expected fs.promises.${name} to be a function`
+          );
           return Reflect.apply(fs.promises[name], fs.promises, args);
         })
         .then((actualResult: any) => {
@@ -214,7 +227,10 @@ describe('fs instrumentation', () => {
           }
         })
         .catch((actualError: any) => {
-          assert(actualError instanceof Error, `Expected caugth error to be instance of Error. Got ${actualError}`);
+          assert(
+            actualError instanceof Error,
+            `Expected caugth error to be instance of Error. Got ${actualError}`
+          );
           if (error) {
             assert(
               error.test(actualError?.message ?? ''),


### PR DESCRIPTION
## Which problem is this PR solving?

`fs.exists` has an unusual signature with the callback never returning an error.
To get around that when using `util.promisify`, custom promisifing function is defined.
Our instrumentation doesn't take that into account.

Fixes #1185

## Short description of the changes

Added separate patcher for `fs.exists` that is aware of the above and define a new custom promisifying function for our patched function.
