### PR TITLE
chore(deps): unpin @opentelemetry/* in fastify instrumentation and mysql example

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-fastify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-fastify/package.json
@@ -49,7 +49,7 @@
     "@fastify/express": "^2.0.2",
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/context-async-hooks": "^1.8.0",
-    "@opentelemetry/instrumentation-http": "0.45.1",
+    "@opentelemetry/instrumentation-http": "^0.45.1",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/express": "4.17.18",

--- a/plugins/node/opentelemetry-instrumentation-mysql/examples/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql/examples/package.json
@@ -39,7 +39,7 @@
     "@opentelemetry/instrumentation-mysql": "^0.31.0",
     "@opentelemetry/sdk-trace-base": "^1.0.0",
     "@opentelemetry/sdk-trace-node": "^1.0.0",
-    "@opentelemetry/exporter-metrics-otlp-grpc": "0.45.1",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "^0.45.1",
     "mysql": "^2.18.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js#readme",


### PR DESCRIPTION
Experimental dependencies were pinnend in a way to not allow patch releases. This PR changes the pinned to a caret version that'll allow patch releases for experimental packages.
