### PR TITLE
feat(fastify): Skip update HTTP's span name and update RpcMetadata's route instead

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-fastify/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-fastify/src/instrumentation.ts
@@ -96,8 +96,7 @@ export class FastifyInstrumentation extends InstrumentationBase {
       const rpcMetadata = getRPCMetadata(context.active());
       const routeName = request.routerPath;
       if (routeName && rpcMetadata?.type === RPCType.HTTP) {
-        rpcMetadata.span.setAttribute(SemanticAttributes.HTTP_ROUTE, routeName);
-        rpcMetadata.span.updateName(`${request.method} ${routeName}`);
+        rpcMetadata.route = routeName;
       }
       done();
     };


### PR DESCRIPTION
## Which problem is this PR solving?

Each framework has a different approach to updating Span's name and HTTP_ROUTE attribute. We want to delegate this to instrumentation-http for consistent's name and attribute
This PR fixes the above issue for [fastify](https://github.com/fastify/fastify/)
- This will partially fix issue #1381 

## Short description of the changes

- Skip modifying HTTP's Span name directly in instrumentation-koa code
- Update route property of RpcMetadata
- As instrumentation-fastify's unit test already integrate with instrumentation-http, there are no need to update any test