### PR TITLE
fix(dns): remove lookupPromise polyfill for node8 dns promise tests 

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-dns/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/src/utils.ts
@@ -107,7 +107,7 @@ export const setLookupAttributes = (
  * @param obj obj to inspect
  * @param pattern Match pattern
  */
-export const satisfiesPattern = <T>(
+export const satisfiesPattern = (
   constant: string,
   pattern: IgnoreMatcher
 ): boolean => {

--- a/plugins/node/opentelemetry-instrumentation-dns/test/integrations/dnspromise-lookup.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/test/integrations/dnspromise-lookup.test.ts
@@ -30,22 +30,6 @@ const memoryExporter = new InMemorySpanExporter();
 const provider = new NodeTracerProvider();
 provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
 
-async function lookupPromise(
-  hostname: string,
-  options: dns.LookupOptions = {}
-): Promise<any> {
-  return new Promise((resolve, reject) => {
-    dns.lookup(hostname, options, (err, address, family) => {
-      if (err) reject(err);
-      if (options.all) {
-        resolve(address);
-      } else {
-        resolve({ address, family });
-      }
-    });
-  });
-}
-
 describe('dns.promises.lookup()', () => {
   let instrumentation: DnsInstrumentation;
 
@@ -83,7 +67,7 @@ describe('dns.promises.lookup()', () => {
     [4, 6].forEach(ipversion => {
       it(`should export a valid span with "family" arg to ${ipversion}`, async () => {
         const hostname = 'google.com';
-        const { address, family } = await lookupPromise(hostname, {
+        const { address, family } = await dns.promises.lookup(hostname, {
           family: ipversion,
         });
         assert.ok(address);
@@ -100,7 +84,7 @@ describe('dns.promises.lookup()', () => {
   describe('with no options param', () => {
     it('should export a valid span', async () => {
       const hostname = 'google.com';
-      const { address, family } = await lookupPromise(hostname);
+      const { address, family } = await dns.promises.lookup(hostname);
 
       assert.ok(address);
       assert.ok(family);
@@ -119,7 +103,7 @@ describe('dns.promises.lookup()', () => {
       it('should export a valid span with error NOT_FOUND', async () => {
         const hostname = 'ᚕ';
         try {
-          await lookupPromise(hostname);
+          await dns.promises.lookup(hostname);
           assert.fail();
         } catch (error) {
           const spans = memoryExporter.getFinishedSpans();
@@ -141,7 +125,7 @@ describe('dns.promises.lookup()', () => {
     it('should export a valid span with error INVALID_ARGUMENT when "family" param is equal to -1', async () => {
       const hostname = 'google.com';
       try {
-        await lookupPromise(hostname, { family: -1 });
+        await dns.promises.lookup(hostname, { family: -1 });
         assert.fail();
       } catch (error) {
         const spans = memoryExporter.getFinishedSpans();
@@ -163,8 +147,7 @@ describe('dns.promises.lookup()', () => {
     it('should export a valid span with error INVALID_ARGUMENT when "hostname" param is a number', async () => {
       const hostname = 1234;
       try {
-        // tslint:disable-next-line:no-any
-        await lookupPromise(hostname as any, { family: 4 });
+        await dns.promises.lookup(hostname as any, { family: 4 });
         assert.fail();
       } catch (error) {
         const spans = memoryExporter.getFinishedSpans();
@@ -187,7 +170,7 @@ describe('dns.promises.lookup()', () => {
     [4, 6].forEach(ipversion => {
       it(`should export a valid span with "family" to ${ipversion}`, async () => {
         const hostname = 'google.com';
-        const { address, family } = await lookupPromise(hostname, {
+        const { address, family } = await dns.promises.lookup(hostname, {
           family: ipversion,
         });
 
@@ -203,7 +186,7 @@ describe('dns.promises.lookup()', () => {
 
       it(`should export a valid span when setting "verbatim" property to true and "family" to ${ipversion}`, async () => {
         const hostname = 'google.com';
-        const { address, family } = await lookupPromise(hostname, {
+        const { address, family } = await dns.promises.lookup(hostname, {
           family: ipversion,
           verbatim: true,
         });
@@ -221,7 +204,7 @@ describe('dns.promises.lookup()', () => {
 
     it('should export a valid span when setting "all" property to true', async () => {
       const hostname = 'montreal.ca';
-      const addresses = await lookupPromise(hostname, { all: true });
+      const addresses = await dns.promises.lookup(hostname, { all: true });
 
       assert.ok(addresses instanceof Array);
 


### PR DESCRIPTION
## Which problem is this PR solving?

In #110 the `dns` promise based tests were reinstated for node 8 via a ["polyfill"-style function in the test source](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/110/files#diff-3060c03216ba47af1a62f232e8128a3844ab6e97ca67328f4c9c5ec4b5cfc7fcR36-R50) with
[this comment](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/110#discussion_r455406397).

It's unclear to me what exactly was being attempted here, since the net result of making all calls  in the test function funnel through this `lookupPromise()` function was that the functionality that was supposed to be tested (i.e. `dns.promises.lookup()` was no longer tested at all.

This may have been missed because code coverage was probably not run as part of CI then, but looking at code coverage now, the code in `instrumentation.ts` that handles [patching promise based calls](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/a6f054de256acc3415deb8137c7ea4bd6926c08d/plugins/node/opentelemetry-instrumentation-dns/src/instrumentation.ts#L133-L157) is [uncovered](https://app.codecov.io/gh/open-telemetry/opentelemetry-js-contrib/commit/55c81e71f316e288d4b5d641eb5bea08002eff6d/plugins/node/opentelemetry-instrumentation-dns/src/instrumentation.ts) by the tests in this file.

## Short description of the changes

* Remove `lookupPromise()` test polyfill for `dns.promise.lookup()`
* Restore original intent of test: directly call `dns.promises.lookup()` function.
