### PR TITLE
fix(instrumentation-dns): use caret range for semver regular dependency

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-dns/package.json
+++ b/plugins/node/opentelemetry-instrumentation-dns/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.41.2",
     "@opentelemetry/semantic-conventions": "^1.0.0",
-    "semver": "7.5.4"
+    "semver": "^7.5.4"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-dns#readme"
 }


### PR DESCRIPTION
#1646 fixed the version of "semver" in the repo, but I accidentally merged it without noticing that it pinned a regular dependency (not dev) to a specific version which does not follow our conventions as documented [here](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/GUIDELINES.md#third-party-library-dependencies).

This PR is to fix this. After it is merged, the "semver" versions in the repo should be aligned correctly