### PR TITLE
docs(instrumentation-graphql): gql supported versions

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-graphql/README.md
+++ b/plugins/node/opentelemetry-instrumentation-graphql/README.md
@@ -21,7 +21,7 @@ npm install @opentelemetry/instrumentation-graphql
 
 ### Supported Versions
 
-`>=14 <16`
+`>=14 <=16`
 
 ## Usage
 


### PR DESCRIPTION

## Which problem is this PR solving?

- GQL instrumentation doc incorrectly stating supported versions are only <16.

## Short description of the changes

- README update to fix supported versions by the instrumentation (PR https://github.com/open-telemetry/opentelemetry-js-contrib/pull/998 should allow to also use GQL version 16, but doc still mentioned only <16).
