### PR TITLE
chore(deps): update dependency @types/semver to v7.5.0

### DIFF
--- a/plugins/node/instrumentation-cucumber/package.json
+++ b/plugins/node/instrumentation-cucumber/package.json
@@ -52,7 +52,7 @@
     "@opentelemetry/sdk-trace-base": "^1.3.1",
     "@opentelemetry/sdk-trace-node": "^1.3.1",
     "@types/mocha": "7.0.2",
-    "@types/semver": "7.3.8",
+    "@types/semver": "7.5.0",
     "@types/shimmer": "1.0.2",
     "@types/sinon": "10.0.2",
     "gts": "3.1.0",

--- a/plugins/node/opentelemetry-instrumentation-restify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-restify/package.json
@@ -53,7 +53,7 @@
     "@types/mocha": "7.0.2",
     "@types/node": "18.16.19",
     "@types/restify": "4.3.9",
-    "@types/semver": "^7.3.12",
+    "@types/semver": "7.5.0",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "restify": "11.1.0",


### PR DESCRIPTION
This PR replaces renovate #1607 but aligns the version also in instrumentation-restify where it was set with caret instead of pinned.

After this PR, the version for `@types/semver` is aligned across all the packages in this monorepo.