### PR TITLE
fix(instrumentation-fastify): stop using fastify types in public api

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-fastify/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-fastify/src/instrumentation.ts
@@ -209,7 +209,7 @@ export class FastifyInstrumentation extends InstrumentationBase {
     return fastify;
   }
 
-  public _patchSend() {
+  private _patchSend() {
     const instrumentation = this;
     this._diag.debug('Patching fastify reply.send function');
 
@@ -238,7 +238,7 @@ export class FastifyInstrumentation extends InstrumentationBase {
     };
   }
 
-  public _hookPreHandler() {
+  private _hookPreHandler() {
     const instrumentation = this;
     this._diag.debug('Patching fastify preHandler function');
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Related to #1266 

Prior to this fix, typescript users that have the fastify instrumentation installed but do not have the `fastify` package installed would get compilation errors because typescript was expecting the `fastify` package to be present. This issue is bound to happen for anyone using the auto instrumentation feature.

## Short description of the changes

- Mark all methods that use types from `fastify` as private in `instrumentation.ts`.
