### PR TITLE
feat(instrumentation-pg): Span Names Matching Semantic Conventions

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-pg/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/instrumentation.ts
@@ -46,12 +46,10 @@ import {
 } from '@opentelemetry/semantic-conventions';
 import { VERSION } from './version';
 
-const PG_POOL_COMPONENT = 'pg-pool';
-
 export class PgInstrumentation extends InstrumentationBase {
   static readonly COMPONENT = 'pg';
 
-  static readonly BASE_SPAN_NAME = PgInstrumentation.COMPONENT + '.query';
+  static readonly BASE_SPAN_NAME = 'query';
 
   constructor(config: PgInstrumentationConfig = {}) {
     super(
@@ -138,7 +136,7 @@ export class PgInstrumentation extends InstrumentationBase {
         }
 
         const span = plugin.tracer.startSpan(
-          `${PgInstrumentation.COMPONENT}.connect`,
+          `connect${this.database ? ` ${this.database}` : ''}`,
           {
             kind: SpanKind.CLIENT,
             attributes: {
@@ -362,16 +360,19 @@ export class PgInstrumentation extends InstrumentationBase {
         }
 
         // setup span
-        const span = plugin.tracer.startSpan(`${PG_POOL_COMPONENT}.connect`, {
-          kind: SpanKind.CLIENT,
-          attributes: {
-            [SemanticAttributes.DB_SYSTEM]: DbSystemValues.POSTGRESQL,
-            ...utils.getSemanticAttributesFromConnection(this.options),
-            [AttributeNames.IDLE_TIMEOUT_MILLIS]:
-              this.options.idleTimeoutMillis,
-            [AttributeNames.MAX_CLIENT]: this.options.maxClient,
-          },
-        });
+        const span = plugin.tracer.startSpan(
+          `connect ${this.options.database}`,
+          {
+            kind: SpanKind.CLIENT,
+            attributes: {
+              [SemanticAttributes.DB_SYSTEM]: DbSystemValues.POSTGRESQL,
+              ...utils.getSemanticAttributesFromConnection(this.options),
+              [AttributeNames.IDLE_TIMEOUT_MILLIS]:
+                this.options.idleTimeoutMillis,
+              [AttributeNames.MAX_CLIENT]: this.options.maxClient,
+            },
+          }
+        );
 
         if (callback) {
           const parentSpan = trace.getSpan(context.active());

--- a/plugins/node/opentelemetry-instrumentation-pg/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/utils.ts
@@ -78,7 +78,7 @@ export function getQuerySpanName(
       ? queryConfig.name
       : parseNormalizedOperationName(queryConfig.text);
 
-  return `${PgInstrumentation.BASE_SPAN_NAME}:${command}${
+  return `${command}${
     dbName ? ` ${dbName}` : ''
   }`;
 }

--- a/plugins/node/opentelemetry-instrumentation-pg/test/utils.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/test/utils.test.ts
@@ -85,14 +85,14 @@ describe('utils.ts', () => {
     it('uses prepared statement name when given, over query text', () => {
       assert.strictEqual(
         utils.getQuerySpanName('dbName', dummyQuery),
-        'pg.query:select-placeholder-val dbName'
+        'select-placeholder-val dbName'
       );
     });
 
     it('falls back to parsing query text when no (valid) name is available', () => {
       assert.strictEqual(
         utils.getQuerySpanName('dbName', { ...dummyQuery, name: undefined }),
-        'pg.query:SELECT dbName'
+        'SELECT dbName'
       );
     });
 
@@ -109,21 +109,21 @@ describe('utils.ts', () => {
     it('ignores trailing semicolons when parsing operation names', () => {
       assert.strictEqual(
         utils.getQuerySpanName('dbName', { text: 'COMMIT;' }),
-        'pg.query:COMMIT dbName'
+        'COMMIT dbName'
       );
     });
 
     it('omits db name if missing', () => {
       assert.strictEqual(
         utils.getQuerySpanName(undefined, dummyQuery),
-        'pg.query:select-placeholder-val'
+        'select-placeholder-val'
       );
     });
 
     it('should omit all info if the queryConfig is invalid', () => {
       assert.strictEqual(
         utils.getQuerySpanName('db-name-ignored', undefined),
-        'pg.query'
+        'query'
       );
     });
   });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Currently, the span names generated by the instrumentation library are not matching what is defined in the database spans [semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/specification/trace/semantic_conventions/database.md).
Which calls out that names for db spans should be composed by: `<db.operation> <db.name>.<db.sql.table>` or `<db.operation> <db.name>`  if the table is not available.

## Short description of the changes

- Removes the Component prefix from all span names
- Uses the command as operation plus the database to name the span
- Updates the connect spans to not include the component name
