### PR TITLE
chore: add @pichlermarc as instrumentation-fastify owner

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -9,7 +9,6 @@ components:
   detectors/node/opentelemetry-resource-detector-gcp:
     - aabmass
     - punya
-    # Unmaintained?
   detectors/node/opentelemetry-resource-detector-github: []
     # Unmaintained?
   detectors/node/opentelemetry-resource-detector-instana:
@@ -68,8 +67,8 @@ components:
   plugins/node/opentelemetry-instrumentation-express:
     - JamieDanielson
     - pkanal
-  plugins/node/opentelemetry-instrumentation-fastify: []
-    # Unmaintained?
+  plugins/node/opentelemetry-instrumentation-fastify:
+    - pichlermarc
   plugins/node/opentelemetry-instrumentation-generic-pool:
     - rauno56
   plugins/node/opentelemetry-instrumentation-graphql:


### PR DESCRIPTION
`@opentelemetry/instrumentation-fastify` did not have a component owner. This PR adds me as an owner, I'm not too familiar with it but I'll learn as I go. :slightly_smiling_face: 

Fixes #1500 