### PR TITLE
chore(test-utils): improve handling of running docker containers

### DIFF
--- a/packages/opentelemetry-test-utils/src/test-utils.ts
+++ b/packages/opentelemetry-test-utils/src/test-utils.ts
@@ -60,7 +60,6 @@ export function startDocker(db: keyof typeof dockerRunCmds) {
 
 export function cleanUpDocker(db: keyof typeof dockerRunCmds) {
   run(`docker stop otel-${db}`);
-  run(`docker rm otel-${db}`);
 }
 
 function run(cmd: string) {
@@ -68,15 +67,16 @@ function run(cmd: string) {
     const proc = childProcess.spawnSync(cmd, {
       shell: true,
     });
+    const output = Buffer.concat(
+      proc.output.filter(c => c) as Buffer[]
+    ).toString('utf8');
     if (proc.status !== 0) {
       console.error('Failed run command:', cmd);
-      console.error(proc.output);
+      console.error(output);
     }
     return {
       code: proc.status,
-      output: proc.output
-        .map(v => String.fromCharCode.apply(null, v as any))
-        .join(''),
+      output,
     };
   } catch (e) {
     console.log(e);


### PR DESCRIPTION
- Convert the output of run commands to a string that is readable.
- No need to `docker rm ...` test containers for `npm run test:local` usage because the `docker run --rm ...` option will remove them when stopped.


## Which problem is this PR solving?

When running `npm run test:local` in some of the packages (e.g. in "plugins/node/opentelemetry-instrumentation-ioredis") there were a couple problems with the running of docker commands:

1. If one of the commands failed, the printed output would be a raw array of Buffer content, e.g.:

Before:

```
...
Failed run command: docker rm otel-redis
[
  null,
  <Buffer >,
  <Buffer 45 72 72 6f 72 20 72 65 73 70 6f 6e 73 65 20 66 72 6f 6d 20 64 61 65 6d 6f 6e 3a 20 4e 6f 20 73 75 63 68 20 63 6f 6e 74 61 69 6e 65 72 3a 20 6f 74 65 ... 8 more bytes>
]
```

After:

```
...
Failed run command: docker rm otel-redis
Error response from daemon: No such container: otel-redis
```

2. The cleanup steps were running `docker stop ...` and `docker rm ...`. The latter is unnecessary, given that all the `docker run ...` commands use the `--rm` argument. The result was, for example:

```
Failed run command: docker rm otel-redis
Error response from daemon: No such container: otel-redis
```

Removing the `docker rm ...` in the cleanup resolves this issue.

