### PR TITLE
fix: remove component attribute from instrumentations

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-graphql/src/enums/AttributeNames.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/src/enums/AttributeNames.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 export enum AttributeNames {
-  COMPONENT = 'graphql',
   SOURCE = 'graphql.source',
   FIELD_NAME = 'graphql.field.name',
   FIELD_PATH = 'graphql.field.path',

--- a/plugins/node/opentelemetry-instrumentation-koa/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/src/instrumentation.ts
@@ -33,15 +33,10 @@ import { AttributeNames } from './enums/AttributeNames';
 import { VERSION } from './version';
 import { getMiddlewareMetadata, isLayerIgnored } from './utils';
 import { getRPCMetadata, RPCType, setRPCMetadata } from '@opentelemetry/core';
-import {
-  kLayerPatched,
-  KoaComponentName,
-  KoaPatchedMiddleware,
-} from './internal-types';
+import { kLayerPatched, KoaPatchedMiddleware } from './internal-types';
 
 /** Koa instrumentation for OpenTelemetry */
 export class KoaInstrumentation extends InstrumentationBase<typeof koa> {
-  static readonly component = KoaComponentName;
   constructor(config: KoaInstrumentationConfig = {}) {
     super(
       '@opentelemetry/instrumentation-koa',

--- a/plugins/node/opentelemetry-instrumentation-koa/src/internal-types.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/src/internal-types.ts
@@ -24,5 +24,3 @@ export const kLayerPatched: unique symbol = Symbol('koa-layer-patched');
 export type KoaPatchedMiddleware = KoaMiddleware & {
   [kLayerPatched]?: boolean;
 };
-
-export const KoaComponentName = 'koa';

--- a/plugins/web/opentelemetry-instrumentation-document-load/src/enums/AttributeNames.ts
+++ b/plugins/web/opentelemetry-instrumentation-document-load/src/enums/AttributeNames.ts
@@ -15,7 +15,6 @@
  */
 
 export enum AttributeNames {
-  COMPONENT = 'component',
   DOCUMENT_LOAD = 'documentLoad',
   DOCUMENT_FETCH = 'documentFetch',
   RESOURCE_FETCH = 'resourceFetch',

--- a/plugins/web/opentelemetry-instrumentation-document-load/src/instrumentation.ts
+++ b/plugins/web/opentelemetry-instrumentation-document-load/src/instrumentation.ts
@@ -214,7 +214,6 @@ export class DocumentLoadInstrumentation extends InstrumentationBase<unknown> {
         },
         parentSpan ? trace.setSpan(context.active(), parentSpan) : undefined
       );
-      span.setAttribute(AttributeNames.COMPONENT, this.component);
       return span;
     }
     return undefined;

--- a/plugins/web/opentelemetry-instrumentation-long-task/src/instrumentation.ts
+++ b/plugins/web/opentelemetry-instrumentation-long-task/src/instrumentation.ts
@@ -25,9 +25,7 @@ import type {
 const LONGTASK_PERFORMANCE_TYPE = 'longtask';
 
 export class LongTaskInstrumentation extends InstrumentationBase {
-  readonly component: string = 'long-task';
   readonly version: string = VERSION;
-  moduleName = this.component;
 
   private _observer?: PerformanceObserver;
   override _config!: LongtaskInstrumentationConfig;
@@ -66,7 +64,6 @@ export class LongTaskInstrumentation extends InstrumentationBase {
         diag.error('longtask instrumentation: observer callback failed', err);
       }
     }
-    span.setAttribute('component', this.component);
     span.setAttribute('longtask.name', entry.name);
     span.setAttribute('longtask.entry_type', entry.entryType);
     span.setAttribute('longtask.duration', entry.duration);


### PR DESCRIPTION

## Which problem is this PR solving?

- The "component" attribute [was removed from semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/pull/447) back in Feb 2020, but some instrumentations were written before this change and still report this attribute.

## Short description of the changes

- remove the "component" attribute from "@opentelemetry/instrumentation-document-load" and "@opentelemetry/instrumentation-long-task" as well as clean up some related dead code in other places
