### PR TITLE
fix(mysql2-tav): add 'pretest' command to tav.yml for mysql2 version 3

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-mysql2/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/.tav.yml
@@ -1,6 +1,8 @@
 mysql2:
   - versions: <4 >=3.2.0 || 3.1.0 || 3.0.0
     commands: npm run test
+    # Fix missing `test-utils` package
+    pretest: npm run --prefix ../../../ lerna:link
 
   - versions: <3 >=2.3.2 || 2.3.0 || 2.2.5 || 2.1.0
     # Skip 2.3.3 which installs types from git which takes 10m on it's own


### PR DESCRIPTION
## Which problem is this PR solving?

- tav is failing on the main branch because of [this problem](https://github.com/open-telemetry/opentelemetry-js-contrib/actions/runs/4906701688/jobs/8761324293#step:9:20761).
I think it happens because mysql2 version3 doesn't have a 'pretest' command in the tav.yml (my fault because I added this version) and this is why it complains `Cannot find module '@opentelemetry/contrib-test-utils'`

## Short description of the changes

- I added a 'pretest' command for version3 test like the other version (v1 & v2) have. 


adding a screenshot of the error in case the link won't work:
![image](https://user-images.githubusercontent.com/85441461/236695342-1ec8d111-09a7-44c1-896a-1ed177a49110.png)
