### PR TITLE
fix(instrumentation-redis-4): multi.exec patch should only throw error once

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-redis-4/test/redis.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-redis-4/test/redis.test.ts
@@ -429,7 +429,7 @@ describe('redis@^4.0.0', () => {
       assert.ok(endTimeDiff < 10); // spans should all end together when multi response arrives from redis server
     });
 
-    it('WatchErrors are caught and handled as expected', async () => {
+    it('WatchErrors are caught and handled as expected when triggered from a multi exec', async () => {
       // Arrange
       const watchedKey = 'watched-key';
 


### PR DESCRIPTION
This prevents undefined behaviour as it  before this would throw two errors where the second one was seemingly impossible to catch.

I'm unsure if this is the optimal approach, but it appears to function and I can't see that it would/has broken any existing functionality.

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Fixes #1708 

## Short description of the changes

- Add a no-op `catch` branch to the return value of the `exec` patch to prevent double errors
