### PR TITLE
ci: skip a broken aws-sdk version in TAV

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/.tav.yml
@@ -1,21 +1,21 @@
 "aws-sdk":
   # there are so many version to test, it can take forever.
   # we will just sample few of them
-  versions: ">=2.1230.0 || 2.1219.0 || 2.1152.0 || 2.1048.0 || 2.1012.0 || 2.647.0 || 2.308.0"
+  versions: ">=2.1266.0 || 2.1262.0 || 2.1219.0 || 2.1048.0 || 2.1012.0 || 2.647.0 || 2.308.0"
   commands:
     - npm run test
   # Fix missing `contrib-test-utils` package
   pretest: npm run --prefix ../../../ lerna:link
 
 "@aws-sdk/client-s3":
-  versions: ">=3.188.0 || 3.154.0 || 3.107.0 || 3.54.0 || 3.6.1"
+  versions: ">=3.223.0 || 3.218.0 || 3.216.0 || 3.154.0 || 3.107.0 || 3.54.0 || 3.6.1"
   commands:
     - npm run test
   # Fix missing `contrib-test-utils` package
   pretest: npm run --prefix ../../../ lerna:link
 
 "@aws-sdk/client-sqs":
-  versions: ">=3.188.0 || 3.171.0 || 3.107.0 || 3.58.0 || 3.54.0 || 3.43.0 || 3.24.0"
+  versions: ">=3.216.0 || 3.171.0 || 3.58.0 || 3.54.0 || 3.43.0 || 3.24.0"
   commands:
     - npm run test
   # Fix missing `contrib-test-utils` package


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

TAV builds for `aws-sdk` are breaking due to a incompatible/borken version of `aws-sdk`. Skip that in TAV runs.

