### PR TITLE
feat(opentelemetry-instrumentation-mongodb): Mongo v6 support

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-mongodb/README.md
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/README.md
@@ -17,7 +17,7 @@ npm install --save @opentelemetry/instrumentation-mongodb
 
 ### Supported Versions
 
-- `>=3.3 <5`
+- `>=3.3`
 
 ## Usage
 

--- a/plugins/node/opentelemetry-instrumentation-mongodb/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/src/instrumentation.ts
@@ -95,25 +95,25 @@ export class MongoDBInstrumentation extends InstrumentationBase {
       ),
       new InstrumentationNodeModuleDefinition<any>(
         'mongodb',
-        ['4.*', '5.*'],
+        ['4.*', '5.*', '6.*'],
         undefined,
         undefined,
         [
           new InstrumentationNodeModuleFile<V4Connection>(
             'mongodb/lib/cmap/connection.js',
-            ['4.*', '5.*'],
+            ['4.*', '5.*', '6.*'],
             v4PatchConnection,
             v4UnpatchConnection
           ),
           new InstrumentationNodeModuleFile<V4Connect>(
             'mongodb/lib/cmap/connect.js',
-            ['4.*', '5.*'],
+            ['4.*', '5.*', '6.*'],
             v4PatchConnect,
             v4UnpatchConnect
           ),
           new InstrumentationNodeModuleFile<V4Session>(
             'mongodb/lib/sessions.js',
-            ['4.*', '5.*'],
+            ['4.*', '5.*', '6.*'],
             v4PatchSessions,
             v4UnpatchSessions
           ),


### PR DESCRIPTION
## Short description of the changes

After upgrading to mongo client v6, telemetry stopped working. Adding '6.*' to the wrapping code for v4+ worked for me locally
