### PR TITLE
feat(instrumentation-aws-lambda): use `require-in-the-middle` directly

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
@@ -63,7 +63,8 @@
     "@opentelemetry/propagator-aws-xray": "^1.1.1",
     "@opentelemetry/resources": "^1.8.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
-    "@types/aws-lambda": "8.10.81"
+    "@types/aws-lambda": "8.10.81",
+    "require-in-the-middle": "^5.0.3"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-aws-lambda#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
@@ -59,7 +59,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.32.0",
+    "@opentelemetry/instrumentation": "^0.34.0",
     "@opentelemetry/propagator-aws-xray": "^1.1.1",
     "@opentelemetry/resources": "^1.8.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/require-in-the-middle.d.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/require-in-the-middle.d.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare module 'require-in-the-middle' {
+  namespace hook {
+    type Options = {
+      internals?: boolean;
+    };
+    type OnRequireFn = <T>(exports: T, name: string, basedir?: string) => T;
+    type Hooked = { unhook(): void };
+  }
+  function hook(
+    modules: string[] | null,
+    options: hook.Options | null,
+    onRequire: hook.OnRequireFn
+  ): hook.Hooked;
+  function hook(
+    modules: string[] | null,
+    onRequire: hook.OnRequireFn
+  ): hook.Hooked;
+  function hook(onRequire: hook.OnRequireFn): hook.Hooked;
+  export = hook;
+}


### PR DESCRIPTION
## Which problem is this PR solving?

`@opentelemetry/instrumentation-aws-lambda` is incompatible with `@opentelemetry/instrumentation@^0.34.0` and higher, since it no longer supports instrumentation of absolute paths. This PR switches to using `require-in-the-middle` directly.

Fixes https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1285

## Short description of the changes

This PR replaces usage of `InstrumentationNodeModuleDefinition` and `InstrumentationNodeModuleFile` with direct invocation of `require-in-the-middle`. Any instrumentation plugins that instrument absolute paths will need to use this strategy; currently, this is the only one.

One downside of this approach is that it does not use the normal instrumentation patching infrastructure, so some features (e.g. `instrumentation.disable`) may not work.

In https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1285, we discussed a few options for resolving the need to instrument absolute paths. This PR represents option 3:
> In `@opentelemetry/instrumentation-aws-lambda`, instrument code using another method, e.g. use `require-in-the-middle` directly, or patch the code directly