### PR TITLE
fix: allow hapi plugin from array to be registered as argument

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-hapi/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-hapi/src/instrumentation.ts
@@ -149,7 +149,7 @@ export class HapiInstrumentation extends InstrumentationBase {
       if (Array.isArray(pluginInput)) {
         for (const pluginObj of pluginInput) {
           instrumentation._wrapRegisterHandler(
-            pluginObj.plugin?.plugin ?? pluginObj.plugin
+            pluginObj.plugin?.plugin ?? pluginObj.plugin ?? pluginObj
           );
         }
       } else {

--- a/plugins/node/opentelemetry-instrumentation-hapi/test/hapi-plugin.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-hapi/test/hapi-plugin.test.ts
@@ -228,6 +228,64 @@ describe('Hapi Instrumentation - Hapi.Plugin Tests', () => {
       );
     });
 
+    it('should create spans for routes across multiple plugins declared in attribute level', async () => {
+      const rootSpan = tracer.startSpan('rootSpan');
+
+      await server.register([packagePlugin, simplePlugin]);
+      await server.start();
+      assert.strictEqual(memoryExporter.getFinishedSpans().length, 0);
+
+      await context.with(
+        trace.setSpan(context.active(), rootSpan),
+        async () => {
+          const res1 = await server.inject({
+            method: 'GET',
+            url: '/package',
+          });
+          assert.strictEqual(res1.statusCode, 200);
+          const res2 = await server.inject({
+            method: 'GET',
+            url: '/hello',
+          });
+          assert.strictEqual(res2.statusCode, 200);
+
+          rootSpan.end();
+
+          assert.deepStrictEqual(memoryExporter.getFinishedSpans().length, 3);
+
+          const firstHandlerSpan = memoryExporter
+            .getFinishedSpans()
+            .find(span => span.name === 'plugin-by-package: route - /package');
+          assert.notStrictEqual(firstHandlerSpan, undefined);
+          assert.strictEqual(
+            firstHandlerSpan?.attributes[AttributeNames.HAPI_TYPE],
+            HapiLayerType.PLUGIN
+          );
+          assert.strictEqual(
+            firstHandlerSpan?.attributes[AttributeNames.PLUGIN_NAME],
+            'plugin-by-package'
+          );
+          const secondHandlerSpan = memoryExporter
+            .getFinishedSpans()
+            .find(span => span.name === 'simplePlugin: route - /hello');
+          assert.notStrictEqual(secondHandlerSpan, undefined);
+          assert.strictEqual(
+            secondHandlerSpan?.attributes[AttributeNames.HAPI_TYPE],
+            HapiLayerType.PLUGIN
+          );
+          assert.strictEqual(
+            secondHandlerSpan?.attributes[AttributeNames.PLUGIN_NAME],
+            'simplePlugin'
+          );
+
+          const exportedRootSpan = memoryExporter
+            .getFinishedSpans()
+            .find(span => span.name === 'rootSpan');
+          assert.notStrictEqual(exportedRootSpan, undefined);
+        }
+      );
+    });
+
     it('should instrument multiple versions of the same plugin just once', async () => {
       const rootSpan = tracer.startSpan('rootSpan');
 


### PR DESCRIPTION
## Which problem is this PR solving?

I missed this in #1046.
HAPI plugins can be registered directly as objects, with `server.register(plugin)`. But they can also be registered as an array, with `server.register([plugin])`.

Right now, we only accept `server.register([{plugin: plugin}]);`, which doesn't match the hapi documentation.
See https://hapi.dev/tutorials/plugins/?lang=en_US#loading

## Short description of the changes

Allow registering hapi plugins from an array when the object is passed directly, and they are not nested within a deeper object.
