### PR TITLE
chore(graphql): update span name to show the resolver name

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-graphql/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/src/utils.ts
@@ -129,7 +129,7 @@ function createResolverSpan(
   };
 
   const span = tracer.startSpan(
-    SpanNames.RESOLVE,
+    `${SpanNames.RESOLVE} ${attributes[AttributeNames.FIELD_PATH]}`,
     {
       attributes,
     },

--- a/plugins/node/opentelemetry-instrumentation-graphql/test/graphql.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/test/graphql.test.ts
@@ -613,7 +613,7 @@ describe('graphql', () => {
       await graphql({ schema: simpleSchemaWithResolver, source: '{ hello }' });
       const resovleSpans = exporter
         .getFinishedSpans()
-        .filter(span => span.name === SpanNames.RESOLVE);
+        .filter(span => span.name === `${SpanNames.RESOLVE} hello`);
       assert.deepStrictEqual(resovleSpans.length, 1);
       const resolveSpan = resovleSpans[0];
       assert(resolveSpan.attributes[AttributeNames.FIELD_PATH] === 'hello');
@@ -633,7 +633,7 @@ describe('graphql', () => {
       await graphql({ schema, source: '{ hello }', rootValue });
       const resovleSpans = exporter
         .getFinishedSpans()
-        .filter(span => span.name === SpanNames.RESOLVE);
+        .filter(span => span.name === `${SpanNames.RESOLVE} hello`);
       assert.deepStrictEqual(resovleSpans.length, 1);
       const resolveSpan = resovleSpans[0];
       assert(resolveSpan.attributes[AttributeNames.FIELD_PATH] === 'hello');
@@ -653,7 +653,7 @@ describe('graphql', () => {
       await graphql({ schema, source: '{ hello }', rootValue });
       const resovleSpans = exporter
         .getFinishedSpans()
-        .filter(span => span.name === SpanNames.RESOLVE);
+        .filter(span => span.name === `${SpanNames.RESOLVE} hello`);
       assert.deepStrictEqual(resovleSpans.length, 0);
     });
 
@@ -682,7 +682,7 @@ describe('graphql', () => {
       await graphql({ schema, source: '{ hello }', rootValue, fieldResolver });
       const resovleSpans = exporter
         .getFinishedSpans()
-        .filter(span => span.name === SpanNames.RESOLVE);
+        .filter(span => span.name === `${SpanNames.RESOLVE} hello`);
       assert.deepStrictEqual(resovleSpans.length, 1);
       const resolveSpan = resovleSpans[0];
       assert(resolveSpan.attributes[AttributeNames.FIELD_PATH] === 'hello');
@@ -1355,7 +1355,9 @@ describe('graphql', () => {
       const spans = exporter.getFinishedSpans();
 
       // single resolve span with error and event for exception
-      const resolveSpans = spans.filter(s => s.name === SpanNames.RESOLVE);
+      const resolveSpans = spans.filter(
+        s => s.name === `${SpanNames.RESOLVE} hello`
+      );
       assert.deepStrictEqual(resolveSpans.length, 1);
       const resolveSpan = resolveSpans[0];
       assert.deepStrictEqual(resolveSpan.status.code, SpanStatusCode.ERROR);

--- a/plugins/node/opentelemetry-instrumentation-graphql/test/helper.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/test/helper.ts
@@ -28,7 +28,10 @@ export function assertResolveSpan(
   parentSpanId?: string
 ) {
   const attrs = span.attributes;
-  assert.deepStrictEqual(span.name, SpanNames.RESOLVE);
+  assert.deepStrictEqual(
+    span.name,
+    `${SpanNames.RESOLVE} ${attrs[AttributeNames.FIELD_PATH]}`
+  );
   assert.deepStrictEqual(attrs[AttributeNames.FIELD_NAME], fieldName);
   assert.deepStrictEqual(attrs[AttributeNames.FIELD_PATH], fieldPath);
   assert.deepStrictEqual(attrs[AttributeNames.FIELD_TYPE], fieldType);


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes #1791 
-

## Short description of the changes
This PR updates (opentelemetry-instrumentation-graphql) the resolvers' span name. 
It will show something like: `graphql-resolve hello` instead of `graphql-resolve`. This is very useful to easily understand at a top level which field is being resolved.

E.g.,
```
query ExampleQuery {
  me {
    name 
    }
}
```

<img width="232" alt="Screenshot 2023-11-13 at 11 25 18" src="https://github.com/open-telemetry/opentelemetry-js-contrib/assets/19807377/a90e3668-c600-4039-99ce-cc1d47aa652c">
