### PR TITLE
ci: fix lint

### DIFF
--- a/metapackages/auto-instrumentations-node/src/utils.ts
+++ b/metapackages/auto-instrumentations-node/src/utils.ts
@@ -98,7 +98,7 @@ const InstrumentationMap = {
 type ConfigArg<T> = T extends new (...args: infer U) => unknown ? U[0] : never;
 export type InstrumentationConfigMap = {
   [Name in keyof typeof InstrumentationMap]?: ConfigArg<
-    typeof InstrumentationMap[Name]
+    (typeof InstrumentationMap)[Name]
   >;
 };
 

--- a/metapackages/auto-instrumentations-web/src/utils.ts
+++ b/metapackages/auto-instrumentations-web/src/utils.ts
@@ -34,7 +34,7 @@ const InstrumentationMap = {
 type ConfigArg<T> = T extends new (...args: infer U) => unknown ? U[0] : never;
 export type InstrumentationConfigMap = {
   [Name in keyof typeof InstrumentationMap]?: ConfigArg<
-    typeof InstrumentationMap[Name]
+    (typeof InstrumentationMap)[Name]
   >;
 };
 

--- a/plugins/node/instrumentation-dataloader/src/instrumentation.ts
+++ b/plugins/node/instrumentation-dataloader/src/instrumentation.ts
@@ -38,8 +38,8 @@ type DataloaderInternal = typeof Dataloader.prototype & {
   _batch: { spanLinks?: Link[] } | null;
 };
 
-type LoadFn = typeof Dataloader.prototype['load'];
-type LoadManyFn = typeof Dataloader.prototype['loadMany'];
+type LoadFn = (typeof Dataloader.prototype)['load'];
+type LoadManyFn = (typeof Dataloader.prototype)['loadMany'];
 
 export class DataloaderInstrumentation extends InstrumentationBase {
   constructor(config: DataloaderInstrumentationConfig = {}) {

--- a/plugins/node/instrumentation-fs/src/types.ts
+++ b/plugins/node/instrumentation-fs/src/types.ts
@@ -24,7 +24,7 @@ export type FunctionPropertyNames<T> = {
 export type FunctionProperties<T> = Pick<T, FunctionPropertyNames<T>>;
 
 export type FMember = FunctionPropertyNames<typeof fs>;
-export type FPMember = FunctionPropertyNames<typeof fs['promises']>;
+export type FPMember = FunctionPropertyNames<(typeof fs)['promises']>;
 
 export type CreateHook = (
   functionName: FMember | FPMember,

--- a/plugins/node/opentelemetry-instrumentation-graphql/src/internal-types.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/src/internal-types.ts
@@ -18,8 +18,8 @@ import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import type * as graphqlTypes from 'graphql';
 import type * as api from '@opentelemetry/api';
 import type { PromiseOrValue } from 'graphql/jsutils/PromiseOrValue';
-import { DocumentNode } from 'graphql/language/ast';
-import {
+import type { DocumentNode } from 'graphql/language/ast';
+import type {
   GraphQLFieldResolver,
   GraphQLTypeResolver,
 } from 'graphql/type/definition';


### PR DESCRIPTION
CI currently fails on lint workflow for a few days, and we can't merge approved PRs. I guess some transitive dependency was updated and change the prettier config/functioning.

I do not have time to understand where it comes from, but run `lint:fix` on the repo to make CI green again.
