### PR TITLE
fix(nestjs): update dependency @nestjs/x to v9

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
+++ b/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
@@ -48,11 +48,11 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "devDependencies": {
-    "@nestjs/common": "8.2.6",
-    "@nestjs/core": "8.2.6",
-    "@nestjs/microservices": "8.2.6",
-    "@nestjs/platform-express": "8.2.6",
-    "@nestjs/websockets": "8.2.6",
+    "@nestjs/common": "9.4.3",
+    "@nestjs/core": "9.4.3",
+    "@nestjs/microservices": "9.4.3",
+    "@nestjs/platform-express": "9.4.3",
+    "@nestjs/websockets": "9.4.3",
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/context-async-hooks": "^1.8.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",


### PR DESCRIPTION
## Which problem is this PR solving?

- in https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1422 renovate tried to update only one @nestjs/core without taking into account other @nestjs/x libraries that also should be updated. this PR update all of them. 

