### PR TITLE
fix(instrumentation-fastify): do not wrap preClose and onRequestAbort hooks

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-fastify/src/constants.ts
+++ b/plugins/node/opentelemetry-instrumentation-fastify/src/constants.ts
@@ -18,9 +18,18 @@ export const spanRequestSymbol = Symbol(
   'opentelemetry.instrumentation.fastify.request_active_span'
 );
 
-export const applicationHookNames = [
-  'onRegister',
-  'onRoute',
-  'onReady',
-  'onClose',
-];
+// The instrumentation creates a span for invocations of lifecycle hook handlers
+// that take `(request, reply, ...[, done])` arguments. Currently this is all
+// lifecycle hooks except `onRequestAbort`.
+// https://fastify.dev/docs/latest/Reference/Hooks
+export const hooksNamesToWrap = new Set([
+  'onTimeout',
+  'onRequest',
+  'preParsing',
+  'preValidation',
+  'preSerialization',
+  'preHandler',
+  'onSend',
+  'onResponse',
+  'onError',
+]);

--- a/plugins/node/opentelemetry-instrumentation-fastify/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-fastify/src/instrumentation.ts
@@ -33,7 +33,7 @@ import type {
   FastifyRequest,
   FastifyReply,
 } from 'fastify';
-import { applicationHookNames } from './constants';
+import { hooksNamesToWrap } from './constants';
 import {
   AttributeNames,
   FastifyNames,
@@ -178,8 +178,8 @@ export class FastifyInstrumentation extends InstrumentationBase {
         const name = args[0] as string;
         const handler = args[1] as HandlerOriginal;
         const pluginName = this.pluginName;
-        if (applicationHookNames.includes(name)) {
-          return original.apply(this, [name, handler] as never);
+        if (!hooksNamesToWrap.has(name)) {
+          return original.apply(this, args);
         }
 
         const syncFunctionWithDone =

--- a/plugins/node/opentelemetry-instrumentation-fastify/test/instrumentation.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-fastify/test/instrumentation.test.ts
@@ -424,6 +424,14 @@ describe('fastify', () => {
         await startServer();
       });
 
+      it('preClose is not instrumented', async () => {
+        app.addHook('preClose', () => {
+          assertRootContextActive();
+        });
+
+        await startServer();
+      });
+
       it('onClose is not instrumented', async () => {
         app.addHook('onClose', () => {
           assertRootContextActive();


### PR DESCRIPTION
Fixes: https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1762

This changes to an allow-list of hook names to wrap -- which means that if a new hook is added, then we won't create spans for it, but we also won't accidentally crash. :)

