### PR TITLE
chore: update fastify dev-dependency instrumentation-http to 0.34.0

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-fastify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-fastify/package.json
@@ -48,7 +48,7 @@
     "@fastify/express": "^2.0.2",
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/context-async-hooks": "^1.8.0",
-    "@opentelemetry/instrumentation-http": "0.30.0",
+    "@opentelemetry/instrumentation-http": "0.34.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/express": "4.17.13",


### PR DESCRIPTION
## Short description of the changes

Update fastify dev dependency  instrumentation-http to 0.34.0. Seems this slipped through in #1278