### PR TITLE
Eventbus propagation

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -336,8 +336,13 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
       {
         kind: SpanKind.SERVER,
         attributes: {
+          ...Object.fromEntries( Object.entries( event.multiValueQueryStringParameters ).map( ( [ k, v ] ) => [ `http.request.query.${k}`, v.length == 1 ? v[0] : v ] ) ), // We don't have a semantic attribute for that, but would be useful nonetheless
+          ...Object.fromEntries( Object.entries( event.multiValueHeaders ).map( ( [ k, v ] ) => [ `http.request.header.${k}`, v.length == 1 ? v[0] : v ] ) ), // See https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/http/#http-request-and-response-headers
+          ...Object.fromEntries( Object.entries( event.pathParameters ).map( ( [ k, v ] ) => [ `http.request.parameters.${k}`, v ] ) ), 
+          [SemanticAttributes.NET_PEER_IP]: requestContext.identity.sourceIp,
           [SemanticAttributes.HTTP_METHOD]: requestContext.httpMethod,
           [SemanticAttributes.HTTP_ROUTE]: requestContext.resourcePath,
+          [SemanticAttributes.HTTP_URL]: requestContext.domainName + requestContext.path,
           [SemanticAttributes.HTTP_SERVER_NAME]: requestContext.domainName,
           [SemanticResourceAttributes.CLOUD_ACCOUNT_ID]:
             requestContext.accountId,

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/internal-types.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/internal-types.ts
@@ -15,6 +15,10 @@
  */
 import { Handler } from 'aws-lambda';
 
+export const enum TriggerOrigin {
+    API_GATEWAY
+}
+
 export type ApiGatewayEvent = {
   resource: string;
   path: string;

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/internal-types.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/internal-types.ts
@@ -15,4 +15,58 @@
  */
 import { Handler } from 'aws-lambda';
 
+export type ApiGatewayEvent = {
+  resource: string;
+  path: string;
+  httpMethod: string;
+  requestContext: ApiGatewayRequestContext;
+  headers: Record<string, string>;
+  multiValueHeaders: Record<string, string[]>;
+  queryStringParameters: string | null;
+  multiValueQueryStringParameters: any;
+  pathParameters: any;
+  stageVariables: any;
+  body: string;
+  isBase64Encoded: boolean;
+};
+
+export type ApiGatewayRequestContext = {
+  accountId: string;
+  apiId: string;
+  resourceId: string;
+  authorizer: {
+    claims: string | null;
+    scopes: string | null;
+    principalId: string | null;
+  };
+  domainName: string;
+  domainPrefix: string;
+  extendedRequestId: string;
+  httpMethod: string;
+
+  identity: {
+    accessKey: string | null;
+    accountId: string | null;
+    caller: string | null;
+    cognitoAuthenticationProvider: string | null;
+    cognitoAuthenticationType: string | null;
+    cognitoIdentityPool: string | null;
+    principalOrdId: string | null;
+    sourceIp: string | null;
+    user: string | null;
+    userAgent: string;
+    userArn: string | null;
+    clientCert: any;
+  };
+  path: string;
+  protocol: string;
+  requestId: string;
+
+  requestTime: string;
+  requestTimeEpoch: string;
+  stage: string;
+
+  resourcePath: any;
+};
+
 export type LambdaModule = Record<string, Handler>;

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/internal-types.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/internal-types.ts
@@ -23,7 +23,7 @@ export type ApiGatewayEvent = {
   headers: Record<string, string>;
   multiValueHeaders: Record<string, string[]>;
   queryStringParameters: string | null;
-  multiValueQueryStringParameters: any;
+  multiValueQueryStringParameters: Record<string, string[]>;
   pathParameters: any;
   stageVariables: any;
   body: string;

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/types.ts
@@ -39,5 +39,6 @@ export interface AwsLambdaInstrumentationConfig extends InstrumentationConfig {
   requestHook?: RequestHook;
   responseHook?: ResponseHook;
   disableAwsContextPropagation?: boolean;
+  detectApiGateway?: boolean;
   eventContextExtractor?: EventContextExtractor;
 }

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler-gateway.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler-gateway.test.ts
@@ -162,6 +162,7 @@ describe("gateway API handler", () => {
       const [spanLambda, spanGateway] = spans;
       assertSpanSuccess(spanLambda);
       assertGatewaySpanSuccess(spanGateway);
+      assert.strictEqual( spanGateway.attributes[ SemanticAttributes.HTTP_STATUS_CODE ], 200 )
       assert.strictEqual(spanGateway.parentSpanId, undefined);
       assert.strictEqual(
         spanLambda.parentSpanId,
@@ -191,6 +192,8 @@ describe("gateway API handler", () => {
       assertSpanSuccess(spanLambda);
       assertGatewaySpanFailure(spanGateway);
       assert.strictEqual(spanGateway.parentSpanId, undefined);
+      assert.strictEqual( spanGateway.attributes[ SemanticAttributes.HTTP_STATUS_CODE ], 500 )
+
       assert.strictEqual(
         spanLambda.parentSpanId,
         spanGateway.spanContext().spanId
@@ -208,7 +211,10 @@ describe("gateway API handler", () => {
       assert.strictEqual(result.statusCode, 400);
       const spans = memoryExporter.getFinishedSpans();
       assert.strictEqual(spans.length, 2);
+      
       const [_, spanGateway] = spans;
+
+      assert.strictEqual( spanGateway.attributes[ SemanticAttributes.HTTP_STATUS_CODE ], 400 )
       assert.strictEqual(
         spanGateway.status.message,
         "Return to API Gateway with error 400"
@@ -236,6 +242,8 @@ describe("gateway API handler", () => {
       const spans = memoryExporter.getFinishedSpans();
       assert.strictEqual(spans.length, 2);
       const [_, spanGateway] = spans;
+
+      assert.strictEqual( spanGateway.attributes[ SemanticAttributes.HTTP_STATUS_CODE ], 400 )
       assert.strictEqual(
         spanGateway.status.message,
         "Return to API Gateway with error 400"

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler-gateway.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler-gateway.test.ts
@@ -121,7 +121,9 @@ describe("gateway API handler", () => {
 
   const initializeHandler = (
     handler: string,
-    config: AwsLambdaInstrumentationConfig = {}
+    config: AwsLambdaInstrumentationConfig = {
+      detectApiGateway: true
+    }
   ) => {
     process.env._HANDLER = handler;
 
@@ -244,11 +246,11 @@ describe("gateway API handler", () => {
     it("gateway span should reject when throwing error", async () => {
       initializeHandler("lambda-test/gateway.errorAsync");
 
-      let err: any;
+      //let err: any;
       try {
         await lambdaRequire("lambda-test/gateway").errorAsync(event, ctx);
       } catch (e) {
-        err = e;
+        //err = e;
       }
 
       const spans = memoryExporter.getFinishedSpans();

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler-gateway.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler-gateway.test.ts
@@ -1,0 +1,261 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// We access through node_modules to allow it to be patched.
+/* eslint-disable node/no-extraneous-require */
+
+import * as path from "path";
+
+import {
+  AwsLambdaInstrumentation,
+  AwsLambdaInstrumentationConfig,
+} from "../../src";
+import {
+  BatchSpanProcessor,
+  InMemorySpanExporter,
+  ReadableSpan,
+} from "@opentelemetry/sdk-trace-base";
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
+import { Context } from "aws-lambda";
+import * as assert from "assert";
+import {
+  SemanticAttributes,
+  SemanticResourceAttributes,
+} from "@opentelemetry/semantic-conventions";
+import {
+  SpanKind,
+  SpanStatusCode,
+} from "@opentelemetry/api";
+import { assertSpanSuccess } from "./lambda-handler.test";
+
+const memoryExporter = new InMemorySpanExporter();
+const provider = new NodeTracerProvider();
+provider.addSpanProcessor(new BatchSpanProcessor(memoryExporter));
+provider.register();
+
+const event = {
+  requestContext: {
+    accountId: "123456789012",
+    apiId: "id",
+    authorizer: {
+      claims: null,
+      scopes: null,
+    },
+    domainName: "id.execute-api.us-east-1.amazonaws.com",
+    domainPrefix: "id",
+    extendedRequestId: "request-id",
+    httpMethod: "GET",
+    path: "/my/path",
+    protocol: "HTTP/1.1",
+    requestId: "id=",
+    requestTime: "04/Mar/2020:19:15:17 +0000",
+    requestTimeEpoch: 1583349317135,
+    resourceId: null,
+    resourcePath: "/my/path",
+    stage: "$default",
+  },
+};
+
+const assertGatewaySpanSuccess = (span: ReadableSpan) => {
+  assert.strictEqual(span.kind, SpanKind.SERVER);
+  assert.strictEqual(
+    span.name,
+    event.requestContext.domainName + event.requestContext.path
+  );
+
+  assert.strictEqual(span.status.code, SpanStatusCode.OK);
+  assert.strictEqual(span.status.message, undefined);
+
+  assert.strictEqual(
+    span.attributes[SemanticAttributes.HTTP_METHOD],
+    event.requestContext.httpMethod
+  );
+  assert.strictEqual(
+    span.attributes[SemanticAttributes.HTTP_ROUTE],
+    event.requestContext.resourcePath
+  );
+
+  assert.strictEqual(
+    span.attributes[SemanticAttributes.HTTP_SERVER_NAME],
+    event.requestContext.domainName
+  );
+  assert.strictEqual(
+    span.attributes[SemanticResourceAttributes.CLOUD_ACCOUNT_ID],
+    event.requestContext.accountId
+  );
+};
+
+const assertGatewaySpanFailure = (span: ReadableSpan) => {
+  assert.strictEqual(span.kind, SpanKind.SERVER);
+  assert.strictEqual(
+    span.name,
+    event.requestContext.domainName + event.requestContext.path
+  );
+
+  assert.strictEqual(span.status.code, SpanStatusCode.ERROR);
+};
+
+describe("gateway API handler", () => {
+  let instrumentation: AwsLambdaInstrumentation;
+
+  let oldEnv: NodeJS.ProcessEnv;
+
+  const ctx = {
+    functionName: "my_function",
+    invokedFunctionArn: "my_arn",
+    awsRequestId: "aws_request_id",
+  } as Context;
+
+  const initializeHandler = (
+    handler: string,
+    config: AwsLambdaInstrumentationConfig = {}
+  ) => {
+    process.env._HANDLER = handler;
+
+    instrumentation = new AwsLambdaInstrumentation(config);
+    instrumentation.setTracerProvider(provider);
+  };
+
+  const lambdaRequire = (module: string) =>
+    require(path.resolve(__dirname, "..", module));
+
+
+  beforeEach(() => {
+    oldEnv = { ...process.env };
+    process.env.LAMBDA_TASK_ROOT = path.resolve(__dirname, "..");
+  });
+
+  afterEach(() => {
+    process.env = oldEnv;
+    instrumentation.disable();
+
+    memoryExporter.reset();
+  });
+
+  describe("gateway span tests", () => {
+    it("should export two valid span", async () => {
+      initializeHandler("lambda-test/gateway.handler");
+
+      const result = await lambdaRequire("lambda-test/gateway").handler(
+        event,
+        ctx
+      );
+
+      assert.strictEqual(result.statusCode, 200);
+      const spans = memoryExporter.getFinishedSpans();
+      assert.strictEqual(spans.length, 2);
+      const [spanLambda, spanGateway] = spans;
+      assertSpanSuccess(spanLambda);
+      assertGatewaySpanSuccess(spanGateway);
+      assert.strictEqual(spanGateway.parentSpanId, undefined);
+      assert.strictEqual(
+        spanLambda.parentSpanId,
+        spanGateway.spanContext().spanId
+      );
+    });
+
+    it("gateway span should reject when returning 500 ", async () => {
+      initializeHandler("lambda-test/gateway.error500");
+
+      const result = await lambdaRequire("lambda-test/gateway").error500(
+        event,
+        ctx
+      );
+
+      assert.strictEqual(result.statusCode, 500);
+
+      const spans = memoryExporter.getFinishedSpans();
+      assert.strictEqual(spans.length, 2);
+      const [spanLambda, spanGateway] = spans;
+
+      assert.strictEqual(
+        spanGateway.status.message,
+        "Return to API Gateway with error 500"
+      );
+
+      assertSpanSuccess(spanLambda);
+      assertGatewaySpanFailure(spanGateway);
+      assert.strictEqual(spanGateway.parentSpanId, undefined);
+      assert.strictEqual(
+        spanLambda.parentSpanId,
+        spanGateway.spanContext().spanId
+      );
+    });
+
+    it("gateway span should reject when returning 400 ", async () => {
+      initializeHandler("lambda-test/gateway.error400");
+
+      const result = await lambdaRequire("lambda-test/gateway").error400(
+        event,
+        ctx
+      );
+
+      assert.strictEqual(result.statusCode, 400);
+      const spans = memoryExporter.getFinishedSpans();
+      assert.strictEqual(spans.length, 2);
+      const [_, spanGateway] = spans;
+      assert.strictEqual(
+        spanGateway.status.message,
+        "Return to API Gateway with error 400"
+      );
+      assertGatewaySpanFailure(spanGateway);
+    });
+
+    it("gateway span should reject when returning 400 sync", async () => {
+      initializeHandler("lambda-test/gateway.error400Sync");
+
+      await new Promise((resolve, reject) => {
+        lambdaRequire("lambda-test/gateway").error400Sync(
+          event,
+          ctx,
+          (err: Error, res: any) => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve(res);
+            }
+          }
+        );
+      });
+
+      const spans = memoryExporter.getFinishedSpans();
+      assert.strictEqual(spans.length, 2);
+      const [_, spanGateway] = spans;
+      assert.strictEqual(
+        spanGateway.status.message,
+        "Return to API Gateway with error 400"
+      );
+      assertGatewaySpanFailure(spanGateway);
+    });
+
+    it("gateway span should reject when throwing error", async () => {
+      initializeHandler("lambda-test/gateway.errorAsync");
+
+      let err: any;
+      try {
+        await lambdaRequire("lambda-test/gateway").errorAsync(event, ctx);
+      } catch (e) {
+        err = e;
+      }
+
+      const spans = memoryExporter.getFinishedSpans();
+      assert.strictEqual(spans.length, 2);
+      const [_, spanGateway] = spans;
+      assert.strictEqual(spanGateway.status.message, "handler error");
+    });
+
+  });
+});

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler.test.ts
@@ -55,7 +55,7 @@ const provider = new NodeTracerProvider();
 provider.addSpanProcessor(new BatchSpanProcessor(memoryExporter));
 provider.register();
 
-const assertSpanSuccess = (span: ReadableSpan) => {
+export const assertSpanSuccess = (span: ReadableSpan) => {
   assert.strictEqual(span.kind, SpanKind.SERVER);
   assert.strictEqual(span.name, 'my_function');
   assert.strictEqual(
@@ -67,7 +67,7 @@ const assertSpanSuccess = (span: ReadableSpan) => {
   assert.strictEqual(span.status.message, undefined);
 };
 
-const assertSpanFailure = (span: ReadableSpan) => {
+export const assertSpanFailure = (span: ReadableSpan) => {
   assert.strictEqual(span.kind, SpanKind.SERVER);
   assert.strictEqual(span.name, 'my_function');
   assert.strictEqual(

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/lambda-test/gateway.js
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/lambda-test/gateway.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const api = require('@opentelemetry/api');
+const { callbackerror } = require('./sync');
+
+exports.handler = async function (event, context) {
+  return { statusCode: 200 };
+};
+
+exports.error500 = async function (event, context) {
+  return { statusCode: 500 };
+}
+
+exports.error400 = async function (event, context) {
+  return { statusCode: 400 };
+}
+
+exports.error500Sync = async function (event, context) {
+  return { statusCode: 500 };
+}
+
+exports.error400Sync =  function (event, context, callback) {
+  return callback( undefined, { statusCode: 400 } );
+}
+
+exports.errorAsync = async function (event, context) {
+  throw new Error('handler error');
+}
+
+exports.errorSync =  function (event, context) {
+  throw new Error('handler error');
+}

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/ServicesExtensions.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/ServicesExtensions.ts
@@ -24,6 +24,7 @@ import {
 import { DynamodbServiceExtension } from './dynamodb';
 import { SnsServiceExtension } from './sns';
 import { LambdaServiceExtension } from './lambda';
+import { EventBridgeServiceExtension } from './eventbridge';
 
 export class ServicesExtensions implements ServiceExtension {
   services: Map<string, ServiceExtension> = new Map();
@@ -31,6 +32,7 @@ export class ServicesExtensions implements ServiceExtension {
   constructor() {
     this.services.set('SQS', new SqsServiceExtension());
     this.services.set('SNS', new SnsServiceExtension());
+    this.services.set('EventBridge', new EventBridgeServiceExtension());
     this.services.set('DynamoDB', new DynamodbServiceExtension());
     this.services.set('Lambda', new LambdaServiceExtension());
   }

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/eventbridge.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/eventbridge.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  Tracer,
+  SpanKind,
+  Span,
+  diag,
+  propagation,
+  context,
+  TextMapSetter,
+} from '@opentelemetry/api';
+import { RequestMetadata, ServiceExtension } from './ServiceExtension';
+import {
+  AwsSdkInstrumentationConfig,
+  NormalizedRequest,
+  NormalizedResponse,
+} from '../types';
+import {
+  MessagingDestinationKindValues,
+  SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
+import { EventBridge } from 'aws-sdk';
+
+class ContextSetter
+  implements TextMapSetter<EventBridge.PutEventsRequestEntry>
+{
+  set(carrier: EventBridge.PutEventsRequestEntry, key: string, value: string) {
+    carrier['TraceHeader'] = value as string;
+  }
+}
+export const contextSetter = new ContextSetter();
+
+export class EventBridgeServiceExtension implements ServiceExtension {
+  requestPreSpanHook(request: NormalizedRequest): RequestMetadata {
+    let spanKind: SpanKind = SpanKind.CLIENT;
+    let spanName: string | undefined;
+
+    const spanAttributes = {
+      [SemanticAttributes.MESSAGING_SYSTEM]: 'aws.eventbridge',
+      [SemanticAttributes.MESSAGING_DESTINATION_KIND]:
+        MessagingDestinationKindValues.TOPIC,
+      [SemanticAttributes.MESSAGING_DESTINATION]:
+        request.commandInput.EndpointId,
+    };
+
+    let isIncoming = false;
+
+    switch (request.commandName) {
+      case 'PutEvents':
+        spanKind = SpanKind.PRODUCER;
+        spanName = `Event bridge put`;
+        break;
+    }
+
+    return {
+      isIncoming,
+      spanAttributes,
+      spanKind,
+      spanName,
+    };
+  }
+
+  requestPostSpanHook = (request: NormalizedRequest) => {
+    switch (request.commandName) {
+      case 'PutEvents':
+        request.commandInput?.Entries?.forEach(
+          (entry: EventBridge.PutEventsRequestEntry) => {
+            try {
+              propagation.inject(context.active(), entry, contextSetter);
+            } catch (e) {
+              diag.warn(
+                'Could not deserialize EventBridge event. Not a valid JSON'
+              );
+            }
+          }
+        );
+        break;
+    }
+  };
+
+  responseHook = (
+    response: NormalizedResponse,
+    span: Span,
+    tracer: Tracer,
+    config: AwsSdkInstrumentationConfig
+  ) => {
+    switch (response.request.commandName) {
+    }
+  };
+}

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/eventbridge.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/eventbridge.test.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AwsInstrumentation, AwsSdkSqsProcessHookInformation } from '../src';
+import {
+  getTestSpans,
+  registerInstrumentationTesting,
+} from '@opentelemetry/contrib-test-utils';
+const instrumentation = registerInstrumentationTesting(
+  new AwsInstrumentation()
+);
+import * as AWS from 'aws-sdk';
+import { AWSError } from 'aws-sdk';
+
+import {
+  MessagingDestinationKindValues,
+  MessagingOperationValues,
+  SemanticAttributes,
+} from '@opentelemetry/semantic-conventions';
+import {
+  context,
+  SpanKind,
+  SpanStatusCode,
+  trace,
+  Span,
+} from '@opentelemetry/api';
+import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { mockV2AwsSend } from './testing-utils';
+import { Message } from 'aws-sdk/clients/sqs';
+import * as expect from 'expect';
+import * as sinon from 'sinon';
+import * as messageAttributes from '../src/services/MessageAttributes';
+import { AttributeNames } from '../src/enums';
+
+const responseMockSuccess = {
+  requestId: '0000000000000',
+  error: null,
+  httpResponse: { statusCode: 200 },
+} as AWS.Response<any, any>;
+
+describe('Event Bridge', () => {
+  before(() => {
+    AWS.config.credentials = {
+      accessKeyId: 'test key id',
+      expired: false,
+      expireTime: new Date(),
+      secretAccessKey: 'test acc key',
+      sessionToken: 'test token',
+    };
+  });
+
+  beforeEach(() => {
+    mockV2AwsSend(responseMockSuccess, {
+      Messages: [{ Body: 'msg 1 payload' }, { Body: 'msg 2 payload' }],
+    } as AWS.SQS.Types.ReceiveMessageResult);
+  });
+
+  describe('hooks', () => {
+    const Entry: AWS.EventBridge.PutEventsRequestEntry = {
+      Detail: 'detail',
+      DetailType: 'detailType',
+      Source: 'Src',
+    };
+
+    it('eventBridgeResponseHook for putEvents should add messaging attributes', async () => {
+      const region = 'us-east-1';
+      const eb = new AWS.EventBridge();
+      eb.config.update({ region });
+
+      await eb
+        .putEvents({
+          Entries: [Entry],
+        })
+        .promise();
+
+      expect(getTestSpans().length).toBe(1);
+      const [span] = getTestSpans();
+
+      // make sure we have the general aws attributes:
+      expect(span.attributes[SemanticAttributes.RPC_SYSTEM]).toEqual('aws-api');
+      expect(span.attributes[SemanticAttributes.RPC_METHOD]).toEqual(
+        'PutEvents'
+      );
+      expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual(
+        'EventBridge'
+      );
+      expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
+
+      // custom messaging attributes
+      expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual(
+        'aws.eventbridge'
+      );
+      expect(
+        span.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]
+      ).toEqual(MessagingDestinationKindValues.TOPIC);
+
+      expect(span.attributes[SemanticAttributes.HTTP_STATUS_CODE]).toEqual(200);
+    });
+
+    it('inject context propagation', async () => {
+      const eb = new AWS.EventBridge();
+      const hookSpy = sinon.spy(
+        (instrumentation['servicesExtensions'] as any)['services'].get(
+          'EventBridge'
+        ),
+        'requestPostSpanHook'
+      );
+
+      await eb
+        .putEvents({
+          Entries: [Entry],
+        })
+        .promise();
+
+      const publishSpans = getTestSpans();
+      expect(publishSpans.length).toBe(1);
+      expect(
+        hookSpy.args[0][0].commandInput.Entries[0].TraceHeader
+      ).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Adds context propagation through the EventBridge `putEvents` methods


## Short description of the changes

Uses the TraceHeader available from the SDK.
Sadly this only works with the X-Ray propagator, because it seems like AWS won't accept another type of propagator in the TraceHeader field.
The good part is that the AWS Lambda instrument already works without any change
