### PR TITLE
fix(instrumentation-redis-4): avoid shimmer warning by only wrapping multi/MULTI if they exist

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-redis-4/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-redis-4/src/instrumentation.ts
@@ -169,7 +169,8 @@ export class RedisInstrumentation extends InstrumentationBase<any> {
         // In some @redis/client versions 'multi' is a method. In later
         // versions, as of https://github.com/redis/node-redis/pull/2324,
         // 'MULTI' is a method and 'multi' is a property defined in the
-        // constructor that points to 'MULTI'.
+        // constructor that points to 'MULTI', and therefore it will not
+        // be defined on the prototype.
         if (redisClientPrototype?.multi) {
           if (isWrapped(redisClientPrototype?.multi)) {
             this._unwrap(redisClientPrototype, 'multi');


### PR DESCRIPTION
This fixes the "no original function multi to wrap" warning from shimmer when wrapping recent versions of `@redis/client`.

Refs: #1708
