### PR TITLE
feat: allow disabling auto-instrumentations using env variable

### DIFF
--- a/metapackages/auto-instrumentations-node/src/register.ts
+++ b/metapackages/auto-instrumentations-node/src/register.ts
@@ -25,8 +25,17 @@ diag.setLogger(
   opentelemetry.core.getEnv().OTEL_LOG_LEVEL
 );
 
+const disabledAutoinstrumentations = (
+  process.env.OTEL_DISABLED_AUTOINSTRUMENTATIONS ?? ''
+).split(',');
+
 const sdk = new opentelemetry.NodeSDK({
-  instrumentations: getNodeAutoInstrumentations(),
+  instrumentations: getNodeAutoInstrumentations(
+    Object.fromEntries(
+    disabledAutoinstrumentations.map(instrumentationName =>
+      [instrumentationName, { enabled: false }]
+    ))
+  ),
   resourceDetectors: getResourceDetectorsFromEnv(),
 });
 


### PR DESCRIPTION
# Rationale

While I am pretty happy with provided default instrumentations I would like to be able to disable some of them based on environment variables alone without getting into business of configuring integration manually
