### PR TITLE
feat(instrumentation-document-load): Baggage Support

### DIFF
--- a/plugins/web/opentelemetry-instrumentation-document-load/test/documentLoad.test.ts
+++ b/plugins/web/opentelemetry-instrumentation-document-load/test/documentLoad.test.ts
@@ -18,8 +18,6 @@ import { context, HrTime, propagation, Attributes } from '@opentelemetry/api';
 import {
   W3CTraceContextPropagator,
   TRACE_PARENT_HEADER,
-  //W3CBaggagePropagator,
-  //CompositePropagator,
 } from '@opentelemetry/core';
 import {
   BasicTracerProvider,
@@ -248,7 +246,6 @@ describe('DocumentLoad Instrumentation', () => {
 
   before(() => {
     propagation.setGlobalPropagator(new W3CTraceContextPropagator());
-    //propagation.setGlobalPropagator(new CompositePropagator({propagators:[new W3CTraceContextPropagator, new W3CBaggagePropagator]}));
   });
 
   describe('constructor', () => {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?
I am opening this PR to present the added feature of supporting Baggage extraction in the Document Load Instrumentation.


## Short description of the changes
Initial testing reveals baggage extraction works as expected and is a fairly un-obtrusive change. The only issue is creating proper unit tests to be able to capture active baggage at the right time. You'll see console log statements in both code and the test suite to log out the active baggage. The test data is accurately logged out in code, proving the extraction went as expected. However, due to the asynchronous nature of the tests (they are retroactively checking finished Spans for correct trace context values), I am struggling cook up a way to accurately unit test the baggage extraction.

Output from a test run:
```
LOG LOG: 'From code: ', [['key1', Object{value: ...}], ['key2', Object{value: ...}]]
LOG: 'From code: ', [['key1', Object{value: ...}], ['key2', Object{value: ...}]]
LOG LOG: 'From Test: ', undefined
LOG: 'From Test: ', undefined
```

Would love some ideas on how this can be achieved.

Note: CLA will be signed once my Senior Management becomes a CLA Manager with EasyCLA.
