### PR TITLE
feat(resource-detector-aws): allow synchronous lambda detection

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsLambdaDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsLambdaDetector.ts
@@ -18,12 +18,12 @@ import {
   Detector,
   Resource,
   ResourceDetectionConfig,
-} from '@opentelemetry/resources';
+} from "@opentelemetry/resources";
 import {
   CloudProviderValues,
   CloudPlatformValues,
   SemanticResourceAttributes,
-} from '@opentelemetry/semantic-conventions';
+} from "@opentelemetry/semantic-conventions";
 
 /**
  * The AwsLambdaDetector can be used to detect if a process is running in AWS Lambda
@@ -31,7 +31,7 @@ import {
  * Returns an empty Resource if detection fails.
  */
 export class AwsLambdaDetector implements Detector {
-  async detect(_config?: ResourceDetectionConfig): Promise<Resource> {
+  detectSync(_config?: ResourceDetectionConfig): Resource {
     const functionName = process.env.AWS_LAMBDA_FUNCTION_NAME;
     if (!functionName) {
       return Resource.empty();
@@ -60,6 +60,10 @@ export class AwsLambdaDetector implements Detector {
     }
 
     return new Resource(attributes);
+  }
+
+  async detect(_config?: ResourceDetectionConfig): Promise<Resource> {
+    return this.detectSync(_config);
   }
 }
 

--- a/detectors/node/opentelemetry-resource-detector-aws/test/detectors/AwsLambdaDetector.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/test/detectors/AwsLambdaDetector.test.ts
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import * as assert from 'assert';
+import * as assert from "assert";
 import {
   assertCloudResource,
   assertEmptyResource,
-} from '@opentelemetry/contrib-test-utils';
+} from "@opentelemetry/contrib-test-utils";
 
-import { awsLambdaDetector } from '../../src';
+import { awsLambdaDetector } from "../../src";
 
-describe('awsLambdaDetector', () => {
+describe("awsLambdaDetector", () => {
   let oldEnv: NodeJS.ProcessEnv;
 
   beforeEach(() => {
@@ -33,28 +33,44 @@ describe('awsLambdaDetector', () => {
     process.env = oldEnv;
   });
 
-  describe('on lambda', () => {
-    it('fills resource', async () => {
-      process.env.AWS_LAMBDA_FUNCTION_NAME = 'name';
-      process.env.AWS_LAMBDA_FUNCTION_VERSION = 'v1';
-      process.env.AWS_REGION = 'us-east-1';
+  describe("on lambda", () => {
+    it("fills resource", async () => {
+      process.env.AWS_LAMBDA_FUNCTION_NAME = "name";
+      process.env.AWS_LAMBDA_FUNCTION_VERSION = "v1";
+      process.env.AWS_REGION = "us-east-1";
 
       const resource = await awsLambdaDetector.detect();
 
       assertCloudResource(resource, {
-        provider: 'aws',
-        region: 'us-east-1',
+        provider: "aws",
+        region: "us-east-1",
       });
 
-      assert.strictEqual(resource.attributes['faas.name'], 'name');
-      assert.strictEqual(resource.attributes['faas.version'], 'v1');
+      assert.strictEqual(resource.attributes["faas.name"], "name");
+      assert.strictEqual(resource.attributes["faas.version"], "v1");
+    });
+
+    it("also works synchronously", async () => {
+      process.env.AWS_LAMBDA_FUNCTION_NAME = "name";
+      process.env.AWS_LAMBDA_FUNCTION_VERSION = "v1";
+      process.env.AWS_REGION = "us-east-1";
+
+      const resource = awsLambdaDetector.detectSync();
+
+      assertCloudResource(resource, {
+        provider: "aws",
+        region: "us-east-1",
+      });
+
+      assert.strictEqual(resource.attributes["faas.name"], "name");
+      assert.strictEqual(resource.attributes["faas.version"], "v1");
     });
   });
 
-  describe('not on lambda', () => {
-    it('returns empty resource', async () => {
-      process.env.AWS_LAMBDA_FUNCTION_VERSION = 'v1';
-      process.env.AWS_REGION = 'us-east-1';
+  describe("not on lambda", () => {
+    it("returns empty resource", async () => {
+      process.env.AWS_LAMBDA_FUNCTION_VERSION = "v1";
+      process.env.AWS_REGION = "us-east-1";
 
       const resource = await awsLambdaDetector.detect();
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

See #1273
When using asynchronous SDK init, the lambda might have executed before the SDK has terminated its init (as no top-level await is possible for any of the AWS node runtimes)

Our kubernetes services are usually long-lived, so if we miss a few traces at startup, it's not a problem. For lambdas it's a bit of a different story. I need to find a way to ensure that the init is synchronous.

As it turns out, the detector is actually synchronous, but just returns a Promise. If we can bypass that by exposing a synchronous method (and ditching the detectResources method at the same time at the application level), then everything becomes peachy :)


## Short description of the changes

Added a synchronous method for lambda resource detection.

(PS: Sorry for the quote replacement, maybe we could add a .prettierrc somewhere)
