### PR TITLE
fix: prevent accessing deprecated Fastify property in NestJS instrumentation

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-nestjs-core/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-nestjs-core/src/instrumentation.ts
@@ -188,7 +188,8 @@ function createWrapCreateHandler(tracer: api.Tracer, moduleVersion?: string) {
             [AttributeNames.TYPE]: NestType.REQUEST_CONTEXT,
             [SemanticAttributes.HTTP_METHOD]: req.method,
             [SemanticAttributes.HTTP_URL]: req.originalUrl || req.url,
-            [SemanticAttributes.HTTP_ROUTE]: req.route?.path || req.routerPath,
+            [SemanticAttributes.HTTP_ROUTE]:
+              req.route?.path || req.routeOptions?.url || req.routerPath,
             [AttributeNames.CONTROLLER]: instanceName,
             [AttributeNames.CALLBACK]: callbackName,
           },


### PR DESCRIPTION
## Which problem is this PR solving?

Installing `@opentelemetry/instrumentation-nestjs-core` and using the NestJS instrumentation plugin produces a deprecation warning with Fastify for every request. This deprecation warning was introduced in Fastify [v4.23.0](https://github.com/fastify/fastify/releases/tag/v4.23.0).

Resolves #1698.

## Short description of the changes

This PR prevents accessing the deprecated `routerPath` property in Fastify if `req.routeOptions.url` exists.
