### PR TITLE
test(ioredis): test ioredis ESM usage

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-ioredis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/package.json
@@ -6,7 +6,7 @@
   "types": "build/src/index.d.ts",
   "repository": "open-telemetry/opentelemetry-js-contrib",
   "scripts": {
-    "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
+    "test": "cross-env NODE_NO_WARNINGS=1 NODE_OPTIONS='--loader @opentelemetry/instrumentation/hook.mjs' nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts' 'test/**/*.test.mjs'",
     "test:debug": "cross-env RUN_REDIS_TESTS_LOCAL=true ts-mocha --inspect-brk --no-timeouts -p tsconfig.json 'test/**/*.test.ts'",
     "test:local": "cross-env RUN_REDIS_TESTS_LOCAL=true npm run test",
     "test-all-versions": "tav",

--- a/plugins/node/opentelemetry-instrumentation-ioredis/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/src/instrumentation.ts
@@ -54,6 +54,10 @@ export class IORedisInstrumentation extends InstrumentationBase<any> {
             module[Symbol.toStringTag] === 'Module'
               ? module.default // ESM
               : module; // CommonJS
+          console.log(
+            'XXX IORedisInstrumentation: esm?',
+            module[Symbol.toStringTag] === 'Module'
+          );
           diag.debug('Applying patch for ioredis');
           if (isWrapped(moduleExports.prototype.sendCommand)) {
             this._unwrap(moduleExports.prototype, 'sendCommand');

--- a/plugins/node/opentelemetry-instrumentation-ioredis/test/esm.test.mjs
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/test/esm.test.mjs
@@ -1,0 +1,98 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import assert from 'assert';
+
+import { context } from '@opentelemetry/api';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import testUtils from '@opentelemetry/contrib-test-utils';
+import Redis from 'ioredis';
+
+import { IORedisInstrumentation } from '../build/src/index.js';
+
+const CONFIG = {
+  host: process.env.OPENTELEMETRY_REDIS_HOST || 'localhost',
+  port: parseInt(process.env.OPENTELEMETRY_REDIS_PORT || '63790', 10),
+};
+const REDIS_URL = `redis://${CONFIG.host}:${CONFIG.port}`;
+
+describe('ioredis ESM', () => {
+  const shouldTestLocal = process.env.RUN_REDIS_TESTS_LOCAL;
+  const shouldTest = process.env.RUN_REDIS_TESTS || shouldTestLocal;
+  const memoryExporter = new InMemorySpanExporter();
+  const provider = new NodeTracerProvider();
+  let instrumentation;
+  let contextManager;
+  let client;
+
+  before(() => {
+    if (!shouldTest) {
+      this.skip();
+    }
+    if (shouldTestLocal) {
+      testUtils.startDocker('redis');
+    }
+
+    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+    instrumentation = new IORedisInstrumentation();
+    instrumentation.setTracerProvider(provider);
+
+    client = new Redis(REDIS_URL);
+  });
+
+  after(async () => {
+    await client.quit();
+    if (shouldTestLocal) {
+      testUtils.cleanUpDocker('redis');
+    }
+  });
+
+  beforeEach(() => {
+    contextManager = new AsyncHooksContextManager().enable();
+    context.setGlobalContextManager(contextManager);
+  });
+  afterEach(() => {
+    context.disable();
+  });
+
+  it('should create spans', async () => {
+    // Use a random part in key names because redis instance is used for parallel running tests.
+    const randomId = ((Math.random() * 2 ** 32) >>> 0).toString(16);
+    const testKeyName = `test-${randomId}`;
+
+    const tracer = provider.getTracer('ioredis-test');
+    await tracer.startActiveSpan('manual', async (span) => {
+      client.set(testKeyName, 'bar');
+      let val = await client.get(testKeyName);
+      assert(val === 'bar');
+      span.end();
+    });
+
+    const spans = memoryExporter.getFinishedSpans();
+    assert.strictEqual(spans.length, 3);
+    assert.strictEqual(spans[0].name, 'set');
+    assert.strictEqual(spans[0].attributes['db.system'], 'redis');
+    assert.strictEqual(spans[1].name, 'get');
+    assert.strictEqual(spans[1].attributes['db.system'], 'redis');
+    assert.strictEqual(spans[2].name, 'manual');
+  });
+});
+


### PR DESCRIPTION
**This PR is not intended for merging. It is to support discussion of #1731. Maintainers can unassign themselves, and perhaps assign me.**

This is an attempt to test ESM usage of ioredis based on Marc's comment at https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1731#issuecomment-1765998373

This *passes*, but the thing that scares me is enabling the ESM hook for .test.ts tests as well. The IORedisInstrumentation patch method is being called *both* for ESM and CommonJS for ioredis.test.ts -- I don't understand that.

Refs: #1731
Refs: #1735

---

This would be an alternative to #1735.

@pichlermarc Is this close to what you tried for your ESM testing experiements? This *runs and passes*, however I don't grok the:

```
XXX IORedisInstrumentation: esm? true
XXX IORedisInstrumentation: esm? false
```

output for the execution of "test/ioredis.test.ts" -- for what should be just CommonJS.  It would scare me a little bit to turn on `NODE_OPTIONS='--loader @opentelemetry/instrumentation/hook.mjs'` for all `*.test.ts` files. :)

A full test run with this patch:

```
[.../opentelemetry-js-contrib4/plugins/node/opentelemetry-instrumentation-ioredis]
% npm run test:local

> @opentelemetry/instrumentation-ioredis@0.35.2 test:local
> cross-env RUN_REDIS_TESTS_LOCAL=true npm run test


> @opentelemetry/instrumentation-ioredis@0.35.2 test
> cross-env NODE_NO_WARNINGS=1 NODE_OPTIONS='--loader @opentelemetry/instrumentation/hook.mjs' nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts' 'test/**/*.test.mjs'



  ioredis
XXX IORedisInstrumentation: esm? true
XXX IORedisInstrumentation: esm? false
    ✓ should have correct module name
    #createClient()
      ✓ should propagate the current span to event handlers
    #send_internal_message()
      Instrumenting query operations
XXX IORedisInstrumentation: esm? true
XXX IORedisInstrumentation: esm? false
        ✓ should create a child span for cb style insert
        ✓ should create a child span for cb style get
        ✓ should create a child span for hset promise
        ✓ should set span with error when redis return reject
        ✓ should create a child span for streamify scanning
        - should create a child span for pubsub
        ✓ should create a child span for multi/transaction
        ✓ should create a child span for pipeline
        ✓ should create a child span for get promise
        ✓ should create a child span for del
        ✓ should create a child span for lua
      Instrumenting without parent span
        ✓ should not create child span for query
        ✓ should not create child span for connect
      Instrumentation with requireParentSpan
        ✓ should instrument queries with requireParentSpan equal false
        - should instrument connect with requireParentSpan equal false
        ✓ should not instrument queries with requireParentSpan equal true
        ✓ should not instrument connect with requireParentSpan equal true
      Instrumenting with a custom db.statement serializer
        ✓ should tag the span with a custom db.statement for cb style insert
        ✓ should tag the span with a custom db.statement for cb style get
      Removing instrumentation
        ✓ should not create a child span for cb style insert
        ✓ should not create a child span for cb style get
        ✓ should not create a child span for hset promise upon error
      Instrumenting with a custom hooks
XXX IORedisInstrumentation: esm? true
XXX IORedisInstrumentation: esm? false
        ✓ should call requestHook when set in config
        ✓ should ignore requestHook which throws exception
        ✓ should call responseHook when set in config
        ✓ should ignore responseHook which throws exception
      setConfig - custom dbStatementSerializer config
        ✓ should properly execute the db statement serializer for operation insert
        ✓ should properly execute the db statement serializer for operation get

  ioredis ESM
XXX IORedisInstrumentation: esm? true
    ✓ should create spans


  29 passing (1s)
  2 pending
```