### PR TITLE
feat(instrumentation-aws-lambda): Propagate context when called from SQS

### DIFF
--- a/packages/opentelemetry-propagation-utils/src/pubsub-propagation.ts
+++ b/packages/opentelemetry-propagation-utils/src/pubsub-propagation.ts
@@ -154,10 +154,11 @@ const startMessagingProcessSpan = <T>(
   parentContext: Context,
   propagatedContext: Context,
   tracer: Tracer,
-  processHook?: ProcessHook<T>
+  processHook?: ProcessHook<T>,
+  propagatedContextAsActive?: boolean
 ): Span => {
   const links: Link[] = [];
-  const spanContext = trace.getSpanContext(propagatedContext);
+  const spanContext = trace.getSpanContext(propagatedContextAsActive ? parentContext : propagatedContext);
   if (spanContext) {
     links.push({
       context: spanContext,
@@ -175,7 +176,7 @@ const startMessagingProcessSpan = <T>(
       },
       links,
     },
-    parentContext
+    propagatedContextAsActive ? propagatedContext : parentContext
   );
 
   Object.defineProperty(message, START_SPAN_FUNCTION, {
@@ -220,6 +221,7 @@ interface PatchForProcessingPayload<T> {
   parentContext: Context;
   messageToSpanDetails: (message: T) => SpanDetails;
   processHook?: ProcessHook<T>;
+  propagatedContextAsActive?: boolean;
 }
 
 const patchMessagesArrayToStartProcessSpans = <T>({
@@ -228,6 +230,7 @@ const patchMessagesArrayToStartProcessSpans = <T>({
   parentContext,
   messageToSpanDetails,
   processHook,
+  propagatedContextAsActive
 }: PatchForProcessingPayload<T>) => {
   messages.forEach(message => {
     const {
@@ -247,7 +250,8 @@ const patchMessagesArrayToStartProcessSpans = <T>({
           parentContext,
           propagatedContext,
           tracer,
-          processHook
+          processHook,
+          propagatedContextAsActive
         ),
     });
   });

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
@@ -51,6 +51,7 @@
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/mocha": "7.0.2",
     "@types/node": "18.11.7",
+    "aws-sdk": "^2.1262.0",
     "gts": "3.1.0",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
@@ -60,6 +61,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.32.0",
+    "@opentelemetry/propagation-utils": "^0.29.1",
     "@opentelemetry/propagator-aws-xray": "^1.1.1",
     "@opentelemetry/resources": "^1.8.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",

--- a/propagators/opentelemetry-propagator-aws-xray/src/AWSXRayPropagator.ts
+++ b/propagators/opentelemetry-propagator-aws-xray/src/AWSXRayPropagator.ts
@@ -31,6 +31,7 @@ import {
 } from '@opentelemetry/api';
 
 export const AWSXRAY_TRACE_ID_HEADER = 'x-amzn-trace-id';
+export const AWS_TRACE_ID_MESSAGE = 'AWSTraceHeader';
 
 const TRACE_HEADER_DELIMITER = ';';
 const KV_DELIMITER = '=';
@@ -85,14 +86,14 @@ export class AWSXRayPropagator implements TextMapPropagator {
   }
 
   fields(): string[] {
-    return [AWSXRAY_TRACE_ID_HEADER];
+    return [AWSXRAY_TRACE_ID_HEADER, AWS_TRACE_ID_MESSAGE];
   }
 
   private getSpanContextFromHeader(
     carrier: unknown,
     getter: TextMapGetter
   ): SpanContext {
-    const traceHeader = getter.get(carrier, AWSXRAY_TRACE_ID_HEADER);
+    const traceHeader = getter.get(carrier, AWSXRAY_TRACE_ID_HEADER) || getter.get( carrier, AWS_TRACE_ID_MESSAGE );
     if (!traceHeader || typeof traceHeader !== 'string')
       return INVALID_SPAN_CONTEXT;
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

When an AWS Lambda is used as the target of an SQS Event, propagate context from the event producer to the consumer

Note on the following:

- In my tests, when using open telemetry, the trace header is actually found both in the MessageAttributes (that's the AWS-SDK SQS Service extension) as well as in Attributes > AWSTraceHeader (I'm not sure who sets this tbh). The context in AWSTraceHeader refers to the HTTP Post span, while the MessageAttribute refers to the `SendMessage` call.


## Short description of the changes

- In this implementation, we first look for the header in Attributes.AWSTraceHeader and falls back to the MessageAttributes when not found.

- Because the link to the producer span is more important than the wrapping lambda imo, I added a flag to consider the producer span as the contextual span, and the parent span (the lambda invocation) as the linked span

- The code change is still a bit rough, but I'd like to get an idea if this has any chance to go through, in which case I could pour more efforts into this :).
