### PR TITLE
fix(instrumentation-redis-4): fix unhandledRejection in client.multi(...) handling

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-redis-4/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-redis-4/src/instrumentation.ts
@@ -278,41 +278,61 @@ export class RedisInstrumentation extends InstrumentationBase<any> {
           return execRes;
         }
 
-        execRes.then((redisRes: unknown[]) => {
-          const openSpans = this[OTEL_OPEN_SPANS];
-          if (!openSpans) {
-            return plugin._diag.error(
-              'cannot find open spans to end for redis multi command'
-            );
-          }
-          if (redisRes.length !== openSpans.length) {
-            return plugin._diag.error(
-              'number of multi command spans does not match response from redis'
-            );
-          }
-          for (let i = 0; i < openSpans.length; i++) {
-            const { span, commandName, commandArgs } = openSpans[i];
-            const currCommandRes = redisRes[i];
-            if (currCommandRes instanceof Error) {
+        return execRes
+          .then((redisRes: unknown[]) => {
+            const openSpans = this[OTEL_OPEN_SPANS];
+            if (!openSpans) {
+              return plugin._diag.error(
+                'cannot find open spans to end for redis multi command'
+              );
+            }
+            if (redisRes.length !== openSpans.length) {
+              return plugin._diag.error(
+                'number of multi command spans does not match response from redis'
+              );
+            }
+            for (let i = 0; i < openSpans.length; i++) {
+              const { span, commandName, commandArgs } = openSpans[i];
+              const currCommandRes = redisRes[i];
+              if (currCommandRes instanceof Error) {
+                plugin._endSpanWithResponse(
+                  span,
+                  commandName,
+                  commandArgs,
+                  null,
+                  currCommandRes
+                );
+              } else {
+                plugin._endSpanWithResponse(
+                  span,
+                  commandName,
+                  commandArgs,
+                  currCommandRes,
+                  undefined
+                );
+              }
+            }
+            return redisRes;
+          })
+          .catch((err: Error) => {
+            const openSpans = this[OTEL_OPEN_SPANS];
+            if (!openSpans) {
+              return plugin._diag.error(
+                'cannot find open spans to end for redis multi command'
+              );
+            }
+            for (let i = 0; i < openSpans.length; i++) {
+              const { span, commandName, commandArgs } = openSpans[i];
               plugin._endSpanWithResponse(
                 span,
                 commandName,
                 commandArgs,
                 null,
-                currCommandRes
-              );
-            } else {
-              plugin._endSpanWithResponse(
-                span,
-                commandName,
-                commandArgs,
-                currCommandRes,
-                undefined
+                err
               );
             }
-          }
-        });
-        return execRes;
+            return Promise.reject(err);
+          });
       };
     };
   }


### PR DESCRIPTION
The instrumentation was not handling a rejection of the promise from client.multi(), resulting in unended spans and an unhandleRejection event.

Fixes: #1708

---

This is based on work by @FredrikAugust in https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1717.