### PR TITLE
feat(instrumentation-pg): support custom SQL Commenter attributes

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-pg/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/instrumentation.ts
@@ -215,18 +215,28 @@ export class PgInstrumentation extends InstrumentationBase {
         // Modify query text w/ a tracing comment before invoking original for
         // tracing, but only if args[0] has one of our expected shapes.
         //
-        // TODO: remove the `as ...` casts below when the TS version is upgraded.
+        // TODO: remove the `as ...` casts on `arg0` below when the TS version is upgraded.
         // Newer TS versions will use the result of firstArgIsQueryObjectWithText
         // to properly narrow arg0, but TS 4.3.5 does not.
         if (instrumentationConfig.addSqlCommenterCommentToQueries) {
+          const customSqlCommenterAttributes = context
+            .active()
+            .getValue(
+              Symbol('customSqlCommenterAttributes')
+            ) as utils.SqlCommenterAttributes;
           args[0] = firstArgIsString
-            ? utils.addSqlCommenterComment(span, arg0 as string)
+            ? utils.addSqlCommenterComment(
+                span,
+                arg0 as string,
+                customSqlCommenterAttributes
+              )
             : firstArgIsQueryObjectWithText
             ? {
                 ...(arg0 as utils.ObjectWithText),
                 text: utils.addSqlCommenterComment(
                   span,
-                  (arg0 as utils.ObjectWithText).text
+                  (arg0 as utils.ObjectWithText).text,
+                  customSqlCommenterAttributes
                 ),
               }
             : args[0];

--- a/plugins/node/opentelemetry-instrumentation-pg/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/utils.ts
@@ -47,7 +47,7 @@ function arrayStringifyHelper(arr: Array<unknown>): string {
   return '[' + arr.toString() + ']';
 }
 
-type SqlCommenterAttributes = Record<string, string>;
+export type SqlCommenterAttributes = Record<string, string>;
 
 /**
  * Helper function to get a low cardinality span name from whatever info we have


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Closes https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1353

## Short description of the changes

- This PR is a follow-up to https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1286 that adds support for custom attributes in the SQL commenter comments. Since the pg instrumentation has no way (that I know of) of getting the attributes itself, this PR uses the active context to get the attributes that'd have to be set by the user. If this approach is approved, I'll add docs for it.
