### PR TITLE
Move @types/ packages to devDependencies

### DIFF
--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -99,7 +99,7 @@ To support this use case, you can choose one of the following options:
     // package.json
     {
         ...
-        "dependencies": {
+        "devDependencies": {
             "@types/foo": "1.2.3"
         },
         ...

--- a/plugins/node/instrumentation-tedious/package.json
+++ b/plugins/node/instrumentation-tedious/package.json
@@ -53,6 +53,7 @@
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@types/mocha": "7.0.2",
     "@types/node": "18.11.7",
+    "@types/tedious": "^4.0.6",
     "gts": "3.1.0",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
@@ -64,8 +65,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.35.1",
-    "@opentelemetry/semantic-conventions": "^1.0.0",
-    "@types/tedious": "^4.0.6"
+    "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-tedious#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
@@ -50,6 +50,7 @@
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@opentelemetry/sdk-metrics": "^1.8.0",
+    "@types/aws-lambda": "8.10.81",
     "@types/mocha": "7.0.2",
     "@types/node": "18.11.7",
     "gts": "3.1.0",
@@ -63,8 +64,7 @@
     "@opentelemetry/instrumentation": "^0.35.1",
     "@opentelemetry/propagator-aws-xray": "^1.2.0",
     "@opentelemetry/resources": "^1.8.0",
-    "@opentelemetry/semantic-conventions": "^1.0.0",
-    "@types/aws-lambda": "8.10.81"
+    "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-aws-lambda#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-bunyan/package.json
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/package.json
@@ -51,6 +51,7 @@
     "@opentelemetry/context-async-hooks": "^1.8.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
+    "@types/bunyan": "1.8.7",
     "@types/mocha": "7.0.2",
     "@types/node": "18.11.7",
     "@types/sinon": "10.0.2",
@@ -65,8 +66,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.35.1",
-    "@types/bunyan": "1.8.7"
+    "@opentelemetry/instrumentation": "^0.35.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-bunyan#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-connect/package.json
+++ b/plugins/node/opentelemetry-instrumentation-connect/package.json
@@ -48,6 +48,7 @@
     "@opentelemetry/context-async-hooks": "^1.8.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
+    "@types/connect": "3.4.35",
     "@types/mocha": "7.0.2",
     "@types/node": "18.11.7",
     "connect": "3.7.0",
@@ -61,8 +62,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.35.1",
-    "@opentelemetry/semantic-conventions": "^1.0.0",
-    "@types/connect": "3.4.35"
+    "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-connect#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-express/package.json
+++ b/plugins/node/opentelemetry-instrumentation-express/package.json
@@ -52,6 +52,7 @@
     "@opentelemetry/context-async-hooks": "^1.8.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
+    "@types/express": "4.17.13",
     "@types/mocha": "7.0.2",
     "@types/node": "18.11.7",
     "@types/sinon": "10.0.9",
@@ -68,8 +69,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.35.1",
-    "@opentelemetry/semantic-conventions": "^1.0.0",
-    "@types/express": "4.17.13"
+    "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-express#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
+++ b/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
@@ -49,6 +49,7 @@
     "@opentelemetry/context-async-hooks": "^1.8.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
+    "@types/generic-pool": "^3.1.9",
     "@types/mocha": "7.0.2",
     "@types/node": "18.11.7",
     "@types/semver": "7.3.8",
@@ -63,8 +64,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.35.1",
-    "@opentelemetry/semantic-conventions": "^1.0.0",
-    "@types/generic-pool": "^3.1.9"
+    "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-generic-pool#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-hapi/package.json
+++ b/plugins/node/opentelemetry-instrumentation-hapi/package.json
@@ -50,6 +50,7 @@
     "@opentelemetry/context-async-hooks": "^1.8.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
+    "@types/hapi__hapi": "20.0.9",
     "@types/mocha": "7.0.2",
     "@types/node": "18.11.7",
     "gts": "3.1.0",
@@ -62,8 +63,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.35.1",
-    "@opentelemetry/semantic-conventions": "^1.0.0",
-    "@types/hapi__hapi": "20.0.9"
+    "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-hapi#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-ioredis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/package.json
@@ -55,6 +55,7 @@
     "@opentelemetry/contrib-test-utils": "^0.33.1",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
+    "@types/ioredis4": "npm:@types/ioredis@^4.28.10",
     "@types/mocha": "7.0.2",
     "@types/sinon": "10.0.9",
     "@types/node": "18.11.7",
@@ -72,8 +73,7 @@
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.35.1",
     "@opentelemetry/redis-common": "^0.35.0",
-    "@opentelemetry/semantic-conventions": "^1.0.0",
-    "@types/ioredis4": "npm:@types/ioredis@^4.28.10"
+    "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-ioredis#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-koa/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/package.json
@@ -54,6 +54,8 @@
     "@opentelemetry/context-async-hooks": "^1.8.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
+    "@types/koa": "2.13.4",
+    "@types/koa__router": "8.0.7",
     "@types/mocha": "7.0.2",
     "@types/node": "18.11.7",
     "@types/sinon": "10.0.9",
@@ -70,9 +72,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.35.1",
-    "@opentelemetry/semantic-conventions": "^1.0.0",
-    "@types/koa": "2.13.4",
-    "@types/koa__router": "8.0.7"
+    "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-koa#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-memcached/package.json
+++ b/plugins/node/opentelemetry-instrumentation-memcached/package.json
@@ -52,6 +52,7 @@
     "@opentelemetry/contrib-test-utils": "^0.33.1",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
+    "@types/memcached": "^2.2.6",
     "@types/mocha": "7.0.2",
     "@types/node": "18.11.7",
     "cross-env": "7.0.3",
@@ -65,8 +66,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.35.1",
-    "@opentelemetry/semantic-conventions": "^1.0.0",
-    "@types/memcached": "^2.2.6"
+    "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-memcached#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-mysql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql/package.json
@@ -51,6 +51,7 @@
     "@opentelemetry/context-async-hooks": "^1.8.0",
     "@opentelemetry/contrib-test-utils": "^0.33.1",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
+    "@types/mysql": "2.15.19",
     "@types/mocha": "7.0.2",
     "@types/node": "18.11.7",
     "@types/sinon": "10.0.13",
@@ -65,8 +66,7 @@
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.35.1",
     "@opentelemetry/semantic-conventions": "^1.0.0",
-    "mysql": "2.18.1",
-    "@types/mysql": "2.15.19"
+    "mysql": "2.18.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-mysql#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-pg/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pg/package.json
@@ -60,6 +60,8 @@
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/mocha": "7.0.2",
     "@types/node": "18.11.7",
+    "@types/pg": "8.6.1",
+    "@types/pg-pool": "2.0.3",
     "@types/sinon": "10.0.2",
     "cross-env": "7.0.3",
     "gts": "3.1.0",
@@ -77,9 +79,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.35.1",
-    "@opentelemetry/semantic-conventions": "^1.0.0",
-    "@types/pg": "8.6.1",
-    "@types/pg-pool": "2.0.3"
+    "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-pg#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-redis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis/package.json
@@ -59,6 +59,7 @@
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/mocha": "7.0.2",
     "@types/node": "18.11.7",
+    "@types/redis": "2.8.31",
     "cross-env": "7.0.3",
     "gts": "3.1.0",
     "mocha": "7.2.0",
@@ -72,8 +73,7 @@
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.35.1",
     "@opentelemetry/redis-common": "^0.35.0",
-    "@opentelemetry/semantic-conventions": "^1.0.0",
-    "@types/redis": "2.8.31"
+    "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-redis#readme"
 }


### PR DESCRIPTION
TypeScript type packages are normally dev-only dependencies. You generally only need types for development, not at run time.

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Excessive size of `node_modules` directory when using these plugins.

## Short description of the changes

- Move all `@types/` packages from `dependencies` to `devDependencies`.
- Update `GUIDELINES.md`.
