### PR TITLE
chore: Update component owners for the Document Load web instrumentation

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -109,7 +109,8 @@ components:
   plugins/node/opentelemetry-instrumentation-winston:
     - seemk
   plugins/web/opentelemetry-instrumentation-document-load:
-    - obecny
+    - pkanal
+    - martinkuba 
   plugins/web/opentelemetry-instrumentation-long-task:
     - mhennoch
     - t2t2


### PR DESCRIPTION
Per the recent [component ownership audit](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1478) and as discussed in the SIG on 6/14/23, @pkanal and I are volunteering to take over the ownership of this component.

@obecny If you would like to continue being the owner, please let us know.
