### PR TITLE
fix(opentelemetry-instrumentation-user-interaction): donot patch empt…

### DIFF
--- a/plugins/web/opentelemetry-instrumentation-user-interaction/src/instrumentation.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/src/instrumentation.ts
@@ -320,7 +320,7 @@ export class UserInteractionInstrumentation extends InstrumentationBase<unknown>
             return plugin._invokeListener(listener, this, args);
           }
         };
-        if (plugin.addPatchedListener(this, type, listener, patchedListener)) {
+        if (listener && plugin.addPatchedListener(this, type, listener, patchedListener)) {
           return original.call(this, type, patchedListener, useCapture);
         }
       };


### PR DESCRIPTION
improve opentelemetry-js-contrib/plugins/web/opentelemetry-instrumentation-user-interaction/src/instrumentation.ts/_patchAddEventListener 

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- when listener is null value，plugin.addPatchedListener will throw error because WeakMap key is not valid.
`new WeakMap<AnyFunction | EventListenerObject, Map<string, Map<HTMLElement, AnyFunction>>>();`


## Short description of the changes
- check listener before addPatchedListener

