### PR TITLE
fix(component owner): add haddasbronfman as component owner of openlemetry-redis-common

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -14,6 +14,8 @@ components:
     - legendecas
   packages/opentelemetry-id-generator-aws-xray:
     - willarmiros
+  packages/opentelemetry-redis-common:
+    - haddasbronfman
   plugins/node/instrumentation-amqplib:
     - blumamir
   plugins/node/instrumentation-dataloader:


### PR DESCRIPTION
## Short description of the changes

- add haddasbronfman as component owner of openlemetry-redis-common
