### PR TITLE
fix: use context API to bind connection checkOut callback

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-mongodb/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/src/instrumentation.ts
@@ -330,7 +330,7 @@ export class MongoDBInstrumentation extends InstrumentationBase {
   private _getV4ConnectionPoolCheckOut() {
     return (original: V4ConnectionPool['checkOut']) => {
       return function patchedCheckout(this: unknown, callback: any) {
-        const patchedCallback = context.bind(context.active(), callback)
+        const patchedCallback = context.bind(context.active(), callback);
         return original.call(this, patchedCallback);
       };
     };

--- a/plugins/node/opentelemetry-instrumentation-mongodb/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/src/instrumentation.ts
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { AsyncResource } from 'async_hooks';
-
 import {
   context,
   diag,
@@ -332,7 +330,7 @@ export class MongoDBInstrumentation extends InstrumentationBase {
   private _getV4ConnectionPoolCheckOut() {
     return (original: V4ConnectionPool['checkOut']) => {
       return function patchedCheckout(this: unknown, callback: any) {
-        const patchedCallback = AsyncResource.bind(callback);
+        const patchedCallback = context.bind(context.active(), callback)
         return original.call(this, patchedCallback);
       };
     };


### PR DESCRIPTION
## Which problem is this PR solving?

- Previous fix for `mongodb` instrumentation was using `AsynResource.bind` API which has different behaviour in different node versions. This leads to the instrumentation breaking `mongodb` driver for node v14

## Short description of the changes

- make use of `context.bind` from `@opentelemetry/api` which is not affected by different node versions and is the recommended way to do it (thanks for the tip @Flarna)

Closes: #1759 