### PR TITLE
feat(fastify): Add `onError` configuration

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-fastify/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-fastify/src/instrumentation.ts
@@ -102,6 +102,22 @@ export class FastifyInstrumentation extends InstrumentationBase {
     };
   }
 
+  private _hookOnError() {
+    const instrumentation = this;
+
+    return (request: any, reply: any, error: Error, done: () => void) => {
+      if (!instrumentation.isEnabled()) {
+        return done();
+      }
+
+      const onError = instrumentation.getConfig().onError;
+      if (onError) {
+        onError(request, reply, error);
+      }
+      done();
+    };
+  }
+
   private _wrapHandler(
     pluginName: string,
     hookName: string,
@@ -206,6 +222,7 @@ export class FastifyInstrumentation extends InstrumentationBase {
       const app: FastifyInstance = moduleExports.fastify.apply(this, args);
       app.addHook('onRequest', instrumentation._hookOnRequest());
       app.addHook('preHandler', instrumentation._hookPreHandler());
+      app.addHook('onError', instrumentation._hookOnError());
 
       instrumentation._wrap(app, 'addHook', instrumentation._wrapAddHook());
 

--- a/plugins/node/opentelemetry-instrumentation-fastify/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-fastify/src/types.ts
@@ -30,10 +30,16 @@ export interface FastifyCustomAttributeFunction {
   (span: Span, info: FastifyRequestInfo): void;
 }
 
+export interface FastifyOnErrorFunction {
+  (request: any, reply: any, error: Error): void;
+}
+
 /**
  * Options available for the Fastify Instrumentation
  */
 export interface FastifyInstrumentationConfig extends InstrumentationConfig {
   /** Function for adding custom attributes to each handler span */
   requestHook?: FastifyCustomAttributeFunction;
+  /** Function to call when an error is captured by Fastify. */
+  onError?: FastifyOnErrorFunction;
 }

--- a/plugins/node/opentelemetry-instrumentation-fastify/test/instrumentation.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-fastify/test/instrumentation.test.ts
@@ -498,5 +498,30 @@ describe('fastify', () => {
         });
       });
     });
+
+    describe('using onError in config', () => {
+      it('calls onError provided function when set in config', async () => {
+        const errors: Error[] = [];
+
+        const onError = (request: unknown, res: unknown, error: Error) => {
+          console.log('on error');
+          errors.push(error);
+        };
+
+        instrumentation.setConfig({
+          ...instrumentation.getConfig(),
+          onError,
+        });
+
+        app.get('/test', (req, res) => {
+          throw new Error('test error here');
+        });
+
+        await startServer();
+        await httpRequest.get(`http://localhost:${PORT}/test`);
+
+        assert.deepEqual(errors, [new Error('test error here')]);
+      });
+    });
   });
 });


### PR DESCRIPTION
This makes it very easy to provide an error handler for the instrumentation. This is helpful for libraries because users may add their own error handlers, which may swallow errors. For example, at Sentry, we want to have an `onError` handler in order to ensure we capture all errors that happen, even if users add their own `onError` to e.g. render a custom 400 or 500 response.

Usage:

```js
new FastifyInstrumentation({
  onError: (request, reply, error) => {
    // do something with the error
  }
})
```

For e.g. libraries wrapping this under the hood, this is extremely helpful as it allows to provide an error handler without the user needing to do anything.