### PR TITLE
fix(instrumentation-mysql2): sql-common should be a dependency

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-mysql2/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/package.json
@@ -51,7 +51,6 @@
     "@opentelemetry/context-async-hooks": "^1.8.0",
     "@opentelemetry/contrib-test-utils": "^0.34.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
-    "@opentelemetry/sql-common": "^0.40.0",
     "@types/mocha": "7.0.2",
     "@types/mysql2": "github:types/mysql2",
     "@types/node": "18.11.7",
@@ -68,6 +67,7 @@
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.41.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
+    "@opentelemetry/sql-common": "^0.40.0",
     "tslib": "^2.3.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-mysql2#readme"


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- `sql-common` was accidentally listed as a dev dependency

## Short description of the changes

- Moves it to dependencies
