### PR TITLE
feat(restify): add requestHook support

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-restify/README.md
+++ b/plugins/node/opentelemetry-instrumentation-restify/README.md
@@ -41,6 +41,27 @@ registerInstrumentations({
 
 See [examples/restify](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/examples/restify) for a short example.
 
+## Restify Instrumentation Options
+
+| Options | Type | Example | Description |
+| `requestHook` | `RestifyCustomAttributeFunction` | `(span, requestInfo) => {}` | Function for adding custom attributes to restify requests. Receives params: `Span, RestifyRequestInfo`. |
+
+### Using `requestHook`
+
+Instrumentation configuration accepts a custom "hook" function which will be called for every instrumented restify request. Custom attributes can be set on the span or run any custom logic per request.
+
+```javascript
+import { RestifyInstrumentation } from "@opentelemetry/instrumentation-restify"
+const restifyInstrumentation = new RestifyInstrumentation({
+  requestHook: function (span: Span, info: RestifyRequestInfo) {
+    span.setAttribute(
+      'http.method',
+      info.request.method,
+    )
+  }
+});
+```
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/plugins/node/opentelemetry-instrumentation-restify/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/src/index.ts
@@ -20,3 +20,4 @@ export * from './instrumentation';
 export default RestifyInstrumentation;
 
 export * from './enums/AttributeNames';
+export * from './types';

--- a/plugins/node/opentelemetry-instrumentation-restify/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/src/instrumentation.ts
@@ -200,11 +200,11 @@ export class RestifyInstrumentation extends InstrumentationBase<any> {
         );
 
         const instrumentation = this;
-        const requestHook = instrumentation.getConfig().requestHook
+        const requestHook = instrumentation.getConfig().requestHook;
         if (requestHook) {
           safeExecuteInTheMiddle(
             () => requestHook!(span, { request: req }),
-            (e) => {
+            e => {
               if (e) {
                 instrumentation._diag.error('request hook failed', e);
               }

--- a/plugins/node/opentelemetry-instrumentation-restify/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/src/instrumentation.ts
@@ -19,7 +19,7 @@ import type * as restify from 'restify';
 
 import * as api from '@opentelemetry/api';
 import type { Server } from 'restify';
-import { LayerType } from './internal-types';
+import { LayerType } from './types';
 import * as AttributeNames from './enums/AttributeNames';
 import { VERSION } from './version';
 import * as constants from './constants';
@@ -203,7 +203,12 @@ export class RestifyInstrumentation extends InstrumentationBase<any> {
         const requestHook = instrumentation.getConfig().requestHook;
         if (requestHook) {
           safeExecuteInTheMiddle(
-            () => requestHook!(span, { request: req }),
+            () => {
+              return requestHook!(span, {
+                request: req,
+                layerType: metadata.type,
+              });
+            },
             e => {
               if (e) {
                 instrumentation._diag.error('request hook failed', e);

--- a/plugins/node/opentelemetry-instrumentation-restify/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/src/instrumentation.ts
@@ -25,24 +25,33 @@ import { VERSION } from './version';
 import * as constants from './constants';
 import {
   InstrumentationBase,
-  InstrumentationConfig,
   InstrumentationNodeModuleDefinition,
   InstrumentationNodeModuleFile,
   isWrapped,
+  safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { isPromise, isAsyncFunction } from './utils';
 import { getRPCMetadata, RPCType, setRPCMetadata } from '@opentelemetry/core';
+import type { RestifyInstrumentationConfig } from './types';
 
 const { diag } = api;
 
 export class RestifyInstrumentation extends InstrumentationBase<any> {
-  constructor(config: InstrumentationConfig = {}) {
+  constructor(config: RestifyInstrumentationConfig = {}) {
     super(`@opentelemetry/instrumentation-${constants.MODULE_NAME}`, VERSION);
   }
 
   private _moduleVersion?: string;
   private _isDisabled = false;
+
+  override setConfig(config: RestifyInstrumentationConfig = {}) {
+    this._config = Object.assign({}, config);
+  }
+
+  override getConfig(): RestifyInstrumentationConfig {
+    return this._config as RestifyInstrumentationConfig;
+  }
 
   init() {
     const module = new InstrumentationNodeModuleDefinition<any>(
@@ -185,6 +194,21 @@ export class RestifyInstrumentation extends InstrumentationBase<any> {
           },
           api.context.active()
         );
+
+        const instrumentation = this;
+        const requestHook = instrumentation.getConfig().requestHook
+        if (requestHook) {
+          safeExecuteInTheMiddle(
+            () => requestHook!(span, { request: req }),
+            (e) => {
+              if (e) {
+                instrumentation._diag.error('request hook failed', e);
+              }
+            },
+            true
+          );
+        }
+
         const patchedNext = (err?: any) => {
           span.end();
           next(err);

--- a/plugins/node/opentelemetry-instrumentation-restify/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/src/instrumentation.ts
@@ -39,7 +39,11 @@ const { diag } = api;
 
 export class RestifyInstrumentation extends InstrumentationBase<any> {
   constructor(config: RestifyInstrumentationConfig = {}) {
-    super(`@opentelemetry/instrumentation-${constants.MODULE_NAME}`, VERSION);
+    super(
+      `@opentelemetry/instrumentation-${constants.MODULE_NAME}`,
+      VERSION,
+      Object.assign({}, config)
+    );
   }
 
   private _moduleVersion?: string;

--- a/plugins/node/opentelemetry-instrumentation-restify/src/internal-types.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/src/internal-types.ts
@@ -15,11 +15,7 @@
  */
 import { Span } from '@opentelemetry/api';
 import type * as restify from 'restify';
-
-export enum LayerType {
-  MIDDLEWARE = 'middleware',
-  REQUEST_HANDLER = 'request_handler',
-}
+import { LayerType } from './types';
 
 declare interface RequestWithRoute extends restify.Request {
   route: { path: string };

--- a/plugins/node/opentelemetry-instrumentation-restify/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/src/types.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Span } from '@opentelemetry/api';
+import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+
+export interface RestifyRequestInfo {
+  request: any; // RestifyRequest object from restify package
+}
+
+/**
+ * Function that can be used to add custom attributes to the current span
+ * @param span - The restify handler span.
+ * @param info - The restify request info object.
+ */
+export interface RestifyCustomAttributeFunction {
+  (span: Span, info: RestifyRequestInfo): void;
+}
+
+/**
+ * Options available for the restify Instrumentation
+ */
+export interface RestifyInstrumentationConfig extends InstrumentationConfig {
+  /** Function for adding custom attributes to each handler span */
+  requestHook?: RestifyCustomAttributeFunction;
+}

--- a/plugins/node/opentelemetry-instrumentation-restify/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/src/types.ts
@@ -18,7 +18,7 @@ import { Span } from '@opentelemetry/api';
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 
 export interface RestifyRequestInfo {
-  request: any; // RestifyRequest object from restify package
+  request: any; // Restify type from restify types package
 }
 
 /**

--- a/plugins/node/opentelemetry-instrumentation-restify/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/src/types.ts
@@ -17,8 +17,14 @@
 import { Span } from '@opentelemetry/api';
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 
+export enum LayerType {
+  MIDDLEWARE = 'middleware',
+  REQUEST_HANDLER = 'request_handler',
+}
+
 export interface RestifyRequestInfo {
   request: any; // Request type from @types/restify package
+  layerType: LayerType;
 }
 
 /**

--- a/plugins/node/opentelemetry-instrumentation-restify/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/src/types.ts
@@ -18,7 +18,7 @@ import { Span } from '@opentelemetry/api';
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 
 export interface RestifyRequestInfo {
-  request: any; // Restify type from @types/restify package
+  request: any; // Request type from @types/restify package
 }
 
 /**

--- a/plugins/node/opentelemetry-instrumentation-restify/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/src/types.ts
@@ -18,7 +18,7 @@ import { Span } from '@opentelemetry/api';
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 
 export interface RestifyRequestInfo {
-  request: any; // Restify type from restify types package
+  request: any; // Restify type from @types/restify package
 }
 
 /**

--- a/plugins/node/opentelemetry-instrumentation-restify/test/restify.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/test/restify.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { context, trace } from '@opentelemetry/api';
+import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { RPCType, setRPCMetadata } from '@opentelemetry/core';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
@@ -486,6 +487,74 @@ describe('Restify Instrumentation', () => {
       const res = await httpRequest.get(`http://localhost:${port}/route/bar`);
       assert.strictEqual(memoryExporter.getFinishedSpans().length, 3);
       assert.strictEqual(res, '{"route":"bar"}');
+    });
+
+    describe('using requestHook in config', () => {
+      it('calls requestHook provided function when set in config', async () => {
+        const requestHook = (span: Span, info: RestifyRequestInfo) => {
+          span.setAttribute(
+            SemanticAttributes.HTTP_METHOD,
+            info.request.method
+          );
+        };
+
+        plugin.setConfig({
+          ...plugin.getConfig(),
+          requestHook,
+        });
+
+        const rootSpan = tracer.startSpan('clientSpan');
+
+        await context.with(
+          trace.setSpan(context.active(), rootSpan),
+          async () => {
+            await httpRequest.get(`http://localhost:${port}/route/foo`);
+            rootSpan.end();
+            assert.strictEqual(memoryExporter.getFinishedSpans().length, 4);
+
+            {
+              // span from get
+              const span = memoryExporter.getFinishedSpans()[2];
+              assert.notStrictEqual(span, undefined);
+              assert.strictEqual(span.attributes[SemanticAttributes.HTTP_METHOD], 'GET');
+            }
+          }
+        );
+      });
+
+      it('does not propagate an error from a requestHook that throws exception', async () => {
+        const requestHook = (span: Span, info: RestifyRequestInfo) => {
+          span.setAttribute(
+            SemanticAttributes.HTTP_METHOD,
+            info.request.method
+          );
+
+          throw Error('error thrown in requestHook');
+        };
+
+        plugin.setConfig({
+          ...plugin.getConfig(),
+          requestHook,
+        });
+
+        const rootSpan = tracer.startSpan('clientSpan');
+
+        await context.with(
+          trace.setSpan(context.active(), rootSpan),
+          async () => {
+            await httpRequest.get(`http://localhost:${port}/route/foo`);
+            rootSpan.end();
+            assert.strictEqual(memoryExporter.getFinishedSpans().length, 4);
+
+            {
+              // span from get
+              const span = memoryExporter.getFinishedSpans()[2];
+              assert.notStrictEqual(span, undefined);
+              assert.strictEqual(span.attributes[SemanticAttributes.HTTP_METHOD], 'GET');
+            }
+          }
+        );
+      });
     });
   });
 

--- a/plugins/node/opentelemetry-instrumentation-restify/test/restify.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/test/restify.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { context, trace } from '@opentelemetry/api';
+import { context, trace, Span } from '@opentelemetry/api';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { RPCType, setRPCMetadata } from '@opentelemetry/core';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';

--- a/plugins/node/opentelemetry-instrumentation-restify/test/restify.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/test/restify.test.ts
@@ -26,6 +26,7 @@ import {
 
 import RestifyInstrumentation from '../src';
 import * as types from '../src/internal-types';
+import { RestifyRequestInfo } from '../src/types';
 const plugin = new RestifyInstrumentation();
 
 import * as semver from 'semver';

--- a/plugins/node/opentelemetry-instrumentation-restify/test/restify.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/test/restify.test.ts
@@ -516,7 +516,10 @@ describe('Restify Instrumentation', () => {
               // span from get
               const span = memoryExporter.getFinishedSpans()[2];
               assert.notStrictEqual(span, undefined);
-              assert.strictEqual(span.attributes[SemanticAttributes.HTTP_METHOD], 'GET');
+              assert.strictEqual(
+                span.attributes[SemanticAttributes.HTTP_METHOD],
+                'GET'
+              );
             }
           }
         );
@@ -550,7 +553,10 @@ describe('Restify Instrumentation', () => {
               // span from get
               const span = memoryExporter.getFinishedSpans()[2];
               assert.notStrictEqual(span, undefined);
-              assert.strictEqual(span.attributes[SemanticAttributes.HTTP_METHOD], 'GET');
+              assert.strictEqual(
+                span.attributes[SemanticAttributes.HTTP_METHOD],
+                'GET'
+              );
             }
           }
         );

--- a/plugins/node/opentelemetry-instrumentation-restify/test/restify.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/test/restify.test.ts
@@ -497,6 +497,7 @@ describe('Restify Instrumentation', () => {
             SemanticAttributes.HTTP_METHOD,
             info.request.method
           );
+          span.setAttribute('restify.layer', info.layerType);
         };
 
         plugin.setConfig({
@@ -520,6 +521,10 @@ describe('Restify Instrumentation', () => {
               assert.strictEqual(
                 span.attributes[SemanticAttributes.HTTP_METHOD],
                 'GET'
+              );
+              assert.strictEqual(
+                span.attributes['restify.layer'],
+                'request_handler'
               );
             }
           }


### PR DESCRIPTION
The `requestHook` config option allows custom span handling per request layer.

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Adds `requestHook` support so users can add custom handling on spans.


## Short description of the changes

- It's inspired by how ~requestHook` is implemented in web instrumentations.
- The ~requestHook` user-defined function is called any time `_handlerPatcher` is executed.
