### PR TITLE
fix(mysql): metrics - align metrics description and unit to semconv

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-mysql/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql/src/instrumentation.ts
@@ -73,8 +73,8 @@ export class MySQLInstrumentation extends InstrumentationBase<
       'db.client.connections.usage', //TODO:: use semantic convention
       {
         description:
-          'The number of connections that are currently in the state referenced by the attribute "state".',
-        unit: '{connections}',
+          'The number of connections that are currently in state described by the state attribute.',
+        unit: '{connection}',
       }
     );
   }

--- a/plugins/node/opentelemetry-instrumentation-mysql/test/index.metrics.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql/test/index.metrics.test.ts
@@ -159,9 +159,9 @@ describe('mysql@2.x-Metrics', () => {
 
           assert.strictEqual(
             metrics[0].descriptor.description,
-            'The number of connections that are currently in the state referenced by the attribute "state".'
+            'The number of connections that are currently in state described by the state attribute.'
           );
-          assert.strictEqual(metrics[0].descriptor.unit, '{connections}');
+          assert.strictEqual(metrics[0].descriptor.unit, '{connection}');
           assert.strictEqual(
             metrics[0].descriptor.name,
             'db.client.connections.usage'
@@ -248,9 +248,9 @@ describe('mysql@2.x-Metrics', () => {
         assert.strictEqual(metrics[0].dataPointType, DataPointType.SUM);
         assert.strictEqual(
           metrics[0].descriptor.description,
-          'The number of connections that are currently in the state referenced by the attribute "state".'
+          'The number of connections that are currently in state described by the state attribute.'
         );
-        assert.strictEqual(metrics[0].descriptor.unit, '{connections}');
+        assert.strictEqual(metrics[0].descriptor.unit, '{connection}');
         assert.strictEqual(
           metrics[0].descriptor.name,
           'db.client.connections.usage'
@@ -325,9 +325,9 @@ describe('mysql@2.x-Metrics', () => {
 
           assert.strictEqual(
             metrics[0].descriptor.description,
-            'The number of connections that are currently in the state referenced by the attribute "state".'
+            'The number of connections that are currently in state described by the state attribute.'
           );
-          assert.strictEqual(metrics[0].descriptor.unit, '{connections}');
+          assert.strictEqual(metrics[0].descriptor.unit, '{connection}');
           assert.strictEqual(
             metrics[0].descriptor.name,
             'db.client.connections.usage'


### PR DESCRIPTION
## Which problem is this PR solving?

While reviewing this PR: #1170, there were to comments that were relevant to mysql metrics too:
1. regarding the [metric description](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1170/#discussion_r1172510542) 
2. regarding the [metric unit](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1170/#discussion_r1172506395)

## Short description of the changes

1. the description was replaced to 'The number of connections that are currently in state described by the state attribute.'
2. the unit was replaced to {connection}
