### PR TITLE
fix(mongodb): remove broken type export `V4Connection`

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-mongodb/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/src/types.ts
@@ -69,14 +69,3 @@ export enum MongodbCommandType {
   COUNT = 'count',
   UNKNOWN = 'unknown',
 }
-
-// https://github.com/mongodb/node-mongodb-native/blob/v4.2.2/src/cmap/connection.ts
-export type V4Connection = {
-  id: number | '<monitor>';
-  command(
-    ns: any,
-    cmd: Document,
-    options: undefined | unknown,
-    callback: any
-  ): void;
-};


### PR DESCRIPTION


<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?
The type `V4Connection` re-introduced in #1170 is missing any type definitions or imports for `Document`, breaking the build with Typescript strict mode.


BREAKING CHANGE: removes the broken exported type `V4Connection`.
Fixes #1639


## Short description of the changes
`V4Connection` in `types.ts` is not referenced anywhere (the type definition in `internal-types.ts` is used. So lets just drop this type definition.
