### PR TITLE
fix(instrumentation-fastify): fix fastify typescript compilation issue

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-fastify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-fastify/package.json
@@ -54,7 +54,7 @@
     "@types/express": "4.17.13",
     "@types/mocha": "7.0.2",
     "@types/node": "18.11.7",
-    "fastify": "^4.5.3",
+    "fastify": "4.18.0",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "rimraf": "5.0.0",


### PR DESCRIPTION
## Which problem is this PR solving?
- Looks like recent changes over at fastify desupported older versions of typescript, which breaks CI at the moment
- The PR pins the devDependency to `4.18.0` until https://github.com/fastify/fastify/issues/4873 is resolved
  - if the resolution to this issue is that support will be restored, I'll unpin it again
  - if the resolution to this issue is that support will **not** be restored, I'll look into alternative ways of testing newer versions of fastify (possibly via TAV).
