### PR TITLE
fix(pg): update requireParentSpan to skip instrumentation when parent not present

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-pg/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/instrumentation.ts
@@ -20,7 +20,14 @@ import {
   safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
 
-import { context, diag, trace, Span, SpanStatusCode } from '@opentelemetry/api';
+import {
+  context,
+  diag,
+  trace,
+  Span,
+  SpanStatusCode,
+  SpanKind,
+} from '@opentelemetry/api';
 import type * as pgTypes from 'pg';
 import type * as pgPoolTypes from 'pg-pool';
 import {
@@ -39,7 +46,6 @@ import {
   DbSystemValues,
 } from '@opentelemetry/semantic-conventions';
 import { VERSION } from './version';
-import { startSpan } from './utils';
 
 const PG_POOL_COMPONENT = 'pg-pool';
 
@@ -131,13 +137,18 @@ export class PgInstrumentation extends InstrumentationBase {
         this: pgTypes.Client,
         callback?: PgErrorCallback
       ) {
-        const span = startSpan(
-          plugin.tracer,
-          plugin.getConfig(),
+        if (utils.shouldSkipInstrumentation(plugin.getConfig())) {
+          return original.call(this, callback);
+        }
+
+        const span = plugin.tracer.startSpan(
           `${PgInstrumentation.COMPONENT}.connect`,
           {
-            [SemanticAttributes.DB_SYSTEM]: DbSystemValues.POSTGRESQL,
-            ...utils.getSemanticAttributesFromConnection(this),
+            kind: SpanKind.CLIENT,
+            attributes: {
+              [SemanticAttributes.DB_SYSTEM]: DbSystemValues.POSTGRESQL,
+              ...utils.getSemanticAttributesFromConnection(this),
+            },
           }
         );
 
@@ -168,6 +179,10 @@ export class PgInstrumentation extends InstrumentationBase {
         `Patching ${PgInstrumentation.COMPONENT}.Client.prototype.query`
       );
       return function query(this: PgClientExtended, ...args: unknown[]) {
+        if (utils.shouldSkipInstrumentation(plugin.getConfig())) {
+          return original.apply(this, args as never);
+        }
+
         // client.query(text, cb?), client.query(text, values, cb?), and
         // client.query(configObj, cb?) are all valid signatures. We construct
         // a queryConfig obj from all (valid) signatures to build the span in a
@@ -348,19 +363,21 @@ export class PgInstrumentation extends InstrumentationBase {
     const plugin = this;
     return (originalConnect: typeof pgPoolTypes.prototype.connect) => {
       return function connect(this: PgPoolExtended, callback?: PgPoolCallback) {
+        if (utils.shouldSkipInstrumentation(plugin.getConfig())) {
+          return originalConnect.call(this, callback as any);
+        }
+
         // setup span
-        const span = startSpan(
-          plugin.tracer,
-          plugin.getConfig(),
-          `${PG_POOL_COMPONENT}.connect`,
-          {
+        const span = plugin.tracer.startSpan(`${PG_POOL_COMPONENT}.connect`, {
+          kind: SpanKind.CLIENT,
+          attributes: {
             [SemanticAttributes.DB_SYSTEM]: DbSystemValues.POSTGRESQL,
             ...utils.getSemanticAttributesFromConnection(this.options),
             [AttributeNames.IDLE_TIMEOUT_MILLIS]:
               this.options.idleTimeoutMillis,
             [AttributeNames.MAX_CLIENT]: this.options.maxClient,
-          }
-        );
+          },
+        });
 
         if (callback) {
           const parentSpan = trace.getSpan(context.active());

--- a/plugins/node/opentelemetry-instrumentation-pg/test/pg-pool.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/test/pg-pool.test.ts
@@ -269,6 +269,24 @@ describe('pg-pool', () => {
         assert.strictEqual(resNoPromise, undefined, 'No promise is returned');
       });
     });
+
+    it('should not generate traces when requireParentSpan=true is specified', async () => {
+      // The pool gets shared between tests. We need to create a separate one
+      // to test cold start, which can cause nested spans
+      const newPool = new pgPool(CONFIG);
+      create({
+        requireParentSpan: true,
+      });
+      memoryExporter.reset();
+      const client = await newPool.connect();
+      try {
+        await client.query('SELECT NOW()');
+      } finally {
+        client.release();
+      }
+      const spans = memoryExporter.getFinishedSpans();
+      assert.strictEqual(spans.length, 0);
+    });
   });
 
   describe('#pool.query()', () => {


### PR DESCRIPTION
## Which problem is this PR solving?

I previously added a `requireParentSpan` config flag that can be used to suppress instrumentation if there is no active trace (see #1199). The implementation created a no-op span, imitating the [implementation for the requireParent flags in instrumentation-http](https://github.com/open-telemetry/opentelemetry-js/blob/597ea98e58a4f68bcd9aec5fd283852efe444cd6/experimental/packages/opentelemetry-instrumentation-http/src/http.ts#L665-L683), then continued running instrumentation code as usual.

This doesn't seem to be working well in practice. There are cases where the pg instrumentation creates a (no-op) span, then does something else that tries to create another span. The second invocation sees that a parent span exists, so it creates a real span. But this span is created as a _sibling_ of the no-op span, not as a child, so then it gets emitted as a real trace. For example, I saw cases where BoundPool.connect created a (no-op) span and then called Client.connect, which saw an existing span in the context and subsequently created a (real) span.

I considered modifying `startSpan` to create real spans as children of whatever `currentSpan` was returned by `trace.getSpan(context.active())`; that way, the spans would get dropped as children of a no-op span. But it doesn't look like other opentelemetry instrumentation libraries do this often. I'm not very familiar with opentelemetry so I'm not sure if this is the right thing to do. It seems like a context can have multiple sibling spans, so it seems like making the span a child of `trace.getSpan(context.active())` could end up creating a span as a child of the wrong parent span?

## Short description of the changes

I changed the `requireParentSpan` implementation to avoid running instrumentation on calls when a parent span is required but doesn't exist. This way, no span is created at all. This matches the implementation in [instrumentation-ioredis](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/8b8bfebdd6b4f43a8df540979874a6c01c999957/plugins/node/opentelemetry-instrumentation-ioredis/src/instrumentation.ts#L111-L113).