### PR TITLE
chore(mysql): remove mysql from dependencies

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-mysql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql/package.json
@@ -56,6 +56,7 @@
     "@types/sinon": "10.0.13",
     "gts": "3.1.0",
     "mocha": "7.2.0",
+    "mysql": "2.18.1",
     "nyc": "15.1.0",
     "rimraf": "4.2.0",
     "sinon": "15.0.1",
@@ -65,7 +66,6 @@
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.35.1",
     "@opentelemetry/semantic-conventions": "^1.0.0",
-    "mysql": "2.18.1",
     "@types/mysql": "2.15.19"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-mysql#readme"

--- a/plugins/node/opentelemetry-instrumentation-mysql/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql/src/utils.ts
@@ -22,7 +22,7 @@ import type {
   Query,
   QueryOptions,
 } from 'mysql';
-import * as mysqlTypes from 'mysql';
+import type * as mysqlTypes from 'mysql';
 
 /**
  * Get an SpanAttributes map from a mysql connection config object


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Remove unnecessary dependency on `mysql` package, which is only used in tests.

## Short description of the changes

Moved `mysql` to dev dependencies.