### PR TITLE
fix: pg span names

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-pg/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/instrumentation.ts
@@ -26,7 +26,6 @@ import {
   PgClientConnect,
   PgClientExtended,
   PgErrorCallback,
-  NormalizedQueryConfig,
   PostgresCallback,
   PgPoolExtended,
   PgPoolCallback,
@@ -173,72 +172,70 @@ export class PgInstrumentation extends InstrumentationBase {
         `Patching ${PgInstrumentation.COMPONENT}.Client.prototype.query`
       );
       return function query(this: PgClientExtended, ...args: unknown[]) {
-        let span: Span;
+        // client.query(text, cb?), client.query(text, values, cb?), and
+        // client.query(configObj, cb?) are all valid signatures. We construct
+        // a queryConfig obj from all (valid) signatures to build the span in a
+        // unified way. We verify that we at least have query text, and code
+        // defensively when dealing with `queryConfig` after that (to handle all
+        // the other invalid cases, like a non-array for values being provided).
+        // The type casts here reflect only what we've actually validated.
+        const arg0 = args[0];
+        const firstArgIsString = typeof arg0 === 'string';
+        const firstArgIsQueryObjectWithText =
+          utils.isObjectWithTextString(arg0);
 
-        // Handle different client.query(...) signatures
-        if (typeof args[0] === 'string') {
-          const query = args[0];
+        // TODO: remove the `as ...` casts below when the TS version is upgraded.
+        // Newer TS versions will use the result of firstArgIsQueryObjectWithText
+        // to properly narrow arg0, but TS 4.3.5 does not.
+        const queryConfig = firstArgIsString
+          ? {
+              text: arg0 as string,
+              values: Array.isArray(args[1]) ? args[1] : undefined,
+            }
+          : firstArgIsQueryObjectWithText
+          ? (arg0 as utils.ObjectWithText)
+          : undefined;
 
-          if (args.length > 1 && args[1] instanceof Array) {
-            const params = args[1];
-            span = utils.handleParameterizedQuery.call(
-              this,
-              plugin.tracer,
-              plugin.getConfig(),
-              query,
-              params
-            );
-          } else {
-            span = utils.handleTextQuery.call(
-              this,
-              plugin.tracer,
-              plugin.getConfig(),
-              query
-            );
-          }
+        const instrumentationConfig = plugin.getConfig();
 
-          if (plugin.getConfig().addSqlCommenterCommentToQueries) {
-            // Modify the query with a tracing comment
-            args[0] = utils.addSqlCommenterComment(span, args[0]);
-          }
-        } else if (typeof args[0] === 'object') {
-          const queryConfig = args[0] as NormalizedQueryConfig;
+        const span = utils.handleConfigQuery.call(
+          this,
+          plugin.tracer,
+          instrumentationConfig,
+          queryConfig
+        );
 
-          span = utils.handleConfigQuery.call(
-            this,
-            plugin.tracer,
-            plugin.getConfig(),
-            queryConfig
-          );
-
-          if (plugin.getConfig().addSqlCommenterCommentToQueries) {
-            // Copy the query config instead of writing to args[0].text so that we don't modify user's
-            // original query config reference
-            args[0] = {
-              ...queryConfig,
-              text: utils.addSqlCommenterComment(span, queryConfig.text),
-            };
-          }
-        } else {
-          return utils.handleInvalidQuery.call(
-            this,
-            plugin.tracer,
-            plugin.getConfig(),
-            original,
-            ...args
-          );
+        // Modify query text w/ a tracing comment before invoking original for
+        // tracing, but only if args[0] has one of our expected shapes.
+        //
+        // TODO: remove the `as ...` casts below when the TS version is upgraded.
+        // Newer TS versions will use the result of firstArgIsQueryObjectWithText
+        // to properly narrow arg0, but TS 4.3.5 does not.
+        if (instrumentationConfig.addSqlCommenterCommentToQueries) {
+          args[0] = firstArgIsString
+            ? utils.addSqlCommenterComment(span, arg0 as string)
+            : firstArgIsQueryObjectWithText
+            ? {
+                ...(arg0 as utils.ObjectWithText),
+                text: utils.addSqlCommenterComment(
+                  span,
+                  (arg0 as utils.ObjectWithText).text
+                ),
+              }
+            : args[0];
         }
 
-        // Bind callback to parent span
+        // Bind callback (if any) to parent span (if any)
         if (args.length > 0) {
           const parentSpan = trace.getSpan(context.active());
           if (typeof args[args.length - 1] === 'function') {
             // Patch ParameterQuery callback
             args[args.length - 1] = utils.patchCallback(
-              plugin.getConfig(),
+              instrumentationConfig,
               span,
-              args[args.length - 1] as PostgresCallback
+              args[args.length - 1] as PostgresCallback // nb: not type safe.
             );
+
             // If a parent span exists, bind the callback
             if (parentSpan) {
               args[args.length - 1] = context.bind(
@@ -246,28 +243,37 @@ export class PgInstrumentation extends InstrumentationBase {
                 args[args.length - 1]
               );
             }
-          } else if (
-            typeof (args[0] as NormalizedQueryConfig).callback === 'function'
-          ) {
+          } else if (typeof queryConfig?.callback === 'function') {
             // Patch ConfigQuery callback
             let callback = utils.patchCallback(
               plugin.getConfig(),
               span,
-              (args[0] as NormalizedQueryConfig).callback!
+              queryConfig.callback as PostgresCallback // nb: not type safe.
             );
+
             // If a parent span existed, bind the callback
             if (parentSpan) {
               callback = context.bind(context.active(), callback);
             }
 
-            // Copy the callback instead of writing to args.callback so that we don't modify user's
-            // original callback reference
+            // Copy the callback instead of writing to args.callback so that we
+            // don't modify user's original callback reference
             args[0] = { ...(args[0] as object), callback };
           }
         }
 
-        // Perform the original query
-        const result: unknown = original.apply(this, args as any);
+        let result: unknown;
+        try {
+          result = original.apply(this, args as never);
+        } catch (e: unknown) {
+          // span.recordException(e);
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: utils.getErrorMessage(e),
+          });
+          span.end();
+          throw e;
+        }
 
         // Bind promise to parent span and end the span
         if (result instanceof Promise) {
@@ -359,10 +365,10 @@ function handleConnectResult(span: Span, connectResult: unknown) {
         span.end();
         return result;
       })
-      .catch((error: Error) => {
+      .catch((error: unknown) => {
         span.setStatus({
           code: SpanStatusCode.ERROR,
-          message: error.message,
+          message: utils.getErrorMessage(error),
         });
         span.end();
         return Promise.reject(error);

--- a/plugins/node/opentelemetry-instrumentation-pg/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/instrumentation.ts
@@ -136,12 +136,7 @@ export class PgInstrumentation extends InstrumentationBase {
           `${PgInstrumentation.COMPONENT}.connect`,
           {
             [SemanticAttributes.DB_SYSTEM]: DbSystemValues.POSTGRESQL,
-            [SemanticAttributes.DB_NAME]: this.database,
-            [SemanticAttributes.NET_PEER_NAME]: this.host,
-            [SemanticAttributes.DB_CONNECTION_STRING]:
-              utils.getConnectionString(this),
-            [SemanticAttributes.NET_PEER_PORT]: this.port,
-            [SemanticAttributes.DB_USER]: this.user,
+            ...utils.getSemanticAttributesFromConnection(this),
           }
         );
 
@@ -308,7 +303,6 @@ export class PgInstrumentation extends InstrumentationBase {
     const plugin = this;
     return (originalConnect: typeof pgPoolTypes.prototype.connect) => {
       return function connect(this: PgPoolExtended, callback?: PgPoolCallback) {
-        const connString = utils.getConnectionString(this.options);
         // setup span
         const span = startSpan(
           plugin.tracer,
@@ -316,11 +310,7 @@ export class PgInstrumentation extends InstrumentationBase {
           `${PG_POOL_COMPONENT}.connect`,
           {
             [SemanticAttributes.DB_SYSTEM]: DbSystemValues.POSTGRESQL,
-            [SemanticAttributes.DB_NAME]: this.options.database, // required
-            [SemanticAttributes.NET_PEER_NAME]: this.options.host, // required
-            [SemanticAttributes.DB_CONNECTION_STRING]: connString, // required
-            [SemanticAttributes.NET_PEER_PORT]: this.options.port,
-            [SemanticAttributes.DB_USER]: this.options.user,
+            ...utils.getSemanticAttributesFromConnection(this.options),
             [AttributeNames.IDLE_TIMEOUT_MILLIS]:
               this.options.idleTimeoutMillis,
             [AttributeNames.MAX_CLIENT]: this.options.maxClient,

--- a/plugins/node/opentelemetry-instrumentation-pg/src/internal-types.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/internal-types.ts
@@ -32,12 +32,6 @@ export interface PgClientExtended extends pgTypes.Client {
   connectionParameters: PgClientConnectionParams;
 }
 
-// Interface name based on original driver implementation
-// https://github.com/brianc/node-postgres/blob/2ef55503738eb2cbb6326744381a92c0bc0439ab/packages/pg/lib/utils.js#L157
-export interface NormalizedQueryConfig extends pgTypes.QueryConfig {
-  callback?: PostgresCallback;
-}
-
 export type PgPoolCallback = (
   err: Error,
   client: any,

--- a/plugins/node/opentelemetry-instrumentation-pg/test/pg.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/test/pg.test.ts
@@ -203,6 +203,26 @@ describe('pg', () => {
     runCallbackTest(null, DEFAULT_ATTRIBUTES, [], errorStatus);
     memoryExporter.reset();
 
+    assert.throws(
+      () => {
+        (client as any).query(null);
+      },
+      assertPgError,
+      'pg should throw when null provided as only arg'
+    );
+    runCallbackTest(null, DEFAULT_ATTRIBUTES, [], errorStatus);
+    memoryExporter.reset();
+
+    assert.throws(
+      () => {
+        (client as any).query(undefined);
+      },
+      assertPgError,
+      'pg should throw when undefined provided as only arg'
+    );
+    runCallbackTest(null, DEFAULT_ATTRIBUTES, [], errorStatus);
+    memoryExporter.reset();
+
     assert.doesNotThrow(
       () =>
         (client as any).query({ foo: 'bar' }, undefined, () => {

--- a/plugins/node/opentelemetry-instrumentation-pg/test/utils.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/test/utils.test.ts
@@ -33,7 +33,7 @@ import * as assert from 'assert';
 import * as pg from 'pg';
 import { PgInstrumentationConfig } from '../src';
 import { AttributeNames } from '../src/enums/AttributeNames';
-import { PgClientExtended, NormalizedQueryConfig } from '../src/internal-types';
+import { PgClientExtended } from '../src/internal-types';
 import * as utils from '../src/utils';
 
 const memoryExporter = new InMemorySpanExporter();
@@ -131,7 +131,7 @@ describe('utils.ts', () => {
   });
 
   describe('.handleConfigQuery()', () => {
-    const queryConfig: NormalizedQueryConfig = {
+    const queryConfig = {
       text: 'SELECT $1::text',
       values: ['0'],
     };
@@ -161,47 +161,6 @@ describe('utils.ts', () => {
         tracer,
         extPluginConfig,
         queryConfig
-      );
-      querySpan.end();
-
-      const readableSpan = getLatestSpan();
-
-      const pgValues = readableSpan.attributes[AttributeNames.PG_VALUES];
-      assert.strictEqual(pgValues, '[0]');
-    });
-  });
-
-  describe('.handleParameterizedQuery()', () => {
-    const query = 'SELECT $1::text';
-    const values = ['0'];
-
-    it('does not track pg.values by default', async () => {
-      const querySpan = utils.handleParameterizedQuery.call(
-        client,
-        tracer,
-        instrumentationConfig,
-        query,
-        values
-      );
-      querySpan.end();
-
-      const readableSpan = getLatestSpan();
-
-      const pgValues = readableSpan.attributes[AttributeNames.PG_VALUES];
-      assert.strictEqual(pgValues, undefined);
-    });
-
-    it('tracks pg.values if enabled explicitly', async () => {
-      const extPluginConfig: PgInstrumentationConfig & InstrumentationConfig = {
-        ...instrumentationConfig,
-        enhancedDatabaseReporting: true,
-      };
-      const querySpan = utils.handleParameterizedQuery.call(
-        client,
-        tracer,
-        extPluginConfig,
-        query,
-        values
       );
       querySpan.end();
 


### PR DESCRIPTION
## Which problem is this PR solving?

The primary functional change in this PR is to address a number of issues with how the pg instrumentation was generating span names.

1. Before this PR, when the query being executed was a prepared statement with a `name`, the `name` was transformed first before it was put into the span's name. E.g., `client.query({ name: 'find user', text: 'SELECT * from user where id = ?', values: [1] })` would generate a span name of `pg.query:find`, because the string `'find user'` would be split on spaces and only the first word would be used. However, it's the full prepared statement name that constitutes the low cardinality identifier, so this commit now makes the span name: `pg.query:find user`.

2. Similarly, before this PR, the parsed out operation name wasn't normalized before using it in the span name. Accordingly, a `select * from x` would get a span name of `pg.query:select`, while a `SELECT * from x` query would generate `pg.query:SELECT`. Now, they'll both have the latter span name.

3. Previously, the generated span names did not include the DB name, although the examples in the otel spec recommend this. Now, the db name is included, as it's specified in the connection info.

There are also two commits prior to the commit that adjusts the span naming strategy. Those commits do not make any functional changes, but just refactor/DRY up the existing code, which allows the new span names to be constructed in only one place. They also make the logic a bit more defensive, so that various edge cases with invalid arguments (e.g., `client.query(null)` or `client.query(queryText, valuesThatArentAnArray)`) can no longer cause the instrumentation itself to fail with an uncaught exception (though errors raised synchronously or asynchronously from `client.query` are still propagated as before). 

## Short description of the changes

See each commit message and the overview above.
