### PR TITLE
test: reduce number of aws-sdk versions for tav

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/.tav.yml
@@ -1,21 +1,21 @@
 "aws-sdk":
   # there are so many version to test, it can take forever.
   # we will just sample few of them
-  versions: ">=2.1157.0 || 2.1152.0 || 2.1132.0 || 2.1048.0 || 2.1012.0 || 2.647.0 || 2.308.0"
+  versions: ">=2.1230.0 || 2.1219.0 || 2.1152.0 || 2.1048.0 || 2.1012.0 || 2.647.0 || 2.308.0"
   commands:
     - npm run test
   # Fix missing `contrib-test-utils` package
   pretest: npm run --prefix ../../../ lerna:link
 
 "@aws-sdk/client-s3":
-  versions: ">=3.113.0 || 3.107.0 || 3.54.0 || 3.6.1"
+  versions: ">=3.188.0 || 3.154.0 || 3.107.0 || 3.54.0 || 3.6.1"
   commands:
     - npm run test
   # Fix missing `contrib-test-utils` package
   pretest: npm run --prefix ../../../ lerna:link
 
 "@aws-sdk/client-sqs":
-  versions: ">=3.112.0 || 3.107.0 || 3.58.0 || 3.54.0 || 3.43.0 || 3.24.0"
+  versions: ">=3.188.0 || 3.171.0 || 3.107.0 || 3.58.0 || 3.54.0 || 3.43.0 || 3.24.0"
   commands:
     - npm run test
   # Fix missing `contrib-test-utils` package


### PR DESCRIPTION
Once in a while, we need to reduce the number of aws-sdk versions to test with "test-all-versions".
They publish many versions and it takes too much time to test them all