### PR TITLE
fix: Removed deprecated properties usage in Fastify instrumentation

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-fastify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-fastify/package.json
@@ -53,13 +53,13 @@
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/express": "4.17.18",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
-    "fastify": "4.18.0",
+    "@types/node": "18.15.3",
+    "fastify": "4.23.0",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "rimraf": "5.0.5",
     "ts-mocha": "10.0.0",
-    "typescript": "4.4.4"
+    "typescript": "5.2.2"
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",

--- a/plugins/node/opentelemetry-instrumentation-fastify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-fastify/package.json
@@ -59,7 +59,7 @@
     "nyc": "15.1.0",
     "rimraf": "5.0.5",
     "ts-mocha": "10.0.0",
-    "typescript": "5.2.2"
+    "typescript": "4.7.4"
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",

--- a/plugins/node/opentelemetry-instrumentation-fastify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-fastify/package.json
@@ -54,12 +54,12 @@
     "@types/express": "4.17.18",
     "@types/mocha": "7.0.2",
     "@types/node": "18.15.3",
-    "fastify": "4.23.0",
+    "fastify": "4.18.0",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "rimraf": "5.0.5",
     "ts-mocha": "10.0.0",
-    "typescript": "4.7.4"
+    "typescript": "4.4.4"
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",

--- a/plugins/node/opentelemetry-instrumentation-fastify/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-fastify/src/instrumentation.ts
@@ -93,10 +93,11 @@ export class FastifyInstrumentation extends InstrumentationBase {
       }
       instrumentation._wrap(reply, 'send', instrumentation._patchSend());
 
-      const anyRequest = (request as any);
+      const anyRequest = request as any;
 
       const rpcMetadata = getRPCMetadata(context.active());
-      const routeName = anyRequest.routeOptions?.config?.url || request.routerPath;
+      const routeName =
+        anyRequest.routeOptions?.config?.url || request.routerPath;
       if (routeName && rpcMetadata?.type === RPCType.HTTP) {
         rpcMetadata.route = routeName;
       }
@@ -261,9 +262,10 @@ export class FastifyInstrumentation extends InstrumentationBase {
       if (!instrumentation.isEnabled()) {
         return done();
       }
-      const anyRequest = (request as any);
+      const anyRequest = request as any;
 
-      const handler = anyRequest.routeOptions?.handler || anyRequest.context?.handler || {};
+      const handler =
+        anyRequest.routeOptions?.handler || anyRequest.context?.handler || {};
 
       const handlerName = handler?.name.substr(6);
       const spanName = `${FastifyNames.REQUEST_HANDLER} - ${
@@ -273,7 +275,8 @@ export class FastifyInstrumentation extends InstrumentationBase {
       const spanAttributes: SpanAttributes = {
         [AttributeNames.PLUGIN_NAME]: this.pluginName,
         [AttributeNames.FASTIFY_TYPE]: FastifyTypes.REQUEST_HANDLER,
-        [SemanticAttributes.HTTP_ROUTE]: anyRequest.routeOptions?.config?.url || request.routerPath,
+        [SemanticAttributes.HTTP_ROUTE]:
+          anyRequest.routeOptions?.config?.url || request.routerPath,
       };
       if (handlerName) {
         spanAttributes[AttributeNames.FASTIFY_NAME] = handlerName;

--- a/plugins/node/opentelemetry-instrumentation-fastify/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-fastify/src/utils.ts
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  Span,
-  SpanAttributes,
-  SpanStatusCode,
-  Tracer,
-} from '@opentelemetry/api';
+import { Attributes, Span, SpanStatusCode, Tracer } from '@opentelemetry/api';
 import { spanRequestSymbol } from './constants';
 
 import type { PluginFastifyReply } from './internal-types';
@@ -35,13 +30,14 @@ export function startSpan(
   reply: PluginFastifyReply,
   tracer: Tracer,
   spanName: string,
-  spanAttributes: SpanAttributes = {}
+  spanAttributes: Attributes = {}
 ) {
   const span = tracer.startSpan(spanName, { attributes: spanAttributes });
 
   const spans: Span[] = reply[spanRequestSymbol] || [];
   spans.push(span);
 
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
   Object.defineProperty(reply, spanRequestSymbol, {
     enumerable: false,
     configurable: true,

--- a/plugins/node/opentelemetry-instrumentation-fastify/test/instrumentation.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-fastify/test/instrumentation.test.ts
@@ -190,7 +190,7 @@ describe('fastify', () => {
         async function subsystem(fastify: FastifyInstance) {
           fastify.addHook(
             'onRequest',
-            async (
+            (
               req: FastifyRequest,
               res: FastifyReply,
               next: HookHandlerDoneFunction


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Instrumentation has been using deprecated properties producing errors like `FastifyDeprecation: Request#context property access is deprecated. Please use "Request#routeConfig" or "Request#routeSchema" instead for accessing Route settings. The "Request#context" will be removed in fastify@5.`
https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1275

## Short description of the changes

I've added getting deprecated properties from newly introduced `routeOptions` object in fastify request. It supports also old versions that doesn't have this object exposed. It has been introduced in fastify https://github.com/fastify/fastify/releases/tag/v4.23.0
