### PR TITLE
feat(instrumentation-bunyan): add log sending to Logs Bridge API

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-bunyan/README.md
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/README.md
@@ -3,7 +3,7 @@
 [![NPM Published Version][npm-img]][npm-url]
 [![Apache License][license-image]][license-image]
 
-This module provides automatic instrumentation for the injection of trace context to [`bunyan`](https://www.npmjs.com/package/bunyan), which may be loaded using the [`@opentelemetry/sdk-trace-node`](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-node) package and is included in the [`@opentelemetry/auto-instrumentations-node`](https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-node) bundle.
+This module provides automatic instrumentation of the [`bunyan`](https://www.npmjs.com/package/bunyan) module to inject trace-context into Bunyan log records and to bridge Bunyan logging to the OpenTelemetry Logging SDK. It may be loaded using the [`@opentelemetry/sdk-trace-node`](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-sdk-trace-node) package and is included in the [`@opentelemetry/auto-instrumentations-node`](https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-node) bundle.
 
 If total installation size is not constrained, it is recommended to use the [`@opentelemetry/auto-instrumentations-node`](https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-node) bundle with [@opentelemetry/sdk-node](`https://www.npmjs.com/package/@opentelemetry/sdk-node`) for the most seamless instrumentation experience.
 
@@ -15,46 +15,74 @@ Compatible with OpenTelemetry JS API and SDK `1.0+`.
 npm install --save @opentelemetry/instrumentation-bunyan
 ```
 
-### Supported Versions
+## Supported Versions
 
 - `^1.0.0`
 
 ## Usage
 
 ```js
-const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
+const { NodeSDK, tracing, logs, api } = require('@opentelemetry/sdk-node');
 const { BunyanInstrumentation } = require('@opentelemetry/instrumentation-bunyan');
-const { registerInstrumentations } = require('@opentelemetry/instrumentation');
-
-const provider = new NodeTracerProvider();
-provider.register();
-
-registerInstrumentations({
+const sdk = new NodeSDK({
+  spanProcessor: new tracing.SimpleSpanProcessor(new tracing.ConsoleSpanExporter()),
+  logRecordProcessor: new logs.SimpleLogRecordProcessor(new logs.ConsoleLogRecordExporter()),
   instrumentations: [
     new BunyanInstrumentation({
-      // Optional hook to insert additional context to bunyan records.
-      // Called after trace context is added to the record.
-      logHook: (span, record) => {
-        record['resource.service.name'] = provider.resource.attributes['service.name'];
-      },
+      // See below for Bunyan instrumentation options.
     }),
-    // other instrumentations
-  ],
-});
+  ]
+})
 
-bunyan.createLogger({ name: 'example' }).info('foo');
-// {"name":"example","msg":"foo","trace_id":"e21c7a95fff34e04f77c7bd518779621","span_id":"b7589a981fde09f4","trace_flags":"01", ...}
+const log = bunyan.createLogger({name: 'example'});
+
+log.info('hi');
+// 1. Log records will be sent to the SDK-registered log record processor, if any.
+//    This is called "bridging".
+
+const tracer = api.getTracer('example');
+tracer.startActiveSpan('manual-span', span => {
+  log.info('in a span');
+  // 2. Fields identifying the current span will be injected into log records:
+  //    {"name":"example",...,"msg":"in a span","trace_id":"d61b4e4af1032e0aae279d12f3ab0159","span_id":"d140da862204f2a2","trace_flags":"01"}
+})
 ```
 
-### Fields added to bunyan records
+### Logs Bridge
 
-For the current active span, the following will be added to the bunyan record:
+Creation of a Bunyan Logger will automatically add a [Bunyan stream](https://github.com/trentm/node-bunyan#streams) that sends log records to the OpenTelemetry Logs Bridge API. The OpenTelemetry SDK can be configured to handle those records -- for example, sending them on to an OpenTelemetry collector for log archiving and processing. The example above shows a minimal configuration that emits OpenTelemetry log records to the console for debugging.
+
+If the OpenTelemetry SDK is not configured with a Logger provider, then this added stream will be a no-op.
+
+The logs bridge can be disabled with the `enableLogsBridge: false` option.
+
+### Log injection
+
+Bunyan logger calls in the context of a tracing span will have fields indentifying
+the span ([spec](https://opentelemetry.io/docs/specs/otel/compatibility/logging_trace_context/)):
 
 - `trace_id`
 - `span_id`
 - `trace_flags`
 
+After adding these fields, the optional `logHook` is called to allow injecting additional fields. For example:
+
+```js
+  logHook: (span, record) => {
+    record['resource.service.name'] = provider.resource.attributes['service.name'];
+  }
+```
+
 When no span context is active or the span context is invalid, injection is skipped.
+Log injection can be disabled with the `enableInjection: false` option.
+
+### Bunyan instrumentation options
+
+| Option             | Type              | Description |
+| ------------------ | ----------------- | ----------- |
+| `enableLogsBridge` | `boolean`         | Whether [logs bridging](#logs-bridge) is enabled. Default `true`. |
+| `enableInjection`  | `boolean`         | Whether [log injection](#log-injection) is enabled. Default `true`. |
+| `logHook`          | `LogHookFunction` | An option hook to inject additional context to a log record after span context has been added. This requires `enableInjection` to be true. |
 
 ## Useful links
 

--- a/plugins/node/opentelemetry-instrumentation-bunyan/examples/README.md
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/examples/README.md
@@ -1,0 +1,80 @@
+This is a small example app, "app.js", that shows using the
+[Bunyan](https://github.com/trentm/node-bunyan) logger with OpenTelemetry. See
+[the OpenTelemetry Bunyan instrumentation README](../) for full details.
+
+# Usage
+
+```
+npm install
+node -r ./telemetry.js app.js
+```
+
+# Overview
+
+"telemetry.js" sets up the OpenTelemetry SDK to write OTel tracing spans and
+log records to the *console* for simplicity. In a real setup you would
+configure exporters to send to remote observability apps for viewing and
+analysis.
+
+An example run looks like this:
+
+```
+$ node -r ./telemetry.js app.js
+{"name":"myapp","hostname":"amachine.local","pid":93017,"level":20,"msg":"hi","time":"2023-09-27T23:24:06.074Z","v":0}
+{
+  timestamp: 1695857046074000,
+  traceId: undefined,
+  spanId: undefined,
+  traceFlags: undefined,
+  severityText: 'debug',
+  severityNumber: 5,
+  body: 'hi',
+  attributes: { name: 'myapp', hostname: 'amachine.local', pid: 93017 }
+}
+{"name":"myapp","hostname":"amachine.local","pid":93017,"level":30,"msg":"this record will have trace_id et al fields for the current span","time":"2023-09-27T23:24:06.079Z","v":0,"trace_id":"af5ce23816c4feabb713ee1dc84ef4d3","span_id":"5f50e181ec7bc621","trace_flags":"01"}
+{
+  timestamp: 1695857046079000,
+  traceId: 'af5ce23816c4feabb713ee1dc84ef4d3',
+  spanId: '5f50e181ec7bc621',
+  traceFlags: 1,
+  severityText: 'info',
+  severityNumber: 9,
+  body: 'this record will have trace_id et al fields for the current span',
+  attributes: {
+    name: 'myapp',
+    hostname: 'amachine.local',
+    pid: 93017,
+    trace_id: 'af5ce23816c4feabb713ee1dc84ef4d3',
+    span_id: '5f50e181ec7bc621',
+    trace_flags: '01'
+  }
+}
+{
+  traceId: 'af5ce23816c4feabb713ee1dc84ef4d3',
+  parentId: undefined,
+  traceState: undefined,
+  name: 'manual-span',
+  id: '5f50e181ec7bc621',
+  kind: 0,
+  timestamp: 1695857046079000,
+  duration: 1407.196,
+  attributes: {},
+  status: { code: 0 },
+  events: [],
+  links: []
+}
+```
+
+There are two separate Bunyan instrumentation functionalities. The first is
+that Bunyan log records emitted in the context of a tracing span will include
+`trace_id` and `span_id` fields that can be used for correlating with collect
+tracing data. Line 3 shows an example of this.
+
+The second is that a [Bunyan
+stream](https://github.com/trentm/node-bunyan#streams) is automatically added
+to created Loggers that will send every log record to the OpenTelemetry Logs
+Bridge API. This means that if the OpenTelemetry SDK has been configured with
+a Logger Provider, it will receive them. (If the OpenTelemetry SDK is not
+configured for this, then the added Bunyan stream will be a no-op.) Lines 2
+and 4 show a dumped OpenTelemetry Log Record.
+

--- a/plugins/node/opentelemetry-instrumentation-bunyan/examples/app.js
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/examples/app.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// A small example that shows using OpenTelemetry's instrumentation of
+// Bunyan loggers. Usage:
+//    node --require ./telemetry.js app.js
+
+const otel = require('@opentelemetry/api');
+const bunyan = require('bunyan');
+
+const log = bunyan.createLogger({name: 'myapp', level: 'debug'});
+
+log.debug('hi');
+
+const tracer = otel.trace.getTracer('example');
+tracer.startActiveSpan('manual-span', span => {
+  log.info('this record will have trace_id et al fields for the current span');
+  span.end();
+});

--- a/plugins/node/opentelemetry-instrumentation-bunyan/examples/app.mjs
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/examples/app.mjs
@@ -1,0 +1,33 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// The equivalent of "app.js", but showing usage with ESM code.
+// Usage:
+//    node --require ./telemetry.js --experimental-loader ../node_modules/@opentelemetry/instrumentation/hook.mjs app.js
+
+import { trace } from '@opentelemetry/api';
+import bunyan from 'bunyan';
+
+const log = bunyan.createLogger({name: 'myapp', level: 'debug'});
+
+log.debug('hi');
+
+const tracer = trace.getTracer('example');
+tracer.startActiveSpan('manual-span', span => {
+  log.info('this record will have trace_id et al fields for the current span');
+  span.end();
+});
+

--- a/plugins/node/opentelemetry-instrumentation-bunyan/examples/package.json
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/examples/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "bunyan-example",
+  "private": true,
+  "version": "0.43.0",
+  "description": "Example of Bunyan integration with OpenTelemetry",
+  "scripts": {
+    "start": "node -r ./telemetry.js app.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/open-telemetry/opentelemetry-js.git"
+  },
+  "engines": {
+    "node": ">=14"
+  },
+  "author": "OpenTelemetry Authors",
+  "license": "Apache-2.0",
+  "// @opentelemetry/instrumentation-bunyan": "TODO: change to a ver when there is a next release",
+  "dependencies": {
+    "@opentelemetry/api": "^1.6.0",
+    "@opentelemetry/instrumentation-bunyan": "../",
+    "@opentelemetry/sdk-node": "^0.43.0",
+    "bunyan": "^1.8.15"
+  }
+}

--- a/plugins/node/opentelemetry-instrumentation-bunyan/examples/telemetry.js
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/examples/telemetry.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Setup telemetry for tracing and Bunyan logging.
+//
+// This writes OTel spans and log records to the console for simplicity. In a
+// real setup you would configure exporters to send to remote observability apps
+// for viewing and analysis.
+
+const { NodeSDK, tracing, logs, api } = require('@opentelemetry/sdk-node');
+// api.diag.setLogger(new api.DiagConsoleLogger(), api.DiagLogLevel.DEBUG);
+
+const { BunyanInstrumentation } = require('@opentelemetry/instrumentation-bunyan');
+
+const sdk = new NodeSDK({
+  serviceName: 'bunyan-example',
+  spanProcessor: new tracing.SimpleSpanProcessor(new tracing.ConsoleSpanExporter()),
+  logRecordProcessor: new logs.SimpleLogRecordProcessor(new logs.ConsoleLogRecordExporter()),
+  instrumentations: [
+    new BunyanInstrumentation(),
+  ]
+})
+process.on("SIGTERM", () => {
+  sdk
+    .shutdown()
+    .then(
+      () => {},
+      (err) => console.log("warning: error shutting down OTel SDK", err)
+    )
+    .finally(() => process.exit(0));
+});
+sdk.start();

--- a/plugins/node/opentelemetry-instrumentation-bunyan/package.json
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/package.json
@@ -48,9 +48,11 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/context-async-hooks": "^1.8.0",
+    "@opentelemetry/resources": "^1.17.0",
+    "@opentelemetry/sdk-logs": "^0.43.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
+    "@opentelemetry/semantic-conventions": "^1.17.0",
     "@types/mocha": "7.0.2",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.16",
@@ -64,6 +66,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
+    "@opentelemetry/api-logs": "^0.43.0",
     "@opentelemetry/instrumentation": "^0.43.0",
     "@types/bunyan": "1.8.9"
   },

--- a/plugins/node/opentelemetry-instrumentation-bunyan/src/OpenTelemetryBunyanStream.ts
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/src/OpenTelemetryBunyanStream.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { logs, SeverityNumber, Logger } from '@opentelemetry/api-logs';
+import type { LoggerOptions } from '@opentelemetry/api-logs';
+import type * as BunyanLogger from 'bunyan';
+import { VERSION } from './version';
+
+const DEFAULT_INSTRUMENTATION_SCOPE_NAME = 'io.opentelemetry.contrib.bunyan';
+const DEFAULT_INSTRUMENTATION_SCOPE_VERSION = VERSION;
+
+// This block is a copy (modulo code style and TypeScript types) of the Bunyan
+// code that defines log level value and names. These values won't ever change
+// in bunyan@1. This file is part of *instrumenting* Bunyan, so we want to
+// avoid a dependency on the library.
+const TRACE = 10;
+const DEBUG = 20;
+const INFO = 30;
+const WARN = 40;
+const ERROR = 50;
+const FATAL = 60;
+const levelFromName: { [name in BunyanLogger.LogLevelString]: number } = {
+  trace: TRACE,
+  debug: DEBUG,
+  info: INFO,
+  warn: WARN,
+  error: ERROR,
+  fatal: FATAL,
+};
+const nameFromLevel: { [level: number]: string } = {};
+Object.keys(levelFromName).forEach(function (name) {
+  nameFromLevel[levelFromName[name as BunyanLogger.LogLevelString]] = name;
+});
+
+const OTEL_SEV_NUM_FROM_BUNYAN_LEVEL: { [level: number]: number } = {
+  [TRACE]: SeverityNumber.TRACE,
+  [DEBUG]: SeverityNumber.DEBUG,
+  [INFO]: SeverityNumber.INFO,
+  [WARN]: SeverityNumber.WARN,
+  [ERROR]: SeverityNumber.ERROR,
+  [FATAL]: SeverityNumber.FATAL,
+};
+
+const EXTRA_SEV_NUMS = [
+  SeverityNumber.TRACE2,
+  SeverityNumber.TRACE3,
+  SeverityNumber.TRACE4,
+  SeverityNumber.DEBUG2,
+  SeverityNumber.DEBUG3,
+  SeverityNumber.DEBUG4,
+  SeverityNumber.INFO2,
+  SeverityNumber.INFO3,
+  SeverityNumber.INFO4,
+  SeverityNumber.WARN2,
+  SeverityNumber.WARN3,
+  SeverityNumber.WARN4,
+  SeverityNumber.ERROR2,
+  SeverityNumber.ERROR3,
+  SeverityNumber.ERROR4,
+  SeverityNumber.FATAL2,
+  SeverityNumber.FATAL3,
+  SeverityNumber.FATAL4,
+];
+
+function severityNumberFromBunyanLevel(lvl: number) {
+  // Fast common case: one of the known levels
+  const sev = OTEL_SEV_NUM_FROM_BUNYAN_LEVEL[lvl];
+  if (sev !== undefined) {
+    return sev;
+  }
+
+  // Otherwise, scale the Bunyan level range -- 10 (TRACE) to 70 (FATAL+10)
+  // -- onto the extra OTel severity numbers (TRACE2, TRACE3, ..., FATAL4).
+  // Values below bunyan.TRACE map to SeverityNumber.TRACE2, which is a bit
+  // weird.
+  return EXTRA_SEV_NUMS[
+    Math.min(
+      EXTRA_SEV_NUMS.length - 1,
+      Math.max(0, Math.floor(((lvl - 10) / (70 - 10)) * EXTRA_SEV_NUMS.length))
+    )
+  ];
+}
+
+/**
+ * A Bunyan stream for sending log records to the OpenTelemetry Logs Bridge API.
+ */
+export class OpenTelemetryBunyanStream {
+  private _otelLogger: Logger;
+
+  constructor(name?: string, version?: string, options?: LoggerOptions) {
+    this._otelLogger = logs.getLogger(
+      name || DEFAULT_INSTRUMENTATION_SCOPE_NAME,
+      version || DEFAULT_INSTRUMENTATION_SCOPE_VERSION,
+      options
+    );
+  }
+
+  /**
+   * Convert from https://github.com/trentm/node-bunyan#log-record-fields
+   * to https://opentelemetry.io/docs/specs/otel/logs/data-model/
+   *
+   * Dev Notes:
+   * - We drop the Bunyan 'v' field. It is meant to indicate the format
+   *   of the Bunyan log record. FWIW, it has always been `0`.
+   * - Some Bunyan fields would naturally map to Resource attributes:
+   *      hostname -> host.name
+   *      name -> service.name
+   *      pid -> process.pid
+   *   However, AFAIK there isn't a way to influence the LoggerProvider's
+   *   `resource` from here.
+   * - Strip the `trace_id` et al fields that may have been added by the
+   *   the _emit wrapper.
+   */
+  write(rec: Record<string, any>) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { time, level, msg, v, trace_id, span_id, trace_flags, ...fields } =
+      rec;
+    let timestamp = undefined;
+    if (typeof time.getTime === 'function') {
+      timestamp = time.getTime(); // ms
+    } else {
+      fields.time = time; // Expose non-Date "time" field on attributes.
+    }
+    const otelRec = {
+      timestamp,
+      observedTimestamp: timestamp,
+      severityNumber: severityNumberFromBunyanLevel(level),
+      severityText: nameFromLevel[level],
+      body: msg,
+      attributes: fields,
+    };
+    this._otelLogger.emit(otelRec);
+  }
+}

--- a/plugins/node/opentelemetry-instrumentation-bunyan/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/src/instrumentation.ts
@@ -14,28 +14,32 @@
  * limitations under the License.
  */
 
-import {
-  context,
-  diag,
-  trace,
-  isSpanContextValid,
-  Span,
-} from '@opentelemetry/api';
+import { inherits } from 'util';
+import { context, trace, isSpanContextValid, Span } from '@opentelemetry/api';
 import {
   InstrumentationBase,
   InstrumentationNodeModuleDefinition,
-  isWrapped,
   safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
 import { BunyanInstrumentationConfig } from './types';
 import { VERSION } from './version';
+import { OpenTelemetryBunyanStream } from './OpenTelemetryBunyanStream';
 import type * as BunyanLogger from 'bunyan';
+
+const DEFAULT_CONFIG: BunyanInstrumentationConfig = {
+  enableLogsBridge: true,
+  enableInjection: true,
+};
 
 export class BunyanInstrumentation extends InstrumentationBase<
   typeof BunyanLogger
 > {
   constructor(config: BunyanInstrumentationConfig = {}) {
-    super('@opentelemetry/instrumentation-bunyan', VERSION, config);
+    super(
+      '@opentelemetry/instrumentation-bunyan',
+      VERSION,
+      Object.assign({}, DEFAULT_CONFIG, config)
+    );
   }
 
   protected init() {
@@ -43,25 +47,55 @@ export class BunyanInstrumentation extends InstrumentationBase<
       new InstrumentationNodeModuleDefinition<typeof BunyanLogger>(
         'bunyan',
         ['<2.0'],
-        logger => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const proto = logger.prototype as any;
-          if (isWrapped(proto['_emit'])) {
-            this._unwrap(proto, '_emit');
-          }
+        (module: any, moduleVersion) => {
+          this._diag.debug(`Applying patch for bunyan@${moduleVersion}`);
+          const instrumentation = this;
+          const Logger =
+            module[Symbol.toStringTag] === 'Module'
+              ? module.default // ESM
+              : module; // CommonJS
 
           this._wrap(
-            proto,
+            Logger.prototype,
             '_emit',
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             this._getPatchedEmit() as any
           );
-          return logger;
-        },
-        logger => {
-          if (logger === undefined) return;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          this._unwrap(logger.prototype as any, '_emit');
+
+          function LoggerTraced(this: any, ...args: unknown[]) {
+            let inst;
+            let retval = undefined;
+            if (this instanceof LoggerTraced) {
+              // called with `new Logger()`
+              inst = this;
+              Logger.call(this, ...args);
+            } else {
+              // called without `new`
+              inst = Logger.call(null, ...args);
+              retval = inst;
+            }
+            // If `_childOptions` is defined, this is a `Logger#child(...)`
+            // call. We must not add an OTel stream again.
+            if (args[1] /* _childOptions */ === undefined) {
+              instrumentation._addStream(inst);
+            }
+            return retval;
+          }
+          // Must use the deprecated `inherits` to support this style:
+          //    const log = require('bunyan')({name: 'foo'});
+          // i.e. calling the constructor function without `new`.
+          inherits(LoggerTraced, Logger);
+
+          const patchedExports = Object.assign(LoggerTraced, Logger);
+
+          this._wrap(
+            patchedExports,
+            'createLogger',
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            this._getPatchedCreateLogger() as any
+          );
+
+          return patchedExports;
         }
       ),
     ];
@@ -72,21 +106,24 @@ export class BunyanInstrumentation extends InstrumentationBase<
   }
 
   override setConfig(config: BunyanInstrumentationConfig) {
-    this._config = config;
+    this._config = Object.assign({}, DEFAULT_CONFIG, config);
   }
 
   private _getPatchedEmit() {
     return (original: (...args: unknown[]) => void) => {
       const instrumentation = this;
       return function patchedEmit(this: BunyanLogger, ...args: unknown[]) {
-        const span = trace.getSpan(context.active());
+        const config = instrumentation.getConfig();
+        if (!instrumentation.isEnabled() || !config.enableInjection) {
+          return original.apply(this, args);
+        }
 
+        const span = trace.getSpan(context.active());
         if (!span) {
           return original.apply(this, args);
         }
 
         const spanContext = span.spanContext();
-
         if (!isSpanContextValid(spanContext)) {
           return original.apply(this, args);
         }
@@ -103,6 +140,30 @@ export class BunyanInstrumentation extends InstrumentationBase<
     };
   }
 
+  private _getPatchedCreateLogger() {
+    return (original: (...args: unknown[]) => void) => {
+      const instrumentation = this;
+      return function patchedCreateLogger(...args: unknown[]) {
+        const logger = original(...args);
+        instrumentation._addStream(logger);
+        return logger;
+      };
+    };
+  }
+
+  private _addStream(logger: any) {
+    const config: BunyanInstrumentationConfig = this._config;
+    if (!this.isEnabled() || !config.enableLogsBridge) {
+      return;
+    }
+    this._diag.debug('Adding OpenTelemetryBunyanStream to logger');
+    logger.addStream({
+      type: 'raw',
+      stream: new OpenTelemetryBunyanStream(),
+      level: logger.level(),
+    });
+  }
+
   private _callHook(span: Span, record: Record<string, string>) {
     const hook = this.getConfig().logHook;
 
@@ -114,7 +175,7 @@ export class BunyanInstrumentation extends InstrumentationBase<
       () => hook(span, record),
       err => {
         if (err) {
-          diag.error('bunyan instrumentation: error calling logHook', err);
+          this._diag.error('error calling logHook', err);
         }
       },
       true

--- a/plugins/node/opentelemetry-instrumentation-bunyan/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/src/types.ts
@@ -21,5 +21,24 @@ import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 export type LogHookFunction = (span: Span, record: Record<string, any>) => void;
 
 export interface BunyanInstrumentationConfig extends InstrumentationConfig {
+  /**
+   * Whether to enable the automatic sending of log records to the OpenTelemetry
+   * Logs Bridge API.
+   * @default true
+   */
+  enableLogsBridge?: boolean;
+
+  /**
+   * Whether to enable the injection of data such as trace-context fields into
+   * log output.
+   * @default true
+   */
+  enableInjection?: boolean;
+
+  /**
+   * A function that allows injecting additional fields in log records. It is
+   * called, as `logHook(span, record)`, for each log record emitted in a valid
+   * span context. It requires `enableInjection` to be true.
+   */
   logHook?: LogHookFunction;
 }

--- a/plugins/node/opentelemetry-instrumentation-bunyan/test/bunyan.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/test/bunyan.test.ts
@@ -19,47 +19,74 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 import { context, INVALID_SPAN_CONTEXT, trace } from '@opentelemetry/api';
+import { logs, SeverityNumber } from '@opentelemetry/api-logs';
+import {
+  LoggerProvider,
+  SimpleLogRecordProcessor,
+  InMemoryLogRecordExporter,
+} from '@opentelemetry/sdk-logs';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { isWrapped } from '@opentelemetry/instrumentation';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { Resource } from '@opentelemetry/resources';
+import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import * as assert from 'assert';
-import * as Logger from 'bunyan';
+import * as os from 'os';
 import * as sinon from 'sinon';
 import { Writable } from 'stream';
 import { BunyanInstrumentation } from '../src';
+import { VERSION } from '../src/version';
 
-const memoryExporter = new InMemorySpanExporter();
-const provider = new NodeTracerProvider();
-const tracer = provider.getTracer('default');
-provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
-context.setGlobalContextManager(new AsyncHooksContextManager());
+import type * as BunyanLogger from 'bunyan';
+
+// import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
+// diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
+
+const tracerProvider = new NodeTracerProvider();
+tracerProvider.register();
+tracerProvider.addSpanProcessor(
+  new SimpleSpanProcessor(new InMemorySpanExporter())
+);
+const tracer = tracerProvider.getTracer('default');
+
+const resource = new Resource({
+  [SemanticResourceAttributes.SERVICE_NAME]: 'test-instrumentation-bunyan',
+});
+const loggerProvider = new LoggerProvider({ resource });
+const memExporter = new InMemoryLogRecordExporter();
+loggerProvider.addLogRecordProcessor(new SimpleLogRecordProcessor(memExporter));
+logs.setGlobalLoggerProvider(loggerProvider);
+
+const instrumentation = new BunyanInstrumentation();
+const Logger = require('bunyan');
 
 describe('BunyanInstrumentation', () => {
-  let logger: Logger;
-  let stream;
+  let log: BunyanLogger;
+  let stream: Writable;
   let writeSpy: sinon.SinonSpy;
-  let instrumentation: BunyanInstrumentation;
 
-  before(() => {
-    instrumentation = new BunyanInstrumentation();
-    require('bunyan');
+  it('is instrumented', () => {
     assert.ok(isWrapped((Logger.prototype as any)['_emit']));
   });
 
   describe('enabled instrumentation', () => {
     beforeEach(() => {
-      instrumentation.setConfig({ enabled: true });
+      instrumentation.setConfig({}); // reset to defaults
+      memExporter.getFinishedLogRecords().length = 0; // clear
       stream = new Writable();
       stream._write = () => {};
       writeSpy = sinon.spy(stream, 'write');
-      logger = Logger.createLogger({ name: 'test', stream });
+      log = Logger.createLogger({
+        name: 'test-logger-name',
+        level: 'debug',
+        stream,
+      });
     });
 
     it('injects span context to records', () => {
       const span = tracer.startSpan('abc');
       context.with(trace.setSpan(context.active(), span), () => {
         const { traceId, spanId, traceFlags } = span.spanContext();
-        logger.info('foo');
+        log.info('foo');
         sinon.assert.calledOnce(writeSpy);
         const record = JSON.parse(writeSpy.firstCall.args[0].toString());
         assert.strictEqual(record['trace_id'], traceId);
@@ -73,16 +100,15 @@ describe('BunyanInstrumentation', () => {
       });
     });
 
-    it('calls the users log hook', () => {
+    it('calls the logHook', () => {
       const span = tracer.startSpan('abc');
       instrumentation.setConfig({
-        enabled: true,
         logHook: (_span, record) => {
           record['resource.service.name'] = 'test-service';
         },
       });
       context.with(trace.setSpan(context.active(), span), () => {
-        logger.info('foo');
+        log.info('foo');
         sinon.assert.calledOnce(writeSpy);
         const record = JSON.parse(writeSpy.firstCall.args[0].toString());
         assert.strictEqual(record['resource.service.name'], 'test-service');
@@ -90,7 +116,7 @@ describe('BunyanInstrumentation', () => {
     });
 
     it('does not inject span context if no span is active', () => {
-      logger.info('foo');
+      log.info('foo');
       assert.strictEqual(trace.getSpan(context.active()), undefined);
       sinon.assert.calledOnce(writeSpy);
       const record = JSON.parse(writeSpy.firstCall.args[0].toString());
@@ -103,7 +129,7 @@ describe('BunyanInstrumentation', () => {
     it('does not inject span context if span context is invalid', () => {
       const span = trace.wrapSpanContext(INVALID_SPAN_CONTEXT);
       context.with(trace.setSpan(context.active(), span), () => {
-        logger.info('foo');
+        log.info('foo');
         sinon.assert.calledOnce(writeSpy);
         const record = JSON.parse(writeSpy.firstCall.args[0].toString());
         assert.strictEqual(record['trace_id'], undefined);
@@ -113,23 +139,188 @@ describe('BunyanInstrumentation', () => {
       });
     });
 
-    it('does not propagate exceptions from user hooks', () => {
+    it('does not propagate exceptions from logHook', () => {
       const span = tracer.startSpan('abc');
       instrumentation.setConfig({
-        enabled: true,
         logHook: () => {
           throw new Error('Oops');
         },
       });
       context.with(trace.setSpan(context.active(), span), () => {
         const { traceId, spanId } = span.spanContext();
-        logger.info('foo');
+        log.info('foo');
         sinon.assert.calledOnce(writeSpy);
         const record = JSON.parse(writeSpy.firstCall.args[0].toString());
         assert.strictEqual(record['trace_id'], traceId);
         assert.strictEqual(record['span_id'], spanId);
         assert.strictEqual('foo', record['msg']);
       });
+    });
+
+    it('does not inject or call logHook if enableInjection=false', () => {
+      instrumentation.setConfig({
+        enableInjection: false,
+        logHook: (_span, record) => {
+          record['resource.service.name'] = 'test-service';
+        },
+      });
+      tracer.startActiveSpan('abc', span => {
+        log.info('foo');
+        sinon.assert.calledOnce(writeSpy);
+        const record = JSON.parse(writeSpy.firstCall.args[0].toString());
+        assert.strictEqual('foo', record['msg']);
+        assert.strictEqual(record['trace_id'], undefined);
+        assert.strictEqual(record['span_id'], undefined);
+        assert.strictEqual(record['trace_flags'], undefined);
+        assert.strictEqual(record['resource.service.name'], undefined);
+        assert.strictEqual(
+          memExporter.getFinishedLogRecords().length,
+          1,
+          'Logs Bridge still works'
+        );
+        span.end();
+      });
+    });
+
+    it('emits log records to Logs Bridge API', () => {
+      const logRecords = memExporter.getFinishedLogRecords();
+
+      // levels
+      log.trace('at trace level');
+      log.debug('at debug level');
+      log.info('at info level');
+      log.warn('at warn level');
+      log.error('at error level');
+      log.fatal('at fatal level');
+      assert.strictEqual(logRecords.length, 5);
+      assert.strictEqual(logRecords[0].severityNumber, SeverityNumber.DEBUG);
+      assert.strictEqual(logRecords[0].severityText, 'debug');
+      assert.strictEqual(logRecords[1].severityNumber, SeverityNumber.INFO);
+      assert.strictEqual(logRecords[1].severityText, 'info');
+      assert.strictEqual(logRecords[2].severityNumber, SeverityNumber.WARN);
+      assert.strictEqual(logRecords[2].severityText, 'warn');
+      assert.strictEqual(logRecords[3].severityNumber, SeverityNumber.ERROR);
+      assert.strictEqual(logRecords[3].severityText, 'error');
+      assert.strictEqual(logRecords[4].severityNumber, SeverityNumber.FATAL);
+      assert.strictEqual(logRecords[4].severityText, 'fatal');
+
+      // attributes, resource, instrumentationScope, etc.
+      log.info({ foo: 'bar' }, 'a message');
+      const rec = logRecords[logRecords.length - 1];
+      assert.strictEqual(rec.body, 'a message');
+      assert.deepStrictEqual(rec.attributes, {
+        name: 'test-logger-name',
+        hostname: os.hostname(),
+        pid: process.pid,
+        foo: 'bar',
+      });
+      assert.strictEqual(
+        rec.resource.attributes['service.name'],
+        'test-instrumentation-bunyan'
+      );
+      assert.strictEqual(
+        rec.instrumentationScope.name,
+        'io.opentelemetry.contrib.bunyan'
+      );
+      assert.strictEqual(rec.instrumentationScope.version, VERSION);
+      assert.strictEqual(rec.spanContext, undefined);
+
+      // spanContext
+      tracer.startActiveSpan('abc', span => {
+        const { traceId, spanId, traceFlags } = span.spanContext();
+        log.info('in active span');
+        const rec = logRecords[logRecords.length - 1];
+        assert.strictEqual(rec.spanContext?.traceId, traceId);
+        assert.strictEqual(rec.spanContext?.spanId, spanId);
+        assert.strictEqual(rec.spanContext?.traceFlags, traceFlags);
+
+        // This rec should *NOT* have the `trace_id` et al attributes.
+        assert.strictEqual(rec.attributes.trace_id, undefined);
+        assert.strictEqual(rec.attributes.span_id, undefined);
+        assert.strictEqual(rec.attributes.trace_flags, undefined);
+
+        span.end();
+      });
+    });
+
+    it('handles log record edge cases', () => {
+      let rec;
+      const logRecords = memExporter.getFinishedLogRecords();
+
+      // A non-Date "time" Bunyan field.
+      log.info({ time: 'miller' }, 'hi');
+      rec = logRecords[logRecords.length - 1];
+      assert.deepEqual(
+        rec.hrTime.map(n => typeof n),
+        ['number', 'number']
+      );
+      assert.strictEqual(rec.attributes.time, 'miller');
+
+      // An atypical Bunyan level number.
+      log.info({ level: 42 }, 'just above Bunyan WARN==40');
+      rec = logRecords[logRecords.length - 1];
+      assert.strictEqual(rec.severityNumber, SeverityNumber.WARN2);
+      assert.strictEqual(rec.severityText, undefined);
+
+      log.info({ level: 200 }, 'far above Bunyan FATAL==60');
+      rec = logRecords[logRecords.length - 1];
+      assert.strictEqual(rec.severityNumber, SeverityNumber.FATAL4);
+      assert.strictEqual(rec.severityText, undefined);
+    });
+
+    it('does not emit to the Logs Bridge API if enableLogsBridge=false', () => {
+      instrumentation.setConfig({ enableLogsBridge: false });
+
+      // Changing `enableLogsBridge` only has an impact on Loggers created
+      // *after* it is set. So we cannot test with the `log` created in
+      // `beforeEach()` above.
+      log = Logger.createLogger({ name: 'test-logger-name', stream });
+
+      tracer.startActiveSpan('abc', span => {
+        const { traceId, spanId } = span.spanContext();
+        log.info('foo');
+        assert.strictEqual(memExporter.getFinishedLogRecords().length, 0);
+
+        // Test log injection still works.
+        sinon.assert.calledOnce(writeSpy);
+        const record = JSON.parse(writeSpy.firstCall.args[0].toString());
+        assert.strictEqual('foo', record['msg']);
+        assert.strictEqual(record['trace_id'], traceId);
+        assert.strictEqual(record['span_id'], spanId);
+        span.end();
+      });
+    });
+
+    it('emits to the Logs Bridge API with `new Logger(...)`', () => {
+      log = new Logger({ name: 'test-logger-name', stream });
+      log.info('foo');
+
+      const logRecords = memExporter.getFinishedLogRecords();
+      assert.strictEqual(logRecords.length, 1);
+      let rec = logRecords[logRecords.length - 1];
+      assert.strictEqual(rec.body, 'foo');
+
+      const child = log.child({ aProperty: 'bar' });
+      child.info('hi');
+      rec = logRecords[logRecords.length - 1];
+      assert.strictEqual(rec.body, 'hi');
+      assert.strictEqual(rec.attributes.aProperty, 'bar');
+    });
+
+    it('emits to the Logs Bridge API with `Logger(...)`', () => {
+      log = Logger({ name: 'test-logger-name', stream });
+      log.info('foo');
+
+      const logRecords = memExporter.getFinishedLogRecords();
+      assert.strictEqual(logRecords.length, 1);
+      let rec = logRecords[logRecords.length - 1];
+      assert.strictEqual(rec.body, 'foo');
+
+      const child = log.child({ aProperty: 'bar' });
+      child.info('hi');
+      rec = logRecords[logRecords.length - 1];
+      assert.strictEqual(rec.body, 'hi');
+      assert.strictEqual(rec.attributes.aProperty, 'bar');
     });
   });
 
@@ -146,13 +337,14 @@ describe('BunyanInstrumentation', () => {
       stream = new Writable();
       stream._write = () => {};
       writeSpy = sinon.spy(stream, 'write');
-      logger = Logger.createLogger({ name: 'test', stream });
+      log = Logger.createLogger({ name: 'test', stream });
+      memExporter.getFinishedLogRecords().length = 0; // clear
     });
 
     it('does not inject span context', () => {
       const span = tracer.startSpan('abc');
       context.with(trace.setSpan(context.active(), span), () => {
-        logger.info('foo');
+        log.info('foo');
         sinon.assert.calledOnce(writeSpy);
         const record = JSON.parse(writeSpy.firstCall.args[0].toString());
         assert.strictEqual(record['trace_id'], undefined);
@@ -166,16 +358,22 @@ describe('BunyanInstrumentation', () => {
     it('does not call log hook', () => {
       const span = tracer.startSpan('abc');
       instrumentation.setConfig({
-        enabled: false,
         logHook: (_span, record) => {
           record['resource.service.name'] = 'test-service';
         },
       });
       context.with(trace.setSpan(context.active(), span), () => {
-        logger.info('foo');
+        log.info('foo');
         sinon.assert.calledOnce(writeSpy);
         const record = JSON.parse(writeSpy.firstCall.args[0].toString());
         assert.strictEqual(record['resource.service.name'], undefined);
+      });
+    });
+
+    it('does not emit to the Logs Bridge API', () => {
+      tracer.startActiveSpan('abc', span => {
+        log.info('foo');
+        assert.strictEqual(memExporter.getFinishedLogRecords().length, 0);
       });
     });
   });


### PR DESCRIPTION
This extends the Bunyan instrumentation to automatically add a Bunyan stream to created loggers that will send log records to the Logs Bridge API: https://opentelemetry.io/docs/specs/otel/logs/bridge-api/

Now that the instrumentation supports separate "injection" of fields and "bridging" of log records functionality, this also adds two boolean options to disable those independently: `enableInjection` and `enableLogsBridge`.

This also updates the instrumentation to work with ES module usage.

Closes: #1559
