### PR TITLE
chore(detectors/node): adapted breaking change in @opentelemetry/sdk-node@0.37.0

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-instana/README.md
+++ b/detectors/node/opentelemetry-resource-detector-instana/README.md
@@ -42,33 +42,6 @@ const sdk = new NodeSDK({
 sdk.start()
 ```
 
-```typescript
-import {
-  Resource,
-  processDetector,
-  envDetector,
-} from "@opentelemetry/resources";
-import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
-import { NodeSDK } from "@opentelemetry/sdk-node";
-import { instanaAgentDetector } from "@opentelemetry/resource-detector-instana";
-
-const globalResource = new Resource({
-   [SemanticResourceAttributes.SERVICE_NAME]: "TestService",
-});
-
-const sdk = new NodeSDK({
-   resourceDetectors: [envDetector, processDetector, instanaAgentDetector],
-   resource: globalResource,
-});
-
-sdk.start()
-
-(async () => {
-   const resource = sdk["_resource"];
-   await resource.waitForAsyncAttributes?.();
-}());
-```
-
 ## Useful links
 
 - For more information about Instana Agent, visit: <https://www.ibm.com/docs/en/instana-observability/current?topic=instana-host-agent>

--- a/detectors/node/opentelemetry-resource-detector-instana/README.md
+++ b/detectors/node/opentelemetry-resource-detector-instana/README.md
@@ -40,10 +40,11 @@ const sdk = new NodeSDK({
    resource: globalResource,
 });
 
-(async () => {
-   await sdk.detectResources();
+sdk.start()
 
-   await sdk.start();
+(async () => {
+   const resource = sdk["_resource"];
+   await resource.waitForAsyncAttributes?.();
 }());
 ```
 

--- a/detectors/node/opentelemetry-resource-detector-instana/README.md
+++ b/detectors/node/opentelemetry-resource-detector-instana/README.md
@@ -35,7 +35,28 @@ const globalResource = new Resource({
 });
 
 const sdk = new NodeSDK({
-   autoDetectResources: false,
+   resourceDetectors: [envDetector, processDetector, instanaAgentDetector],
+   resource: globalResource,
+});
+
+sdk.start()
+```
+
+```typescript
+import {
+  Resource,
+  processDetector,
+  envDetector,
+} from "@opentelemetry/resources";
+import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { instanaAgentDetector } from "@opentelemetry/resource-detector-instana";
+
+const globalResource = new Resource({
+   [SemanticResourceAttributes.SERVICE_NAME]: "TestService",
+});
+
+const sdk = new NodeSDK({
    resourceDetectors: [envDetector, processDetector, instanaAgentDetector],
    resource: globalResource,
 });

--- a/detectors/node/opentelemetry-resource-detector-instana/package.json
+++ b/detectors/node/opentelemetry-resource-detector-instana/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/contrib-test-utils": "^0.33.1",
-    "@opentelemetry/sdk-node": "^0.35.1",
+    "@opentelemetry/sdk-node": "^0.37.0",
     "@types/mocha": "8.2.3",
     "@types/node": "18.11.7",
     "@types/semver": "7.3.8",

--- a/detectors/node/opentelemetry-resource-detector-instana/src/detectors/InstanaAgentDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-instana/src/detectors/InstanaAgentDetector.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Detector, Resource } from '@opentelemetry/resources';
+import { Detector, Resource, IResource } from '@opentelemetry/resources';
 import { diag } from '@opentelemetry/api';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import * as http from 'http';
@@ -22,7 +22,7 @@ class InstanaAgentDetector implements Detector {
   readonly INSTANA_AGENT_DEFAULT_HOST = 'localhost';
   readonly INSTANA_AGENT_DEFAULT_PORT = 42699;
 
-  async detect(): Promise<Resource> {
+  async detect(): Promise<IResource> {
     const host =
       process.env.INSTANA_AGENT_HOST || this.INSTANA_AGENT_DEFAULT_HOST;
     const port = Number(
@@ -112,7 +112,6 @@ class InstanaAgentDetector implements Detector {
 
           try {
             const data = JSON.parse(rawData);
-
             if (data.pid && data.agentUuid) {
               return resolve(data);
             }

--- a/detectors/node/opentelemetry-resource-detector-instana/test/InstanaAgentDetectorIntegrationTest.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-instana/test/InstanaAgentDetectorIntegrationTest.test.ts
@@ -41,7 +41,7 @@ describe('[Integration] instanaAgentDetector', () => {
     nock.cleanAll();
   });
 
-  it('should return merged resource', async () => {
+  it('#1 should return merged resource', async () => {
     const mockedReply = {
       pid: 123,
       agentUuid: '14:7d:da:ff:fe:e4:08:d5',
@@ -80,7 +80,7 @@ describe('[Integration] instanaAgentDetector', () => {
     scope.done();
   });
 
-  it('[autoDetectResources:true] should return merged resource', async () => {
+  it('#2 should return merged resource', async () => {
     const mockedReply = {
       pid: 123,
       agentUuid: '14:7d:da:ff:fe:e4:08:d5',

--- a/detectors/node/opentelemetry-resource-detector-instana/test/InstanaAgentDetectorIntegrationTest.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-instana/test/InstanaAgentDetectorIntegrationTest.test.ts
@@ -25,6 +25,11 @@ import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { instanaAgentDetector } from '../src';
 
+const delay = (ms: number) =>
+  new Promise<void>(resolve => {
+    setTimeout(resolve, ms);
+  });
+
 describe('[Integration] instanaAgentDetector', () => {
   beforeEach(() => {
     nock.disableNetConnect();
@@ -53,17 +58,53 @@ describe('[Integration] instanaAgentDetector', () => {
     });
 
     const sdk = new NodeSDK({
-      autoDetectResources: false,
       resourceDetectors: [envDetector, processDetector, instanaAgentDetector],
       resource: globalResource,
     });
 
-    sdk.detectResources();
+    sdk.start();
 
     const resource = sdk['_resource'];
     // await sdk.detectResources(); [< @opentelemetry/sdk-node@0.37.0]
     // await resource.waitForAsyncAttributes?.(); [>= @opentelemetry/sdk-node@0.37.0]
     await resource.waitForAsyncAttributes?.();
+
+    assert.equal(resource.attributes['process.pid'], 123);
+    assert.equal(resource.attributes['process.runtime.name'], 'nodejs');
+    assert.equal(resource.attributes['service.name'], 'TestService');
+    assert.equal(
+      resource.attributes['service.instance.id'],
+      '14:7d:da:ff:fe:e4:08:d5'
+    );
+
+    scope.done();
+  });
+
+  it('[autoDetectResources:true] should return merged resource', async () => {
+    const mockedReply = {
+      pid: 123,
+      agentUuid: '14:7d:da:ff:fe:e4:08:d5',
+    };
+
+    const scope = nock('http://localhost:42699')
+      .persist()
+      .put('/com.instana.plugin.nodejs.discovery')
+      .reply(200, () => mockedReply);
+
+    const serviceName = 'TestService';
+    const globalResource = new Resource({
+      [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
+    });
+
+    const sdk = new NodeSDK({
+      resourceDetectors: [envDetector, processDetector, instanaAgentDetector],
+      resource: globalResource,
+    });
+
+    sdk.start();
+    const resource = sdk['_resource'];
+
+    await delay(500);
 
     assert.equal(resource.attributes['process.pid'], 123);
     assert.equal(resource.attributes['process.runtime.name'], 'nodejs');

--- a/detectors/node/opentelemetry-resource-detector-instana/test/InstanaAgentDetectorIntegrationTest.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-instana/test/InstanaAgentDetectorIntegrationTest.test.ts
@@ -58,10 +58,12 @@ describe('[Integration] instanaAgentDetector', () => {
       resource: globalResource,
     });
 
-    // attributes are automatically merged!
-    await sdk.detectResources();
+    sdk.detectResources();
 
     const resource = sdk['_resource'];
+    // await sdk.detectResources(); [< @opentelemetry/sdk-node@0.37.0]
+    // await resource.waitForAsyncAttributes?.(); [>= @opentelemetry/sdk-node@0.37.0]
+    await resource.waitForAsyncAttributes?.();
 
     assert.equal(resource.attributes['process.pid'], 123);
     assert.equal(resource.attributes['process.runtime.name'], 'nodejs');


### PR DESCRIPTION
Refs https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1459#issuecomment-1498805145

I do no have write permissions for renovate-bot:renovate/otel-core-experimental.
Feel free to close this PR and cherry-pick the commit.

The README files for all detectors needs to be updated too. Let me know if you want me to update them too.