### PR TITLE
chore(ci): pin lerna in github workflows

### DIFF
--- a/.github/workflows/peer-api.yaml
+++ b/.github/workflows/peer-api.yaml
@@ -15,9 +15,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install lerna
-        run: npm install -g lerna
-
       - name: Install script dependencies
         run: npm install
 

--- a/.github/workflows/peer-api.yaml
+++ b/.github/workflows/peer-api.yaml
@@ -15,6 +15,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Install lerna
+        run: npm install -g lerna@6.6.2
+
       - name: Install script dependencies
         run: npm install
 

--- a/.github/workflows/peer-api.yaml
+++ b/.github/workflows/peer-api.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install lerna
-        run: npm install -g lerna@6.6.2
+        run: npm install -g lerna@5.5.2
 
       - name: Install script dependencies
         run: npm install

--- a/.github/workflows/release-please-validate.yaml
+++ b/.github/workflows/release-please-validate.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install lerna
-        run: npm install -g lerna
+        run: npm install -g lerna@5.5.2
 
       - name: Ensure Release Please Config and Manifest are in sync with the repository
         run: node scripts/check-release-please.mjs

--- a/.github/workflows/test-all-versions.pr.yml
+++ b/.github/workflows/test-all-versions.pr.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
         # Need lerna to list all packages
       - name: Install lerna
-        run: npm install -g lerna
+        run: npm install -g lerna@5.5.2
       - name: Parse labels into lerna scope arguments
         id: lerna-args
         run: |


### PR DESCRIPTION
## Which problem is this PR solving?

- Our GitHub workflows pull the latest version of `lerna`, but `lerna` `v7` and up do remove `lerna bootstrap`.
 
## Short description of the changes

- pins the same version (`5.5.2`) as in our top-level `package.json` for now to unblock PRs, I'll open a follow-up issue to upgrade to `lerna` `v7`. 

See also https://github.com/open-telemetry/opentelemetry-js/issues/3894, #1542 
