### PR TITLE
fix: address webpack memory issue for browser tests

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -165,6 +165,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NPM_CONFIG_UNSAFE_PERM: true
+      NODE_OPTIONS: --max-old-space-size=4096
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/archive/opentelemetry-browser-extension-autoinjection/package.json
+++ b/archive/opentelemetry-browser-extension-autoinjection/package.json
@@ -58,7 +58,7 @@
     "ts-loader": "9.2.5",
     "ts-mocha": "10.0.0",
     "typescript": "4.3.5",
-    "webpack": "5.48.0",
+    "webpack": "4.46.0",
     "webpack-cli": "4.7.2",
     "webpack-merge": "5.8.0"
   },

--- a/metapackages/auto-instrumentations-web/package.json
+++ b/metapackages/auto-instrumentations-web/package.json
@@ -43,7 +43,7 @@
     "gts": "3.1.0",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "karma": "6.3.16",
-    "karma-chrome-launcher": "3.1.0",
+    "karma-chrome-launcher": "^3.1.1",
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-mocha": "2.0.1",
     "karma-spec-reporter": "0.0.32",

--- a/packages/opentelemetry-id-generator-aws-xray/package.json
+++ b/packages/opentelemetry-id-generator-aws-xray/package.json
@@ -62,7 +62,7 @@
     "gts": "3.1.0",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "karma": "6.3.16",
-    "karma-chrome-launcher": "3.1.0",
+    "karma-chrome-launcher": "^3.1.1",
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-mocha": "2.0.1",
     "karma-spec-reporter": "0.0.32",

--- a/plugins/web/opentelemetry-instrumentation-document-load/package.json
+++ b/plugins/web/opentelemetry-instrumentation-document-load/package.json
@@ -60,7 +60,7 @@
     "gts": "3.1.0",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "karma": "6.3.16",
-    "karma-chrome-launcher": "3.1.0",
+    "karma-chrome-launcher": "^3.1.1",
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-mocha": "2.0.1",
     "karma-spec-reporter": "0.0.32",

--- a/plugins/web/opentelemetry-instrumentation-long-task/package.json
+++ b/plugins/web/opentelemetry-instrumentation-long-task/package.json
@@ -59,7 +59,7 @@
     "gts": "3.1.0",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "karma": "6.3.16",
-    "karma-chrome-launcher": "3.1.0",
+    "karma-chrome-launcher": "^3.1.1",
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-jquery": "0.2.4",
     "karma-mocha": "2.0.1",

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
@@ -61,7 +61,7 @@
     "gts": "3.1.0",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "karma": "6.3.16",
-    "karma-chrome-launcher": "3.1.0",
+    "karma-chrome-launcher": "^3.1.1",
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-jquery": "0.2.4",
     "karma-mocha": "2.0.1",

--- a/plugins/web/opentelemetry-plugin-react-load/package.json
+++ b/plugins/web/opentelemetry-plugin-react-load/package.json
@@ -62,7 +62,7 @@
     "gts": "3.1.0",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "karma": "6.3.16",
-    "karma-chrome-launcher": "3.1.0",
+    "karma-chrome-launcher": "^3.1.1",
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-mocha": "2.0.1",
     "karma-spec-reporter": "0.0.32",

--- a/propagators/opentelemetry-propagator-aws-xray/package.json
+++ b/propagators/opentelemetry-propagator-aws-xray/package.json
@@ -55,7 +55,7 @@
     "gts": "3.1.0",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "karma": "6.3.16",
-    "karma-chrome-launcher": "3.1.0",
+    "karma-chrome-launcher": "^3.1.1",
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-mocha": "2.0.1",
     "karma-spec-reporter": "0.0.32",

--- a/propagators/opentelemetry-propagator-instana/package.json
+++ b/propagators/opentelemetry-propagator-instana/package.json
@@ -61,14 +61,14 @@
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-mocha": "2.0.1",
     "karma-spec-reporter": "0.0.33",
-    "karma-webpack": "5.0.0",
+    "karma-webpack": "4.0.2",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "process": "0.11.10",
     "ts-loader": "8.3.0",
     "ts-mocha": "8.0.0",
     "typescript": "4.3.5",
-    "webpack": "5.72.0",
+    "webpack": "4.46.0",
     "webpack-cli": "4.9.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/propagators/opentelemetry-propagator-instana#readme"

--- a/propagators/opentelemetry-propagator-ot-trace/package.json
+++ b/propagators/opentelemetry-propagator-ot-trace/package.json
@@ -56,7 +56,7 @@
     "gts": "3.1.0",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "karma": "6.3.16",
-    "karma-chrome-launcher": "3.1.0",
+    "karma-chrome-launcher": "^3.1.1",
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-mocha": "2.0.1",
     "karma-spec-reporter": "0.0.32",


### PR DESCRIPTION
## Which problem is this PR solving?

- Contrib Browser tests are failing with out of memory issue #1248

## Short description of the changes

- Make sure the same versions of webpack and karma-webpack are used for all packages 
