### PR TITLE
feat(@opentelemetry/instrumentation-user-interaction): Add custom span attributes

### DIFF
--- a/plugins/web/opentelemetry-instrumentation-user-interaction/src/types.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/src/types.ts
@@ -25,6 +25,10 @@ export type ShouldPreventSpanCreation = (
   span: Span
 ) => boolean | void;
 
+export interface UserInteractionCustomAttributeFunction {
+  (span: Span): void;
+}
+
 export interface UserInteractionInstrumentationConfig
   extends InstrumentationConfig {
   /**
@@ -39,4 +43,9 @@ export interface UserInteractionInstrumentationConfig
    * You can also use this handler to enhance created span with extra attributes.
    */
   shouldPreventSpanCreation?: ShouldPreventSpanCreation;
+
+  /**
+   * Function for adding custom attributes on the span
+   */
+  applyCustomAttributesOnSpan?: UserInteractionCustomAttributeFunction;
 }

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.nozone.test.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.nozone.test.ts
@@ -582,6 +582,26 @@ describe('UserInteractionInstrumentation', () => {
       assertInteractionSpan(span, { name: 'play' });
     });
 
+    it('should apply custom attributes to spans', () => {
+      const customAttributeName = 'custom_attribute';
+      const customAttributeValue = 'custom_attribute_value';
+      registerTestInstrumentations({
+        eventNames: ['play'],
+        applyCustomAttributesOnSpan: (span) => {
+          span.setAttribute(customAttributeName, customAttributeValue)
+        },
+      });
+
+      fakeEventInteraction('play');
+      assert.strictEqual(exportSpy.args.length, 1, 'should export one span');
+      const span = exportSpy.args[0][0][0];
+      assert.strictEqual(
+        span.attributes[customAttributeName],
+        customAttributeValue,
+        'should have custom attribute on span'
+      );
+    });
+
     it('should not be exported not configured spans', () => {
       registerTestInstrumentations({
         eventNames: ['play'],

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.test.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.test.ts
@@ -248,6 +248,26 @@ describe('UserInteractionInstrumentation', () => {
       assertInteractionSpan(span, { name: 'play' });
     });
 
+    it('should apply custom attributes to spans', () => {
+      const customAttributeName = 'custom_attribute';
+      const customAttributeValue = 'custom_attribute_value';
+      registerTestInstrumentations({
+        eventNames: ['play'],
+        applyCustomAttributesOnSpan: (span) => {
+          span.setAttribute(customAttributeName, customAttributeValue)
+        },
+      });
+
+      fakeEventInteraction('play');
+      assert.strictEqual(exportSpy.args.length, 1, 'should export one span');
+      const span = exportSpy.args[0][0][0];
+      assert.strictEqual(
+        span.attributes[customAttributeName],
+        customAttributeValue,
+        'should have custom attribute on span'
+      );
+    });
+
     it('not configured spans should not be exported', () => {
       registerTestInstrumentations({
         eventNames: ['play'],


### PR DESCRIPTION
## Which problem is this PR solving?
https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1770

## Short description of the changes

Added the ability to add custom attributes on a span
I have set it up to be configured with a `UserInteractionCustomAttributeFunction` which is in the same fashion as the other plugins for consistency.