### PR TITLE
fix: Move @types/generic-pool from `dependencies` to `devDependencies`

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
+++ b/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
@@ -49,6 +49,7 @@
     "@opentelemetry/context-async-hooks": "^1.8.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
+    "@types/generic-pool": "^3.1.9",
     "@types/mocha": "7.0.2",
     "@types/node": "18.11.7",
     "@types/semver": "7.3.8",
@@ -63,7 +64,6 @@
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.40.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
-    "@types/generic-pool": "^3.1.9",
     "tslib": "^2.3.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-generic-pool#readme"


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

`@opentelemetry/auto-instrumentations-node` is unusable with TypeScript 5 due to following error:
```
> tsc && tsc-alias && touch .ok

error TS2688: Cannot find type definition file for 'generic-pool'.
  The file is in the program because:
    Entry point for implicit type library 'generic-pool'


Found 1 error.
```

Honesly, this fix is untested, but makes the most sense.

## Short description of the changes

Move @types/generic-pool from `dependencies` to `devDependencies`.
