### PR TITLE
feat(opentelemetry-instrumentation-aws-sdk): add missing spec-defined DynamoDB attributes

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/dynamodb.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/dynamodb.ts
@@ -26,6 +26,10 @@ import {
 } from '../types';
 
 export class DynamodbServiceExtension implements ServiceExtension {
+  toArray<T>(values: T | T[]): T[] {
+    return Array.isArray(values) ? values : [values];
+  }
+
   requestPreSpanHook(normalizedRequest: NormalizedRequest): RequestMetadata {
     const spanKind: SpanKind = SpanKind.CLIENT;
     let spanName: string | undefined;
@@ -41,10 +45,138 @@ export class DynamodbServiceExtension implements ServiceExtension {
       ),
     };
 
-    if (operation === 'BatchGetItem') {
+    // normalizedRequest.commandInput.RequestItems) is undefined when no table names are returned
+    // keys in this object are the table names
+    if (normalizedRequest.commandInput?.TableName) {
+      // Necessary for commands with only 1 table name (example: CreateTable). Attribute is TableName not keys of RequestItems
+      // single table name returned for operations like CreateTable
+      spanAttributes[SemanticAttributes.AWS_DYNAMODB_TABLE_NAMES] = [
+        normalizedRequest.commandInput.TableName,
+      ];
+    } else if (normalizedRequest.commandInput?.RequestItems) {
       spanAttributes[SemanticAttributes.AWS_DYNAMODB_TABLE_NAMES] = Object.keys(
         normalizedRequest.commandInput.RequestItems
       );
+    }
+
+    if (operation === 'CreateTable' || operation === 'UpdateTable') {
+      // only check for ProvisionedThroughput since ReadCapacityUnits and WriteCapacity units are required attributes
+      if (normalizedRequest.commandInput?.ProvisionedThroughput) {
+        spanAttributes[
+          SemanticAttributes.AWS_DYNAMODB_PROVISIONED_READ_CAPACITY
+        ] =
+          normalizedRequest.commandInput.ProvisionedThroughput.ReadCapacityUnits;
+        spanAttributes[
+          SemanticAttributes.AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY
+        ] =
+          normalizedRequest.commandInput.ProvisionedThroughput.WriteCapacityUnits;
+      }
+    }
+
+    if (
+      operation === 'GetItem' ||
+      operation === 'Scan' ||
+      operation === 'Query'
+    ) {
+      spanAttributes[SemanticAttributes.AWS_DYNAMODB_CONSISTENT_READ] =
+        normalizedRequest.commandInput.ConsistentRead;
+    }
+
+    if (operation === 'Query' || operation === 'Scan') {
+      spanAttributes[SemanticAttributes.AWS_DYNAMODB_PROJECTION] =
+        normalizedRequest.commandInput.ProjectionExpression;
+    }
+
+    if (operation === 'CreateTable') {
+      if (normalizedRequest.commandInput?.GlobalSecondaryIndexes) {
+        spanAttributes[
+          SemanticAttributes.AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES
+        ] = this.toArray(
+          normalizedRequest.commandInput.GlobalSecondaryIndexes
+        ).map((x: { [DictionaryKey: string]: any }) => JSON.stringify(x));
+      }
+
+      if (normalizedRequest.commandInput?.LocalSecondaryIndexes) {
+        spanAttributes[
+          SemanticAttributes.AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES
+        ] = this.toArray(
+          normalizedRequest.commandInput.LocalSecondaryIndexes
+        ).map((x: { [DictionaryKey: string]: any }) => JSON.stringify(x));
+      }
+    }
+
+    if (
+      operation === 'ListTables' ||
+      operation === 'Query' ||
+      operation === 'Scan'
+    ) {
+      if (normalizedRequest.commandInput?.Limit) {
+        spanAttributes[SemanticAttributes.AWS_DYNAMODB_LIMIT] =
+          normalizedRequest.commandInput.Limit;
+      }
+    }
+
+    if (operation === 'ListTables') {
+      if (normalizedRequest.commandInput?.ExclusiveStartTableName) {
+        spanAttributes[SemanticAttributes.AWS_DYNAMODB_EXCLUSIVE_START_TABLE] =
+          normalizedRequest.commandInput.ExclusiveStartTableName;
+      }
+    }
+
+    if (operation === 'Query') {
+      if (normalizedRequest.commandInput?.ScanIndexForward) {
+        spanAttributes[SemanticAttributes.AWS_DYNAMODB_SCAN_FORWARD] =
+          normalizedRequest.commandInput.ScanIndexForward;
+      }
+
+      if (normalizedRequest.commandInput?.IndexName) {
+        spanAttributes[SemanticAttributes.AWS_DYNAMODB_INDEX_NAME] =
+          normalizedRequest.commandInput.IndexName;
+      }
+
+      if (normalizedRequest.commandInput?.Select) {
+        spanAttributes[SemanticAttributes.AWS_DYNAMODB_SELECT] =
+          normalizedRequest.commandInput.Select;
+      }
+    }
+
+    if (operation === 'Scan') {
+      if (normalizedRequest.commandInput?.Segment) {
+        spanAttributes[SemanticAttributes.AWS_DYNAMODB_SEGMENT] =
+          normalizedRequest.commandInput?.Segment;
+      }
+
+      if (normalizedRequest.commandInput?.TotalSegments) {
+        spanAttributes[SemanticAttributes.AWS_DYNAMODB_TOTAL_SEGMENTS] =
+          normalizedRequest.commandInput?.TotalSegments;
+      }
+
+      if (normalizedRequest.commandInput?.IndexName) {
+        spanAttributes[SemanticAttributes.AWS_DYNAMODB_INDEX_NAME] =
+          normalizedRequest.commandInput.IndexName;
+      }
+
+      if (normalizedRequest.commandInput?.Select) {
+        spanAttributes[SemanticAttributes.AWS_DYNAMODB_SELECT] =
+          normalizedRequest.commandInput.Select;
+      }
+    }
+
+    if (operation === 'UpdateTable') {
+      if (normalizedRequest.commandInput?.AttributeDefinitions) {
+        spanAttributes[SemanticAttributes.AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS] =
+          this.toArray(normalizedRequest.commandInput.AttributeDefinitions).map(
+            (x: { [DictionaryKey: string]: any }) => JSON.stringify(x)
+          );
+      }
+
+      if (normalizedRequest.commandInput?.GlobalSecondaryIndexUpdates) {
+        spanAttributes[
+          SemanticAttributes.AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES
+        ] = this.toArray(
+          normalizedRequest.commandInput.GlobalSecondaryIndexUpdates
+        ).map((x: { [DictionaryKey: string]: any }) => JSON.stringify(x));
+      }
     }
 
     return {
@@ -70,6 +202,44 @@ export class DynamodbServiceExtension implements ServiceExtension {
           response.data.ConsumedCapacity.map(
             (x: { [DictionaryKey: string]: any }) => JSON.stringify(x)
           )
+        );
+      }
+    }
+
+    if (
+      operation === 'BatchWriteItem' ||
+      operation === 'CreateTable' ||
+      operation === 'DeleteItem' ||
+      operation === 'PutItem' ||
+      operation === 'UpdateItem'
+    ) {
+      span.setAttribute(
+        SemanticAttributes.AWS_DYNAMODB_ITEM_COLLECTION_METRICS,
+        response.data.ItemCollectionMetrics
+      );
+    }
+
+    if (operation === 'ListTables') {
+      if (response.data?.TableNames) {
+        span.setAttribute(
+          SemanticAttributes.AWS_DYNAMODB_TABLE_COUNT,
+          response.data?.TableNames.length
+        );
+      }
+    }
+
+    if (operation === 'Scan') {
+      if (response.data?.Count) {
+        span.setAttribute(
+          SemanticAttributes.AWS_DYNAMODB_COUNT,
+          response.data?.Count
+        );
+      }
+
+      if (response.data?.ScannedCount) {
+        span.setAttribute(
+          SemanticAttributes.AWS_DYNAMODB_SCANNED_COUNT,
+          response.data?.ScannedCount
         );
       }
     }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- DynamoDB spans generated by the AWS SDK instrumentation are missing attributes defined in the [opentelemetry spec for AWS instrumentations](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/instrumentation/aws-sdk.md#dynamodb). 
- This PR builds on the addition of attributes for the `BatchGetItem` operation in #678 and is completed by #1365 which adds the `ConsumedCapacity` attribute for all applicable operations.

## Short description of the changes

- Added operation-specific attributes for DynamoDB operations that did not have attributes added according to the spec. 
- This implementation captures request/response parameters for both AWS SDK v2 and v3 calls.
- AWS SDK v2 is on a deprecation path and the recommendation is for all users to start using or migrate to v3. In v3, the `AttributesToGet` request parameter (used in [DynamoDB.query](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/instrumentation/aws-sdk.md#dynamodbquery) and [DynamoDB.Scan](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/instrumentation/aws-sdk.md#dynamodbscan)), and by extension the `AWS_DYNAMODB_ATTRIBUTES_TO_GET` attribute, are no longer necessary since the [AttributesToGet parameter has been deprecated in favor of ProjectedExpression](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.AttributesToGet.html). Since the value of the ProjectionExpression parameter is already being captured for the `AWS_DYNAMODB_PROJECTION` attribute in this PR, it is redundant to include a backwards-compatible check for the deprecated attribute. 

## Testing 
These changes were tested end-to-end using a simple application that makes a DynamoDB `ListItems` call and uses the aws-otel-collector to export data to AWS X-Ray. For ListItems operation, the new `aws.dynamodb.table_count`, `aws.dynamodb.exclusive_start_table`, and `aws.dynamodb.exclusive_start_table` are now being populated correctly
```js
"metadata": {
      "default": {
          "db.statement": "{\"ExclusiveStartTableName\":\"Movies2\",\"Limit\":20}",
          "rpc.service": "DynamoDB",
          "db.system": "dynamodb",
          "db.operation": "ListTables",
          "aws.dynamodb.table_count": 12,
          "rpc.system": "aws-api",
          "aws.dynamodb.exclusive_start_table": "Movies2",
          "aws.dynamodb.limit": 20
      }
  },
```
