### PR TITLE
feat: use GA version of metrics

### DIFF
--- a/packages/opentelemetry-host-metrics/package.json
+++ b/packages/opentelemetry-host-metrics/package.json
@@ -59,7 +59,6 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/sdk-metrics": "^1.8.0",
     "systeminformation": "^5.0.0"
   },

--- a/packages/opentelemetry-host-metrics/package.json
+++ b/packages/opentelemetry-host-metrics/package.json
@@ -43,10 +43,10 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.0.0"
+    "@opentelemetry/api": "^1.3.0"
   },
   "devDependencies": {
-    "@opentelemetry/api": "^1.0.0",
+    "@opentelemetry/api": "^1.3.0",
     "@types/mocha": "8.2.3",
     "@types/node": "18.11.7",
     "@types/sinon": "10.0.2",
@@ -59,9 +59,8 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/api-metrics": "^0.32.0",
-    "@opentelemetry/core": "^1.0.0",
-    "@opentelemetry/sdk-metrics": "^0.32.0",
+    "@opentelemetry/core": "^1.8.0",
+    "@opentelemetry/sdk-metrics": "^1.8.0",
     "systeminformation": "^5.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/opentelemetry-host-metrics#readme"

--- a/packages/opentelemetry-host-metrics/src/BaseMetrics.ts
+++ b/packages/opentelemetry-host-metrics/src/BaseMetrics.ts
@@ -15,7 +15,6 @@
  */
 
 import * as api from '@opentelemetry/api';
-import * as apiMetrics from '@opentelemetry/api-metrics';
 import * as metrics from '@opentelemetry/sdk-metrics';
 
 import { VERSION } from './version';
@@ -45,7 +44,7 @@ const DEFAULT_NAME = 'opentelemetry-host-metrics';
 export abstract class BaseMetrics {
   protected _logger = api.diag;
   protected _maxTimeoutUpdateMS: number;
-  protected _meter: apiMetrics.Meter;
+  protected _meter: api.Meter;
   private _name: string;
 
   constructor(config: MetricsCollectorConfig) {
@@ -53,7 +52,7 @@ export abstract class BaseMetrics {
     this._maxTimeoutUpdateMS =
       config.maxTimeoutUpdateMS || DEFAULT_MAX_TIMEOUT_UPDATE_MS;
     const meterProvider =
-      config.meterProvider! || apiMetrics.metrics.getMeterProvider();
+      config.meterProvider! || api.metrics.getMeterProvider();
     if (!config.meterProvider) {
       this._logger.warn('No meter provider, using default');
     }

--- a/packages/opentelemetry-host-metrics/src/metric.ts
+++ b/packages/opentelemetry-host-metrics/src/metric.ts
@@ -15,7 +15,7 @@
  */
 
 import { BaseMetrics } from './BaseMetrics';
-import * as api from '@opentelemetry/api-metrics';
+import * as api from '@opentelemetry/api';
 import * as enums from './enum';
 
 import { getCpuUsageData, getMemoryData } from './stats/common';

--- a/packages/opentelemetry-host-metrics/test/metric.test.ts
+++ b/packages/opentelemetry-host-metrics/test/metric.test.ts
@@ -15,7 +15,7 @@
  */
 
 const SI = require('systeminformation');
-import { MetricAttributes } from '@opentelemetry/api-metrics';
+import { MetricAttributes } from '@opentelemetry/api';
 import {
   AggregationTemporality,
   DataPoint,
@@ -33,7 +33,7 @@ const cpuJson = require('./mocks/cpu.json');
 const networkJson = require('./mocks/network.json');
 
 class TestMetricReader extends MetricReader {
-  public selectAggregationTemporality(): AggregationTemporality {
+  public override selectAggregationTemporality(): AggregationTemporality {
     return AggregationTemporality.CUMULATIVE;
   }
   protected async onForceFlush(): Promise<void> {}

--- a/packages/opentelemetry-host-metrics/test/metric.test.ts
+++ b/packages/opentelemetry-host-metrics/test/metric.test.ts
@@ -15,7 +15,7 @@
  */
 
 const SI = require('systeminformation');
-import { MetricAttributes } from '@opentelemetry/api';
+import { Attributes } from '@opentelemetry/api';
 import {
   AggregationTemporality,
   DataPoint,
@@ -231,7 +231,7 @@ async function getRecords(
 
 function ensureValue(
   metric: MetricData,
-  attributes: MetricAttributes,
+  attributes: Attributes,
   value: number
 ) {
   const attrHash = hashAttributes(attributes);
@@ -247,7 +247,7 @@ function ensureValue(
   assert.strictEqual(aggValue, value);
 }
 
-function hashAttributes(attributes: MetricAttributes) {
+function hashAttributes(attributes: Attributes) {
   return Object.entries(attributes)
     .sort(([a], [b]) => {
       return a < b ? -1 : 1;

--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,14 @@
     },
     {
       "groupName": "Otel Core experimental",
-      "matchPackageNames": ["@opentelemetry/sdk-node", "@opentelemetry/instrumentation", "@opentelemetry/instrumentation-grpc", "@opentelemetry/instrumentation-http", "@opentelemetry/instrumentation-fetch", "@opentelemetry/instrumentation-xml-http-request", "@opentelemetry/api-metrics", "@opentelemetry/sdk-metrics" ],
+      "matchPackageNames": [
+        "@opentelemetry/instrumentation",
+        "@opentelemetry/instrumentation-grpc",
+        "@opentelemetry/instrumentation-http",
+        "@opentelemetry/instrumentation-fetch",
+        "@opentelemetry/instrumentation-xml-http-request",
+        "@opentelemetry/sdk-node"
+      ],
       "rangeStrategy": "bump"
     }
   ],


### PR DESCRIPTION
Update host-metrics to use the GA version of metrics SDK and no longer use api-metrics.

Remove metrics packages from experimental OTel renovate config.

