### PR TITLE
feat(dns): record looked-up hostname as attribute

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-dns/src/enums/AttributeNames.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/src/enums/AttributeNames.ts
@@ -18,4 +18,5 @@ export enum AttributeNames {
   DNS_ERROR_CODE = 'dns.error_code',
   DNS_ERROR_NAME = 'dns.error_name',
   DNS_ERROR_MESSAGE = 'dns.error_message',
+  DNS_HOSTNAME = 'dns.hostname',
 }

--- a/plugins/node/opentelemetry-instrumentation-dns/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/src/instrumentation.ts
@@ -32,6 +32,7 @@ import {
   LookupCallbackSignature,
   LookupPromiseSignature,
 } from './internal-types';
+import { AttributeNames } from './enums/AttributeNames';
 
 /**
  * Dns instrumentation for Opentelemetry
@@ -112,6 +113,7 @@ export class DnsInstrumentation extends InstrumentationBase<Dns> {
       const name = utils.getOperationName('lookup');
       const span = plugin.tracer.startSpan(name, {
         kind: SpanKind.CLIENT,
+        attributes: { [AttributeNames.DNS_HOSTNAME]: hostname },
       });
 
       const originalCallback = args[argsCount - 1];


### PR DESCRIPTION
## Which problem is this PR solving?

The span for a DNS lookup should contain the hostname that was being looked up. This stores it on the span as an attribute.