### PR TITLE
fix(gql)!: conform GraphQL span name to spec

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-graphql/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/src/instrumentation.ts
@@ -411,14 +411,15 @@ export class GraphQLInstrumentation extends InstrumentationBase {
 
       const operationName = nameNode?.value;
 
-      if (operationName) {
-        span.setAttribute(AttributeNames.OPERATION_NAME, operationName);
-      }
-
       // https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/instrumentation/graphql/
       // > The span name MUST be of the format <graphql.operation.type> <graphql.operation.name> provided that graphql.operation.type and graphql.operation.name are available.
       // > If graphql.operation.name is not available, the span SHOULD be named <graphql.operation.type>.
-      span.updateName(`${operationType} ${operationName ?? ''}`.trim());
+      if (operationName) {
+        span.setAttribute(AttributeNames.OPERATION_NAME, operationName);
+        span.updateName(`${operationType} ${operationName}`);
+      } else {
+        span.updateName(operationType);
+      }
     } else {
       let operationName = ' ';
       if (processedArgs.operationName) {

--- a/plugins/node/opentelemetry-instrumentation-graphql/test/graphql.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/test/graphql.test.ts
@@ -169,7 +169,7 @@ describe('graphql', () => {
           executeSpan.attributes[AttributeNames.OPERATION_NAME],
           undefined
         );
-        assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
+        assert.deepStrictEqual(executeSpan.name, 'query');
         assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
       });
 
@@ -297,7 +297,7 @@ describe('graphql', () => {
           executeSpan.attributes[AttributeNames.OPERATION_NAME],
           undefined
         );
-        assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
+        assert.deepStrictEqual(executeSpan.name, 'query');
         assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
       });
 
@@ -395,7 +395,7 @@ describe('graphql', () => {
           executeSpan.attributes[`${AttributeNames.VARIABLES}id`],
           undefined
         );
-        assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
+        assert.deepStrictEqual(executeSpan.name, 'query Query1');
         assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
       });
 
@@ -487,7 +487,7 @@ describe('graphql', () => {
           executeSpan.attributes[AttributeNames.OPERATION_NAME],
           undefined
         );
-        assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
+        assert.deepStrictEqual(executeSpan.name, 'query');
         assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
       });
     });
@@ -555,7 +555,7 @@ describe('graphql', () => {
           executeSpan.attributes[AttributeNames.OPERATION_NAME],
           undefined
         );
-        assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
+        assert.deepStrictEqual(executeSpan.name, 'query');
         assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
       });
     });
@@ -752,7 +752,7 @@ describe('graphql', () => {
           executeSpan.attributes[AttributeNames.OPERATION_NAME],
           undefined
         );
-        assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
+        assert.deepStrictEqual(executeSpan.name, 'query');
         assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
       });
 
@@ -848,7 +848,7 @@ describe('graphql', () => {
           executeSpan.attributes[AttributeNames.OPERATION_NAME],
           'AddBook'
         );
-        assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
+        assert.deepStrictEqual(executeSpan.name, 'mutation AddBook');
         assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
       });
 
@@ -946,7 +946,7 @@ describe('graphql', () => {
           executeSpan.attributes[`${AttributeNames.VARIABLES}id`],
           2
         );
-        assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
+        assert.deepStrictEqual(executeSpan.name, 'query Query1');
         assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
       });
 
@@ -1044,7 +1044,7 @@ describe('graphql', () => {
         executeSpan.attributes[AttributeNames.OPERATION_NAME],
         'AddBook'
       );
-      assert.deepStrictEqual(executeSpan.name, SpanNames.EXECUTE);
+      assert.deepStrictEqual(executeSpan.name, 'mutation AddBook');
       assert.deepStrictEqual(executeSpan.parentSpanId, undefined);
     });
 
@@ -1317,7 +1317,7 @@ describe('graphql', () => {
 
       // validate execute span is present
       const spans = exporter.getFinishedSpans();
-      const executeSpans = spans.filter(s => s.name === SpanNames.EXECUTE);
+      const executeSpans = spans.filter(s => s.name === 'query');
       assert.deepStrictEqual(executeSpans.length, 1);
       const [executeSpan] = executeSpans;
       assert.deepStrictEqual(
@@ -1371,7 +1371,7 @@ describe('graphql', () => {
       );
 
       // single execute span
-      const executeSpans = spans.filter(s => s.name === SpanNames.EXECUTE);
+      const executeSpans = spans.filter(s => s.name === 'query');
       assert.deepStrictEqual(executeSpans.length, 1);
     });
   });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Rename graphql "execute" spans to "<operation.type> <operation.name>" to conform to the [spec](https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/instrumentation/graphql/).

In addition to conforming to the spec, this change can provide additional value for monitoring purposes. In cases where o11y providers generate metrics from pre-ingested traces (without all the attributes), the new naming convention makes it easier to group and filter metrics by operation type and name, since it is now reflected in the span name. This can be particularly useful for setting up monitors or alerts.

## Short description of the changes

When operation name and type are determined within the execute span, `span.updateName()` is called.

The query steps other than "execute"'s spans are out of scope as they
do not need to be renamed.
