### PR TITLE
chore(renovate): change strategy for @opentelemetry/api, run experimental update every weekday

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,10 +16,10 @@
     },
     {
       "matchPackageNames": ["@opentelemetry/api"],
-      "rangeStrategy": "bump"
+      "rangeStrategy": "widen"
     },
     {
-      "groupName": "Otel Core experimental",
+      "groupName": "OTel Core experimental",
       "matchPackageNames": [
         "@opentelemetry/instrumentation",
         "@opentelemetry/instrumentation-grpc",
@@ -29,7 +29,8 @@
         "@opentelemetry/exporter-metrics-otlp-grpc",
         "@opentelemetry/sdk-node"
       ],
-      "rangeStrategy": "bump"
+      "rangeStrategy": "bump",
+      "schedule": ["before 3am every weekday"]
     }
   ],
   "ignoreDeps": ["lerna", "lerna-changelog"],


### PR DESCRIPTION
## Which problem is this PR solving?

- use "widen" range strategy for `@opentelemetry/api`
  - renovate bot tries to bump api, but we want to keep it compatible with older api versions
- run experimental updates every weekday
  - we can release on any day of the week, so this way we don't need to wait for a week if renovate fails or we release on a Friday