### PR TITLE
fix(aws-sdk): bump instrumentation version to align with previous release

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-aws-sdk",
-  "version": "0.9.2",
+  "version": "0.32.0",
   "description": "OpenTelemetry automatic instrumentation for the `aws-sdk` package",
   "keywords": [
     "aws",


### PR DESCRIPTION
## Which problem is this PR solving?

- fixes #1153 

## Short description of the changes

- bump the aws-sdk instrumentation version to 0.32.0 so that it's higher than "0.25.0" which was released by mistake on 19/10/2021. [release on npm](https://www.npmjs.com/package/@opentelemetry/instrumentation-aws-sdk/v/0.25.0).
