### PR TITLE
fix(aws-xray): align aws xray to use contrib-test-utils v0.34.0

### DIFF
--- a/packages/opentelemetry-sampler-aws-xray/package.json
+++ b/packages/opentelemetry-sampler-aws-xray/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/contrib-test-utils": "^0.33.1",
+    "@opentelemetry/contrib-test-utils": "^0.34.0",
     "@types/mocha": "8.2.3",
     "@types/node": "18.11.7",
     "@types/sinon": "10.0.6",


### PR DESCRIPTION
align aws xray to use contrib-test-utils v0.34.0 as all other packages.