### PR TITLE
ci: increase memory for browser tests

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NPM_CONFIG_UNSAFE_PERM: true
-      NODE_OPTIONS: --max-old-space-size=4096
+      NODE_OPTIONS: --max-old-space-size=6144
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Browser test are currently failing because of "JavaScript heap out of memory".

This PR increases the memory for the node process in CI browser-test job. I don't know if anything changed that now consumes more memory, or if it makes sense that browser tests consume so much.