### PR TITLE
chore: exclude examples from renovate

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npx --no-install commitlint --edit $1

--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
     }
   ],
   "ignoreDeps": ["lerna", "lerna-changelog"],
-  "ignorePaths": ["archive/**"],
+  "ignorePaths": ["archive/**", "examples/**"],
   "assignees": ["@blumamir", "@dyladan", "@legendecas", "@Rauno56", "@vmarchaud"],
   "schedule": [
     "before 3am on Friday"


### PR DESCRIPTION
Exclude examples from renovate runs because there is no CI to verify that they still work after the update.

As they are terrible outdated already any update is likely breaking them because some still use components not released anymore and therefore no compatibility to actual release without code change.

Refs: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1459
