### PR TITLE
feat(opentelemetry-sampler-aws-xray): add sampling targets logic and fallback sampler

### DIFF
--- a/packages/opentelemetry-remote-sampler-aws-xray/LICENSE
+++ b/packages/opentelemetry-remote-sampler-aws-xray/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2022] OpenTelemetry Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/opentelemetry-remote-sampler-aws-xray/README.md
+++ b/packages/opentelemetry-remote-sampler-aws-xray/README.md
@@ -1,0 +1,1 @@
+# AWS X-Ray Remote Sampler

--- a/packages/opentelemetry-remote-sampler-aws-xray/package.json
+++ b/packages/opentelemetry-remote-sampler-aws-xray/package.json
@@ -4,7 +4,6 @@
   "description": "OpenTelemetry remote sampler for AWS X-Ray",
   "keywords": [
     "aws",
-    "aws-sdk",
     "nodejs",
     "opentelemetry"
   ],
@@ -48,19 +47,12 @@
     "@opentelemetry/propagation-utils": "^0.29.2"
   },
   "devDependencies": {
-    "@aws-sdk/client-dynamodb": "3.85.0",
-    "@aws-sdk/client-lambda": "3.85.0",
-    "@aws-sdk/client-s3": "3.85.0",
-    "@aws-sdk/client-sqs": "3.85.0",
-    "@aws-sdk/client-sns": "3.85.0",
-    "@aws-sdk/types": "3.78.0",
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/contrib-test-utils": "^0.33.1",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@types/mocha": "8.2.3",
     "@types/node": "18.11.7",
     "@types/sinon": "10.0.6",
-    "aws-sdk": "2.1008.0",
     "eslint": "8.7.0",
     "expect": "29.2.0",
     "gts": "3.1.0",

--- a/packages/opentelemetry-remote-sampler-aws-xray/package.json
+++ b/packages/opentelemetry-remote-sampler-aws-xray/package.json
@@ -1,0 +1,79 @@
+{
+  "name": "@opentelemetry/remote-sampler-aws-xray",
+  "version": "0.34.0",
+  "description": "OpenTelemetry remote sampler for AWS X-Ray",
+  "keywords": [
+    "aws",
+    "aws-sdk",
+    "nodejs",
+    "opentelemetry"
+  ],
+  "license": "Apache-2.0",
+  "author": "OpenTelemetry Authors",
+  "bugs": {
+    "url": "https://github.com/open-telemetry/opentelemetry-js-contrib/issues"
+  },
+  "main": "build/src/index.js",
+  "types": "build/src/index.d.ts",
+  "files": [
+    "build/src/**/*.js",
+    "build/src/**/*.js.map",
+    "build/src/**/*.d.ts",
+    "doc",
+    "LICENSE",
+    "README.md"
+  ],
+  "repository": "open-telemetry/opentelemetry-js-contrib",
+  "scripts": {
+    "clean": "rimraf build/*",
+    "compile": "tsc -p .",
+    "lint": "eslint . --ext .ts",
+    "lint:fix": "eslint . --ext .ts --fix",
+    "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/remote-sampler-aws-xray --include-dependencies",
+    "prewatch": "npm run precompile",
+    "prepare": "npm run compile",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
+    "test": "nyc ts-mocha -p tsconfig.json --require '@opentelemetry/contrib-test-utils' 'test/**/*.test.ts'",
+    "test-all-versions": "tav",
+    "version:update": "node ../../scripts/version-update.js",
+    "watch": "tsc -w"
+  },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.3.0"
+  },
+  "dependencies": {
+    "@opentelemetry/core": "^1.8.0",
+    "@opentelemetry/instrumentation": "^0.35.1",
+    "@opentelemetry/semantic-conventions": "^1.0.0",
+    "@opentelemetry/propagation-utils": "^0.29.2"
+  },
+  "devDependencies": {
+    "@aws-sdk/client-dynamodb": "3.85.0",
+    "@aws-sdk/client-lambda": "3.85.0",
+    "@aws-sdk/client-s3": "3.85.0",
+    "@aws-sdk/client-sqs": "3.85.0",
+    "@aws-sdk/client-sns": "3.85.0",
+    "@aws-sdk/types": "3.78.0",
+    "@opentelemetry/api": "^1.3.0",
+    "@opentelemetry/contrib-test-utils": "^0.33.1",
+    "@opentelemetry/sdk-trace-base": "^1.8.0",
+    "@types/mocha": "8.2.3",
+    "@types/node": "18.11.7",
+    "@types/sinon": "10.0.6",
+    "aws-sdk": "2.1008.0",
+    "eslint": "8.7.0",
+    "expect": "29.2.0",
+    "gts": "3.1.0",
+    "mocha": "7.2.0",
+    "nock": "13.2.1",
+    "nyc": "15.1.0",
+    "rimraf": "4.2.0",
+    "sinon": "15.0.1",
+    "test-all-versions": "5.0.1",
+    "ts-mocha": "10.0.0",
+    "typescript": "4.3.4"
+  },
+  "engines": {
+    "node": ">=14"
+  }
+}

--- a/packages/opentelemetry-remote-sampler-aws-xray/src/fallback-sampler.ts
+++ b/packages/opentelemetry-remote-sampler-aws-xray/src/fallback-sampler.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Sampler, SamplingResult, AlwaysOnSampler } from '@opentelemetry/sdk-trace-base';
+import {
+    Context,
+    Link,
+    Attributes,
+    SpanKind,
+  } from '@opentelemetry/api';
+
+export class FallbackSampler implements Sampler {
+
+    private _alwaysOnSampler = new AlwaysOnSampler();
+
+    shouldSample(    
+        context: Context,
+        traceId: string,
+        spanName: string,
+        spanKind: SpanKind,
+        attributes: Attributes,
+        links: Link[]): SamplingResult {
+
+        // This will be updated to be a rate limiting sampler in the next PR 
+        return this._alwaysOnSampler.shouldSample();
+    }
+
+    public toString = () : string => {
+        return "FallbackSampler"
+    }
+}

--- a/packages/opentelemetry-remote-sampler-aws-xray/src/index.ts
+++ b/packages/opentelemetry-remote-sampler-aws-xray/src/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export * from './remote-sampler';
+export * from './remote-sampler.types';

--- a/packages/opentelemetry-remote-sampler-aws-xray/src/remote-sampler.ts
+++ b/packages/opentelemetry-remote-sampler-aws-xray/src/remote-sampler.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Sampler, SamplingDecision, SamplingResult } from '@opentelemetry/sdk-trace-base';
+import { SamplingRule } from './remote-sampler.types';
+import axios from 'axios';
+
+const DEFAULT_INTERVAL = 5 * 60 * 1000;// 5 minutes on sampling rules fetch (default polling interval)
+
+
+// IN PROGRESS - SKELETON CLASS 
+export class AWSXRayRemoteSampler implements Sampler {
+    private _pollingInterval: number;
+    private _endpoint: string;
+    private _samplingRulesEndpoint: string;
+
+    constructor(endpoint: string, pollingInterval: number = DEFAULT_INTERVAL) {
+
+        if (pollingInterval <= 0 || !Number.isInteger(pollingInterval)) {
+            throw new TypeError('pollingInterval must be a positive integer');
+        }
+
+        this._pollingInterval = pollingInterval;
+        this._endpoint = endpoint;
+        this._samplingRulesEndpoint = "/GetSamplingRules";
+
+        // execute first get Sampling rules update using polling interval
+        this.getSamplingRules();
+    }
+
+    shouldSample(): SamplingResult {
+        // Implementation to be added
+        return { decision: SamplingDecision.NOT_RECORD };
+    }
+
+    toString(): string {
+        return `AWSXRayRemoteSampler`;
+    }
+
+    getEndpoint(): string {
+        return this._endpoint;
+    }
+
+    getPollingInterval(): number {
+        return this._pollingInterval;
+    }
+
+
+    // fetch sampling rules every polling interval
+    public async getSamplingRules(): Promise<void> {
+        const endpoint = this._endpoint + this._samplingRulesEndpoint;
+
+        setInterval(async () => {
+            const samplingRules: SamplingRule[] = []; // reset rules array
+
+            const headers = {
+                headers: {
+                    'Content-Type': 'application/json',
+                }
+            };
+
+            try {
+                const response = await axios.post(endpoint, null, headers);
+                const responseJson = response.data;
+
+                responseJson?.SamplingRuleRecords.forEach((record: any) => {
+                    if (record.SamplingRule) {
+                        samplingRules.push(record.SamplingRule);
+                    }
+                });
+            } catch (error) {
+                // Log error
+                console.log("Error fetching sampling rules: ", error);
+            }
+        }, this._pollingInterval);
+
+    }
+
+}

--- a/packages/opentelemetry-remote-sampler-aws-xray/src/remote-sampler.types.ts
+++ b/packages/opentelemetry-remote-sampler-aws-xray/src/remote-sampler.types.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+// cast to interface type to validate JSON 
+// e.g: const jsonData = {}
+// const rule: SamplingRule = JSON.parse(jsonData) as SamplingRule;
+export interface SamplingRule {
+    // a unique name for the rule 
+    RuleName: string;
+
+    // (integer between 1 and 9999) - the priority of the sampling rule. Services evaluate rules in ascending order of 
+    // priority, and make a sampling decision with the first rule that matches. 
+    Priority: number;
+
+    // A fixed number of matching requests to instrument per second, before applying the fixed rate. 
+    ReservoirSize: number;
+
+    // The percentage of matching requests to instrument, after the reservoir is exhausted. 
+    FixedRate: number;
+
+    // The name of the instrumented service, as it appears in the X-Ray service map. 
+    ServiceName: string; 
+
+    // The service type, as it appears in the X-Ray service map.
+    ServiceType: string;
+
+    // The hostname from the HTTP host header. 
+    Host: string;
+    
+    // The method of the HTTP request. 
+    HTTPMethod: string;
+
+    // the URL path of the request
+    URLPath: string;
+
+    // The ARN of the AWS resource running the service. 
+    ResourceARN: string; 
+
+    // (Optional) segment attributes that are known when the sampling decision is made. 
+    Attributes?: {[key: string]: string};
+    Version: number;
+}
+
+export interface SamplingRuleRecord {
+    CreatedAt: number;
+    ModifiedAt: number;
+    SamplingRule?: SamplingRule;
+}
+
+
+export interface GetSamplingRulesResponse {
+    NextToken?: string;
+    SamplingRuleRecords? : SamplingRuleRecord[];
+}
+
+
+// samplingStatisticsDocument is used to store current state of sampling data.
+export interface SamplingStatisticsDocument {
+    // A unique identifier for the service in hexadecimal.
+    ClientID: string;
+    // The name of the sampling rule.
+    RuleName: string;
+    // The number of requests that matched the rule.
+    RequestCount: number;
+    // The number of requests borrowed.
+    BorrowCount: number;
+    // The number of requests sampled using the rule.
+    SampledCount: number;
+    // The current time.
+    Timestamp: number;
+
+}
+
+
+
+
+

--- a/packages/opentelemetry-remote-sampler-aws-xray/src/remote-sampler.types.ts
+++ b/packages/opentelemetry-remote-sampler-aws-xray/src/remote-sampler.types.ts
@@ -99,7 +99,33 @@ export interface SamplingStatisticsDocument {
 
 }
 
+export interface SamplingTargetDocument {
+    // The percentage of matching requests to instrument, after the reservoir is exhausted.
+    FixedRate: number;
+    // The number of seconds to wait before fetching sampling targets again 
+    Interval: number;
+    // The number of requests per second that X-Ray allocated this service.
+    ReservoirQuota: number; 
+    // Time before the reservoir quota expires
+    ReservoirQuotaTTL: number; 
+    // The name of the sampling rule
+    RuleName: string;
+}
+
+export interface UnprocessedStatistic {
+    ErrorCode: string; 
+    Message: string; 
+    RuleName: string;
+}
 
 
+export interface GetSamplingTargetsInput {
+    samplingStatisticsDocument: SamplingStatisticsDocument
+}
 
+export interface GetSamplingTargetsOutput {
+    lastRuleModification: number, 
+    samplingTargetDocuments: SamplingTargetDocument[], 
+    unprocessedStatistics: UnprocessedStatistic[]
+}
 

--- a/packages/opentelemetry-remote-sampler-aws-xray/src/remote-sampler.types.ts
+++ b/packages/opentelemetry-remote-sampler-aws-xray/src/remote-sampler.types.ts
@@ -15,10 +15,10 @@
  */
 
 
-// cast to interface type to validate JSON 
-// e.g: const jsonData = {}
-// const rule: SamplingRule = JSON.parse(jsonData) as SamplingRule;
-export interface SamplingRule {
+import { SamplingRule } from "./sampling-rule";
+import { Resource } from '@opentelemetry/resources';
+
+export interface ISamplingRule {
     // a unique name for the rule 
     RuleName: string;
 
@@ -53,6 +53,9 @@ export interface SamplingRule {
     // (Optional) segment attributes that are known when the sampling decision is made. 
     Attributes?: {[key: string]: string};
     Version: number;
+
+    matches(samplingRequest: any, resource: Resource): boolean; 
+
 }
 
 export interface SamplingRuleRecord {
@@ -65,6 +68,17 @@ export interface SamplingRuleRecord {
 export interface GetSamplingRulesResponse {
     NextToken?: string;
     SamplingRuleRecords? : SamplingRuleRecord[];
+}
+
+export interface ISamplingStatistics {
+    // matchedRequests is the number of requests matched against specific rule.
+	matchedRequests: number;
+
+	// sampledRequests is the number of requests sampled using specific rule.
+	sampledRequests: number;
+
+	// borrowedRequests is the number of requests borrowed using specific rule.
+	borrowedRequests: number;
 }
 
 

--- a/packages/opentelemetry-remote-sampler-aws-xray/src/reservoir.ts
+++ b/packages/opentelemetry-remote-sampler-aws-xray/src/reservoir.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+export class Reservoir {
+    // This class will be implemented in the next PR
+    private _quota: number; 
+
+    constructor (quota: number) {
+        this._quota = quota;
+    }
+}

--- a/packages/opentelemetry-remote-sampler-aws-xray/src/reservoir.ts
+++ b/packages/opentelemetry-remote-sampler-aws-xray/src/reservoir.ts
@@ -14,12 +14,106 @@
  * limitations under the License.
  */
 
+import { SamplingTargetDocument } from "./remote-sampler.types";
 
+/**
+ * The reservoir keeps track of the number of traces per second sampled and
+ * the fixed rate for a given sampling rule. This information is fetched from X-Ray serivce.
+ * It decides if a given trace should be borrowed or sampled or not sampled based on the state of current second.
+ */
 export class Reservoir {
-    // This class will be implemented in the next PR
-    private _quota: number; 
+     // Quota assigned to client to consume per second.
+    public _quota: number;
+    public _TTL: number; 
+    public _interval: number | undefined;
+    // Size of the reservoir from the Sampling Rule  
+    private _reservoirSize: number;
+    private _lastTick: number; 
 
-    constructor (quota: number) {
-        this._quota = quota;
+    // Current balance of quota.
+    private _quotaBalance: number = 0; 
+
+    constructor (reservoirSize: number) {
+        this._reservoirSize = reservoirSize;
+        this._quota = 0; // TODO: check initial values
+        this._TTL = 0; 
+        this._interval = undefined; 
+        this._lastTick = 0;
+        this._quotaBalance = 0;
     }
+
+    public getQuotaBalance = (): number => {
+        return this._quotaBalance;
+    }
+
+    // take consumes quota from reservoir, if any remains, then returns true. 
+    // False otherwise.
+
+    public take = (now: any, borrowed: boolean, itemCost: any) : boolean => {
+        if (this._reservoirSize === 0) return false 
+
+        if (this._lastTick === 0) {
+            this._lastTick = now; 
+
+
+            if (borrowed){
+                this._quotaBalance = 1;
+            } else {
+                this._quotaBalance = this._quota;
+            }
+        }
+        console.log(`quotaBalance: ${this._quotaBalance}, itemCost: ${itemCost}`)
+        if (this._quotaBalance >= itemCost){
+            this._quotaBalance -= itemCost;
+            return true; 
+        }
+
+        // update quota balance based on elapsed time 
+        this.updateQuotaBalance(now, borrowed);
+        console.log(`UPDATED quotaBalance: ${this._quotaBalance}, itemCost: ${itemCost}`)
+
+        if (this._quotaBalance >= itemCost){
+            this._quotaBalance -= itemCost;
+            return true; 
+        }
+
+        return false; 
+    }
+
+    public updateQuotaBalance = (now: number, borrowed: boolean) => {
+        let elapsedTime = now - this._lastTick; 
+
+         // update lastTick
+        this._lastTick = now; 
+
+        // calculated how much credit has accumulated since the last tick 
+        if(borrowed) {
+            if(elapsedTime > 1) {// in seconds 
+                this._quotaBalance += 1; 
+            } else {
+                this._quotaBalance += elapsedTime; 
+            }
+        } else {
+            this._quotaBalance += elapsedTime * this._quota;
+
+            if(this._quotaBalance > this._quota) {
+                this._quotaBalance = this._quota
+            }
+        }
+    }
+
+
+    public updateReservoir = (target: SamplingTargetDocument): void => {
+        // updates the reservoir for the rule based on the targets retreived
+
+        // Using if statements because attributes are optional 
+        if (target.ReservoirQuota) this._quota = target.ReservoirQuota; 
+        if (target.ReservoirQuotaTTL) this._TTL = target.ReservoirQuotaTTL; 
+        if (target.Interval) this._interval = target.Interval;
+    }
+
+    public isExpired = (now: number) => {
+        return now >= this._TTL;
+    }
+
 }

--- a/packages/opentelemetry-remote-sampler-aws-xray/src/rule-cache.ts
+++ b/packages/opentelemetry-remote-sampler-aws-xray/src/rule-cache.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SamplingRule } from "./sampling-rule";
+import { Attributes } from '@opentelemetry/api'; 
+import { Resource } from '@opentelemetry/resources';
+
+const RuleCacheTTL_SECONDS = 60 * 60; // The cache expires 1 hour after the last refresh time. (in seconds)
+
+export class RuleCache {
+    public rules: SamplingRule[];
+    private lastUpdated: number | undefined = undefined;
+
+    constructor() {
+        this.rules = []; 
+    }
+
+    public isExpired = (): boolean => {
+
+        if(this.lastUpdated === undefined){
+            return true; 
+        }
+
+        const now = Math.floor(new Date().getTime() / 1000); // getTime returns milliseconds -> /1000 gives seconds
+        return now > this.lastUpdated + RuleCacheTTL_SECONDS;
+    }
+
+
+    public getMatchedRule = (attributes: Attributes, resource: Resource) : SamplingRule | undefined => {
+        if(this.isExpired()) {
+            return undefined;
+        }
+
+        return this.rules.find(rule => rule.matches(attributes, resource) || rule.RuleName === "Default");
+    }
+
+    private _sortRulesByPriority = () => {
+        this.rules.sort((rule1: SamplingRule, rule2: SamplingRule) : number => {
+            let value = rule1.Priority - rule2.Priority; 
+
+            if (value !== 0) return value; 
+
+            if (rule1.RuleName > rule2.RuleName) {
+                return 1; 
+            } else return -1; 
+        })
+    } 
+
+    public updateRules = (newRules: SamplingRule[]) : void => {
+        // store previous rules
+        let oldRules: { [key: string]: SamplingRule } = {};
+
+        this.rules.forEach((rule: SamplingRule) => {
+            // use Object.assign to create a new copy of the rules object to store by value
+            oldRules[rule.RuleName] = Object.assign({}, rule);
+        })
+
+        // update rules in the cache 
+        this.rules = newRules;
+
+        this.rules.forEach((rule: SamplingRule) => {
+            let oldRule: SamplingRule = oldRules[rule.RuleName]; 
+
+            if(oldRule){
+                rule.reservoir = oldRule.reservoir; 
+                rule.statistics = oldRule.statistics;
+            }
+        })
+
+        // sort rules by priority and make lastUpdated = now
+        this._sortRulesByPriority();
+        this.lastUpdated = Math.floor(new Date().getTime() / 1000)
+
+        return; 
+    }
+
+}

--- a/packages/opentelemetry-remote-sampler-aws-xray/src/sampling-rule.ts
+++ b/packages/opentelemetry-remote-sampler-aws-xray/src/sampling-rule.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import { ISamplingRule } from "./remote-sampler.types";
+import { wildcardMatch, attributeMatch } from "./utils";
+import { SamplingDecision } from '@opentelemetry/sdk-trace-base';
+import { Attributes, AttributeValue } from '@opentelemetry/api'; 
+import { SemanticAttributes, SemanticResourceAttributes} from '@opentelemetry/semantic-conventions';
+import { Resource } from '@opentelemetry/resources';
+import { Reservoir } from "./reservoir";
+import { Statistics } from "./statistics";
+
+
+export class SamplingRule implements ISamplingRule {
+    public RuleName: string;
+    public Priority: number;
+    public ReservoirSize: number;
+    public FixedRate: number;
+    public ServiceName: string; 
+    public ServiceType: string;
+    public Host: string;
+    public HTTPMethod: string;
+    public URLPath: string;
+    public ResourceARN: string; 
+    public Attributes?: {[key: string]: string};
+    public Version: number;
+    public reservoir: Reservoir;
+    public statistics: Statistics
+
+    constructor(ruleName: string, priority: number, reservoirSize: number, fixedRate: number, serviceName: string, 
+        serviceType: string, host: string, httpMethod: string, urlPath: string, resourceARN: string, version: number,
+        attributes?: any){
+        this.RuleName = ruleName; 
+        this.Priority = priority; 
+        this.ReservoirSize = reservoirSize; 
+        this.FixedRate = fixedRate; 
+        this.ServiceName = serviceName; 
+        this.ServiceType = serviceType; 
+        this.Host = host; 
+        this.HTTPMethod = httpMethod; 
+        this.URLPath = urlPath; 
+        this.ResourceARN = resourceARN; 
+        this.Version = version;
+        this.Attributes = attributes;
+
+        this.reservoir = new Reservoir(this.ReservoirSize);
+        this.statistics = new Statistics();
+    }
+
+    public matches = (attributes: Attributes, resource: Resource): boolean => {
+        const host: AttributeValue | undefined = attributes[SemanticAttributes.HTTP_HOST];
+        const httpMethod = attributes[SemanticAttributes.HTTP_METHOD]
+        const serviceName = attributes[SemanticResourceAttributes.SERVICE_NAME];
+        const urlPath = attributes[SemanticAttributes.HTTP_URL];
+        const serviceType = resource.attributes[SemanticResourceAttributes.CLOUD_PLATFORM];
+    
+        // "Default" is a reserved keyword from X-Ray back-end.
+        if(this.RuleName === 'Default'){
+            return true;
+        }
+    
+        return attributeMatch(attributes, this.Attributes)
+        && (!host || wildcardMatch(this.Host, host))
+        && (!httpMethod || wildcardMatch(this.HTTPMethod, httpMethod))
+        && (!serviceName || wildcardMatch(this.ServiceName, serviceName))
+        && (!urlPath || wildcardMatch(this.URLPath, urlPath))
+        && (!serviceType || wildcardMatch(this.ServiceType, serviceType));
+    }
+
+    public sample = (attributes: Attributes): SamplingDecision => {
+        // Returning a drop sample decision 
+        // TODO: use reservoir in next PR to make this decision 
+        return SamplingDecision.NOT_RECORD;
+
+    }  
+
+}

--- a/packages/opentelemetry-remote-sampler-aws-xray/src/statistics.ts
+++ b/packages/opentelemetry-remote-sampler-aws-xray/src/statistics.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ISamplingStatistics } from "./remote-sampler.types";
+
+export class Statistics implements ISamplingStatistics {
+	public matchedRequests: number;
+	public sampledRequests: number;
+	public borrowedRequests: number;
+
+    constructor() {
+        // This will be modified to accept & initialize these values in the constructor
+        this.matchedRequests = 0; 
+        this.sampledRequests = 0; 
+        this.borrowedRequests = 0;
+    }
+
+    public getStatistics = (): {} => {
+        return {
+            matchedRequests: this.matchedRequests, 
+            sampledRequests: this.sampledRequests, 
+            borrowedRequests: this.borrowedRequests
+        }
+    }
+
+    public resetStatistics = () => {
+        this.matchedRequests = 0; 
+        this.sampledRequests = 0; 
+        this.borrowedRequests = 0;
+    }
+}

--- a/packages/opentelemetry-remote-sampler-aws-xray/src/utils.ts
+++ b/packages/opentelemetry-remote-sampler-aws-xray/src/utils.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Attributes } from '@opentelemetry/api'; 
+
+// Template function from: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
+const escapeRegExp = (regExPattern: string): string => {
+     // removed * and ? so they don't get escaped to maintain them as a wildcard match
+    return regExPattern.replace(/[.+^${}()|[\]\\]/g, "\\$&"); 
+  }
+
+
+const convertPatternToRegex = (pattern: string) : string => {
+    let regexPattern: string = "";
+
+    regexPattern = escapeRegExp(pattern).replace(/\*/g, ".*")
+    regexPattern = regexPattern.replace(/\?/g, ".")
+
+    return regexPattern;
+}
+
+
+export const wildcardMatch = (pattern?: string, text?: any): boolean => {
+    if (pattern === '*') return true;
+    if (pattern === undefined || text === undefined) return false; 
+
+    if (pattern.length === 0) return text.length === 0; 
+
+    let match = text.toLowerCase().match(convertPatternToRegex(pattern.toLowerCase()));
+
+    if(match === null){
+        console.log(`WildcardMatch: no match found for ${text}`);
+        return false; 
+    }
+
+    return true; 
+}
+
+export const attributeMatch = (attributes: Attributes | undefined, ruleAttributes: any) : boolean => {
+
+    if (!ruleAttributes || Object.keys(ruleAttributes).length === 0) {
+        return true; 
+    }
+
+    if (attributes === undefined){
+        return false; 
+    }
+
+    let matchedCount: number = 0; 
+    for (const [key, value] of Object.entries(attributes)) {
+        let foundKey = Object.keys(ruleAttributes).find(ruleKey => ruleKey === key);
+        let foundPattern;
+
+        if (foundKey){
+           foundPattern = ruleAttributes[foundKey] 
+        } else {
+            continue;
+        }
+        
+        console.log(foundPattern);
+
+
+        if(wildcardMatch(foundPattern, value)) {
+            // increment matched count 
+            matchedCount += 1; 
+        }
+    }
+
+    if (matchedCount === Object.keys(ruleAttributes).length) {
+        return true;
+    }
+
+    return false; 
+}

--- a/packages/opentelemetry-remote-sampler-aws-xray/test/AWSXRayRemoteSampler.test.ts
+++ b/packages/opentelemetry-remote-sampler-aws-xray/test/AWSXRayRemoteSampler.test.ts
@@ -20,6 +20,7 @@ import * as nock from 'nock';
 import * as assert from 'assert';
 
 import { AWSXRayRemoteSampler } from "../src";
+import {Resource} from '@opentelemetry/resources';
 
 describe('GetSamplingRules', () => {
     const getSamplingRulesResponseStub: any = {
@@ -93,7 +94,7 @@ describe('GetSamplingRules', () => {
     let axiosPostSpy: sinon.SinonSpy;
 
     before(() => {
-        nock('http://127.0.0.1:2000')
+        nock('http://localhost:2000')
             .persist()
             .post('/GetSamplingRules')
             .reply(200, getSamplingRulesResponseStub);
@@ -104,7 +105,7 @@ describe('GetSamplingRules', () => {
     beforeEach(() => {
         clock = sinon.useFakeTimers();
         axiosPostSpy = sinon.spy(axios, 'post');
-        sampler = new AWSXRayRemoteSampler('http://127.0.0.1:2000', 60 * 1000);
+        sampler = new AWSXRayRemoteSampler(new Resource({}), 'http://localhost:2000', 60 * 1000);
     });
 
     afterEach(() => {
@@ -113,8 +114,8 @@ describe('GetSamplingRules', () => {
     });
 
     it('should throw TypeError when an invalid polling interval is passed in', async () => {
-        assert.throws(() => new AWSXRayRemoteSampler('http://127.0.0.1:2000', 0), TypeError);
-        assert.throws(() => new AWSXRayRemoteSampler('http://127.0.0.1:2000', 1.5), TypeError);
+        assert.throws(() => new AWSXRayRemoteSampler(new Resource({}), 'http://localhost:2000', 0), TypeError);
+        assert.throws(() => new AWSXRayRemoteSampler(new Resource({}), 'http://localhost:2000', 1.5), TypeError);
 
     });
 
@@ -138,14 +139,15 @@ describe('GetSamplingRules', () => {
     });
 
     it('should initialize endpoint and polling interval correctly', async () => {
-        assert.equal(sampler.getEndpoint(), "http://127.0.0.1:2000");
+        assert.equal(sampler.getEndpoint(), "http://localhost:2000");
         assert.equal(sampler.getPollingInterval(), 60 * 1000);
 
     });
 
-    it('should fall back to default polling interval if not specified', async () => {
-        let sampler = new AWSXRayRemoteSampler('http://127.0.0.1:2000');
+    it('should fall back to default endpoint and polling interval if not specified', async () => {
+        let sampler = new AWSXRayRemoteSampler(new Resource({}));
 
+        assert.equal(sampler.getEndpoint(), "http://localhost:2000");
         assert.equal(sampler.getPollingInterval(), 5 * 60 * 1000);
 
     });

--- a/packages/opentelemetry-remote-sampler-aws-xray/test/AWSXRayRemoteSampler.test.ts
+++ b/packages/opentelemetry-remote-sampler-aws-xray/test/AWSXRayRemoteSampler.test.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as sinon from 'sinon';
+import axios from 'axios';
+import * as nock from 'nock';
+import * as assert from 'assert';
+
+import { AWSXRayRemoteSampler } from "../src";
+
+describe('GetSamplingRules', () => {
+    const getSamplingRulesResponseStub: any = {
+        "NextToken": null,
+        "SamplingRuleRecords": [
+            {
+                "CreatedAt": 1.67799933E9,
+                "ModifiedAt": 1.67799933E9,
+                "SamplingRule": {
+                    "Attributes": {
+                        "foo": "bar",
+                        "doo": "baz"
+                    },
+                    "FixedRate": 0.05,
+                    "HTTPMethod": "*",
+                    "Host": "*",
+                    "Priority": 1000,
+                    "ReservoirSize": 10,
+                    "ResourceARN": "*",
+                    "RuleARN": "arn:aws:xray:us-west-2:123456789000:sampling-rule/Rule1",
+                    "RuleName": "Rule1",
+                    "ServiceName": "*",
+                    "ServiceType": "AWS::Foo::Bar",
+                    "URLPath": "*",
+                    "Version": 1
+                }
+            },
+            {
+                "CreatedAt": 0.0,
+                "ModifiedAt": 1.611564245E9,
+                "SamplingRule": {
+                    "Attributes": {},
+                    "FixedRate": 0.05,
+                    "HTTPMethod": "*",
+                    "Host": "*",
+                    "Priority": 10000,
+                    "ReservoirSize": 1,
+                    "ResourceARN": "*",
+                    "RuleARN": "arn:aws:xray:us-west-2:123456789000:sampling-rule/Default",
+                    "RuleName": "Default",
+                    "ServiceName": "*",
+                    "ServiceType": "*",
+                    "URLPath": "*",
+                    "Version": 1
+                }
+            },
+            {
+                "CreatedAt": 1.676038494E9,
+                "ModifiedAt": 1.676038494E9,
+                "SamplingRule": {
+                    "Attributes": {},
+                    "FixedRate": 0.2,
+                    "HTTPMethod": "GET",
+                    "Host": "*",
+                    "Priority": 1,
+                    "ReservoirSize": 10,
+                    "ResourceARN": "*",
+                    "RuleARN": "arn:aws:xray:us-west-2:123456789000:sampling-rule/Rule2",
+                    "RuleName": "Rule2",
+                    "ServiceName": "FooBar",
+                    "ServiceType": "*",
+                    "URLPath": "/foo/bar",
+                    "Version": 1
+                }
+            }
+        ]
+    };
+
+    let clock: sinon.SinonFakeTimers;
+    let sampler: AWSXRayRemoteSampler;
+
+    before(() => {
+        nock('http://127.0.0.1:2000')
+            .persist()
+            .post('/GetSamplingRules')
+            .reply(200, getSamplingRulesResponseStub);
+
+   
+    });
+
+    beforeEach(() => {
+        clock = sinon.useFakeTimers();
+    });
+
+    afterEach(() => {
+        clock.restore();
+    });
+
+
+    it('should make a POST request to the /GetSamplingRules endpoint', async () => {
+        const axiosPostSpy = sinon.spy(axios, 'post');
+        sampler = new AWSXRayRemoteSampler('http://127.0.0.1:2000', 60 * 1000);  
+   
+        clock.tick(60 * 1000);
+        sinon.assert.calledOnce(axiosPostSpy);
+
+    });
+
+    it('should initialize endpoint and polling interval correctly', async () => {
+        sampler = new AWSXRayRemoteSampler('http://127.0.0.1:2000', 60 * 1000);  
+   
+        assert.equal(sampler.getEndpoint(), "http://127.0.0.1:2000");
+        assert.equal(sampler.getPollingInterval(), 60 * 1000);
+
+    });
+
+    it('should fall back to default polling interval if not specified', async () => {
+        sampler = new AWSXRayRemoteSampler('http://127.0.0.1:2000');  
+
+        assert.equal(sampler.getPollingInterval(), 5* 60 * 1000);
+
+    });
+
+});

--- a/packages/opentelemetry-remote-sampler-aws-xray/test/fallback-sampler.test.ts
+++ b/packages/opentelemetry-remote-sampler-aws-xray/test/fallback-sampler.test.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { Sampler, SamplingResult, TraceIdRatioBasedSampler, SamplingDecision } from '@opentelemetry/sdk-trace-base';
+import { ROOT_CONTEXT, SpanKind, TraceFlags, trace } from '@opentelemetry/api';
+import { FallbackSampler } from '../src/fallback-sampler';
+
+describe('FallbackSampler', () => {
+
+    // similar to https://github.com/open-telemetry/opentelemetry-js/blob/df58facddefe70d90006cced5137ffc837b5e908/packages/opentelemetry-sdk-trace-base/test/common/sampler/ParentBasedSampler.test.ts#L26-L28
+    const testTraceId = 'd4cda95b652f4a1592b449d5929fda1b';
+    const testSpanId = '6e0c63257de34c92';
+    const testSpanName = 'testSpanName';
+
+    let fallbackSampler: FallbackSampler;
+    let clock: sinon.SinonFakeTimers;
+
+    beforeEach(() => {
+        clock = sinon.useFakeTimers();
+        fallbackSampler = new FallbackSampler(); 
+    })
+
+    afterEach(() => {
+        clock.restore();
+    })
+
+    it('should be initialized with ratio of 0.05 and quotaBalance of 1.0', () => {
+
+        assert.strictEqual(fallbackSampler.toString(), "FallbackSampler(ratio=0.05, quotaBalance=1)");
+    });
+
+    it('should return a RECORD_AND_SAMPLED sampling decision upon initialization', () => {
+
+        const spanContext = {
+            traceId: testTraceId,
+            spanId: testSpanId,
+            traceFlags: TraceFlags.NONE,
+          };
+
+        assert.deepStrictEqual(fallbackSampler.shouldSample(trace.setSpanContext(ROOT_CONTEXT, spanContext), testTraceId, testSpanName, SpanKind.CLIENT, {}, []), { decision: SamplingDecision.RECORD_AND_SAMPLED } );
+    });
+
+    it('should only borrow 1 request every second', () => {
+        // TODO: check if time should be in milliseconds or seconds 
+
+        // let timeNow = Math.floor(new Date().getTime() / 1000);
+
+        let timeNow = 1681262846; // temp result of Math.floor(new Date().getTime() / 1000);
+        console.log("timenow in test????=", timeNow)
+
+        let borrowed = fallbackSampler.take(timeNow, 1.0);
+        assert.equal(borrowed, true)
+
+        let borrowedAgainInTheSameSecond = fallbackSampler.take(timeNow, 1.0)
+        assert.equal(borrowedAgainInTheSameSecond, false)
+
+        let borrowedAfterOneSecond = fallbackSampler.take(timeNow + 1, 1.0) // add 1 second
+        assert.equal(borrowedAfterOneSecond, true)
+
+
+    });
+
+    it('should have quotaBalance close to 1 after time has elapsed', () => {
+        // TODO: check if time should be in milliseconds or seconds 
+
+        // let timeNow = Math.floor(new Date().getTime() / 1000);
+
+        let timeNow = 1681262846; // temp result of Math.floor(new Date().getTime() / 1000);
+
+        let borrowed = fallbackSampler.take(timeNow, 1.0);
+        assert.equal(borrowed, true)
+
+        let secondBorrow = fallbackSampler.take(timeNow + 9, 1.0)
+        assert.equal(secondBorrow, true)
+        assert.equal(fallbackSampler._quotaBalance, 0)
+
+    });
+
+
+});
+
+

--- a/packages/opentelemetry-remote-sampler-aws-xray/test/reservoir.test.ts
+++ b/packages/opentelemetry-remote-sampler-aws-xray/test/reservoir.test.ts
@@ -1,0 +1,216 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */ 
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { Reservoir } from '../src/reservoir';
+import { SamplingTargetDocument } from '../src/remote-sampler.types';
+
+
+describe('Reservoir', () => {
+
+    let clock: sinon.SinonFakeTimers;
+    let target: SamplingTargetDocument;
+
+    before(() => {
+        clock = sinon.useFakeTimers();
+        target = {FixedRate: 0.05, Interval: 5, ReservoirQuota: 5, ReservoirQuotaTTL: 1681262846, RuleName: "testRule"}
+
+    });
+
+    it('should return false in isExpired when the reservoir is expired', () => {
+        let expiredReservoir = new Reservoir(10);
+        let timeNow = 1500000000; // temp result of Math.floor(new Date().getTime() / 1000);
+        
+        expiredReservoir.updateReservoir(target);
+
+        assert.equal(expiredReservoir.isExpired(timeNow), false);
+    });
+
+    it('should return true in isExpired when the reservoir is expired', () => {
+        let expiredReservoir = new Reservoir(10);
+        let timeNow = 1681262846; // temp result of Math.floor(new Date().getTime() / 1000);
+        
+        expiredReservoir.updateReservoir(target);
+
+        assert.equal(expiredReservoir.isExpired(timeNow), true);
+    });
+
+    it('should return true in isExpired when the time now === TTL', () => {
+        let expiredReservoir = new Reservoir(10);
+        let timeNow = 1500000000; // temp result of Math.floor(new Date().getTime() / 1000);
+        
+
+        target = {FixedRate: 0.05, Interval: 5, ReservoirQuota: 5, ReservoirQuotaTTL: 1500000000, RuleName: "testRule"}
+
+        expiredReservoir.updateReservoir(target);
+
+        assert.equal(expiredReservoir.isExpired(timeNow), true);
+    });
+
+    it('should only borrow 1 request per second', () => {
+        let reservoir = new Reservoir(10);
+        let timeNow = 1500000000; // temp result of Math.floor(new Date().getTime() / 1000);
+        
+        let result = reservoir.take(timeNow, true, 1); 
+        assert.equal(result, true)
+
+        // try to borrow again in the same second, should return false 
+        let result2 = reservoir.take(timeNow, true, 1); 
+        assert.equal(result2, false)
+
+        // add 1 second to timeNow 
+        timeNow += 1; 
+        // should be able to borrow now 
+        let result3 = reservoir.take(timeNow, true, 1); 
+        assert.equal(result3, true)
+
+
+    });
+
+    it('should consume from quota when reservoir is expired', () => {
+        let reservoir = new Reservoir(10);
+        let timeNow = 1500000000; // temp result of Math.floor(new Date().getTime() / 1000);
+        let target = {FixedRate: 0.05, Interval: 5, ReservoirQuota: 2, ReservoirQuotaTTL: 1681262846, RuleName: "testRule"}
+
+        reservoir.updateReservoir(target);
+        
+        let result = reservoir.take(timeNow, true, 1); 
+        assert.equal(result, true)
+
+        // try to borrow again in the same second, should return false 
+        let result2 = reservoir.take(timeNow, true, 1); 
+        assert.equal(result2, false)
+
+        // add 1 second to timeNow 
+        timeNow += 1; 
+        // should be able to borrow now 
+        let result3 = reservoir.take(timeNow, true, 1); 
+        assert.equal(result3, true)
+
+        timeNow += 1 
+        let result4 = reservoir.take(timeNow, false, 1); 
+        assert.equal(result4, true)
+
+        let result5 = reservoir.take(timeNow, false, 1); 
+        assert.equal(result5, true)
+
+        let result6 = reservoir.take(timeNow, false, 1); 
+        assert.equal(result6, false)
+    });
+
+    it('should refresh quotaBalance every second', () => {
+        let reservoir = new Reservoir(100);
+        let timeNow = 1500000000; // temp result of Math.floor(new Date().getTime() / 1000);
+        let target = {FixedRate: 0.05, Interval: 5, ReservoirQuota: 2, ReservoirQuotaTTL: 1681262846, RuleName: "testRule"}
+
+        reservoir.updateReservoir(target);
+        
+        // quotaBalance starts out as 0
+        assert.equal(reservoir.getQuotaBalance(), 0);
+
+        assert.equal(reservoir.take(timeNow, false, 1), true);
+
+        assert.equal(reservoir.getQuotaBalance(), 1);
+
+        assert.equal(reservoir.take(timeNow, false, 1), true);
+        assert.equal(reservoir.getQuotaBalance(), 0);
+
+        // once quota is consumed (=0) the reservoir does not allow for consuming 
+        // any items again within the same second 
+        assert.equal(reservoir.take(timeNow, false, 1), false);
+
+        timeNow += 1; 
+
+        // quotaBalance is updated after one second has passed
+        assert.equal(reservoir.getQuotaBalance(), 0);
+        assert.equal(reservoir.take(timeNow, false, 1), true);
+
+        assert.equal(reservoir.getQuotaBalance(), 1);
+
+        assert.equal(reservoir.take(timeNow, false, 1), true);
+        assert.equal(reservoir.getQuotaBalance(), 0);
+
+        // once quota is consumed (=0) the reservoir does not allow for consuming 
+        // any items again within the same second 
+        assert.equal(reservoir.take(timeNow, false, 1), false);
+
+
+        timeNow += 4 
+        // reservoir updates the quotaBalance with one second worth of quota (even though 4 seconds have passed) and allows to consume
+        assert.equal(reservoir.getQuotaBalance(), 0);
+        assert.equal(reservoir.take(timeNow, false, 1), true);
+
+        assert.equal(reservoir.getQuotaBalance(), 1);
+        assert.equal(reservoir.take(timeNow, false, 1), true);
+        assert.equal(reservoir.getQuotaBalance(), 0);
+
+    });
+
+    it('should not borrow when reservoirSize is 0', () => {
+        let reservoir = new Reservoir(0);
+        let timeNow = 1500000000; // temp result of Math.floor(new Date().getTime() / 1000);
+        let target = {FixedRate: 0.05, Interval: 5, ReservoirQuota: 0, ReservoirQuotaTTL: 1681262846, RuleName: "testRule"}
+
+        reservoir.updateReservoir(target);
+
+        assert.equal(reservoir.getQuotaBalance(), 0);
+        assert.equal(reservoir.take(timeNow, true, 1), false);
+
+        timeNow += 5; 
+        assert.equal(reservoir.getQuotaBalance(), 0);
+        assert.equal(reservoir.take(timeNow, true, 1), false);
+
+    });
+
+    it('should return false when there is no unused quota remaining', () => {
+        let reservoir = new Reservoir(100);
+        let timeNow = 1500000000; // temp result of Math.floor(new Date().getTime() / 1000);
+        let target = {FixedRate: 0.05, Interval: 5, ReservoirQuota: 5, ReservoirQuotaTTL: 1681262846, RuleName: "testRule"}
+
+        reservoir.updateReservoir(target);
+
+        
+        for(let i = 0 ; i < 5;i++) {
+           assert.equal(reservoir.take(timeNow, false, 1), true)
+        }
+
+        // take should return false since there is no unused quota remaining
+        assert.equal(reservoir.take(timeNow, false, 1), false)
+
+    });
+
+    it('should return true when there is unused quota remaining', () => {
+        let reservoir = new Reservoir(100);
+        let timeNow = 1500000000; // temp result of Math.floor(new Date().getTime() / 1000);
+        let target = {FixedRate: 0.05, Interval: 5, ReservoirQuota: 5, ReservoirQuotaTTL: 1681262846, RuleName: "testRule"}
+
+        reservoir.updateReservoir(target);
+
+        
+        for(let i = 0 ; i < 5;i++) {
+           assert.equal(reservoir.take(timeNow, false, 1), true)
+        }
+
+        timeNow += 1
+
+        // take should return true since there is unused quota remaining 
+        assert.equal(reservoir.take(timeNow, false, 1), true)
+
+    });
+
+});
+

--- a/packages/opentelemetry-remote-sampler-aws-xray/test/rule-cache.test.ts
+++ b/packages/opentelemetry-remote-sampler-aws-xray/test/rule-cache.test.ts
@@ -20,10 +20,11 @@ import { Resource } from '@opentelemetry/resources';
 import { Reservoir } from '../src/reservoir';
 import { RuleCache } from '../src/rule-cache';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SamplingStatisticsDocument, SamplingTargetDocument } from '../src/remote-sampler.types';
 
 
-const createRule = (name: string, priority: number, reservoirSize: number, fixedRate: number): SamplingRule => {
-    return new SamplingRule(name, priority, reservoirSize, fixedRate, "*", "*", "*", "*", "*", "*", 1)
+const createRule = (name: string, priority: number, reservoirSize: number, FixedRate: number): SamplingRule => {
+    return new SamplingRule(name, priority, reservoirSize, FixedRate, "*", "*", "*", "*", "*", "*", 1)
 }
 
 describe('RuleCache', () => {
@@ -103,6 +104,89 @@ describe('RuleCache', () => {
         let matchedRule = ruleCache.getMatchedRule(attributes, resource);
         assert.equal(matchedRule?.RuleName, "Rule1") // alphabetical order
     });
+
+    const targetsResponse = {
+        "LastRuleModification": 17000000,
+        "SamplingTargetDocuments": [ 
+           { 
+              "FixedRate": 0.06,
+              "Interval": 25,
+              "ReservoirQuota": 23,
+              "ReservoirQuotaTTL": 15000000,
+              "RuleName": "Rule1"
+           }
+        ],
+        "UnprocessedStatistics": [ 
+           { 
+              "ErrorCode": "200",
+              "Message": "Ok",
+              "RuleName": "Rule1"
+           }, 
+           { 
+            "ErrorCode": "400",
+            "Message": "Bad Request",
+            "RuleName": "Rule2"
+            }, 
+        ]
+     }
+
+    const parseTargets = () => {
+        // parse targets response 
+        let targetDocuments: any = {}; 
+        targetsResponse.SamplingTargetDocuments.forEach((target: SamplingTargetDocument) => {
+
+            let newTarget: SamplingTargetDocument = {
+                FixedRate: target.FixedRate, 
+                ReservoirQuota: target.ReservoirQuota, 
+                ReservoirQuotaTTL: target.ReservoirQuotaTTL, 
+                Interval: target.Interval, 
+                RuleName: target.RuleName
+            }
+
+            targetDocuments[target.RuleName] = newTarget;
+        })
+
+        return targetDocuments;
+    }
+
+    it("should update a rule's reservoir & fixed rate when updateTargets is called", () => {
+        let ruleCache = new RuleCache();
+
+        const defaultRule: SamplingRule = createRule("Default", 10000, 1, 0.05) // priority = 10000
+        const rule1: SamplingRule = createRule("Rule1", 1, 5, 0.20) // priority = 1
+        const rule2: SamplingRule = createRule("Rule2", 1, 10, 0.20) // priority = 1
+
+        ruleCache.updateRules([defaultRule, rule1, rule2]);
+
+        let targets = parseTargets();
+
+        ruleCache.updateTargets(targets, targetsResponse.UnprocessedStatistics);
+
+        assert.equal(rule1.reservoir._quota, 23)
+        assert.equal(rule1.reservoir._TTL, 15000000)
+        assert.equal(rule1.reservoir._interval, 25)
+        assert.equal(rule1.FixedRate, 0.06)
+
+
+
+    })
+
+    it("should return true for updateTargets when unprocessedStatistics contains a 4xx error", () => {
+        let ruleCache = new RuleCache();
+
+        const defaultRule: SamplingRule = createRule("Default", 10000, 1, 0.05) // priority = 10000
+        const rule1: SamplingRule = createRule("Rule1", 1, 5, 0.20) // priority = 1
+        const rule2: SamplingRule = createRule("Rule2", 1, 10, 0.20) // priority = 1
+
+        ruleCache.updateRules([defaultRule, rule1, rule2]);
+
+        let targets = parseTargets();
+
+        let result = ruleCache.updateTargets(targets, targetsResponse.UnprocessedStatistics);
+
+        assert.equal(result, true)
+
+    })
 
 });
 

--- a/packages/opentelemetry-remote-sampler-aws-xray/test/rule-cache.test.ts
+++ b/packages/opentelemetry-remote-sampler-aws-xray/test/rule-cache.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */ 
+
+import * as assert from 'assert';
+import { SamplingRule } from "../src/sampling-rule";
+import { Resource } from '@opentelemetry/resources';
+import { Reservoir } from '../src/reservoir';
+import { RuleCache } from '../src/rule-cache';
+import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+
+
+const createRule = (name: string, priority: number, reservoirSize: number, fixedRate: number): SamplingRule => {
+    return new SamplingRule(name, priority, reservoirSize, fixedRate, "*", "*", "*", "*", "*", "*", 1)
+}
+
+describe('RuleCache', () => {
+
+    it('should update rules in the cache', () => {
+        let defaultRule: SamplingRule = createRule("Default", 10000, 1, 0.05)
+        defaultRule.reservoir = new Reservoir(20);
+
+        let ruleCache = new RuleCache();
+        ruleCache.rules = [defaultRule];
+
+        let newDefaultRule: SamplingRule = createRule('Default', 10000, 10, 0.20)
+        ruleCache.updateRules([newDefaultRule]);
+
+        assert.equal(ruleCache.rules[0].RuleName, 'Default')
+        assert.equal(ruleCache.rules[0].ReservoirSize, 10)
+        assert.equal(ruleCache.rules[0].FixedRate, 0.20)
+
+    });
+
+    it('should remove the old rule from the cache after updating', () => {
+        let defaultRule: SamplingRule = createRule("Default", 10000, 1, 0.05)
+        defaultRule.reservoir = new Reservoir(20);
+
+        let ruleCache = new RuleCache();
+        ruleCache.rules = [defaultRule];
+
+        let newDefaultRule: SamplingRule = createRule('Default', 10000, 10, 0.20)
+        ruleCache.updateRules([newDefaultRule]);
+
+        assert.equal(ruleCache.rules.length, 1)
+
+    });
+
+    it('should sort the rules based on priority', () => {
+        let ruleCache = new RuleCache();
+
+        const defaultRule: SamplingRule = createRule("Default", 10000, 1, 0.05) // priority = 10000
+        const rule1: SamplingRule = createRule("Rule1", 100, 5, 0.20) // priority = 100
+        const rule2: SamplingRule = createRule("Rule2", 1, 10, 0.20) // priority = 1
+
+        ruleCache.updateRules([defaultRule, rule1, rule2]);
+
+        assert.equal(ruleCache.rules.length, 3)
+        assert.equal(ruleCache.rules[0].RuleName, "Rule2")
+        assert.equal(ruleCache.rules[1].RuleName, "Rule1")
+        assert.equal(ruleCache.rules[2].RuleName, "Default")
+
+    });
+
+    it('should match with the rule with the higher priority', () => {
+        let ruleCache = new RuleCache();
+        const attributes = {}
+        const resource = new Resource({[SemanticResourceAttributes.SERVICE_NAME]: "aws_ec2"})
+
+        const defaultRule: SamplingRule = createRule("Default", 10000, 1, 0.05) // priority = 10000
+        const rule1: SamplingRule = createRule("Rule1", 100, 5, 0.20) // priority = 100
+        const rule2: SamplingRule = createRule("Rule2", 1, 10, 0.20) // priority = 1
+
+        ruleCache.updateRules([defaultRule, rule1, rule2]); 
+        
+        let matchedRule = ruleCache.getMatchedRule(attributes, resource);
+        assert.equal(matchedRule?.RuleName, "Rule2")
+    });
+
+    it('should match with the first rule if more than 1 rule have the same priority', () => {
+        let ruleCache = new RuleCache();
+        const attributes = {}
+        const resource = new Resource({[SemanticResourceAttributes.SERVICE_NAME]: "aws_ec2"})
+
+        const defaultRule: SamplingRule = createRule("Default", 10000, 1, 0.05) // priority = 10000
+        const rule1: SamplingRule = createRule("Rule1", 1, 5, 0.20) // priority = 1
+        const rule2: SamplingRule = createRule("Rule2", 1, 10, 0.20) // priority = 1
+
+        ruleCache.updateRules([defaultRule, rule1, rule2]);
+
+        let matchedRule = ruleCache.getMatchedRule(attributes, resource);
+        assert.equal(matchedRule?.RuleName, "Rule1") // alphabetical order
+    });
+
+});
+
+
+
+

--- a/packages/opentelemetry-remote-sampler-aws-xray/test/sampling-rule.test.ts
+++ b/packages/opentelemetry-remote-sampler-aws-xray/test/sampling-rule.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */ 
+
+import * as assert from 'assert';
+import { SamplingRule } from "../src/sampling-rule";
+import { Resource } from '@opentelemetry/resources';
+import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+
+describe('SamplingRule', () => {
+    const samplingRule = new SamplingRule("testRule", 1, 1, 0.05, "myServiceName", "AWS::EC2::Instance", 
+            "localhost", "GET", "/hello", "*", 1, {})
+
+
+    it('should match with all specified attributes', () => {
+    
+        let attributes = {"http.host": "localhost", "http.method": "GET", "http.url": "http://127.0.0.1:5000/hello"}
+        const resource = new Resource({[SemanticResourceAttributes.SERVICE_NAME]: "aws_ec2"})
+
+        assert.equal(samplingRule.matches(attributes, resource), true)
+
+    });
+
+    it('should match with wildcard attributes', () => {
+        const samplingRule = new SamplingRule("testRule", 1, 1, 0.05, "myServiceName", "*", 
+        "*", "*", "/hello", "*", 1, {})
+    
+        let attributes = {"http.host": "localhost", "http.method": "GET", "http.url": "http://127.0.0.1:5000/hello"}
+        const resource = new Resource({[SemanticResourceAttributes.SERVICE_NAME]: "aws_ec2"})
+
+        assert.equal(samplingRule.matches(attributes, resource), true)
+
+    });
+
+    it('should match with no attributes specified', () => {
+        const samplingRule = new SamplingRule("testRule", 1, 1, 0.05, "myServiceName", "*", 
+        "*", "*", "/hello", "*", 1, {})
+    
+        const resource = new Resource({[SemanticResourceAttributes.SERVICE_NAME]: "aws_ec2"})
+
+        assert.equal(samplingRule.matches({}, resource), true)
+
+    });
+
+    it('should match with HTTP target', () => {
+        const samplingRule = new SamplingRule("testRule", 1, 1, 0.05, "myServiceName", "*", 
+        "*", "*", "/hello", "*", 1, {})
+
+        let attributes = {"http.target": "/hello"}
+
+        const resource = new Resource({[SemanticResourceAttributes.SERVICE_NAME]: ""})
+
+        assert.equal(samplingRule.matches(attributes, resource), true)
+
+    });
+
+});

--- a/packages/opentelemetry-remote-sampler-aws-xray/test/utils.test.ts
+++ b/packages/opentelemetry-remote-sampler-aws-xray/test/utils.test.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+
+import { attributeMatch, wildcardMatch } from '../src/utils';
+import {Attributes} from '@opentelemetry/api'
+
+describe('WildcardMatch', () => {
+    const positiveTests: any = [
+        ["*", ""],
+		["foo", "foo"],
+		["foo*bar*?", "foodbaris"],
+		["?o?", "foo"],
+		["*oo", "foo"],
+		["foo*", "foo"],
+		["*o?", "foo"],
+		["*", "boo"],
+		["", ""],
+		["a", "a"],
+		["*a", "a"],
+		["*a", "ba"],
+		["a*", "a"],
+		["a*", "ab"],
+		["a*a", "aa"],
+		["a*a", "aba"],
+		["a*a*", "aaaaaaaaaaaaaaaaaaaaaaa"],
+		["a*b*a*b*a*b*a*b*a*",
+			"akljd9gsdfbkjhaabajkhbbyiaahkjbjhbuykjakjhabkjhbabjhkaabbabbaaakljdfsjklababkjbsdabab"],
+		["a*na*ha", "anananahahanahana"],
+		["***a", "a"],
+		["**a**", "a"],
+		["a**b", "ab"],
+		["*?", "a"],
+		["*??", "aa"],
+		["*?", "a"],
+		["*?*a*", "ba"],
+		["?at", "bat"],
+		["?at", "cat"],
+		["?o?se", "horse"],
+		["?o?se", "mouse"],
+		["*s", "horse"],
+		["J*", "Jeep"],
+		["J*", "jeep"],
+		["*/foo", "/bar/foo"],
+
+    ]
+
+    const negativeTests: any = [
+
+    	["", "whatever"],
+		["foo", "bar"],
+		["f?o", "boo"],
+		["f??", "boo"],
+		["fo*", "boo"],
+		["f?*", "boo"],
+		["abcd", "abc"],
+		["??", "a"],
+		["??", "a"],
+		["*?*a", "a"],
+    ]
+
+    it('should return true for wildcard match', () => {
+        positiveTests.forEach((test: any) => {
+            assert.equal(wildcardMatch(test[0], test[1]), true)
+        })
+    });
+
+    it('should return false for wildcard match', () => {
+        negativeTests.forEach((test: any) => {
+            assert.equal(wildcardMatch(test[0], test[1]), false)
+        }) 
+
+    });
+
+    it('additional wildcardMatch tests', () => {
+        assert.equal(wildcardMatch("*", undefined), true);
+        assert.equal(wildcardMatch("*", ""), true);
+        assert.equal(wildcardMatch("*", "HelloWorld"), true);
+
+        assert.equal(wildcardMatch("Hello*", undefined), false);
+        assert.equal(wildcardMatch(undefined, "HelloWorld"), false);
+
+        assert.equal(wildcardMatch("HelloWorld", "HelloWorld"), true);
+        assert.equal(wildcardMatch("Hello*", "HelloWorld"), true);
+        assert.equal(wildcardMatch("*World", "HelloWorld"), true);
+        assert.equal(wildcardMatch("?ello*", "HelloWorld"), true);
+    });
+
+
+});
+
+
+describe('attributeMatcher', () => {
+    
+    let attributes : Attributes = {"dog": "bark", "cat": "meow", "cow": "mooo"}
+
+    var ruleAttributes = { "dog": "bar?" , "cow": "mooo"};
+
+    it('should return true for attribute match', () => {
+        assert.equal(attributeMatch(attributes, ruleAttributes), true)
+    });
+
+    it('should return true when rule attributes is an empty object', () => {
+        assert.equal(attributeMatch(attributes, {}), true)
+    });
+
+    it('should return false when span attributes is undefined or an empty object', () => {
+        assert.equal(attributeMatch({}, ruleAttributes), false)
+        // TODO: enforce attributes type and remove this test
+        assert.equal(attributeMatch(undefined, ruleAttributes), false) 
+
+    });
+    
+
+});

--- a/packages/opentelemetry-remote-sampler-aws-xray/tsconfig.esm.json
+++ b/packages/opentelemetry-remote-sampler-aws-xray/tsconfig.esm.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.esm.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build/esm",
+    "tsBuildInfoFile": "build/esm/tsconfig.esm.tsbuildinfo"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/opentelemetry-remote-sampler-aws-xray/tsconfig.json
+++ b/packages/opentelemetry-remote-sampler-aws-xray/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ]
+}


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Final PR (Part 3) of the X-Ray Remote Sampler implementation 
    - [Part 1 PR](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1443)
    - [Part 2 PR](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1463)

## Short description of the changes

This PR adds:
- Sampling Targets data model (TS Interfaces) 
- An interval for fetching sampling targets from the [/GetSamplingTargets endpoint from the AWS X-Ray service](https://docs.aws.amazon.com/xray/latest/api/API_GetSamplingTargets.html). 
- Implementation of the Reservoir and Statistics classes which were outlined as skeleton classes in PR #1463 
- Updates to the rule cache for processing the sampling targets and updating existing rules in the cache based on the targets response. The rule's fixed rates + reservoir properties are updated. 
- Support for performing out-of-band sampling rule polling when a 4xx error is returned by `/GetSamplingTargets`


_Temporary note: Since the first and second PRs that this builds on have not yet been merged to main, the commits in it persist in this PR. Please only review the " add sampling targets logic and fallback sampler" commit onwards, as the previous commits will be resolved once changes from main are pulled in._
