### PR TITLE
fix(instrumentation/aws-lambda): Ensure callback is only called once

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -319,8 +319,7 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
       );
     }
 
-    Promise.all(flushers)
-      .then(callback, callback);
+    Promise.all(flushers).then(callback, callback);
   }
 
   private _applyResponseHook(

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -319,10 +319,8 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
       );
     }
 
-    Promise.all(flushers).then(
-      () => callback(),
-      () => callback()
-    );
+    Promise.all(flushers)
+      .then(callback, callback);
   }
 
   private _applyResponseHook(


### PR DESCRIPTION
…regardless how many providers are flushed

Signed-off-by: Anthony J Mirabella <a9@aneurysm9.com>

## Which problem is this PR solving?

Defect identified in https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1370#pullrequestreview-1289551665.

## Short description of the changes

Combine all provider flush invocations to a single `Promise.all()` that can be resolved once.
