### PR TITLE
feat(pg): support hooking into span when query is started

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-pg/README.md
+++ b/plugins/node/opentelemetry-instrumentation-pg/README.md
@@ -47,7 +47,8 @@ PostgreSQL instrumentation has few options available to choose from. You can set
 | Options | Type | Description |
 | ------- | ---- | ----------- |
 | [`enhancedDatabaseReporting`](./src/types.ts#L30) | `boolean` | If true, additional information about query parameters and results will be attached (as `attributes`) to spans representing database operations |
-| `responseHook` | `PgInstrumentationExecutionResponseHook` (function) | Function for adding custom attributes from db response |
+| `requestHook` | `PgInstrumentationExecutionRequestHook` (function) | Function for adding custom span attributes using information about the query being issued and the db to which it's directed |
+| `responseHook` | `PgInstrumentationExecutionResponseHook` (function) | Function for adding custom span attributes from db response |
 | `requireParentSpan` | `boolean` | If true, requires a parent span to create new spans (default false) |
 | `addSqlCommenterCommentToQueries` | `boolean` | If true, adds [sqlcommenter](https://github.com/open-telemetry/opentelemetry-sqlcommenter) specification compliant comment to queries with tracing context (default false). _NOTE: A comment will not be added to queries that already contain `--` or `/* ... */` in them, even if these are not actually part of comments_ |
 

--- a/plugins/node/opentelemetry-instrumentation-pg/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pg/package.json
@@ -68,6 +68,7 @@
     "pg": "8.7.1",
     "pg-pool": "3.4.1",
     "rimraf": "3.0.2",
+    "safe-stable-stringify": "^2.4.1",
     "sinon": "14.0.0",
     "test-all-versions": "5.0.1",
     "ts-mocha": "10.0.0",

--- a/plugins/node/opentelemetry-instrumentation-pg/src/internal-types.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/internal-types.ts
@@ -19,9 +19,17 @@ import type * as pgPoolTypes from 'pg-pool';
 
 export type PostgresCallback = (err: Error, res: object) => unknown;
 
-// These are not included in @types/pg, so manually define them.
-// https://github.com/brianc/node-postgres/blob/fde5ec586e49258dfc4a2fcd861fcdecb4794fc3/lib/client.js#L25
-export interface PgClientConnectionParams {
+// NB: this type describes the shape of a parsed, normalized form of the
+// connection information that's stored inside each pg.Client instance. It's
+// _not_ the same as the ConnectionConfig type exported from `@types/pg`. That
+// type defines how data must be _passed in_ when creating a new `pg.Client`,
+// which doesn't necessarily match the normalized internal form. E.g., a user
+// can call `new Client({ connectionString: '...' }), but `connectionString`
+// will never show up in the type below, because only the extracted host, port,
+// etc. are recorded in this normalized config. The keys listed below are also
+// incomplete, which is fine because the type is internal and these keys are the
+// only ones our code is reading. See https://github.com/brianc/node-postgres/blob/fde5ec586e49258dfc4a2fcd861fcdecb4794fc3/lib/client.js#L25
+export interface PgParsedConnectionParams {
   database?: string;
   host?: string;
   port?: number;
@@ -29,7 +37,7 @@ export interface PgClientConnectionParams {
 }
 
 export interface PgClientExtended extends pgTypes.Client {
-  connectionParameters: PgClientConnectionParams;
+  connectionParameters: PgParsedConnectionParams;
 }
 
 export type PgPoolCallback = (

--- a/plugins/node/opentelemetry-instrumentation-pg/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/types.ts
@@ -26,11 +26,38 @@ export interface PgInstrumentationExecutionResponseHook {
   (span: api.Span, responseInfo: PgResponseHookInformation): void;
 }
 
+export interface PgRequestHookInformation {
+  query: {
+    text: string;
+    name?: string;
+    values?: unknown[];
+  };
+  connection: {
+    database?: string;
+    host?: string;
+    port?: number;
+    user?: string;
+  };
+}
+
+export interface PgInstrumentationExecutionRequestHook {
+  (span: api.Span, queryInfo: PgRequestHookInformation): void;
+}
+
 export interface PgInstrumentationConfig extends InstrumentationConfig {
   /**
-   * If true, additional information about query parameters will be attached (as `attributes`) to spans representing
+   * If true, an attribute containing the query's parameters will be attached
+   * the spans generated to represent the query.
    */
   enhancedDatabaseReporting?: boolean;
+
+  /**
+   * Hook that allows adding custom span attributes or updating the
+   * span's name based on the data about the query to execute.
+   *
+   * @default undefined
+   */
+  requestHook?: PgInstrumentationExecutionRequestHook;
 
   /**
    * Hook that allows adding custom span attributes based on the data

--- a/plugins/node/opentelemetry-instrumentation-pg/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/utils.ts
@@ -36,10 +36,10 @@ import {
 import {
   PgClientExtended,
   PostgresCallback,
-  PgClientConnectionParams,
   PgErrorCallback,
   PgPoolCallback,
   PgPoolExtended,
+  PgParsedConnectionParams,
 } from './internal-types';
 import { PgInstrumentationConfig } from './types';
 import type * as pgTypes from 'pg';
@@ -97,7 +97,7 @@ function parseNormalizedOperationName(queryText: string) {
   return sqlCommand.endsWith(';') ? sqlCommand.slice(0, -1) : sqlCommand;
 }
 
-function getConnectionString(params: PgClientConnectionParams) {
+export function getConnectionString(params: PgParsedConnectionParams) {
   const host = params.host || 'localhost';
   const port = params.port || 5432;
   const database = params.database || '';
@@ -105,7 +105,7 @@ function getConnectionString(params: PgClientConnectionParams) {
 }
 
 export function getSemanticAttributesFromConnection(
-  params: PgClientConnectionParams
+  params: PgParsedConnectionParams
 ) {
   return {
     [SemanticAttributes.DB_NAME]: params.database, // required

--- a/plugins/node/opentelemetry-instrumentation-pg/test/pg.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/test/pg.test.ts
@@ -33,6 +33,7 @@ import {
 import * as assert from 'assert';
 import type * as pg from 'pg';
 import * as sinon from 'sinon';
+import stringify from 'safe-stable-stringify';
 import {
   PgInstrumentation,
   PgInstrumentationConfig,
@@ -510,6 +511,100 @@ describe('pg', () => {
         } catch (e) {
           assert.ok(false, e.message);
         }
+      });
+    });
+
+    describe('when specifying a requestHook configuration', () => {
+      const dataAttributeName = 'pg_data';
+      const query = 'SELECT 0::text';
+      const events: TimedEvent[] = [];
+
+      // these are the attributes that we'd expect would end up on the final
+      // span if there is no requestHook.
+      const attributes = {
+        ...DEFAULT_ATTRIBUTES,
+        [SemanticAttributes.DB_STATEMENT]: query,
+      };
+
+      // These are the attributes we expect on the span after the requestHook
+      // has run. We set up the hook to just add to the span a stringified
+      // version of the args it receives (which is an easy way to assert both
+      // that the proper args were passed and that the hook was called).
+      const attributesAfterHook = {
+        ...attributes,
+        [dataAttributeName]: stringify({
+          connection: {
+            database: CONFIG.database,
+            port: CONFIG.port,
+            host: CONFIG.host,
+            user: CONFIG.user,
+          },
+          query: { text: query },
+        }),
+      };
+
+      describe('AND valid requestHook', () => {
+        beforeEach(async () => {
+          create({
+            enhancedDatabaseReporting: true,
+            requestHook: (span, requestInfo) => {
+              span.setAttribute(dataAttributeName, stringify(requestInfo));
+            },
+          });
+        });
+
+        it('should attach request hook data to resulting spans for query with callback ', done => {
+          const span = tracer.startSpan('test span');
+          context.with(trace.setSpan(context.active(), span), () => {
+            const res = client.query(query, (err, res) => {
+              assert.strictEqual(err, null);
+              assert.ok(res);
+              runCallbackTest(span, attributesAfterHook, events);
+              done();
+            });
+            assert.strictEqual(res, undefined, 'No promise is returned');
+          });
+        });
+
+        it('should attach request hook data to resulting spans for query returning a Promise', async () => {
+          const span = tracer.startSpan('test span');
+          await context.with(
+            trace.setSpan(context.active(), span),
+            async () => {
+              const resPromise = await client.query({ text: query });
+              try {
+                assert.ok(resPromise);
+                runCallbackTest(span, attributesAfterHook, events);
+              } catch (e) {
+                assert.ok(false, e.message);
+              }
+            }
+          );
+        });
+      });
+
+      describe('AND invalid requestHook', () => {
+        beforeEach(async () => {
+          create({
+            enhancedDatabaseReporting: true,
+            requestHook: (_span, _requestInfo) => {
+              throw 'some kind of failure!';
+            },
+          });
+        });
+
+        it('should not do any harm when throwing an exception', done => {
+          const span = tracer.startSpan('test span');
+          context.with(trace.setSpan(context.active(), span), () => {
+            const res = client.query(query, (err, res) => {
+              assert.strictEqual(err, null);
+              assert.ok(res);
+              runCallbackTest(span, attributes, events);
+              done();
+            });
+            assert.strictEqual(res, undefined, 'No promise is returned');
+          });
+        });
       });
     });
 


### PR DESCRIPTION
## Which problem is this PR solving?

Right now, it's possible to modify the span generated for a query after results are returned for the query, using the `responseHook`. However, it isn't possible to modify the span at the start of the query, based on the information available when the query is issued (i.e., the args passed to `client.query`), because that information isn't passed to the `responseHook`.

For my use case, I'm using Datadog and am tracing an app that issues relatively few distinct queries. Therefore, it makes sense to identify each query as a distinct Datadog "resource", by adding a `resource.name` attribute to each span, where the value of the attribute is the query text. However, this is currently impossible, because the query text isn't available in the `responseHook`, and there's no other hook where it is available.

## Short description of the changes

- Add a `queryHook` param to support the above use case.

NB: this PR shares the first two commits with #1306, so it may be simpler to review that first. It relies on the code cleanup from #1306 to simplify implementing the `queryHook` here. (The code cleanup now allows the main code path in `_getClientQueryPatch` to have a single, normalized `queryConfig` object that can be passed to the `queryHook`.)