### PR TITLE
feat(koa): add layer type to request hook context

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-koa/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/src/instrumentation.ts
@@ -196,7 +196,11 @@ export class KoaInstrumentation extends InstrumentationBase<typeof koa> {
       if (this.getConfig().requestHook) {
         safeExecuteInTheMiddle(
           () =>
-            this.getConfig().requestHook!(span, { context, middlewareLayer }),
+            this.getConfig().requestHook!(span, {
+              context,
+              middlewareLayer,
+              layerType,
+            }),
           e => {
             if (e) {
               api.diag.error('koa instrumentation: request hook failed', e);

--- a/plugins/node/opentelemetry-instrumentation-koa/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/src/types.ts
@@ -35,6 +35,7 @@ export type KoaContext = ParameterizedContext<DefaultState, RouterParamContext>;
 export type KoaRequestInfo = {
   context: KoaContext;
   middlewareLayer: KoaMiddleware;
+  layerType: KoaLayerType;
 };
 
 /**

--- a/plugins/node/opentelemetry-instrumentation-koa/test/koa.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/test/koa.test.ts
@@ -601,6 +601,7 @@ describe('Koa Instrumentation', () => {
       const requestHook = sinon.spy((span: Span, info: KoaRequestInfo) => {
         span.setAttribute('http.method', info.context.request.method);
         span.setAttribute('app.env', info.context.app.env);
+        span.setAttribute('koa.layer', info.layerType);
       });
 
       plugin.setConfig({
@@ -633,6 +634,10 @@ describe('Koa Instrumentation', () => {
           assert.strictEqual(
             requestHandlerSpan?.attributes['app.env'],
             'development'
+          );
+          assert.strictEqual(
+            requestHandlerSpan?.attributes['koa.layer'],
+            'router'
           );
         }
       );


### PR DESCRIPTION
## Which problem is this PR solving?

Unlike [the context given to the Express request hook](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-express/src/types.ts#L73-L80), the Koa request hook context does not contain information on whether the layer whose instrumentation is being intercepted by the request hook is a middleware layer or a router layer.

## Short description of the changes

- Add the `layerType` to the context object passed to the `requestHook` interceptor function.
- Add the `layerType` property to the `KoaRequestInfo` context type.
- Add a check on the layer type to the unit tests.
