### PR TITLE
chore(examples-web): bump web examples dependencies and use exporter-trace-otlp-http

### DIFF
--- a/examples/web/examples/document-load/index.js
+++ b/examples/web/examples/document-load/index.js
@@ -4,7 +4,7 @@ import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
 import { DocumentLoadInstrumentation } from '@opentelemetry/instrumentation-document-load';
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
-import { OTLPTraceExporter } from '@opentelemetry/exporter-otlp-http';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { B3Propagator } from '@opentelemetry/propagator-b3';
 import { CompositePropagator, W3CTraceContextPropagator } from '@opentelemetry/core';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';

--- a/examples/web/examples/meta/index.js
+++ b/examples/web/examples/meta/index.js
@@ -1,7 +1,7 @@
 import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
-import { OTLPTraceExporter } from '@opentelemetry/exporter-otlp-http';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { B3Propagator } from '@opentelemetry/propagator-b3';
 import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';

--- a/examples/web/examples/user-interaction/index.js
+++ b/examples/web/examples/user-interaction/index.js
@@ -2,7 +2,7 @@ import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-tra
 import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
 import { UserInteractionInstrumentation } from '@opentelemetry/instrumentation-user-interaction';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
-import { OTLPTraceExporter } from '@opentelemetry/exporter-otlp-http';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { B3Propagator } from '@opentelemetry/propagator-b3';
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -27,29 +27,26 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js-contrib/issues"
   },
   "devDependencies": {
-    "@babel/core": "^7.12.10",
-    "babel-loader": "^8.2.2",
+    "@babel/core": "^7.21.8",
+    "babel-loader": "^8.3.0",
     "ts-loader": "^6.2.2",
-    "webpack": "^4.44.2",
+    "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12",
-    "webpack-dev-server": "^3.11.0",
+    "webpack-dev-server": "^3.11.3",
     "webpack-merge": "^4.2.2"
   },
   "dependencies": {
-    "@opentelemetry/api": "^1.0.3",
-    "@opentelemetry/auto-instrumentations-web": "~0.26.0",
-    "@opentelemetry/context-zone": "~1.0.0",
-    "@opentelemetry/core": "~1.0.0",
-    "@opentelemetry/exporter-otlp-http": "~0.26.0",
-    "@opentelemetry/instrumentation": "~0.26.0",
-    "@opentelemetry/instrumentation-document-load": "~0.26.0",
-    "@opentelemetry/instrumentation-user-interaction": "~0.26.0",
-    "@opentelemetry/instrumentation-xml-http-request": "~0.26.0",
-    "@opentelemetry/propagator-b3": "~1.0.0",
-    "@opentelemetry/resources": "~1.0.0",
-    "@opentelemetry/sdk-trace-base": "~1.0.0",
-    "@opentelemetry/sdk-trace-web": "~1.0.0",
-    "@opentelemetry/semantic-conventions": "~1.0.0"
+    "@opentelemetry/api": "^1.4.1",
+    "@opentelemetry/auto-instrumentations-web": "^0.32.2",
+    "@opentelemetry/context-zone": "^1.13.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.39.1",
+    "@opentelemetry/instrumentation": "~0.39.1",
+    "@opentelemetry/instrumentation-document-load": "^0.32.2",
+    "@opentelemetry/instrumentation-user-interaction": "^0.32.3",
+    "@opentelemetry/instrumentation-xml-http-request": "^0.39.1",
+    "@opentelemetry/propagator-b3": "^1.13.0",
+    "@opentelemetry/sdk-trace-web": "^1.13.0",
+    "@opentelemetry/semantic-conventions": "~1.13.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib#readme"
 }

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -40,7 +40,7 @@
     "@opentelemetry/auto-instrumentations-web": "^0.32.2",
     "@opentelemetry/context-zone": "^1.13.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.39.1",
-    "@opentelemetry/instrumentation": "~0.39.1",
+    "@opentelemetry/instrumentation": "^0.39.1",
     "@opentelemetry/instrumentation-document-load": "^0.32.2",
     "@opentelemetry/instrumentation-user-interaction": "^0.32.3",
     "@opentelemetry/instrumentation-xml-http-request": "^0.39.1",

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -46,7 +46,7 @@
     "@opentelemetry/instrumentation-xml-http-request": "^0.39.1",
     "@opentelemetry/propagator-b3": "^1.13.0",
     "@opentelemetry/sdk-trace-web": "^1.13.0",
-    "@opentelemetry/semantic-conventions": "~1.13.0"
+    "@opentelemetry/semantic-conventions": "^1.13.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib#readme"
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- The web examples used the deprecated exporter package `exporter-otlp-http`

## Short description of the changes

- Switched the use of `exporter-otlp-http` to `exporter-traces-otlp-http` in the web examples and updated the other otel dependencies.
