### PR TITLE
fix(instrumentation-redis): do not use `Callback` from `@types/redis`

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-redis/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-redis/src/types.ts
@@ -16,15 +16,14 @@
 
 import { Span } from '@opentelemetry/api';
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
-import type * as redisTypes from 'redis';
 
 // exported from
-// https://github.com/NodeRedis/node_redis/blob/master/lib/command.js
+// https://github.com/redis/node-redis/blob/v3.1.2/lib/command.js
 export interface RedisCommand {
   command: string;
   args: string[];
   buffer_args: boolean;
-  callback: redisTypes.Callback<unknown>;
+  callback: (err: Error | null, reply: unknown) => void;
   call_on_write: boolean;
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

Having both @opentelemetry/instrumentation-redis and redis@^4.0.2 (common when using `@opentelemetry/autoinstrumentations-node`) installed causes typescript compilation errors. 

Fixes #1323

## Short description of the changes

- This PR fixes the above problem by not using the removed `Callback` type in the public API.
- Also updates the link to command.js in the comment.
