### PR TITLE
chore(instrumentation-fs): remove node 14 promises check from tests

### DIFF
--- a/plugins/node/instrumentation-fs/test/fsPromises.test.ts
+++ b/plugins/node/instrumentation-fs/test/fsPromises.test.ts
@@ -28,9 +28,6 @@ import tests, { FsFunction, TestCase, TestCreator } from './definitions';
 import type { FPMember, EndHook } from '../src/types';
 import { assertSpans, makeRootSpanName } from './utils';
 
-const supportsPromises =
-  parseInt(process.versions.node.split('.')[0], 10) >= 14;
-
 const TEST_ATTRIBUTE = 'test.attr';
 const TEST_VALUE = 'test.attr.value';
 
@@ -45,109 +42,107 @@ const tracer = provider.getTracer('default');
 const memoryExporter = new InMemorySpanExporter();
 provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
 
-if (supportsPromises) {
-  describe('fs/promises instrumentation', () => {
-    let contextManager: AsyncHooksContextManager;
-    let fsPromises: typeof FSPromisesType;
-    let plugin: Instrumentation;
+describe('fs/promises instrumentation', () => {
+  let contextManager: AsyncHooksContextManager;
+  let fsPromises: typeof FSPromisesType;
+  let plugin: Instrumentation;
 
-    beforeEach(async () => {
-      contextManager = new AsyncHooksContextManager();
-      context.setGlobalContextManager(contextManager.enable());
-      plugin = new Instrumentation(pluginConfig);
-      plugin.setTracerProvider(provider);
-      plugin.enable();
-      fsPromises = require('fs/promises');
+  beforeEach(async () => {
+    contextManager = new AsyncHooksContextManager();
+    context.setGlobalContextManager(contextManager.enable());
+    plugin = new Instrumentation(pluginConfig);
+    plugin.setTracerProvider(provider);
+    plugin.enable();
+    fsPromises = require('fs/promises');
+    assert.strictEqual(memoryExporter.getFinishedSpans().length, 0);
+  });
+
+  afterEach(() => {
+    plugin.disable();
+    memoryExporter.reset();
+    context.disable();
+  });
+
+  const promiseTest: TestCreator<FPMember> = (
+    name: FPMember,
+    args,
+    { error, result, resultAsError = null, hasPromiseVersion = true },
+    spans
+  ) => {
+    if (!hasPromiseVersion) return;
+    const rootSpanName = makeRootSpanName(name);
+    it(`promises.${name} ${error ? 'error' : 'success'}`, async () => {
+      const rootSpan = tracer.startSpan(rootSpanName);
+
       assert.strictEqual(memoryExporter.getFinishedSpans().length, 0);
-    });
-
-    afterEach(() => {
-      plugin.disable();
-      memoryExporter.reset();
-      context.disable();
-    });
-
-    const promiseTest: TestCreator<FPMember> = (
-      name: FPMember,
-      args,
-      { error, result, resultAsError = null, hasPromiseVersion = true },
-      spans
-    ) => {
-      if (!hasPromiseVersion) return;
-      const rootSpanName = makeRootSpanName(name);
-      it(`promises.${name} ${error ? 'error' : 'success'}`, async () => {
-        const rootSpan = tracer.startSpan(rootSpanName);
-
-        assert.strictEqual(memoryExporter.getFinishedSpans().length, 0);
-        await context
-          .with(trace.setSpan(context.active(), rootSpan), () => {
-            // eslint-disable-next-line node/no-unsupported-features/node-builtins
+      await context
+        .with(trace.setSpan(context.active(), rootSpan), () => {
+          // eslint-disable-next-line node/no-unsupported-features/node-builtins
+          assert(
+            typeof fsPromises[name] === 'function',
+            `Expected fsPromises.${name} to be a function`
+          );
+          return Reflect.apply(fsPromises[name], fsPromises, args);
+        })
+        .then((actualResult: any) => {
+          if (error) {
+            assert.fail(`promises.${name} did not reject`);
+          } else {
+            assert.deepEqual(actualResult, result ?? resultAsError);
+          }
+        })
+        .catch((actualError: any) => {
+          assert(
+            actualError instanceof Error,
+            `Expected caugth error to be instance of Error. Got ${actualError}`
+          );
+          if (error) {
             assert(
-              typeof fsPromises[name] === 'function',
-              `Expected fsPromises.${name} to be a function`
+              error.test(actualError?.message ?? ''),
+              `Expected "${actualError?.message}" to match ${error}`
             );
-            return Reflect.apply(fsPromises[name], fsPromises, args);
-          })
-          .then((actualResult: any) => {
-            if (error) {
-              assert.fail(`promises.${name} did not reject`);
-            } else {
-              assert.deepEqual(actualResult, result ?? resultAsError);
-            }
-          })
-          .catch((actualError: any) => {
-            assert(
-              actualError instanceof Error,
-              `Expected caugth error to be instance of Error. Got ${actualError}`
-            );
-            if (error) {
-              assert(
-                error.test(actualError?.message ?? ''),
-                `Expected "${actualError?.message}" to match ${error}`
-              );
-            } else {
-              actualError.message = `Did not expect promises.${name} to reject: ${actualError.message}`;
-              assert.fail(actualError);
-            }
-          });
-        rootSpan.end();
-        assertSpans(memoryExporter.getFinishedSpans(), [
-          ...spans.map((s: any) => {
-            const spanName = s.name.replace(/%NAME/, name);
-            const attributes = {
-              ...(s.attributes ?? {}),
-            };
-            attributes[TEST_ATTRIBUTE] = TEST_VALUE;
-            return {
-              ...s,
-              name: spanName,
-              attributes,
-            };
-          }),
-          { name: rootSpanName },
-        ]);
-      });
-    };
-
-    const selection: TestCase[] = tests.filter(
-      ([name, , , , options = {}]) =>
-        options.promise !== false && name !== ('exists' as FsFunction)
-    );
-
-    describe('Instrumentation enabled', () => {
-      selection.forEach(([name, args, result, spans]) => {
-        promiseTest(name as FPMember, args, result, spans);
-      });
+          } else {
+            actualError.message = `Did not expect promises.${name} to reject: ${actualError.message}`;
+            assert.fail(actualError);
+          }
+        });
+      rootSpan.end();
+      assertSpans(memoryExporter.getFinishedSpans(), [
+        ...spans.map((s: any) => {
+          const spanName = s.name.replace(/%NAME/, name);
+          const attributes = {
+            ...(s.attributes ?? {}),
+          };
+          attributes[TEST_ATTRIBUTE] = TEST_VALUE;
+          return {
+            ...s,
+            name: spanName,
+            attributes,
+          };
+        }),
+        { name: rootSpanName },
+      ]);
     });
+  };
 
-    describe('Instrumentation disabled', () => {
-      beforeEach(() => {
-        plugin.disable();
-      });
+  const selection: TestCase[] = tests.filter(
+    ([name, , , , options = {}]) =>
+      options.promise !== false && name !== ('exists' as FsFunction)
+  );
 
-      selection.forEach(([name, args, result]) => {
-        promiseTest(name as FPMember, args, result, []);
-      });
+  describe('Instrumentation enabled', () => {
+    selection.forEach(([name, args, result, spans]) => {
+      promiseTest(name as FPMember, args, result, spans);
     });
   });
-}
+
+  describe('Instrumentation disabled', () => {
+    beforeEach(() => {
+      plugin.disable();
+    });
+
+    selection.forEach(([name, args, result]) => {
+      promiseTest(name as FPMember, args, result, []);
+    });
+  });
+});


### PR DESCRIPTION
## Which problem is this PR solving?

This PR removes unnecessary `supportsPromises` checks in `instrumentation-fs` tests, since we do not run tests for Node.js versions below 14.

Addresses https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1375#discussion_r1118094721.

## Short description of the changes

N/A