### PR TITLE
chore: sync package-lock file to package.json files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34363,7 +34363,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/sdk-metrics": "^1.8.0",
-        "systeminformation": "^5.21.17"
+        "systeminformation": "^5.0.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -34429,7 +34429,7 @@
         "@opentelemetry/contrib-test-utils": "^0.34.3",
         "@types/mocha": "^9.1.1",
         "@types/node": "18.6.5",
-        "@types/sinon": "^10.0.20",
+        "@types/sinon": "^10.0.11",
         "expect": "29.2.0",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -34706,7 +34706,7 @@
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.6.5",
-        "@types/sinon": "^10.0.20",
+        "@types/sinon": "^10.0.11",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
         "rimraf": "5.0.5",
@@ -35363,7 +35363,7 @@
         "express": "^4.17.1"
       },
       "devDependencies": {
-        "@types/express": "^4.17.21",
+        "@types/express": "^4.17.13",
         "ts-node": "^10.6.0",
         "typescript": "4.4.4"
       },
@@ -35915,7 +35915,7 @@
       "version": "0.23.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@koa/router": "^12.0.1",
+        "@koa/router": "^12.0.0",
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/exporter-jaeger": "^1.0.0",
         "@opentelemetry/exporter-zipkin": "^1.0.0",
@@ -35928,7 +35928,7 @@
         "koa": "^2.13.0"
       },
       "devDependencies": {
-        "@types/koa": "^2.13.11",
+        "@types/koa": "^2.13.5",
         "cross-env": "^7.0.0",
         "ts-node": "^10.6.0",
         "typescript": "4.4.4"
@@ -36263,7 +36263,7 @@
         "mysql": "^2.18.1"
       },
       "devDependencies": {
-        "@types/mysql": "^2.15.24",
+        "@types/mysql": "^2.15.21",
         "cross-env": "^7.0.0",
         "ts-node": "^10.6.0",
         "typescript": "4.4.4"
@@ -36666,7 +36666,7 @@
         "redis": "^3.1.1"
       },
       "devDependencies": {
-        "@types/express": "^4.17.21",
+        "@types/express": "^4.17.14",
         "cross-env": "^7.0.0",
         "ts-node": "^10.6.0",
         "typescript": "4.4.4"
@@ -43991,7 +43991,7 @@
         "nyc": "15.1.0",
         "rimraf": "5.0.5",
         "sinon": "15.2.0",
-        "systeminformation": "^5.21.17",
+        "systeminformation": "^5.0.0",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
       }
@@ -44603,7 +44603,7 @@
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.6.5",
-        "@types/sinon": "^10.0.20",
+        "@types/sinon": "^10.0.11",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
         "rimraf": "5.0.5",
@@ -45921,7 +45921,7 @@
         "@opentelemetry/contrib-test-utils": "^0.34.3",
         "@types/mocha": "^9.1.1",
         "@types/node": "18.6.5",
-        "@types/sinon": "^10.0.20",
+        "@types/sinon": "^10.0.11",
         "expect": "29.2.0",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -52171,7 +52171,7 @@
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-node": "^1.0.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/express": "^4.17.21",
+        "@types/express": "^4.17.13",
         "axios": "^0.21.1",
         "cross-env": "^7.0.3",
         "express": "^4.17.1",
@@ -55822,7 +55822,7 @@
     "koa-example": {
       "version": "file:plugins/node/opentelemetry-instrumentation-koa/examples",
       "requires": {
-        "@koa/router": "^12.0.1",
+        "@koa/router": "^12.0.0",
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/exporter-jaeger": "^1.0.0",
         "@opentelemetry/exporter-zipkin": "^1.0.0",
@@ -55831,7 +55831,7 @@
         "@opentelemetry/instrumentation-koa": "^0.31.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-node": "^1.0.0",
-        "@types/koa": "^2.13.11",
+        "@types/koa": "^2.13.5",
         "axios": "^0.21.1",
         "cross-env": "^7.0.0",
         "koa": "^2.13.0",
@@ -58683,7 +58683,7 @@
         "@opentelemetry/instrumentation-mysql": "^0.31.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-node": "^1.0.0",
-        "@types/mysql": "^2.15.24",
+        "@types/mysql": "^2.15.21",
         "cross-env": "^7.0.0",
         "mysql": "^2.18.1",
         "ts-node": "^10.6.0",
@@ -61917,7 +61917,7 @@
         "@opentelemetry/instrumentation-redis": "^0.32.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-node": "^1.0.0",
-        "@types/express": "^4.17.21",
+        "@types/express": "^4.17.14",
         "axios": "^0.21.1",
         "cross-env": "^7.0.0",
         "express": "^4.17.1",


### PR DESCRIPTION
This PR was generated from running `npm install --package-lock-only`. It undoes part of the change by renovate in #1723.
See discussion at https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1806

