### PR TITLE
fix(document-load): compatibility issue with @opentelemetry/sdk-trace-web@1.15.0

### DIFF
--- a/plugins/web/opentelemetry-instrumentation-document-load/package.json
+++ b/plugins/web/opentelemetry-instrumentation-document-load/package.json
@@ -79,7 +79,7 @@
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.40.0",
     "@opentelemetry/sdk-trace-base": "^1.0.0",
-    "@opentelemetry/sdk-trace-web": "^1.8.0",
+    "@opentelemetry/sdk-trace-web": "^1.15.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "tslib": "^2.3.1"
   },

--- a/plugins/web/opentelemetry-instrumentation-document-load/test/documentLoad.test.ts
+++ b/plugins/web/opentelemetry-instrumentation-document-load/test/documentLoad.test.ts
@@ -210,11 +210,10 @@ function ensureNetworkEventsExists(events: TimedEvent[]) {
   assert.strictEqual(events[1].name, PTN.DOMAIN_LOOKUP_START);
   assert.strictEqual(events[2].name, PTN.DOMAIN_LOOKUP_END);
   assert.strictEqual(events[3].name, PTN.CONNECT_START);
-  assert.strictEqual(events[4].name, PTN.SECURE_CONNECTION_START);
-  assert.strictEqual(events[5].name, PTN.CONNECT_END);
-  assert.strictEqual(events[6].name, PTN.REQUEST_START);
-  assert.strictEqual(events[7].name, PTN.RESPONSE_START);
-  assert.strictEqual(events[8].name, PTN.RESPONSE_END);
+  assert.strictEqual(events[4].name, PTN.CONNECT_END);
+  assert.strictEqual(events[5].name, PTN.REQUEST_START);
+  assert.strictEqual(events[6].name, PTN.RESPONSE_START);
+  assert.strictEqual(events[7].name, PTN.RESPONSE_END);
 }
 
 describe('DocumentLoad Instrumentation', () => {
@@ -486,15 +485,7 @@ describe('DocumentLoad Instrumentation', () => {
           'http://localhost:8090/bundle.js'
         );
 
-        assert.strictEqual(srEvents1[0].name, PTN.FETCH_START);
-        assert.strictEqual(srEvents1[1].name, PTN.DOMAIN_LOOKUP_START);
-        assert.strictEqual(srEvents1[2].name, PTN.DOMAIN_LOOKUP_END);
-        assert.strictEqual(srEvents1[3].name, PTN.CONNECT_START);
-        assert.strictEqual(srEvents1[4].name, PTN.SECURE_CONNECTION_START);
-        assert.strictEqual(srEvents1[5].name, PTN.CONNECT_END);
-        assert.strictEqual(srEvents1[6].name, PTN.REQUEST_START);
-        assert.strictEqual(srEvents1[7].name, PTN.RESPONSE_START);
-        assert.strictEqual(srEvents1[8].name, PTN.RESPONSE_END);
+        ensureNetworkEventsExists(srEvents1);
 
         assert.strictEqual(exporter.getFinishedSpans().length, 3);
         done();

--- a/plugins/web/opentelemetry-instrumentation-document-load/test/documentLoad.test.ts
+++ b/plugins/web/opentelemetry-instrumentation-document-load/test/documentLoad.test.ts
@@ -369,7 +369,7 @@ describe('DocumentLoad Instrumentation', () => {
         assert.strictEqual(fsEvents[7].name, PTN.LOAD_EVENT_START);
         assert.strictEqual(fsEvents[8].name, PTN.LOAD_EVENT_END);
 
-        assert.strictEqual(rsEvents.length, 9);
+        assert.strictEqual(rsEvents.length, 8);
         assert.strictEqual(fsEvents.length, 11);
         assert.strictEqual(exporter.getFinishedSpans().length, 2);
         done();
@@ -561,7 +561,7 @@ describe('DocumentLoad Instrumentation', () => {
         assert.strictEqual(rsEvents[7].name, PTN.LOAD_EVENT_START);
         assert.strictEqual(rsEvents[8].name, PTN.LOAD_EVENT_END);
 
-        assert.strictEqual(fsEvents.length, 9);
+        assert.strictEqual(fsEvents.length, 8);
         assert.strictEqual(rsEvents.length, 9);
         assert.strictEqual(exporter.getFinishedSpans().length, 2);
         done();


### PR DESCRIPTION
## Which problem is this PR solving?

- new @opentelemetry/sdk-trace-web@1.15.0 which omit secureConnectionStart if the request if using http => this break some test in @opentelemetry/instrumentation-document-load

## Short description of the changes

- update minimum version of sdk-trace-web in instrumentation-document-load to 1.15.0
- update test to remove check for secureConnectionStart
