### PR TITLE
chore(renovate): split patch and minor rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,9 +4,15 @@
   ],
   "packageRules": [
     {
-      "groupName": "all non-major dependencies",
-      "updateTypes": ["patch", "minor"],
-      "groupSlug": "all-minor-patch"
+      "groupName": "all patch versions",
+      "groupSlug": "all-patch",
+      "matchUpdateTypes": ["patch"],
+      "excludePackageNames": ["prettier"],
+      "schedule": ["before 3am every weekday"]
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "dependencyDashboardApproval": true
     },
     {
       "matchPackageNames": ["@opentelemetry/api"],


### PR DESCRIPTION
## Which problem is this PR solving?

Currently, renovate bot groups all minor and patch version upgrades into one PR, which makes it difficult to handle problems when they occur. This PR separates minor and patch into 2 different rules as we have in [core](https://github.com/open-telemetry/opentelemetry-js/blob/main/renovate.json). 

## Short description of the changes

* Create a rule for bumping all patch versions in one PR, excluding "prettier" (same as in [core](https://github.com/open-telemetry/opentelemetry-js/blob/main/renovate.json#L3C20-L3C20))
* Create a rule for all minor version upgrades, and requires #637 for minor version bumps
