### PR TITLE
fix(preact-example): update example to use latest otelcol/js-core

### DIFF
--- a/examples/react-load/preact/docker/collector-config.yaml
+++ b/examples/react-load/preact/docker/collector-config.yaml
@@ -1,18 +1,26 @@
 receivers:
   otlp:
-    endpoint: 0.0.0.0:55678
+    protocols:
+      http:
+        cors:
+          allowed_origins:
+            - http://*
+            - https://*
+
 
 exporters:
   zipkin:
-    url: "http://zipkin-all-in-one:9411/api/v2/spans"
+    endpoint: "http://zipkin-all-in-one:9411/api/v2/spans"
 
 processors:
   batch:
-  queued_retry:
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
       exporters: [zipkin]
-      processors: [batch, queued_retry]
+      processors: [batch]
+  telemetry:
+    logs:
+      level: "debug"

--- a/examples/react-load/preact/docker/collector-config.yaml
+++ b/examples/react-load/preact/docker/collector-config.yaml
@@ -7,7 +7,6 @@ receivers:
             - http://*
             - https://*
 
-
 exporters:
   zipkin:
     endpoint: "http://zipkin-all-in-one:9411/api/v2/spans"

--- a/examples/react-load/preact/docker/docker-compose.yaml
+++ b/examples/react-load/preact/docker/docker-compose.yaml
@@ -3,12 +3,12 @@ services:
 
   # Collector
   collector:
-    image: omnition/opentelemetry-collector-contrib:0.2.8
-    command: ["--config=/conf/collector-config.yaml", "--log-level=DEBUG"]
+    image: otel/opentelemetry-collector-contrib:0.75.0
+    command: ["--config=/conf/collector-config.yaml"]
     volumes:
       - ./collector-config.yaml:/conf/collector-config.yaml
     ports:
-      - "55678:55678"
+      - "4318:4318"
     depends_on:
       - zipkin-all-in-one
 

--- a/examples/react-load/preact/package.json
+++ b/examples/react-load/preact/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "react-load-preact-example",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Example of using @opentelemetry/plugin-react-load in browser with Preact",
   "main": "index.js",
   "scripts": {
@@ -23,7 +23,7 @@
     "tracing"
   ],
   "engines": {
-    "node": ">=8"
+    "node": ">=14"
   },
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",
@@ -33,15 +33,14 @@
   "devDependencies": {
     "identity-obj-proxy": "^3.0.0",
     "preact-cli": "^3.0.0",
-    "preact-render-spy": "^1.2.1",
     "sirv-cli": "1.0.3"
   },
   "dependencies": {
-    "@opentelemetry/context-zone": "^0.25.0",
-    "@opentelemetry/exporter-collector": "^0.25.0",
-    "@opentelemetry/plugin-react-load": "^0.23.0",
-    "@opentelemetry/sdk-trace-base": "^0.25.0",
-    "@opentelemetry/sdk-trace-web": "^0.25.0",
+    "@opentelemetry/context-zone": "^1.11.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.37.0",
+    "@opentelemetry/plugin-react-load": "^0.28.1",
+    "@opentelemetry/sdk-trace-base": "^1.11.0",
+    "@opentelemetry/sdk-trace-web": "^1.11.0",
     "preact": "^10.3.2",
     "preact-render-to-string": "^5.1.4",
     "preact-router": "^3.2.1"

--- a/examples/react-load/preact/src/web-tracer.js
+++ b/examples/react-load/preact/src/web-tracer.js
@@ -6,8 +6,8 @@ import { ZoneContextManager } from '@opentelemetry/context-zone';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 
 export default (serviceName) => {
-  const provider = new WebTracerProvider();
   diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
+  const provider = new WebTracerProvider();
   const exporter = new OTLPTraceExporter({
     url: 'http://localhost:4318/v1/traces',
   });

--- a/examples/react-load/preact/src/web-tracer.js
+++ b/examples/react-load/preact/src/web-tracer.js
@@ -1,14 +1,15 @@
 import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
 import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
 import { BaseOpenTelemetryComponent } from '@opentelemetry/plugin-react-load';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
-import { CollectorTraceExporter } from '@opentelemetry/exporter-collector';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 
 export default (serviceName) => {
   const provider = new WebTracerProvider();
-
-  const exporter = new CollectorTraceExporter({
-    url: 'http://localhost:55678/v1/trace',
+  diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
+  const exporter = new OTLPTraceExporter({
+    url: 'http://localhost:4318/v1/traces',
   });
 
   provider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
@@ -21,7 +22,6 @@ export default (serviceName) => {
   const tracer = provider.getTracer(serviceName);
 
   BaseOpenTelemetryComponent.setTracer(serviceName)
-  BaseOpenTelemetryComponent.setLogger(provider.logger)
 
   return tracer;
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- Renovate bot is failing to create/update PRs as the `omnition/opentelemetry-collector-contrib:0.2.8` image has been removed from dockerhub. 

Due to restrictions on OAuth apps in the otel organization, and the fact that the logs dashboard is not supported with `forking-renovate`, we cannot access renovate bot logs, so I recreated an environment in a private organization and was able to find that the missing docker image causes the bot to skip any other steps.

This may be caused by a bug in forking-renovate, so if this PR fixes the issue, I'll open an issue on the renovate repository so that this can be investigated.

Fixes (hopefully) #1434 

## Short description of the changes

- update the example to use an existing image
- to use an existing image, I also had to update the example to use a more recent OTel JS version, so I opted to upgrade to 1.11.0/0.37.0.
