### PR TITLE
attempt to instrument esm-lambda

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/esmodule.test.mjs
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/esmodule.test.mjs
@@ -1,0 +1,49 @@
+import { BatchSpanProcessor, InMemorySpanExporter, NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import assert from 'node:assert';
+import test from 'node:test';
+import {
+  AwsLambdaInstrumentation,
+} from '../../build/src/index.js';
+import path from 'node:path';
+import * as url from 'url';
+
+test('synchronous passing test', async (t) => {
+  const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
+  process.env.LAMBDA_TASK_ROOT = path.resolve(__dirname, '..');
+  const memoryExporter = new InMemorySpanExporter();
+
+  let instrumentation
+  const initializeHandler = (
+    handler,
+    config = {}
+  ) => {
+    process.env._HANDLER = handler;
+
+    const provider = new NodeTracerProvider();
+    provider.addSpanProcessor(new BatchSpanProcessor(memoryExporter));
+    provider.register();
+
+    instrumentation = new AwsLambdaInstrumentation(config);
+    instrumentation.setTracerProvider(provider);
+
+    return provider;
+  };
+  const ctx = {
+    functionName: 'my_function',
+    invokedFunctionArn: 'my_arn',
+    awsRequestId: 'aws_request_id',
+  }
+
+
+  initializeHandler('lambda-test/es-module.handler');
+  const result = await (await import('../lambda-test/es-module.mjs')).handler(
+    'arg',
+    ctx
+  );
+  assert.strictEqual(result, 'ok');
+  const spans = memoryExporter.getFinishedSpans();
+  const [span] = spans;
+  assert.strictEqual(spans.length, 1);
+  // assertSpanSuccess(span);
+  assert.strictEqual(span.parentSpanId, undefined);
+});

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler.test.ts
@@ -862,9 +862,22 @@ describe('lambda handler', () => {
       });
     });
 
-    describe('.cjs lambda bundle', () => {
-      it('should export a valid span', async () => {
+    describe('different extensions', () => {
+      it('.cjs should export a valid span', async () => {
         initializeHandler('lambda-test/commonjs.handler');
+        const result = await lambdaRequire('lambda-test/commonjs.cjs').handler(
+          'arg',
+          ctx
+        );
+        assert.strictEqual(result, 'ok');
+        const spans = memoryExporter.getFinishedSpans();
+        const [span] = spans;
+        assert.strictEqual(spans.length, 1);
+        assertSpanSuccess(span);
+        assert.strictEqual(span.parentSpanId, undefined);
+      });
+      it('.mjs should export a valid span', async () => {
+        initializeHandler('lambda-test/es-module.handler');
         const result = await lambdaRequire('lambda-test/commonjs.cjs').handler(
           'arg',
           ctx

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/lambda-test/es-module.mjs
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/lambda-test/es-module.mjs
@@ -1,0 +1,3 @@
+export async function handler (event, context) {
+	return "ok";
+};

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/tsconfig.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/tsconfig.json
@@ -7,5 +7,5 @@
   "include": [
     "src/**/*.ts",
     "test/**/*.ts"
-  ]
+, "test/integrations/esmodule.test.js"  ]
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- Adds support for instrumenting esm lambda functions

## Short description of the changes

- For a lambda to use esm in needs the .esm extension. This resolves that correctly
- Adds a test to verify esm is being handled (its not :confused: )
