### PR TITLE
fix(eslint-no-floating-promises): added `no-floating-promises` rule to match the core repo

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,6 +26,7 @@ module.exports = {
     {
       files: ['*.ts'],
       rules: {
+        "@typescript-eslint/no-floating-promises": "error",
         "@typescript-eslint/no-this-alias": "off",
         "@typescript-eslint/naming-convention": [
           "error",

--- a/plugins/node/opentelemetry-instrumentation-graphql/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/src/instrumentation.ts
@@ -253,13 +253,18 @@ export class GraphQLInstrumentation extends InstrumentationBase {
     }
 
     if (isPromise(result)) {
-      (result as Promise<graphqlTypes.ExecutionResult>).then(resultData => {
-        if (typeof config.responseHook !== 'function') {
-          endSpan(span);
-          return;
+      (result as Promise<graphqlTypes.ExecutionResult>).then(
+        resultData => {
+          if (typeof config.responseHook !== 'function') {
+            endSpan(span);
+            return;
+          }
+          this._executeResponseHook(span, resultData);
+        },
+        error => {
+          endSpan(span, error);
         }
-        this._executeResponseHook(span, resultData);
-      });
+      );
     } else {
       if (typeof config.responseHook !== 'function') {
         endSpan(span);


### PR DESCRIPTION
Fixes #1433 

## Short description of the changes

- Added `"@typescript-eslint/no-floating-promises": "error"` rule in the eslint config to match the core repo.
