### PR TITLE
Remove node 10

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-gcp/src/detectors/GcpDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-gcp/src/detectors/GcpDetector.ts
@@ -45,7 +45,6 @@ class GcpDetector implements Detector {
    */
   async detect(_config?: ResourceDetectionConfig): Promise<Resource> {
     if (
-      !semver.satisfies(process.version, '>=10') ||
       !(await gcpMetadata.isAvailable())
     ) {
       diag.debug('GcpDetector failed: GCP Metadata unavailable.');

--- a/detectors/node/opentelemetry-resource-detector-gcp/test/detectors/GcpDetector.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-gcp/test/detectors/GcpDetector.test.ts
@@ -44,7 +44,7 @@ const ZONE_PATH = BASE_PATH + '/instance/zone';
 const CLUSTER_NAME_PATH = BASE_PATH + '/instance/attributes/cluster-name';
 const HOSTNAME_PATH = BASE_PATH + '/instance/hostname';
 
-(semver.satisfies(process.version, '>=10') ? describe : describe.skip)(
+describe(
   'gcpDetector',
   () => {
     describe('.detect', () => {

--- a/plugins/node/instrumentation-fs/src/instrumentation.ts
+++ b/plugins/node/instrumentation-fs/src/instrumentation.ts
@@ -39,8 +39,6 @@ import { promisify } from 'util';
 
 type FS = typeof fs;
 
-const supportsPromises = parseInt(process.versions.node.split('.')[0], 10) > 8;
-
 export default class FsInstrumentation extends InstrumentationBase<FS> {
   constructor(config?: FsInstrumentationConfig) {
     super('@opentelemetry/instrumentation-fs', VERSION, config);
@@ -83,17 +81,15 @@ export default class FsInstrumentation extends InstrumentationBase<FS> {
               <any>this._patchCallbackFunction.bind(this, fName)
             );
           }
-          if (supportsPromises) {
-            for (const fName of PROMISE_FUNCTIONS) {
-              if (isWrapped(fs.promises[fName])) {
-                this._unwrap(fs.promises, fName);
-              }
-              this._wrap(
-                fs.promises,
-                fName,
-                <any>this._patchPromiseFunction.bind(this, fName)
-              );
+          for (const fName of PROMISE_FUNCTIONS) {
+            if (isWrapped(fs.promises[fName])) {
+              this._unwrap(fs.promises, fName);
             }
+            this._wrap(
+              fs.promises,
+              fName,
+              <any>this._patchPromiseFunction.bind(this, fName)
+            );
           }
           return fs;
         },
@@ -110,11 +106,9 @@ export default class FsInstrumentation extends InstrumentationBase<FS> {
               this._unwrap(fs, fName);
             }
           }
-          if (supportsPromises) {
-            for (const fName of PROMISE_FUNCTIONS) {
-              if (isWrapped(fs.promises[fName])) {
-                this._unwrap(fs.promises, fName);
-              }
+          for (const fName of PROMISE_FUNCTIONS) {
+            if (isWrapped(fs.promises[fName])) {
+              this._unwrap(fs.promises, fName);
             }
           }
         }

--- a/plugins/node/instrumentation-fs/test/hooks.test.ts
+++ b/plugins/node/instrumentation-fs/test/hooks.test.ts
@@ -24,8 +24,6 @@ import * as sinon from 'sinon';
 import type * as FSType from 'fs';
 import type { FsInstrumentationConfig } from '../src/types';
 
-const supportsPromises = parseInt(process.versions.node.split('.')[0], 10) > 8;
-
 const createHookError = new Error('createHook failed');
 const createHook = sinon.spy((_functionName: string) => {
   throw createHookError;
@@ -142,23 +140,21 @@ describe('fs instrumentation: hooks', () => {
     });
   });
 
-  if (supportsPromises) {
-    describe('Promise API', () => {
-      it('should not fail the original successful call when hooks throw', async () => {
-        // eslint-disable-next-line node/no-unsupported-features/node-builtins
-        await fs.promises.access('./test/fixtures/readtest', fs.constants.R_OK);
+  describe('Promise API', () => {
+    it('should not fail the original successful call when hooks throw', async () => {
+      // eslint-disable-next-line node/no-unsupported-features/node-builtins
+      await fs.promises.access('./test/fixtures/readtest', fs.constants.R_OK);
 
-        assertSuccessfulCallHooks('access');
-      });
-
-      it('should not shadow the error from original call when hooks throw', async () => {
-        // eslint-disable-next-line node/no-unsupported-features/node-builtins
-        await fs.promises
-          .access('./test/fixtures/readtest-404', fs.constants.R_OK)
-          .catch(assertNotHookError);
-
-        assertFailingCallHooks('access');
-      });
+      assertSuccessfulCallHooks('access');
     });
-  }
+
+    it('should not shadow the error from original call when hooks throw', async () => {
+      // eslint-disable-next-line node/no-unsupported-features/node-builtins
+      await fs.promises
+        .access('./test/fixtures/readtest-404', fs.constants.R_OK)
+        .catch(assertNotHookError);
+
+      assertFailingCallHooks('access');
+    });
+  });
 });

--- a/plugins/node/instrumentation-fs/test/index.test.ts
+++ b/plugins/node/instrumentation-fs/test/index.test.ts
@@ -29,8 +29,6 @@ import type * as FSType from 'fs';
 import tests, { TestCase, TestCreator } from './definitions';
 import type { FMember, FPMember, CreateHook, EndHook } from '../src/types';
 
-const supportsPromises = parseInt(process.versions.node.split('.')[0], 10) > 8;
-
 const TEST_ATTRIBUTE = 'test.attr';
 const TEST_VALUE = 'test.attr.value';
 
@@ -351,29 +349,27 @@ describe('fs instrumentation', () => {
     });
   });
 
-  if (supportsPromises) {
-    describe('Promise API', () => {
-      const selection: TestCase[] = tests.filter(
-        ([, , , , options = {}]) => options.promise !== false
-      );
+  describe('Promise API', () => {
+    const selection: TestCase[] = tests.filter(
+      ([, , , , options = {}]) => options.promise !== false
+    );
 
-      describe('Instrumentation enabled', () => {
-        selection.forEach(([name, args, result, spans]) => {
-          promiseTest(name as FPMember, args, result, spans);
-        });
-      });
-
-      describe('Instrumentation disabled', () => {
-        beforeEach(() => {
-          plugin.disable();
-        });
-
-        selection.forEach(([name, args, result]) => {
-          promiseTest(name as FPMember, args, result, []);
-        });
+    describe('Instrumentation enabled', () => {
+      selection.forEach(([name, args, result, spans]) => {
+        promiseTest(name as FPMember, args, result, spans);
       });
     });
-  }
+
+    describe('Instrumentation disabled', () => {
+      beforeEach(() => {
+        plugin.disable();
+      });
+
+      selection.forEach(([name, args, result]) => {
+        promiseTest(name as FPMember, args, result, []);
+      });
+    });
+  });
 });
 
 const assertSpans = (spans: ReadableSpan[], expected: any) => {

--- a/plugins/node/instrumentation-fs/test/parent.test.ts
+++ b/plugins/node/instrumentation-fs/test/parent.test.ts
@@ -25,8 +25,6 @@ import type { FsInstrumentationConfig } from '../src/types';
 import * as api from '@opentelemetry/api';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 
-const supportsPromises = parseInt(process.versions.node.split('.')[0], 10) > 8;
-
 const provider = new BasicTracerProvider();
 const memoryExporter = new InMemorySpanExporter();
 provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
@@ -95,22 +93,20 @@ describe('fs instrumentation: requireParentSpan', () => {
       );
     });
 
-    if (supportsPromises) {
-      it(`${prefix} a span with the promises API`, async () => {
-        await new Promise<void>(resolve => {
-          api.context.with(ambientContext, () => {
-            fs.promises
-              .access('./test/fixtures/readtest', fs.constants.R_OK)
-              .finally(() => resolve(endRootSpan()));
-          });
+    it(`${prefix} a span with the promises API`, async () => {
+      await new Promise<void>(resolve => {
+        api.context.with(ambientContext, () => {
+          fs.promises
+            .access('./test/fixtures/readtest', fs.constants.R_OK)
+            .finally(() => resolve(endRootSpan()));
         });
-
-        assert.deepEqual(
-          memoryExporter.getFinishedSpans().length,
-          expectedSpanCount()
-        );
       });
-    }
+
+      assert.deepEqual(
+        memoryExporter.getFinishedSpans().length,
+        expectedSpanCount()
+      );
+    });
   };
 
   const withRootSpan = (fn: () => void) => {

--- a/plugins/node/opentelemetry-instrumentation-dns/src/enums/AttributeNames.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/src/enums/AttributeNames.ts
@@ -15,7 +15,6 @@
  */
 export enum AttributeNames {
   // NOT ON OFFICIAL SPEC
-  DNS_ERROR_CODE = 'dns.error_code',
   DNS_ERROR_NAME = 'dns.error_name',
   DNS_ERROR_MESSAGE = 'dns.error_message',
 }

--- a/plugins/node/opentelemetry-instrumentation-dns/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/src/instrumentation.ts
@@ -53,25 +53,19 @@ export class DnsInstrumentation extends InstrumentationBase<Dns> {
           }
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           this._wrap(moduleExports, 'lookup', this._getLookup() as any);
-          // new promise methods in node >= 10.6.0
-          // https://nodejs.org/docs/latest/api/dns.html#dns_dnspromises_lookup_hostname_options
-          if (semver.gte(process.version, '10.6.0')) {
-            this._wrap(
-              moduleExports.promises,
-              'lookup',
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              this._getLookup() as any
-            );
-          }
+          this._wrap(
+            moduleExports.promises,
+            'lookup',
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            this._getLookup() as any
+          );
           return moduleExports;
         },
         moduleExports => {
           if (moduleExports === undefined) return;
           diag.debug('Removing patch for dns');
           this._unwrap(moduleExports, 'lookup');
-          if (semver.gte(process.version, '10.6.0')) {
-            this._unwrap(moduleExports.promises, 'lookup');
-          }
+          this._unwrap(moduleExports.promises, 'lookup');
         }
       ),
     ];
@@ -124,7 +118,7 @@ export class DnsInstrumentation extends InstrumentationBase<Dns> {
           () => original.apply(this, [hostname, ...args]),
           error => {
             if (error != null) {
-              utils.setError(error, span, process.version);
+              utils.setError(error, span);
               span.end();
             }
           }
@@ -138,7 +132,7 @@ export class DnsInstrumentation extends InstrumentationBase<Dns> {
             ]),
           error => {
             if (error != null) {
-              utils.setError(error, span, process.version);
+              utils.setError(error, span);
               span.end();
             }
           }
@@ -149,7 +143,7 @@ export class DnsInstrumentation extends InstrumentationBase<Dns> {
             span.end();
           },
           (e: NodeJS.ErrnoException) => {
-            utils.setError(e, span, process.version);
+            utils.setError(e, span);
             span.end();
           }
         );
@@ -175,7 +169,7 @@ export class DnsInstrumentation extends InstrumentationBase<Dns> {
       diag.debug('executing wrapped lookup callback function');
 
       if (err !== null) {
-        utils.setError(err, span, process.version);
+        utils.setError(err, span);
       } else {
         utils.setLookupAttributes(span, address, family);
       }

--- a/plugins/node/opentelemetry-instrumentation-dns/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/src/utils.ts
@@ -26,20 +26,12 @@ import { IgnoreMatcher } from './types';
  * @param span the span to be set
  * @param nodeVersion the node version
  */
-export const setError = (
-  err: NodeJS.ErrnoException,
-  span: Span,
-  nodeVersion: string
-) => {
-  const { code, message, name } = err;
+export const setError = (err: NodeJS.ErrnoException, span: Span) => {
+  const { message, name } = err;
   const attributes = {
     [AttributeNames.DNS_ERROR_MESSAGE]: message,
     [AttributeNames.DNS_ERROR_NAME]: name,
   } as SpanAttributes;
-
-  if (nodeVersion.startsWith('v12')) {
-    attributes[AttributeNames.DNS_ERROR_CODE] = code!;
-  }
 
   span.setAttributes(attributes);
 

--- a/plugins/node/opentelemetry-instrumentation-dns/test/functionals/utils.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/test/functionals/utils.test.ts
@@ -154,7 +154,7 @@ describe('Utility', () => {
         { spanId: '', traceId: '', traceFlags: TraceFlags.NONE },
         SpanKind.INTERNAL
       );
-      utils.setError(new Error(errorMessage), span, process.versions.node);
+      utils.setError(new Error(errorMessage), span);
       const attributes = span.attributes;
       assert.strictEqual(
         attributes[AttributeNames.DNS_ERROR_MESSAGE],


### PR DESCRIPTION
This PR clean up some dead code related to node8 and node10 versions which is no longer supported

Minimum supported version for instrumentation is 14, as stated in `package.json` in each file
```json
  "engines": {
    "node": ">=14"
  },
```

And there are no tests to verify any feature for older versions