### PR TITLE
fix(graphql): graphql instrumentation throw for sync calls

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-graphql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-graphql/package.json
@@ -50,6 +50,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/sdk-trace-base": "^1.3.1",
+    "@opentelemetry/semantic-conventions": "^1.3.1",
     "@types/mocha": "8.2.3",
     "@types/node": "16.11.21",
     "graphql": "^16.5.0",

--- a/plugins/node/opentelemetry-instrumentation-graphql/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/src/instrumentation.ts
@@ -46,6 +46,7 @@ import {
   addSpanSource,
   endSpan,
   getOperation,
+  isPromise,
   wrapFieldResolver,
   wrapFields,
 } from './utils';
@@ -249,7 +250,7 @@ export class GraphQLInstrumentation extends InstrumentationBase {
       return;
     }
 
-    if (result.constructor.name === 'Promise') {
+    if (isPromise(result)) {
       (result as Promise<graphqlTypes.ExecutionResult>).then(resultData => {
         if (typeof config.responseHook !== 'function') {
           endSpan(span);

--- a/plugins/node/opentelemetry-instrumentation-graphql/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/src/utils.ts
@@ -28,8 +28,14 @@ import {
   OtelPatched,
   Maybe,
 } from './types';
+import { Span } from '@opentelemetry/sdk-trace-base';
 
 const OPERATION_VALUES = Object.values(AllowedOperationTypes);
+
+// https://github.com/graphql/graphql-js/blob/main/src/jsutils/isPromise.ts
+export const isPromise = (value: any): value is Promise<unknown> => {
+  return typeof value?.then === 'function';
+}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function addInputVariableAttribute(span: api.Span, key: string, variable: any) {
@@ -329,6 +335,23 @@ export function wrapFields(
   });
 }
 
+const handleResolveSpanError = (resolveSpan: Span, err: any, shouldEndSpan: boolean) => {
+  resolveSpan.recordException(err);
+  if (shouldEndSpan) {
+    resolveSpan.setStatus({
+      code: api.SpanStatusCode.ERROR,
+      message: err.message,
+    });    
+    resolveSpan.end();
+  }
+}
+
+const handleResolveSpanSuccess = (resolveSpan: Span, shouldEndSpan: boolean) => {
+  if (shouldEndSpan) {
+    resolveSpan.end();
+  }
+}
+
 export function wrapFieldResolver<TSource = any, TContext = any, TArgs = any>(
   tracer: api.Tracer,
   getConfig: () => Required<GraphQLInstrumentationConfig>,
@@ -380,27 +403,24 @@ export function wrapFieldResolver<TSource = any, TContext = any, TArgs = any>(
     return api.context.with(
       api.trace.setSpan(api.context.active(), field.span),
       () => {
-        return safeExecuteInTheMiddleAsync<
-          | Maybe<graphqlTypes.GraphQLFieldResolver<TSource, TContext, TArgs>>
-          | Promise<
-              Maybe<graphqlTypes.GraphQLFieldResolver<TSource, TContext, TArgs>>
-            >
-        >(
-          () => {
-            return fieldResolver.call(
-              this,
-              source,
-              args,
-              contextValue,
-              info
-            ) as any;
-          },
-          err => {
-            if (shouldEndSpan) {
-              endSpan(field.span, err);
-            }
+        try {
+          const res = fieldResolver.call(this, source, args, contextValue, info);
+          if(isPromise(res)) {
+            return res.then((r: any) => {
+              handleResolveSpanSuccess(field.span, shouldEndSpan);
+              return r;
+            }, (err: Error) => {
+              handleResolveSpanError(field.span, err, shouldEndSpan);
+              throw err;
+            });
+          } else {
+            handleResolveSpanSuccess(field.span, shouldEndSpan);
+            return res;
           }
-        );
+        } catch (err: any) {
+          handleResolveSpanError(field.span, err, shouldEndSpan);
+          throw err;
+        }
       }
     );
   }
@@ -408,33 +428,4 @@ export function wrapFieldResolver<TSource = any, TContext = any, TArgs = any>(
   (wrappedFieldResolver as OtelPatched)[OTEL_PATCHED_SYMBOL] = true;
 
   return wrappedFieldResolver;
-}
-
-/**
- * Async version of safeExecuteInTheMiddle from instrumentation package
- * can be removed once this will be added to instrumentation package
- * @param execute
- * @param onFinish
- * @param preventThrowingError
- */
-async function safeExecuteInTheMiddleAsync<T>(
-  execute: () => T,
-  onFinish: (e: Error | undefined, result: T | undefined) => void,
-  preventThrowingError?: boolean
-): Promise<T> {
-  let error: Error | undefined;
-  let result: T | undefined;
-  try {
-    result = await execute();
-  } catch (e) {
-    error = e as Error;
-  } finally {
-    onFinish(error, result);
-    if (error && !preventThrowingError) {
-      // eslint-disable-next-line no-unsafe-finally
-      throw error;
-    }
-    // eslint-disable-next-line no-unsafe-finally
-    return result as T;
-  }
 }

--- a/plugins/node/opentelemetry-instrumentation-graphql/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/src/utils.ts
@@ -339,23 +339,25 @@ const handleResolveSpanError = (
   err: any,
   shouldEndSpan: boolean
 ) => {
-  resolveSpan.recordException(err);
-  if (shouldEndSpan) {
-    resolveSpan.setStatus({
-      code: api.SpanStatusCode.ERROR,
-      message: err.message,
-    });
-    resolveSpan.end();
+  if (!shouldEndSpan) {
+    return;
   }
+  resolveSpan.recordException(err);
+  resolveSpan.setStatus({
+    code: api.SpanStatusCode.ERROR,
+    message: err.message,
+  });
+  resolveSpan.end();
 };
 
 const handleResolveSpanSuccess = (
   resolveSpan: api.Span,
   shouldEndSpan: boolean
 ) => {
-  if (shouldEndSpan) {
-    resolveSpan.end();
+  if (!shouldEndSpan) {
+    return;
   }
+  resolveSpan.end();
 };
 
 export function wrapFieldResolver<TSource = any, TContext = any, TArgs = any>(

--- a/plugins/node/opentelemetry-instrumentation-graphql/test/graphql-adaptor.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/test/graphql-adaptor.ts
@@ -19,7 +19,11 @@ import type {
   GraphQLTypeResolver,
   Source,
 } from 'graphql';
-import { graphql as origAsyncGraphQl, graphqlSync as origSyncGraphQl, version } from 'graphql';
+import {
+  graphql as origAsyncGraphQl,
+  graphqlSync as origSyncGraphQl,
+  version,
+} from 'graphql';
 import { Maybe } from 'graphql/jsutils/Maybe';
 
 interface GraphQLArgs {
@@ -36,8 +40,9 @@ interface GraphQLArgs {
 }
 
 const executeGraphqlQuery = (queryFunc: Function, args: GraphQLArgs) => {
-  const pre16Version = !version || version.startsWith('14.') || version.startsWith('15.');
-  if(pre16Version) {
+  const pre16Version =
+    !version || version.startsWith('14.') || version.startsWith('15.');
+  if (pre16Version) {
     return queryFunc(
       args.schema,
       args.source,
@@ -51,7 +56,9 @@ const executeGraphqlQuery = (queryFunc: Function, args: GraphQLArgs) => {
   } else {
     return queryFunc(args);
   }
-}
+};
 
-export const graphql = (args: GraphQLArgs) => executeGraphqlQuery(origAsyncGraphQl, args);
-export const graphqlSync = (args: GraphQLArgs) => executeGraphqlQuery(origSyncGraphQl, args);
+export const graphql = (args: GraphQLArgs) =>
+  executeGraphqlQuery(origAsyncGraphQl, args);
+export const graphqlSync = (args: GraphQLArgs) =>
+  executeGraphqlQuery(origSyncGraphQl, args);

--- a/plugins/node/opentelemetry-instrumentation-graphql/test/graphql-adaptor.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/test/graphql-adaptor.ts
@@ -19,10 +19,8 @@ import type {
   GraphQLTypeResolver,
   Source,
 } from 'graphql';
-import { graphql as origGraphql, version } from 'graphql';
+import { graphql as origAsyncGraphQl, graphqlSync as origSyncGraphQl, version } from 'graphql';
 import { Maybe } from 'graphql/jsutils/Maybe';
-
-const variantGraphql = origGraphql as Function;
 
 interface GraphQLArgs {
   schema: GraphQLSchema;
@@ -37,16 +35,23 @@ interface GraphQLArgs {
   typeResolver?: Maybe<GraphQLTypeResolver<any, any>>;
 }
 
-export const graphql = (args: GraphQLArgs) =>
-  !version || version.startsWith('14.') || version.startsWith('15.')
-    ? variantGraphql(
-        args.schema,
-        args.source,
-        args.rootValue,
-        args.contextValue,
-        args.variableValues,
-        args.operationName,
-        args.fieldResolver,
-        args.typeResolver
-      )
-    : variantGraphql(args);
+const executeGraphqlQuery = (queryFunc: Function, args: GraphQLArgs) => {
+  const pre16Version = !version || version.startsWith('14.') || version.startsWith('15.');
+  if(pre16Version) {
+    return queryFunc(
+      args.schema,
+      args.source,
+      args.rootValue,
+      args.contextValue,
+      args.variableValues,
+      args.operationName,
+      args.fieldResolver,
+      args.typeResolver
+    );
+  } else {
+    return queryFunc(args);
+  }
+}
+
+export const graphql = (args: GraphQLArgs) => executeGraphqlQuery(origAsyncGraphQl, args);
+export const graphqlSync = (args: GraphQLArgs) => executeGraphqlQuery(origSyncGraphQl, args);

--- a/plugins/node/opentelemetry-instrumentation-graphql/test/graphql.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/test/graphql.test.ts
@@ -20,7 +20,8 @@ import {
   ReadableSpan,
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
-import { Span } from '@opentelemetry/api';
+import { Span, SpanStatusCode } from '@opentelemetry/api';
+import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import * as assert from 'assert';
 import type * as graphqlTypes from 'graphql';
 import { GraphQLInstrumentation } from '../src';
@@ -39,10 +40,11 @@ graphQLInstrumentation.disable();
 
 // now graphql can be required
 
-import { buildSchema } from './schema';
-import { graphql } from './graphql-adaptor';
+import { buildSchema } from 'graphql';
+import { buildTestSchema } from './schema';
+import { graphql, graphqlSync } from './graphql-adaptor';
 // Construct a schema, using GraphQL schema language
-const schema = buildSchema();
+const schema = buildTestSchema();
 
 const sourceList1 = `
   query {
@@ -126,11 +128,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           parseSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-            '  query {\n' +
-            '    books {\n' +
-            '      name\n' +
-            '    }\n' +
-            '  }\n'
+          '  query {\n' +
+          '    books {\n' +
+          '      name\n' +
+          '    }\n' +
+          '  }\n'
         );
         assert.deepStrictEqual(parseSpan.name, SpanNames.PARSE);
       });
@@ -148,11 +150,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-            '  query {\n' +
-            '    books {\n' +
-            '      name\n' +
-            '    }\n' +
-            '  }\n'
+          '  query {\n' +
+          '    books {\n' +
+          '      name\n' +
+          '    }\n' +
+          '  }\n'
         );
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.OPERATION_TYPE],
@@ -254,11 +256,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           parseSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-            '  query {\n' +
-            '    book(id: *) {\n' +
-            '      name\n' +
-            '    }\n' +
-            '  }\n'
+          '  query {\n' +
+          '    book(id: *) {\n' +
+          '      name\n' +
+          '    }\n' +
+          '  }\n'
         );
         assert.deepStrictEqual(parseSpan.name, SpanNames.PARSE);
       });
@@ -276,11 +278,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-            '  query {\n' +
-            '    book(id: *) {\n' +
-            '      name\n' +
-            '    }\n' +
-            '  }\n'
+          '  query {\n' +
+          '    book(id: *) {\n' +
+          '      name\n' +
+          '    }\n' +
+          '  }\n'
         );
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.OPERATION_TYPE],
@@ -348,11 +350,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           parseSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-            '  query Query1 ($id: Int!) {\n' +
-            '    book(id: $id) {\n' +
-            '      name\n' +
-            '    }\n' +
-            '  }\n'
+          '  query Query1 ($id: Int!) {\n' +
+          '    book(id: $id) {\n' +
+          '      name\n' +
+          '    }\n' +
+          '  }\n'
         );
         assert.deepStrictEqual(parseSpan.name, SpanNames.PARSE);
       });
@@ -370,11 +372,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-            '  query Query1 ($id: Int!) {\n' +
-            '    book(id: $id) {\n' +
-            '      name\n' +
-            '    }\n' +
-            '  }\n'
+          '  query Query1 ($id: Int!) {\n' +
+          '    book(id: $id) {\n' +
+          '      name\n' +
+          '    }\n' +
+          '  }\n'
         );
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.OPERATION_TYPE],
@@ -444,11 +446,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           parseSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-            '  query {\n' +
-            '    books {\n' +
-            '      name\n' +
-            '    }\n' +
-            '  }\n'
+          '  query {\n' +
+          '    books {\n' +
+          '      name\n' +
+          '    }\n' +
+          '  }\n'
         );
         assert.deepStrictEqual(parseSpan.name, SpanNames.PARSE);
       });
@@ -466,11 +468,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-            '  query {\n' +
-            '    books {\n' +
-            '      name\n' +
-            '    }\n' +
-            '  }\n'
+          '  query {\n' +
+          '    books {\n' +
+          '      name\n' +
+          '    }\n' +
+          '  }\n'
         );
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.OPERATION_TYPE],
@@ -512,11 +514,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           parseSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-            '  query {\n' +
-            '    books {\n' +
-            '      name\n' +
-            '    }\n' +
-            '  }\n'
+          '  query {\n' +
+          '    books {\n' +
+          '      name\n' +
+          '    }\n' +
+          '  }\n'
         );
         assert.deepStrictEqual(parseSpan.name, SpanNames.PARSE);
       });
@@ -534,11 +536,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-            '  query {\n' +
-            '    books {\n' +
-            '      name\n' +
-            '    }\n' +
-            '  }\n'
+          '  query {\n' +
+          '    books {\n' +
+          '      name\n' +
+          '    }\n' +
+          '  }\n'
         );
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.OPERATION_TYPE],
@@ -603,11 +605,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           parseSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-            '  query {\n' +
-            '    book(id: 0) {\n' +
-            '      name\n' +
-            '    }\n' +
-            '  }\n'
+          '  query {\n' +
+          '    book(id: 0) {\n' +
+          '      name\n' +
+          '    }\n' +
+          '  }\n'
         );
         assert.deepStrictEqual(parseSpan.name, SpanNames.PARSE);
       });
@@ -625,11 +627,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-            '  query {\n' +
-            '    book(id: 0) {\n' +
-            '      name\n' +
-            '    }\n' +
-            '  }\n'
+          '  query {\n' +
+          '    book(id: 0) {\n' +
+          '      name\n' +
+          '    }\n' +
+          '  }\n'
         );
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.OPERATION_TYPE],
@@ -693,14 +695,14 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           parseSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-            '  mutation AddBook {\n' +
-            '    addBook(\n' +
-            '      name: "Fifth Book"\n' +
-            '      authorIds: "0,2"\n' +
-            '    ) {\n' +
-            '      id\n' +
-            '    }\n' +
-            '  }\n'
+          '  mutation AddBook {\n' +
+          '    addBook(\n' +
+          '      name: "Fifth Book"\n' +
+          '      authorIds: "0,2"\n' +
+          '    ) {\n' +
+          '      id\n' +
+          '    }\n' +
+          '  }\n'
         );
         assert.deepStrictEqual(parseSpan.name, SpanNames.PARSE);
       });
@@ -718,14 +720,14 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-            '  mutation AddBook {\n' +
-            '    addBook(\n' +
-            '      name: "Fifth Book"\n' +
-            '      authorIds: "0,2"\n' +
-            '    ) {\n' +
-            '      id\n' +
-            '    }\n' +
-            '  }\n'
+          '  mutation AddBook {\n' +
+          '    addBook(\n' +
+          '      name: "Fifth Book"\n' +
+          '      authorIds: "0,2"\n' +
+          '    ) {\n' +
+          '      id\n' +
+          '    }\n' +
+          '  }\n'
         );
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.OPERATION_TYPE],
@@ -750,11 +752,11 @@ describe('graphql', () => {
           'addBook',
           'Book',
           'addBook(\n' +
-            '      name: "Fifth Book"\n' +
-            '      authorIds: "0,2"\n' +
-            '    ) {\n' +
-            '      id\n' +
-            '    }',
+          '      name: "Fifth Book"\n' +
+          '      authorIds: "0,2"\n' +
+          '    ) {\n' +
+          '      id\n' +
+          '    }',
           executeSpan.spanContext().spanId
         );
         const parentId = resolveParentSpan.spanContext().spanId;
@@ -793,11 +795,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           parseSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-            '  query Query1 ($id: Int!) {\n' +
-            '    book(id: $id) {\n' +
-            '      name\n' +
-            '    }\n' +
-            '  }\n'
+          '  query Query1 ($id: Int!) {\n' +
+          '    book(id: $id) {\n' +
+          '      name\n' +
+          '    }\n' +
+          '  }\n'
         );
         assert.deepStrictEqual(parseSpan.name, SpanNames.PARSE);
       });
@@ -815,11 +817,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-            '  query Query1 ($id: Int!) {\n' +
-            '    book(id: $id) {\n' +
-            '      name\n' +
-            '    }\n' +
-            '  }\n'
+          '  query Query1 ($id: Int!) {\n' +
+          '    book(id: $id) {\n' +
+          '      name\n' +
+          '    }\n' +
+          '  }\n'
         );
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.OPERATION_TYPE],
@@ -889,14 +891,14 @@ describe('graphql', () => {
       assert.deepStrictEqual(
         parseSpan.attributes[AttributeNames.SOURCE],
         '\n' +
-          '  mutation AddBook {\n' +
-          '    addBook(\n' +
-          '      name: "*"\n' +
-          '      authorIds: "*"\n' +
-          '    ) {\n' +
-          '      id\n' +
-          '    }\n' +
-          '  }\n'
+        '  mutation AddBook {\n' +
+        '    addBook(\n' +
+        '      name: "*"\n' +
+        '      authorIds: "*"\n' +
+        '    ) {\n' +
+        '      id\n' +
+        '    }\n' +
+        '  }\n'
       );
       assert.deepStrictEqual(parseSpan.name, SpanNames.PARSE);
     });
@@ -914,14 +916,14 @@ describe('graphql', () => {
       assert.deepStrictEqual(
         executeSpan.attributes[AttributeNames.SOURCE],
         '\n' +
-          '  mutation AddBook {\n' +
-          '    addBook(\n' +
-          '      name: "*"\n' +
-          '      authorIds: "*"\n' +
-          '    ) {\n' +
-          '      id\n' +
-          '    }\n' +
-          '  }\n'
+        '  mutation AddBook {\n' +
+        '    addBook(\n' +
+        '      name: "*"\n' +
+        '      authorIds: "*"\n' +
+        '    ) {\n' +
+        '      id\n' +
+        '    }\n' +
+        '  }\n'
       );
       assert.deepStrictEqual(
         executeSpan.attributes[AttributeNames.OPERATION_TYPE],
@@ -946,11 +948,11 @@ describe('graphql', () => {
         'addBook',
         'Book',
         'addBook(\n' +
-          '      name: "*"\n' +
-          '      authorIds: "*"\n' +
-          '    ) {\n' +
-          '      id\n' +
-          '    }',
+        '      name: "*"\n' +
+        '      authorIds: "*"\n' +
+        '    ) {\n' +
+        '      id\n' +
+        '    }',
         executeSpan.spanContext().spanId
       );
       const parentId = resolveParentSpan.spanContext().spanId;
@@ -1017,11 +1019,11 @@ describe('graphql', () => {
       assert.deepStrictEqual(
         parseSpan.attributes[AttributeNames.SOURCE],
         '\n' +
-          '  query {\n' +
-          '    book(id: "*") {\n' +
-          '      name\n' +
-          '    }\n' +
-          '  }\n'
+        '  query {\n' +
+        '    book(id: "*") {\n' +
+        '      name\n' +
+        '    }\n' +
+        '  }\n'
       );
       assert.deepStrictEqual(parseSpan.name, SpanNames.PARSE);
     });
@@ -1138,11 +1140,11 @@ describe('graphql', () => {
       assert.deepStrictEqual(
         parseSpan.attributes[AttributeNames.SOURCE],
         '\n' +
-          '  query {\n' +
-          '    book(id: *) {\n' +
-          '      name\n' +
-          '    }\n' +
-          '  }\n'
+        '  query {\n' +
+        '    book(id: *) {\n' +
+        '      name\n' +
+        '    }\n' +
+        '  }\n'
       );
       assert.deepStrictEqual(parseSpan.name, SpanNames.PARSE);
     });
@@ -1163,11 +1165,11 @@ describe('graphql', () => {
       assert.deepStrictEqual(
         executeSpan.attributes[AttributeNames.SOURCE],
         '\n' +
-          '  query {\n' +
-          '    book(id: *) {\n' +
-          '      name\n' +
-          '    }\n' +
-          '  }\n'
+        '  query {\n' +
+        '    book(id: *) {\n' +
+        '      name\n' +
+        '    }\n' +
+        '  }\n'
       );
       assert.deepStrictEqual(
         executeSpan.attributes[AttributeNames.OPERATION_NAME],
@@ -1175,6 +1177,77 @@ describe('graphql', () => {
       );
       assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
       assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
+    });
+  });
+
+  describe('graphqlSync', () => {
+
+    const simpleSyncSchema = buildSchema(`
+      type Query {
+        hello: String
+      }
+    `);
+
+    beforeEach(() => {
+      create({});
+    });
+
+    afterEach(() => {
+      exporter.reset();
+    });
+
+    it('should instrument successful graphqlSync', () => {
+      const rootValue = {
+        hello: () => 'Hello world!',
+      }
+      const source = '{ hello }';
+
+      const res = graphqlSync({ schema: simpleSyncSchema, rootValue, source });
+      assert.deepEqual(res.data, { hello: 'Hello world!' });
+
+      // validate execute span is present
+      const spans = exporter.getFinishedSpans();
+      const executeSpans = spans.filter(s => s.name === SpanNames.EXECUTE);
+      assert.deepStrictEqual(executeSpans.length, 1);
+      const [ executeSpan ] = executeSpans;
+      assert.deepStrictEqual(executeSpan.attributes[AttributeNames.SOURCE], source);
+      assert.deepStrictEqual(executeSpan.attributes[AttributeNames.OPERATION_TYPE], 'query');
+    });
+
+    it('should instrument when sync resolver throws', () => {
+      const rootValue = {
+        hello: () => {
+          throw Error('sync resolver error from tests');
+        },
+      }
+      const source = '{ hello }';
+
+      // graphql will not throw, it will return "errors" in the result and the field will be null
+      const res = graphqlSync({ schema: simpleSyncSchema, rootValue, source });
+      assert.deepEqual(res.data, { hello: null });
+
+      // assert errors are returned correctly
+      assert.deepStrictEqual(res.errors?.length, 1);
+      const resolverError = res.errors?.[0];
+      assert.deepStrictEqual(resolverError.path, ['hello']);
+      assert.deepStrictEqual(resolverError.message, 'sync resolver error from tests');
+
+      // assert relevant spans are still created with error indications
+      const spans = exporter.getFinishedSpans();
+
+      // single resolve span with error and event for exception
+      const resolveSpans = spans.filter(s => s.name === SpanNames.RESOLVE);
+      assert.deepStrictEqual(resolveSpans.length, 1);
+      const resolveSpan = resolveSpans[0];
+      assert.deepStrictEqual(resolveSpan.status.code, SpanStatusCode.ERROR);
+      assert.deepStrictEqual(resolveSpan.status.message, 'sync resolver error from tests');
+      const resolveEvent = resolveSpan.events[0];
+      assert.deepStrictEqual(resolveEvent.name, 'exception');
+      assert.deepStrictEqual(resolveEvent.attributes?.[SemanticAttributes.EXCEPTION_MESSAGE], 'sync resolver error from tests');
+
+      // single execute span
+      const executeSpans = spans.filter(s => s.name === SpanNames.EXECUTE);
+      assert.deepStrictEqual(executeSpans.length, 1);
     });
   });
 });

--- a/plugins/node/opentelemetry-instrumentation-graphql/test/graphql.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/test/graphql.test.ts
@@ -128,11 +128,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           parseSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-          '  query {\n' +
-          '    books {\n' +
-          '      name\n' +
-          '    }\n' +
-          '  }\n'
+            '  query {\n' +
+            '    books {\n' +
+            '      name\n' +
+            '    }\n' +
+            '  }\n'
         );
         assert.deepStrictEqual(parseSpan.name, SpanNames.PARSE);
       });
@@ -150,11 +150,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-          '  query {\n' +
-          '    books {\n' +
-          '      name\n' +
-          '    }\n' +
-          '  }\n'
+            '  query {\n' +
+            '    books {\n' +
+            '      name\n' +
+            '    }\n' +
+            '  }\n'
         );
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.OPERATION_TYPE],
@@ -256,11 +256,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           parseSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-          '  query {\n' +
-          '    book(id: *) {\n' +
-          '      name\n' +
-          '    }\n' +
-          '  }\n'
+            '  query {\n' +
+            '    book(id: *) {\n' +
+            '      name\n' +
+            '    }\n' +
+            '  }\n'
         );
         assert.deepStrictEqual(parseSpan.name, SpanNames.PARSE);
       });
@@ -278,11 +278,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-          '  query {\n' +
-          '    book(id: *) {\n' +
-          '      name\n' +
-          '    }\n' +
-          '  }\n'
+            '  query {\n' +
+            '    book(id: *) {\n' +
+            '      name\n' +
+            '    }\n' +
+            '  }\n'
         );
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.OPERATION_TYPE],
@@ -350,11 +350,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           parseSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-          '  query Query1 ($id: Int!) {\n' +
-          '    book(id: $id) {\n' +
-          '      name\n' +
-          '    }\n' +
-          '  }\n'
+            '  query Query1 ($id: Int!) {\n' +
+            '    book(id: $id) {\n' +
+            '      name\n' +
+            '    }\n' +
+            '  }\n'
         );
         assert.deepStrictEqual(parseSpan.name, SpanNames.PARSE);
       });
@@ -372,11 +372,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-          '  query Query1 ($id: Int!) {\n' +
-          '    book(id: $id) {\n' +
-          '      name\n' +
-          '    }\n' +
-          '  }\n'
+            '  query Query1 ($id: Int!) {\n' +
+            '    book(id: $id) {\n' +
+            '      name\n' +
+            '    }\n' +
+            '  }\n'
         );
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.OPERATION_TYPE],
@@ -446,11 +446,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           parseSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-          '  query {\n' +
-          '    books {\n' +
-          '      name\n' +
-          '    }\n' +
-          '  }\n'
+            '  query {\n' +
+            '    books {\n' +
+            '      name\n' +
+            '    }\n' +
+            '  }\n'
         );
         assert.deepStrictEqual(parseSpan.name, SpanNames.PARSE);
       });
@@ -468,11 +468,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-          '  query {\n' +
-          '    books {\n' +
-          '      name\n' +
-          '    }\n' +
-          '  }\n'
+            '  query {\n' +
+            '    books {\n' +
+            '      name\n' +
+            '    }\n' +
+            '  }\n'
         );
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.OPERATION_TYPE],
@@ -514,11 +514,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           parseSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-          '  query {\n' +
-          '    books {\n' +
-          '      name\n' +
-          '    }\n' +
-          '  }\n'
+            '  query {\n' +
+            '    books {\n' +
+            '      name\n' +
+            '    }\n' +
+            '  }\n'
         );
         assert.deepStrictEqual(parseSpan.name, SpanNames.PARSE);
       });
@@ -536,11 +536,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-          '  query {\n' +
-          '    books {\n' +
-          '      name\n' +
-          '    }\n' +
-          '  }\n'
+            '  query {\n' +
+            '    books {\n' +
+            '      name\n' +
+            '    }\n' +
+            '  }\n'
         );
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.OPERATION_TYPE],
@@ -605,11 +605,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           parseSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-          '  query {\n' +
-          '    book(id: 0) {\n' +
-          '      name\n' +
-          '    }\n' +
-          '  }\n'
+            '  query {\n' +
+            '    book(id: 0) {\n' +
+            '      name\n' +
+            '    }\n' +
+            '  }\n'
         );
         assert.deepStrictEqual(parseSpan.name, SpanNames.PARSE);
       });
@@ -627,11 +627,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-          '  query {\n' +
-          '    book(id: 0) {\n' +
-          '      name\n' +
-          '    }\n' +
-          '  }\n'
+            '  query {\n' +
+            '    book(id: 0) {\n' +
+            '      name\n' +
+            '    }\n' +
+            '  }\n'
         );
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.OPERATION_TYPE],
@@ -695,14 +695,14 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           parseSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-          '  mutation AddBook {\n' +
-          '    addBook(\n' +
-          '      name: "Fifth Book"\n' +
-          '      authorIds: "0,2"\n' +
-          '    ) {\n' +
-          '      id\n' +
-          '    }\n' +
-          '  }\n'
+            '  mutation AddBook {\n' +
+            '    addBook(\n' +
+            '      name: "Fifth Book"\n' +
+            '      authorIds: "0,2"\n' +
+            '    ) {\n' +
+            '      id\n' +
+            '    }\n' +
+            '  }\n'
         );
         assert.deepStrictEqual(parseSpan.name, SpanNames.PARSE);
       });
@@ -720,14 +720,14 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-          '  mutation AddBook {\n' +
-          '    addBook(\n' +
-          '      name: "Fifth Book"\n' +
-          '      authorIds: "0,2"\n' +
-          '    ) {\n' +
-          '      id\n' +
-          '    }\n' +
-          '  }\n'
+            '  mutation AddBook {\n' +
+            '    addBook(\n' +
+            '      name: "Fifth Book"\n' +
+            '      authorIds: "0,2"\n' +
+            '    ) {\n' +
+            '      id\n' +
+            '    }\n' +
+            '  }\n'
         );
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.OPERATION_TYPE],
@@ -752,11 +752,11 @@ describe('graphql', () => {
           'addBook',
           'Book',
           'addBook(\n' +
-          '      name: "Fifth Book"\n' +
-          '      authorIds: "0,2"\n' +
-          '    ) {\n' +
-          '      id\n' +
-          '    }',
+            '      name: "Fifth Book"\n' +
+            '      authorIds: "0,2"\n' +
+            '    ) {\n' +
+            '      id\n' +
+            '    }',
           executeSpan.spanContext().spanId
         );
         const parentId = resolveParentSpan.spanContext().spanId;
@@ -795,11 +795,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           parseSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-          '  query Query1 ($id: Int!) {\n' +
-          '    book(id: $id) {\n' +
-          '      name\n' +
-          '    }\n' +
-          '  }\n'
+            '  query Query1 ($id: Int!) {\n' +
+            '    book(id: $id) {\n' +
+            '      name\n' +
+            '    }\n' +
+            '  }\n'
         );
         assert.deepStrictEqual(parseSpan.name, SpanNames.PARSE);
       });
@@ -817,11 +817,11 @@ describe('graphql', () => {
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.SOURCE],
           '\n' +
-          '  query Query1 ($id: Int!) {\n' +
-          '    book(id: $id) {\n' +
-          '      name\n' +
-          '    }\n' +
-          '  }\n'
+            '  query Query1 ($id: Int!) {\n' +
+            '    book(id: $id) {\n' +
+            '      name\n' +
+            '    }\n' +
+            '  }\n'
         );
         assert.deepStrictEqual(
           executeSpan.attributes[AttributeNames.OPERATION_TYPE],
@@ -891,14 +891,14 @@ describe('graphql', () => {
       assert.deepStrictEqual(
         parseSpan.attributes[AttributeNames.SOURCE],
         '\n' +
-        '  mutation AddBook {\n' +
-        '    addBook(\n' +
-        '      name: "*"\n' +
-        '      authorIds: "*"\n' +
-        '    ) {\n' +
-        '      id\n' +
-        '    }\n' +
-        '  }\n'
+          '  mutation AddBook {\n' +
+          '    addBook(\n' +
+          '      name: "*"\n' +
+          '      authorIds: "*"\n' +
+          '    ) {\n' +
+          '      id\n' +
+          '    }\n' +
+          '  }\n'
       );
       assert.deepStrictEqual(parseSpan.name, SpanNames.PARSE);
     });
@@ -916,14 +916,14 @@ describe('graphql', () => {
       assert.deepStrictEqual(
         executeSpan.attributes[AttributeNames.SOURCE],
         '\n' +
-        '  mutation AddBook {\n' +
-        '    addBook(\n' +
-        '      name: "*"\n' +
-        '      authorIds: "*"\n' +
-        '    ) {\n' +
-        '      id\n' +
-        '    }\n' +
-        '  }\n'
+          '  mutation AddBook {\n' +
+          '    addBook(\n' +
+          '      name: "*"\n' +
+          '      authorIds: "*"\n' +
+          '    ) {\n' +
+          '      id\n' +
+          '    }\n' +
+          '  }\n'
       );
       assert.deepStrictEqual(
         executeSpan.attributes[AttributeNames.OPERATION_TYPE],
@@ -948,11 +948,11 @@ describe('graphql', () => {
         'addBook',
         'Book',
         'addBook(\n' +
-        '      name: "*"\n' +
-        '      authorIds: "*"\n' +
-        '    ) {\n' +
-        '      id\n' +
-        '    }',
+          '      name: "*"\n' +
+          '      authorIds: "*"\n' +
+          '    ) {\n' +
+          '      id\n' +
+          '    }',
         executeSpan.spanContext().spanId
       );
       const parentId = resolveParentSpan.spanContext().spanId;
@@ -1019,11 +1019,11 @@ describe('graphql', () => {
       assert.deepStrictEqual(
         parseSpan.attributes[AttributeNames.SOURCE],
         '\n' +
-        '  query {\n' +
-        '    book(id: "*") {\n' +
-        '      name\n' +
-        '    }\n' +
-        '  }\n'
+          '  query {\n' +
+          '    book(id: "*") {\n' +
+          '      name\n' +
+          '    }\n' +
+          '  }\n'
       );
       assert.deepStrictEqual(parseSpan.name, SpanNames.PARSE);
     });
@@ -1140,11 +1140,11 @@ describe('graphql', () => {
       assert.deepStrictEqual(
         parseSpan.attributes[AttributeNames.SOURCE],
         '\n' +
-        '  query {\n' +
-        '    book(id: *) {\n' +
-        '      name\n' +
-        '    }\n' +
-        '  }\n'
+          '  query {\n' +
+          '    book(id: *) {\n' +
+          '      name\n' +
+          '    }\n' +
+          '  }\n'
       );
       assert.deepStrictEqual(parseSpan.name, SpanNames.PARSE);
     });
@@ -1165,11 +1165,11 @@ describe('graphql', () => {
       assert.deepStrictEqual(
         executeSpan.attributes[AttributeNames.SOURCE],
         '\n' +
-        '  query {\n' +
-        '    book(id: *) {\n' +
-        '      name\n' +
-        '    }\n' +
-        '  }\n'
+          '  query {\n' +
+          '    book(id: *) {\n' +
+          '      name\n' +
+          '    }\n' +
+          '  }\n'
       );
       assert.deepStrictEqual(
         executeSpan.attributes[AttributeNames.OPERATION_NAME],
@@ -1181,7 +1181,6 @@ describe('graphql', () => {
   });
 
   describe('graphqlSync', () => {
-
     const simpleSyncSchema = buildSchema(`
       type Query {
         hello: String
@@ -1199,7 +1198,7 @@ describe('graphql', () => {
     it('should instrument successful graphqlSync', () => {
       const rootValue = {
         hello: () => 'Hello world!',
-      }
+      };
       const source = '{ hello }';
 
       const res = graphqlSync({ schema: simpleSyncSchema, rootValue, source });
@@ -1209,9 +1208,15 @@ describe('graphql', () => {
       const spans = exporter.getFinishedSpans();
       const executeSpans = spans.filter(s => s.name === SpanNames.EXECUTE);
       assert.deepStrictEqual(executeSpans.length, 1);
-      const [ executeSpan ] = executeSpans;
-      assert.deepStrictEqual(executeSpan.attributes[AttributeNames.SOURCE], source);
-      assert.deepStrictEqual(executeSpan.attributes[AttributeNames.OPERATION_TYPE], 'query');
+      const [executeSpan] = executeSpans;
+      assert.deepStrictEqual(
+        executeSpan.attributes[AttributeNames.SOURCE],
+        source
+      );
+      assert.deepStrictEqual(
+        executeSpan.attributes[AttributeNames.OPERATION_TYPE],
+        'query'
+      );
     });
 
     it('should instrument when sync resolver throws', () => {
@@ -1219,7 +1224,7 @@ describe('graphql', () => {
         hello: () => {
           throw Error('sync resolver error from tests');
         },
-      }
+      };
       const source = '{ hello }';
 
       // graphql will not throw, it will return "errors" in the result and the field will be null
@@ -1230,7 +1235,10 @@ describe('graphql', () => {
       assert.deepStrictEqual(res.errors?.length, 1);
       const resolverError = res.errors?.[0];
       assert.deepStrictEqual(resolverError.path, ['hello']);
-      assert.deepStrictEqual(resolverError.message, 'sync resolver error from tests');
+      assert.deepStrictEqual(
+        resolverError.message,
+        'sync resolver error from tests'
+      );
 
       // assert relevant spans are still created with error indications
       const spans = exporter.getFinishedSpans();
@@ -1240,10 +1248,16 @@ describe('graphql', () => {
       assert.deepStrictEqual(resolveSpans.length, 1);
       const resolveSpan = resolveSpans[0];
       assert.deepStrictEqual(resolveSpan.status.code, SpanStatusCode.ERROR);
-      assert.deepStrictEqual(resolveSpan.status.message, 'sync resolver error from tests');
+      assert.deepStrictEqual(
+        resolveSpan.status.message,
+        'sync resolver error from tests'
+      );
       const resolveEvent = resolveSpan.events[0];
       assert.deepStrictEqual(resolveEvent.name, 'exception');
-      assert.deepStrictEqual(resolveEvent.attributes?.[SemanticAttributes.EXCEPTION_MESSAGE], 'sync resolver error from tests');
+      assert.deepStrictEqual(
+        resolveEvent.attributes?.[SemanticAttributes.EXCEPTION_MESSAGE],
+        'sync resolver error from tests'
+      );
 
       // single execute span
       const executeSpans = spans.filter(s => s.name === SpanNames.EXECUTE);

--- a/plugins/node/opentelemetry-instrumentation-graphql/test/schema.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/test/schema.ts
@@ -97,7 +97,7 @@ function prepareData() {
 
 prepareData();
 
-export function buildSchema() {
+export function buildTestSchema() {
   const Author = new graphql.GraphQLObjectType({
     name: 'Author',
     fields: {


### PR DESCRIPTION

## Which problem is this PR solving?

- fixes #1082 

The issue is that graphql resolvers can either be a promise or a sync function. Instrumentation wrapped each result with a promise (using `asyncSafeExecuteInTheMiddle`) which was confusing graphql, making it fail for sync runs, and changing the span times in a way that doesn't make sense (sync calls now overlapped).

## Short description of the changes

- When wrapping graphql resolver, check if the result is a promise and handle promise and sync response accordingly.


I added test and run `test-all-versions` on the PR