### PR TITLE
chore: update lerna to v7 and migrate to npm workspace

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feat-lerna-bootstrap-deprecate
   pull_request:
 
 jobs:
@@ -21,26 +22,21 @@ jobs:
           ignore: "./**/CHANGELOG.md"
           args: "./**/*.md"
 
-      - name: restore lerna
-        uses: actions/cache@master # must use unreleased master to cache multiple paths
-        id: cache
+      - uses: actions/setup-node@v3
         with:
-          path: |
-            ./node_modules
-            ./package-lock.json
-            node_modules
-            detectors/node/*/node_modules
-            metapackages/*/node_modules
-            packages/*/node_modules
-            plugins/node/*/node_modules
-            plugins/web/*/node_modules
-            propagators/*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/package.json') }}
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+          cache-dependency-path: |
+            package.json
+            detectors/node/*/package.json
+            metapackages/*/package.json
+            packages/*/package.json
+            plugins/node/*/package.json
+            plugins/web/*/package.json
+            propagators/*/package.json
 
       - name: Bootstrap
-        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           npm install --only=dev --ignore-scripts
-          npx lerna bootstrap --no-ci --hoist --nohoist='zone.js' --nohoist='gts' --ignore-scripts -- --only=dev
       - name: Lint
         run: npm run lint

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -37,7 +37,6 @@ jobs:
       - name: Build Packages
         run: |
           npm install
-          npx lerna bootstrap --no-ci
 
       - uses: google-github-actions/release-please-action@v3
         id: release

--- a/.github/workflows/test-all-versions.push.yml
+++ b/.github/workflows/test-all-versions.push.yml
@@ -5,6 +5,7 @@ on:
       - "main"
       - "release/**"
       - "release-please/**"
+      - feat-lerna-bootstrap-deprecate
 
 jobs:
   tav:

--- a/.github/workflows/test-all-versions.yml
+++ b/.github/workflows/test-all-versions.yml
@@ -19,6 +19,9 @@ jobs:
       fail-fast: false
       matrix:
         node: ["14", "16", "18"]
+        include:
+          - node: 14
+            npm: 7
     runs-on: ubuntu-latest
     services:
       mongo:
@@ -113,33 +116,23 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
+          cache: 'npm'
+          cache-dependency-path: |
+            package.json
+            detectors/node/*/package.json
+            metapackages/*/package.json
+            packages/*/package.json
+            plugins/node/*/package.json
+            plugins/web/*/package.json
+            propagators/*/package.json
+      - name: Install minimum npm 7
+        if: matrix.npm
+        run: npm install -g npm@${{matrix.npm}}
       - name: Set MySQL variables
         run: mysql --user=root --password=${MYSQL_ROOT_PASSWORD} --host=${MYSQL_HOST} --port=${MYSQL_PORT} -e "SET GLOBAL log_output='TABLE'; SET GLOBAL general_log = 1;" mysql
-      - name: Cache Dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            node_modules
-            package-lock.json
-            detectors/node/*/node_modules
-            detectors/node/*/package-lock.json
-            metapackages/*/node_modules
-            metapackages/*/package-lock.json
-            packages/*/node_modules
-            packages/*/package-lock.json
-            plugins/node/*/node_modules
-            plugins/node/*/package-lock.json
-            plugins/web/*/node_modules
-            plugins/web/*/package-lock.json
-            propagators/*/node_modules
-            propagators/*/package-lock.json
-          key: ${{ runner.os }}-${{ matrix.node }}-${{ hashFiles('package.json', 'detectors/node/*/package.json', 'metapackages/*/package.json', 'packages/*/package.json', 'plugins/node/*/package.json', 'plugins/web/*/package.json', 'propagators/*/package.json') }}
       - name: Legacy Peer Dependencies for npm 7
-        if: matrix.node == '16'
         run: npm config set legacy-peer-deps=true
       - name: Install Root Dependencies
-        run: npm install --ignore-scripts
-      - name: Bootstrap Dependencies
-        run: npx lerna bootstrap --no-ci --hoist --nohoist='zone.js' --nohoist='mocha' --nohoist='ts-mocha'
+        run: npm install
       - name: Run test-all-versions
-        run: npx lerna run test-all-versions ${{ inputs.lerna-args }} ${{ matrix.lerna-extra-args }} --stream --concurrency 1
+        run: npx lerna run --no-bail test-all-versions ${{ inputs.lerna-args }} ${{ matrix.lerna-extra-args }} --stream --concurrency 1

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -130,7 +130,9 @@ jobs:
             metapackages/*/package.json
             packages/*/package.json
             plugins/node/*/package.json
+            plugins/node/*/examples/package.json
             plugins/web/*/package.json
+            plugins/web/*/examples/package.json
             propagators/*/package.json
       - name: Install minimum npm 7
         if: matrix.npm

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,7 +1,8 @@
 name: Unit Tests
 on:
   push:
-    branches: [main]
+    branches: 
+      - feat-lerna-bootstrap-deprecate
   pull_request:
 
 jobs:
@@ -13,6 +14,7 @@ jobs:
         include:
             - node: 14
               code-coverage: true
+              npm: 7
     runs-on: ubuntu-latest
     services:
       memcached:
@@ -121,40 +123,30 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
+          cache: 'npm'
+          cache-dependency-path: |
+            package.json
+            detectors/node/*/package.json
+            metapackages/*/package.json
+            packages/*/package.json
+            plugins/node/*/package.json
+            plugins/web/*/package.json
+            propagators/*/package.json
+      - name: Install minimum npm 7
+        if: matrix.npm
+        run: npm install -g npm@${{matrix.npm}}
       - name: Set MySQL variables
         run: mysql --user=root --password=${MYSQL_ROOT_PASSWORD} --host=${MYSQL_HOST} --port=${MYSQL_PORT} -e "SET GLOBAL log_output='TABLE'; SET GLOBAL general_log = 1;" mysql
-      - name: Cache Dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            node_modules
-            package-lock.json
-            detectors/node/*/node_modules
-            detectors/node/*/package-lock.json
-            metapackages/*/node_modules
-            metapackages/*/package-lock.json
-            packages/*/node_modules
-            packages/*/package-lock.json
-            plugins/node/*/node_modules
-            plugins/node/*/package-lock.json
-            plugins/web/*/node_modules
-            plugins/web/*/package-lock.json
-            propagators/*/node_modules
-            propagators/*/package-lock.json
-          key: ${{ runner.os }}-${{ matrix.node }}-${{ hashFiles('package.json', 'detectors/node/*/package.json', 'metapackages/*/package.json', 'packages/*/package.json', 'plugins/node/*/package.json', 'plugins/web/*/package.json', 'propagators/*/package.json') }}
       - name: Legacy Peer Dependencies for npm 7
-        if: matrix.node == '16'
         run: npm config set legacy-peer-deps=true
-      - name: Install Root Dependencies
-        run: npm install --ignore-scripts
-      - name: Bootstrap Dependencies
-        run: npx lerna bootstrap --no-ci --hoist --nohoist='zone.js' --nohoist='mocha' --nohoist='ts-mocha'
+      - name: Install Dependencies
+        run: npm install
       - name: Unit tests (Full)
         if: matrix.code-coverage
-        run: npm run test -- ${{ matrix.lerna-extra-args }}
+        run: npx lerna run test ${{ matrix.lerna-extra-args }}
       - name: Unit tests (Delta)
         if: ${{ !matrix.code-coverage }}
-        run: npm run test:ci:changed -- ${{ matrix.lerna-extra-args }}
+        run: npx lerna run test ${{ matrix.lerna-extra-args }} --since origin/main
       - name: Build examples
         run: npm run compile:examples
       - name: Report Coverage
@@ -168,6 +160,9 @@ jobs:
       fail-fast: false
       matrix:
         node: ["14"]
+        include:          
+          - node: 14
+            npm: 7
     runs-on: ubuntu-latest
     env:
       NPM_CONFIG_UNSAFE_PERM: true
@@ -180,31 +175,24 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-      - name: Cache Dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            node_modules
-            package-lock.json
-            detectors/node/*/node_modules
-            detectors/node/*/package-lock.json
-            metapackages/*/node_modules
-            metapackages/*/package-lock.json
-            packages/*/node_modules
-            packages/*/package-lock.json
-            plugins/node/*/node_modules
-            plugins/node/*/package-lock.json
-            plugins/web/*/node_modules
-            plugins/web/*/package-lock.json
-            propagators/*/node_modules
-            propagators/*/package-lock.json
-          key: ${{ runner.os }}${{ matrix.node }}-browser-${{ hashFiles('package.json', 'detectors/node/*/package.json', 'metapackages/*/package.json', 'packages/*/package.json', 'plugins/node/*/package.json', 'plugins/web/*/package.json', 'propagators/*/package.json') }}
+          cache: 'npm'
+          cache-dependency-path: |
+            package.json
+            detectors/node/*/package.json
+            metapackages/*/package.json
+            packages/*/package.json
+            plugins/node/*/package.json
+            plugins/web/*/package.json
+            propagators/*/package.json
+      - name: Install minimum npm@${{matrix.npm}}
+        if: matrix.npm
+        run: npm install -g npm@${{matrix.npm}}
+      - name: Legacy Peer Dependencies for npm>7
+        run: npm config set legacy-peer-deps=true
       - name: Install Root Dependencies
-        run: npm install --ignore-scripts
-      - name: Bootstrap Dependencies
-        run: npx lerna bootstrap --no-ci
+        run: npm install --legacy-bundling
       - name: Unit tests
-        run: npm run test:browser
+        run: npx lerna run --no-bail test:browser
       - name: Report Coverage
         uses: codecov/codecov-action@v3
         with:

--- a/archive/opentelemetry-browser-extension-autoinjection/package.json
+++ b/archive/opentelemetry-browser-extension-autoinjection/package.json
@@ -35,7 +35,7 @@
     "@types/mocha": "8.2.3",
     "@types/react": "17.0.16",
     "@types/react-dom": "18.0.2",
-    "@types/sinon": "10.0.2",
+    "@types/sinon": "10.0.15",
     "@types/sinon-chrome": "2.2.11",
     "@typescript-eslint/eslint-plugin": "5.8.1",
     "@typescript-eslint/parser": "5.8.1",

--- a/detectors/node/opentelemetry-resource-detector-alibaba-cloud/package.json
+++ b/detectors/node/opentelemetry-resource-detector-alibaba-cloud/package.json
@@ -12,7 +12,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/resource-detector-alibaba-cloud --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "watch": "tsc -w"

--- a/detectors/node/opentelemetry-resource-detector-aws/package.json
+++ b/detectors/node/opentelemetry-resource-detector-aws/package.json
@@ -12,7 +12,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/resource-detector-aws --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "watch": "tsc -w"

--- a/detectors/node/opentelemetry-resource-detector-container/package.json
+++ b/detectors/node/opentelemetry-resource-detector-container/package.json
@@ -13,7 +13,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version --scope @opentelemetry/resource-detector-container --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "version:update": "node ../../../scripts/version-update.js",

--- a/detectors/node/opentelemetry-resource-detector-gcp/package.json
+++ b/detectors/node/opentelemetry-resource-detector-gcp/package.json
@@ -12,7 +12,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/resource-detector-gcp --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "watch": "tsc -w"

--- a/detectors/node/opentelemetry-resource-detector-github/package.json
+++ b/detectors/node/opentelemetry-resource-detector-github/package.json
@@ -12,7 +12,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/resource-detector-github --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "watch": "tsc -w"

--- a/detectors/node/opentelemetry-resource-detector-instana/package.json
+++ b/detectors/node/opentelemetry-resource-detector-instana/package.json
@@ -12,7 +12,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/resource-detector-instana --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "watch": "tsc -w"

--- a/metapackages/auto-instrumentations-node/package.json
+++ b/metapackages/auto-instrumentations-node/package.json
@@ -25,7 +25,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/auto-instrumentations-node --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "tdd": "yarn test -- --watch-extensions ts --watch",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.ts'",
     "watch": "tsc -w"

--- a/metapackages/auto-instrumentations-web/package.json
+++ b/metapackages/auto-instrumentations-web/package.json
@@ -22,7 +22,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/auto-instrumentations-web --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "test:browser": "nyc karma start --single-run",
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "types": "build/src/index.d.ts",
   "scripts": {
     "clean": "lerna run clean",
-    "postinstall": "npm run bootstrap",
+    "postinstall": "lerna run compile",
     "prepare": "husky install",
     "precompile": "tsc --version && npm run version:update",
     "version:update": "lerna run version:update",
@@ -23,15 +23,12 @@
     "test": "lerna run test",
     "test:ci:changed": "lerna run test --since origin/main",
     "test:browser": "lerna run test:browser --concurrency 1",
-    "bootstrap": "lerna bootstrap --no-ci",
     "bump": "lerna publish",
     "changelog": "lerna-changelog",
-    "lerna:link": "lerna link",
     "lint": "lerna run lint",
     "lint:fix": "lerna run lint:fix",
     "lint:examples": "eslint ./examples/**/*.js",
-    "lint:examples:fix": "eslint ./examples/**/*.js --fix",
-    "lerna:scope": "lerna bootstrap --include-dependents --include-dependencies --scope"
+    "lint:examples:fix": "eslint ./examples/**/*.js --fix"
   },
   "keywords": [
     "opentelemetry",
@@ -56,11 +53,21 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "4.2.1",
     "husky": "7.0.4",
-    "lerna": "5.5.2",
+    "lerna": "7.1.1",
     "lerna-changelog": "2.2.0",
     "prettier": "2.8.8",
     "typescript": "4.4.4"
   },
+  "workspaces": [
+    "packages/*",
+    "metapackages/*",
+    "plugins/node/*",
+    "plugins/node/*/examples",
+    "plugins/web/*",
+    "plugins/web/*/examples",
+    "propagators/*",
+    "detectors/node/*"
+  ],
   "changelog": {
     "labels": {
       "breaking": ":boom: Breaking Change",

--- a/packages/opentelemetry-host-metrics/package.json
+++ b/packages/opentelemetry-host-metrics/package.json
@@ -12,7 +12,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/host-metrics --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "test": "nyc ts-mocha -p tsconfig.json test/**/*.test.ts",
     "version:update": "node ../../scripts/version-update.js",

--- a/packages/opentelemetry-id-generator-aws-xray/package.json
+++ b/packages/opentelemetry-id-generator-aws-xray/package.json
@@ -23,8 +23,7 @@
     "test:browser": "nyc karma start --single-run",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json",
-    "prepare": "npm run compile"
+    "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json"
   },
   "keywords": [
     "opentelemetry",

--- a/packages/opentelemetry-propagation-utils/package.json
+++ b/packages/opentelemetry-propagation-utils/package.json
@@ -13,7 +13,6 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/propagation-utils --include-dependencies",
-    "prepare": "npm run compile",
     "prewatch": "npm run precompile",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",

--- a/packages/opentelemetry-redis-common/package.json
+++ b/packages/opentelemetry-redis-common/package.json
@@ -13,7 +13,6 @@
     "compile": "tsc --build tsconfig.json",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/redis-common --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "watch": "tsc -w"
   },

--- a/packages/opentelemetry-sampler-aws-xray/package.json
+++ b/packages/opentelemetry-sampler-aws-xray/package.json
@@ -34,7 +34,6 @@
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/sampler-aws-xray --include-dependencies",
     "prewatch": "npm run precompile",
     "clean": "tsc --build --clean tsconfig.json tsconfig.esm.json",
-    "prepare": "npm run compile",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "version:update": "node ../../scripts/version-update.js",
@@ -63,7 +62,6 @@
     "ts-mocha": "10.0.0",
     "nyc": "15.1.0",
     "typescript": "4.4.4",
-    "gts": "3.1.1",
     "@typescript-eslint/eslint-plugin": "5.8.1",
     "@typescript-eslint/parser": "5.8.1"
   },

--- a/packages/opentelemetry-sql-common/package.json
+++ b/packages/opentelemetry-sql-common/package.json
@@ -13,7 +13,6 @@
     "compile": "tsc --build tsconfig.json",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/sql-common --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "watch": "tsc -w"
   },

--- a/packages/opentelemetry-test-utils/package.json
+++ b/packages/opentelemetry-test-utils/package.json
@@ -13,7 +13,6 @@
     "compile": "tsc -p .",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/contrib-test-utils --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "watch": "tsc -w"
   },
   "repository": "open-telemetry/opentelemetry-js-contrib",

--- a/plugins/node/instrumentation-amqplib/package.json
+++ b/plugins/node/instrumentation-amqplib/package.json
@@ -34,7 +34,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-amqplib --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "test": "nyc ts-mocha -p tsconfig.json --require '@opentelemetry/contrib-test-utils' 'test/**/*.test.ts'",
     "test-all-versions": "tav",

--- a/plugins/node/instrumentation-dataloader/package.json
+++ b/plugins/node/instrumentation-dataloader/package.json
@@ -12,7 +12,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-dataloader --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "test-all-versions": "tav",

--- a/plugins/node/instrumentation-fs/package.json
+++ b/plugins/node/instrumentation-fs/package.json
@@ -13,7 +13,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-fs --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "npm run version:update && tsc -p ."
   },

--- a/plugins/node/instrumentation-lru-memoizer/.tav.yml
+++ b/plugins/node/instrumentation-lru-memoizer/.tav.yml
@@ -2,6 +2,3 @@
   versions: ">=1.3 <3"
   commands:
     - npm test
-
-  # Fix missing `contrib-test-utils` package
-  pretest: npm run --prefix ../../../ lerna:link

--- a/plugins/node/instrumentation-lru-memoizer/package.json
+++ b/plugins/node/instrumentation-lru-memoizer/package.json
@@ -14,7 +14,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-lru-memoizer --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "npm run version:update && tsc -p ."
   },

--- a/plugins/node/instrumentation-mongoose/package.json
+++ b/plugins/node/instrumentation-mongoose/package.json
@@ -15,7 +15,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-mongoose --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "npm run version:update && tsc -p ."
   },

--- a/plugins/node/instrumentation-socket.io/package.json
+++ b/plugins/node/instrumentation-socket.io/package.json
@@ -14,7 +14,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version --scope @opentelemetry/instrumentation-socket.io --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "npm run version:update && tsc -p ."
   },

--- a/plugins/node/instrumentation-tedious/.tav.yml
+++ b/plugins/node/instrumentation-tedious/.tav.yml
@@ -2,6 +2,3 @@ tedious:
   # 4.0.0 is broken: https://github.com/tediousjs/tedious/commit/4eceb48
   versions: "1.11.0 || 1.14.0 || 2.7.1 || 3.0.1 || 4.2.0 || ^6.7.0 || 8.3.0 || 9.2.3 || 11.0.9 || 11.2.0 || 11.4.0 || ^11.8.0 || ^12.3.0 || ^13.2.0 || ^14.0.0"
   commands: npm run test
-
-  # Fix missing `test-utils` package
-  pretest: npm run --prefix ../../../ lerna:link

--- a/plugins/node/instrumentation-tedious/package.json
+++ b/plugins/node/instrumentation-tedious/package.json
@@ -12,7 +12,6 @@
     "lint": "eslint . --ext .ts",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-tedious --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "test-all-versions": "tav",

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
@@ -13,7 +13,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-aws-lambda --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p ."
   },

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/.tav.yml
@@ -4,19 +4,13 @@
   versions: ">=2.1266.0 || 2.1262.0 || 2.1219.0 || 2.1048.0 || 2.1012.0 || 2.647.0 || 2.308.0"
   commands:
     - npm run test
-  # Fix missing `contrib-test-utils` package
-  pretest: npm run --prefix ../../../ lerna:link
 
 "@aws-sdk/client-s3":
   versions: ">=3.223.0 || 3.218.0 || 3.216.0 || 3.154.0 || 3.107.0 || 3.54.0 || 3.6.1"
   commands:
     - npm run test
-  # Fix missing `contrib-test-utils` package
-  pretest: npm run --prefix ../../../ lerna:link
 
 "@aws-sdk/client-sqs":
   versions: ">=3.216.0 || 3.171.0 || 3.58.0 || 3.54.0 || 3.43.0 || 3.24.0"
   commands:
     - npm run test
-  # Fix missing `contrib-test-utils` package
-  pretest: npm run --prefix ../../../ lerna:link

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
@@ -35,7 +35,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-aws-sdk --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "test": "nyc ts-mocha -p tsconfig.json --require '@opentelemetry/contrib-test-utils' 'test/**/*.test.ts'",
     "test-all-versions": "tav",

--- a/plugins/node/opentelemetry-instrumentation-bunyan/package.json
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/package.json
@@ -12,7 +12,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-bunyan --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "test-all-versions": "tav",

--- a/plugins/node/opentelemetry-instrumentation-cassandra/package.json
+++ b/plugins/node/opentelemetry-instrumentation-cassandra/package.json
@@ -13,7 +13,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-cassandra-driver --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p ."
   },

--- a/plugins/node/opentelemetry-instrumentation-connect/package.json
+++ b/plugins/node/opentelemetry-instrumentation-connect/package.json
@@ -12,7 +12,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-connect --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "version:update": "node ../../../scripts/version-update.js",
     "watch": "tsc -w"

--- a/plugins/node/opentelemetry-instrumentation-dns/package.json
+++ b/plugins/node/opentelemetry-instrumentation-dns/package.json
@@ -13,7 +13,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-dns --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p ."
   },

--- a/plugins/node/opentelemetry-instrumentation-express/examples/package.json
+++ b/plugins/node/opentelemetry-instrumentation-express/examples/package.json
@@ -33,7 +33,7 @@
     "@opentelemetry/exporter-jaeger": "^1.0.0",
     "@opentelemetry/exporter-zipkin": "^1.0.0",
     "@opentelemetry/instrumentation": "^0.41.2",
-    "@opentelemetry/instrumentation-express": "0.28.0",
+    "@opentelemetry/instrumentation-express": "0.33.0",
     "@opentelemetry/instrumentation-http": "^0.41.2",
     "@opentelemetry/resources": "^1.0.0",
     "@opentelemetry/sdk-trace-base": "^1.0.0",

--- a/plugins/node/opentelemetry-instrumentation-express/package.json
+++ b/plugins/node/opentelemetry-instrumentation-express/package.json
@@ -17,7 +17,6 @@
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p .",
     "compile:examples": "cd examples && npm run compile",
-    "prepare": "npm run compile",
     "watch": "tsc -w"
   },
   "keywords": [

--- a/plugins/node/opentelemetry-instrumentation-fastify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-fastify/package.json
@@ -11,7 +11,6 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-fastify --include-dependencies",
-    "prepare": "npm run compile",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "version:update": "node ../../../scripts/version-update.js",
     "prewatch": "npm run precompile",

--- a/plugins/node/opentelemetry-instrumentation-fastify/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-fastify/src/utils.ts
@@ -42,6 +42,7 @@ export function startSpan(
   const spans: Span[] = reply[spanRequestSymbol] || [];
   spans.push(span);
 
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises -- as reply have then method, Object.defineProperty(reply) will also return a promise like object
   Object.defineProperty(reply, spanRequestSymbol, {
     enumerable: false,
     configurable: true,

--- a/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
+++ b/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
@@ -15,7 +15,6 @@
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p .",
-    "prepare": "npm run compile",
     "watch": "tsc -w"
   },
   "keywords": [

--- a/plugins/node/opentelemetry-instrumentation-graphql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-graphql/package.json
@@ -12,7 +12,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-graphql --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "test-all-versions": "tav",
     "tdd": "npm run test -- --watch-extensions ts --watch",

--- a/plugins/node/opentelemetry-instrumentation-hapi/package.json
+++ b/plugins/node/opentelemetry-instrumentation-hapi/package.json
@@ -14,8 +14,7 @@
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-hapi --include-dependencies",
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
-    "compile": "tsc -p .",
-    "prepare": "npm run compile"
+    "compile": "tsc -p ."
   },
   "keywords": [
     "hapi",

--- a/plugins/node/opentelemetry-instrumentation-ioredis/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/.tav.yml
@@ -2,6 +2,3 @@ ioredis:
   # Ignoring v4.19.0. Tests never ends. Caused by https://github.com/luin/ioredis/pull/1219
   versions: "^2.5.0 || ^3.2.2 || 4.14.1 || 4.16.3 || 4.17.3 || 4.18.0 || 4.19.2 || 4.19.4 || 4.22.0 || 4.24.5 || 4.26.0 || 4.27.2 || ^4.27.6 || 5.0.4 || ^5.2.4"
   commands: npm run test
-
-  # Fix missing `contrib-test-utils` package
-  pretest: npm run --prefix ../../../ lerna:link

--- a/plugins/node/opentelemetry-instrumentation-ioredis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/package.json
@@ -18,8 +18,7 @@
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-ioredis --include-dependencies",
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
-    "compile": "tsc -p .",
-    "prepare": "npm run compile"
+    "compile": "tsc -p ."
   },
   "keywords": [
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-knex/package.json
+++ b/plugins/node/opentelemetry-instrumentation-knex/package.json
@@ -15,7 +15,6 @@
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p .",
-    "prepare": "npm run compile",
     "watch": "tsc -w"
   },
   "keywords": [

--- a/plugins/node/opentelemetry-instrumentation-koa/examples/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/examples/package.json
@@ -36,7 +36,7 @@
     "@opentelemetry/exporter-zipkin": "^1.0.0",
     "@opentelemetry/instrumentation": "^0.41.2",
     "@opentelemetry/instrumentation-http": "^0.41.2",
-    "@opentelemetry/instrumentation-koa": "^0.31.0",
+    "@opentelemetry/instrumentation-koa": "^0.35.0",
     "@opentelemetry/sdk-trace-node": "^1.0.0",
     "@opentelemetry/sdk-trace-base": "^1.0.0",
     "axios": "^0.21.1",

--- a/plugins/node/opentelemetry-instrumentation-koa/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/package.json
@@ -17,7 +17,6 @@
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p .",
     "compile:examples": "cd examples && npm run compile",
-    "prepare": "npm run compile",
     "watch": "tsc -w"
   },
   "keywords": [

--- a/plugins/node/opentelemetry-instrumentation-memcached/package.json
+++ b/plugins/node/opentelemetry-instrumentation-memcached/package.json
@@ -12,7 +12,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-memcached --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "test:debug": "cross-env RUN_MEMCACHED_TESTS_LOCAL=true ts-mocha --inspect-brk --no-timeouts -p tsconfig.json 'test/**/*.test.ts'",

--- a/plugins/node/opentelemetry-instrumentation-mongodb/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/.tav.yml
@@ -6,6 +6,3 @@ mongodb:
       commands: npm run test-v4
     - versions: ">=5 <6"
       commands: npm run test-v5
-
-  # Fix missing `contrib-test-utils` package
-  pretest: npm run --prefix ../../../ lerna:link

--- a/plugins/node/opentelemetry-instrumentation-mongodb/examples/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/examples/package.json
@@ -38,7 +38,7 @@
     "@opentelemetry/instrumentation-mongodb": "^0.36.0",
     "@opentelemetry/sdk-trace-node": "^1.0.0",
     "@opentelemetry/sdk-trace-base": "^1.0.0",
-    "mongodb": "^3.7.3"
+    "mongodb": "^4.16.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib#readme",
   "devDependencies": {

--- a/plugins/node/opentelemetry-instrumentation-mongodb/examples/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/examples/package.json
@@ -35,7 +35,7 @@
     "@opentelemetry/exporter-zipkin": "^1.0.0",
     "@opentelemetry/instrumentation": "^0.41.2",
     "@opentelemetry/instrumentation-http": "^0.41.2",
-    "@opentelemetry/instrumentation-mongodb": "^0.32.0",
+    "@opentelemetry/instrumentation-mongodb": "^0.36.0",
     "@opentelemetry/sdk-trace-node": "^1.0.0",
     "@opentelemetry/sdk-trace-base": "^1.0.0",
     "mongodb": "^3.7.3"

--- a/plugins/node/opentelemetry-instrumentation-mongodb/examples/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/examples/src/utils.ts
@@ -28,15 +28,17 @@ export function accessDB(
   options: mongodb.MongoClientOptions = {}
 ): Promise<mongodb.Db> {
   return new Promise((resolve, reject) => {
-    mongodb.MongoClient.connect(url, {
-      serverSelectionTimeoutMS: 1000,
-      useUnifiedTopology: true
-    })
-      .then(client => {
-        resolve(client.db(dbName));
+    try {
+      const client = new mongodb.MongoClient(url, {
+        serverSelectionTimeoutMS: 1000
       })
-      .catch(reason => {
-        reject(reason);
-      });
+
+      const db = client.db(dbName)
+
+      resolve(db)
+    } catch (reason) {
+
+      reject(reason);
+    }
   });
 }

--- a/plugins/node/opentelemetry-instrumentation-mongodb/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/package.json
@@ -21,7 +21,6 @@
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p .",
     "compile:examples": "cd examples && npm run compile",
-    "prepare": "npm run compile",
     "watch": "tsc -w"
   },
   "keywords": [

--- a/plugins/node/opentelemetry-instrumentation-mysql/examples/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql/examples/package.json
@@ -36,7 +36,7 @@
     "@opentelemetry/exporter-zipkin": "^1.0.0",
     "@opentelemetry/instrumentation": "^0.41.2",
     "@opentelemetry/instrumentation-http": "^0.41.2",
-    "@opentelemetry/instrumentation-mysql": "^0.31.0",
+    "@opentelemetry/instrumentation-mysql": "^0.34.0",
     "@opentelemetry/sdk-trace-base": "^1.0.0",
     "@opentelemetry/sdk-trace-node": "^1.0.0",
     "@opentelemetry/exporter-metrics-otlp-grpc": "0.41.2",

--- a/plugins/node/opentelemetry-instrumentation-mysql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql/package.json
@@ -12,7 +12,6 @@
     "lint": "eslint . --ext .ts",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-mysql --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "test": "nyc ts-mocha tsconfig.json 'test/**/*.test.ts'",
     "version:update": "node ../../../scripts/version-update.js",

--- a/plugins/node/opentelemetry-instrumentation-mysql2/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/.tav.yml
@@ -1,18 +1,12 @@
 mysql2:
   - versions: <4 >=3.2.0 || 3.1.0 || 3.0.0
     commands: npm run test
-    # Fix missing `test-utils` package
-    pretest: npm run --prefix ../../../ lerna:link
 
   - versions: <3 >=2.3.2 || 2.3.0 || 2.2.5 || 2.1.0
     # Skip 2.3.3 which installs types from git which takes 10m on it's own
     commands: npm run test
 
-    # Fix missing `test-utils` package
-    pretest: npm run --prefix ../../../ lerna:link
   - versions: 1.4.2 || 1.5.3 || 1.6.4 || 1.6.5 || 1.7.0
     # Skip v1.6.2, which is broken
     commands: npm run test
 
-    # Fix missing `test-utils` package
-    pretest: npm run --prefix ../../../ lerna:link

--- a/plugins/node/opentelemetry-instrumentation-mysql2/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/package.json
@@ -12,7 +12,6 @@
     "lint": "eslint . --ext .ts",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-mysql2 --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "test-all-versions": "tav",

--- a/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
+++ b/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
@@ -13,7 +13,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-nestjs-core --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "test": "nyc ts-mocha --timeout 5000 -p tsconfig.json 'test/**/*.test.ts'",
     "test-all-versions": "tav",

--- a/plugins/node/opentelemetry-instrumentation-net/package.json
+++ b/plugins/node/opentelemetry-instrumentation-net/package.json
@@ -13,7 +13,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-net --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p ."
   },

--- a/plugins/node/opentelemetry-instrumentation-pg/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-pg/.tav.yml
@@ -2,5 +2,4 @@ pg:
     # a sample from supported versions
   - versions: "8.5.1 || 8.6.0 || 8.7.1"
     peerDependencies: pg-pool@^3
-    pretest: npm run --prefix ../../../ lerna:link
     commands: npm run test

--- a/plugins/node/opentelemetry-instrumentation-pg/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pg/package.json
@@ -12,7 +12,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-pg --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "test-all-versions": "cross-env IN_TAV=true tav",

--- a/plugins/node/opentelemetry-instrumentation-pino/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-pino/.tav.yml
@@ -3,11 +3,7 @@ pino:
     node: ">=14"
     commands: npm run test
 
-    # Fix missing `contrib-test-utils` package
-    pretest: npm run --prefix ../../../ lerna:link
   - versions: "^7.11.0 || 7.8.0 || 7.2.0 || ^6.13.1 || 5.17.0 || 5.14.0"
     node: ">=8 <14"
     commands: npm run test
 
-    # Fix missing `contrib-test-utils` package
-    pretest: npm run --prefix ../../../ lerna:link

--- a/plugins/node/opentelemetry-instrumentation-pino/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pino/package.json
@@ -14,7 +14,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-pino --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p ."
   },

--- a/plugins/node/opentelemetry-instrumentation-redis-4/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-redis-4/.tav.yml
@@ -3,6 +3,3 @@ redis:
   jobs:
     - versions: "^4.0.0"
       commands: npm run test
-
-  # Fix missing `contrib-test-utils` package
-  pretest: npm run --prefix ../../../ lerna:link

--- a/plugins/node/opentelemetry-instrumentation-redis-4/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis-4/package.json
@@ -20,8 +20,7 @@
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-redis-4 --include-dependencies",
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
-    "compile": "tsc -p .",
-    "prepare": "npm run compile"
+    "compile": "tsc -p ."
   },
   "keywords": [
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-redis/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-redis/.tav.yml
@@ -1,6 +1,3 @@
 redis:
   versions: ^2.6.0 || ^3.0.0
   commands: npm run test
-
-  # Fix missing `contrib-test-utils` package
-  pretest: npm run --prefix ../../../ lerna:link

--- a/plugins/node/opentelemetry-instrumentation-redis/examples/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis/examples/package.json
@@ -36,7 +36,7 @@
     "@opentelemetry/exporter-zipkin": "^1.0.0",
     "@opentelemetry/instrumentation": "^0.41.2",
     "@opentelemetry/instrumentation-http": "^0.41.2",
-    "@opentelemetry/instrumentation-redis": "^0.32.0",
+    "@opentelemetry/instrumentation-redis": "^0.35.0",
     "@opentelemetry/sdk-trace-base": "^1.0.0",
     "@opentelemetry/sdk-trace-node": "^1.0.0",
     "axios": "^0.21.1",

--- a/plugins/node/opentelemetry-instrumentation-redis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis/package.json
@@ -21,8 +21,7 @@
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p .",
-    "compile:examples": "cd examples && npm run compile",
-    "prepare": "npm run compile"
+    "compile:examples": "cd examples && npm run compile"
   },
   "keywords": [
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-restify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-restify/package.json
@@ -11,7 +11,6 @@
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-restify --include-dependencies",
-    "prepare": "npm run compile",
     "prewatch": "npm run precompile",
     "tdd": "yarn test -- --watch-extensions ts --watch",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.ts'",

--- a/plugins/node/opentelemetry-instrumentation-restify/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/src/instrumentation.ts
@@ -32,7 +32,7 @@ import {
 } from '@opentelemetry/instrumentation';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { isPromise, isAsyncFunction } from './utils';
-import { getRPCMetadata, RPCType, setRPCMetadata } from '@opentelemetry/core';
+import { getRPCMetadata, RPCType } from '@opentelemetry/core';
 import type { RestifyInstrumentationConfig } from './types';
 
 const { diag } = api;
@@ -176,7 +176,7 @@ export class RestifyInstrumentation extends InstrumentationBase<any> {
         // replace HTTP instrumentations name with one that contains a route
         const httpMetadata = getRPCMetadata(api.context.active());
         if (httpMetadata?.type === RPCType.HTTP) {
-          httpMetadata.span.updateName(`${req.method} ${route}`);
+          httpMetadata.route = route;
         }
 
         const fnName = handler.name || undefined;
@@ -237,13 +237,7 @@ export class RestifyInstrumentation extends InstrumentationBase<any> {
             });
         };
 
-        let newContext = api.trace.setSpan(api.context.active(), span);
-        if (httpMetadata) {
-          newContext = setRPCMetadata(
-            newContext,
-            Object.assign(httpMetadata, { route })
-          );
-        }
+        const newContext = api.trace.setSpan(api.context.active(), span);
         return api.context.with(
           newContext,
           (req: types.Request, res: restify.Response, next: restify.Next) => {

--- a/plugins/node/opentelemetry-instrumentation-router/package.json
+++ b/plugins/node/opentelemetry-instrumentation-router/package.json
@@ -15,7 +15,6 @@
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p .",
-    "prepare": "npm run compile",
     "watch": "tsc -w"
   },
   "keywords": [

--- a/plugins/node/opentelemetry-instrumentation-winston/package.json
+++ b/plugins/node/opentelemetry-instrumentation-winston/package.json
@@ -14,7 +14,6 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-winston --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p ."
   },

--- a/plugins/web/opentelemetry-instrumentation-document-load/package.json
+++ b/plugins/web/opentelemetry-instrumentation-document-load/package.json
@@ -14,7 +14,6 @@
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "npm run version:update && tsc --build tsconfig.json tsconfig.esm.json",
-    "prepare": "npm run compile",
     "tdd": "karma start",
     "test:browser": "nyc karma start --single-run",
     "watch": "tsc --build -watch tsconfig.json tsconfig.esm.json"

--- a/plugins/web/opentelemetry-instrumentation-long-task/package.json
+++ b/plugins/web/opentelemetry-instrumentation-long-task/package.json
@@ -14,7 +14,6 @@
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "npm run version:update && tsc --build tsconfig.json tsconfig.esm.json",
-    "prepare": "npm run compile",
     "tdd": "karma start",
     "test:browser": "nyc karma start --single-run",
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json"
@@ -73,8 +72,7 @@
     "typescript": "4.4.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.7.2",
-    "webpack-merge": "5.8.0",
-    "zone.js": "0.11.4"
+    "webpack-merge": "5.8.0"
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",

--- a/plugins/web/opentelemetry-instrumentation-long-task/tsconfig.esm.json
+++ b/plugins/web/opentelemetry-instrumentation-long-task/tsconfig.esm.json
@@ -5,7 +5,6 @@
     "outDir": "build/esm",
     "tsBuildInfoFile": "build/esm/tsconfig.esm.tsbuildinfo"
   },
-  "files": [ "node_modules/zone.js/dist/zone.js.d.ts"],
   "include": [
     "src/**/*.ts"
   ]

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
@@ -14,7 +14,6 @@
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "npm run version:update && tsc --build tsconfig.json tsconfig.esm.json",
-    "prepare": "npm run compile",
     "tdd": "karma start",
     "test:browser": "nyc karma start --single-run",
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json"

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/src/internal-types.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/src/internal-types.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/// <reference types="zone.js" />
 
 import { HrTime } from '@opentelemetry/api';
 import { EventName } from './types';

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/tsconfig.esm.json
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/tsconfig.esm.json
@@ -6,7 +6,6 @@
     "skipLibCheck": true,
     "tsBuildInfoFile": "build/esm/tsconfig.esm.tsbuildinfo"
   },
-  "files": [ "node_modules/zone.js/dist/zone.js.d.ts"],
   "include": [
     "src/**/*.ts"
   ]

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/tsconfig.json
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/tsconfig.json
@@ -5,7 +5,6 @@
     "outDir": "build",
     "skipLibCheck": true
   },
-  "files": [ "node_modules/zone.js/dist/zone.js.d.ts"],
   "include": [
     "src/**/*.ts",
     "test/**/*.ts"

--- a/plugins/web/opentelemetry-plugin-react-load/package.json
+++ b/plugins/web/opentelemetry-plugin-react-load/package.json
@@ -14,7 +14,6 @@
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "npm run version:update && tsc --build tsconfig.json tsconfig.esm.json",
-    "prepare": "npm run compile",
     "tdd": "karma start",
     "test:browser": "nyc karma start --single-run",
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json"

--- a/propagators/opentelemetry-propagator-aws-xray/package.json
+++ b/propagators/opentelemetry-propagator-aws-xray/package.json
@@ -15,8 +15,7 @@
     "test:browser": "nyc karma start --single-run",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json",
-    "prepare": "npm run compile"
+    "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json"
   },
   "keywords": [
     "opentelemetry",

--- a/propagators/opentelemetry-propagator-grpc-census-binary/package.json
+++ b/propagators/opentelemetry-propagator-grpc-census-binary/package.json
@@ -15,7 +15,6 @@
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/propagator-grpc-census-binary --include-dependencies",
     "prewatch": "npm run precompile",
     "compile": "tsc -p .",
-    "prepare": "npm run compile",
     "watch": "tsc -w"
   },
   "keywords": [

--- a/propagators/opentelemetry-propagator-instana/package.json
+++ b/propagators/opentelemetry-propagator-instana/package.json
@@ -15,8 +15,7 @@
     "test:browser": "nyc karma start --single-run",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json",
-    "prepare": "npm run compile"
+    "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json"
   },
   "keywords": [
     "opentelemetry",

--- a/propagators/opentelemetry-propagator-ot-trace/package.json
+++ b/propagators/opentelemetry-propagator-ot-trace/package.json
@@ -15,8 +15,7 @@
     "test:browser": "nyc karma start --single-run",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json",
-    "prepare": "npm run compile"
+    "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json"
   },
   "keywords": [
     "opentelemetry",

--- a/scripts/update-core-deps.js
+++ b/scripts/update-core-deps.js
@@ -27,7 +27,7 @@
  *  `CORE_REPOSITORY=../../otel-core node scripts/update-core-deps.js
  * 
  * Note that this only updates the versions in the package.json for each package
- * and you will still need to run `lerna bootstrap` and make any necessary
+ * and you will still need to run `npm run compile` and make any necessary
  * code changes.
  */
 


### PR DESCRIPTION
## Which problem is this PR solving?

- As lerna@7 drop support for `lerna bootstrap`, `lerna link`, and `lerna add`, we must depend on the package's manager native solution
Fixes #904 
Fixes #1542

## Short description of the changes

- Add "workspaces" definition to root package.json
- Remove the "prepare" script in each workspace's package.json
- Clean up `gts` as it does not use anymore; I just happened to see this because its part of the `lerna bootstrap` arguments
- Fix any hoist issue that occurred with the new setup:
  - `zone.js` => instrumentation-user-interaction depends on zone.js's type, but the way the type is defined in zone.js is generated, it can't be used with the import statement. We must use `/// <reference` syntax so that we don't need to fix the path to `zone.js/dist/zone.js.d.ts`
- Update GH's action cache using setup-node
  - This will cache the ~/.npm instead of node_modules folder and won't cache any generated package-lock.json 
    - this previous setup might create a cache lock file that we unable to replicate on local machine
    - as we also don't use `yarn bootstrap` anymore, the previous [best practice for node lerna cache](https://github.com/actions/cache/blob/main/examples.md#node---lerna) not apply for this case
- Remove lerna:link in .tav.yml file

There might be some hoist issues in the future, and the current npmcli script doesn’t provide enough support for us for more complex hoisting like what `lerna` used to provide.

## Blocker

- [ ] NPM's workspace hoisting issue
  - [ ] Hoisting issue in `example` module
    - [ ] Should `example` module use latest code?
    - [ ] Mongodb's example module is picking up mongodb@v4 from root folder => this cause mongo's example project failt to compule
  - [ ] Should we move to pnpm or Yarn if NPM's hoisting can't be solve?
    - [ ] How to handle `test-all-version`?
    - [ ] Benchmark/toolchain?
    - [ ] Maintainer consensus? 

## Next Step

As lerna@7 is just provide some additional feature on top of nx, ee might consider to include nx.json to increase caching between task and apply for nx-cloud. Nx-cloud should be free for OSS project like opentelemetry-js-contrib. Those change might also fix issue with #1473 