### PR TITLE
chore(instrumentation-mysql2): drop unneed @types/mysql2 dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10458,21 +10458,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/mysql2": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/types/mysql2.git#89378b2cb3974ea8cdd1d633b8f056e54e5d2384",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@types/mysql": "types/mysql"
-      }
-    },
-    "node_modules/@types/mysql2/node_modules/@types/mysql": {
-      "version": "2.0.0",
-      "resolved": "git+ssh://git@github.com/types/mysql.git#c26b1bc2bac17010081455e3127a90fb2eafcec9",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/@types/node": {
       "version": "18.6.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.5.tgz",
@@ -34363,7 +34348,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/sdk-metrics": "^1.8.0",
-        "systeminformation": "^5.21.17"
+        "systeminformation": "^5.0.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -34429,7 +34414,7 @@
         "@opentelemetry/contrib-test-utils": "^0.34.3",
         "@types/mocha": "^9.1.1",
         "@types/node": "18.6.5",
-        "@types/sinon": "^10.0.20",
+        "@types/sinon": "^10.0.11",
         "expect": "29.2.0",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -34706,7 +34691,7 @@
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.6.5",
-        "@types/sinon": "^10.0.20",
+        "@types/sinon": "^10.0.11",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
         "rimraf": "5.0.5",
@@ -35363,7 +35348,7 @@
         "express": "^4.17.1"
       },
       "devDependencies": {
-        "@types/express": "^4.17.21",
+        "@types/express": "^4.17.13",
         "ts-node": "^10.6.0",
         "typescript": "4.4.4"
       },
@@ -35915,7 +35900,7 @@
       "version": "0.23.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@koa/router": "^12.0.1",
+        "@koa/router": "^12.0.0",
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/exporter-jaeger": "^1.0.0",
         "@opentelemetry/exporter-zipkin": "^1.0.0",
@@ -35928,7 +35913,7 @@
         "koa": "^2.13.0"
       },
       "devDependencies": {
-        "@types/koa": "^2.13.11",
+        "@types/koa": "^2.13.5",
         "cross-env": "^7.0.0",
         "ts-node": "^10.6.0",
         "typescript": "4.4.4"
@@ -36263,7 +36248,7 @@
         "mysql": "^2.18.1"
       },
       "devDependencies": {
-        "@types/mysql": "^2.15.24",
+        "@types/mysql": "^2.15.21",
         "cross-env": "^7.0.0",
         "ts-node": "^10.6.0",
         "typescript": "4.4.4"
@@ -36368,7 +36353,6 @@
         "@opentelemetry/contrib-test-utils": "^0.34.3",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/mysql2": "github:types/mysql2",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.3",
         "mocha": "7.2.0",
@@ -36666,7 +36650,7 @@
         "redis": "^3.1.1"
       },
       "devDependencies": {
-        "@types/express": "^4.17.21",
+        "@types/express": "^4.17.14",
         "cross-env": "^7.0.0",
         "ts-node": "^10.6.0",
         "typescript": "4.4.4"
@@ -43991,7 +43975,7 @@
         "nyc": "15.1.0",
         "rimraf": "5.0.5",
         "sinon": "15.2.0",
-        "systeminformation": "^5.21.17",
+        "systeminformation": "^5.0.0",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
       }
@@ -44603,7 +44587,7 @@
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.6.5",
-        "@types/sinon": "^10.0.20",
+        "@types/sinon": "^10.0.11",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
         "rimraf": "5.0.5",
@@ -45165,7 +45149,6 @@
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@opentelemetry/sql-common": "^0.40.0",
         "@types/mocha": "7.0.2",
-        "@types/mysql2": "github:types/mysql2",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.3",
         "mocha": "7.2.0",
@@ -45921,7 +45904,7 @@
         "@opentelemetry/contrib-test-utils": "^0.34.3",
         "@types/mocha": "^9.1.1",
         "@types/node": "18.6.5",
-        "@types/sinon": "^10.0.20",
+        "@types/sinon": "^10.0.11",
         "expect": "29.2.0",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -47776,21 +47759,6 @@
       "integrity": "sha512-wK1pzsJVVAjYCSZWQoWHziQZbNggXFDUEIGf54g4ZM/ERuP86uGdWeKZWMYlqTPMZfHJJvLPyogXGvCOg87yLQ==",
       "requires": {
         "@types/node": "*"
-      }
-    },
-    "@types/mysql2": {
-      "version": "git+ssh://git@github.com/types/mysql2.git#89378b2cb3974ea8cdd1d633b8f056e54e5d2384",
-      "dev": true,
-      "from": "@types/mysql2@github:types/mysql2",
-      "requires": {
-        "@types/mysql": "types/mysql"
-      },
-      "dependencies": {
-        "@types/mysql": {
-          "version": "git+ssh://git@github.com/types/mysql.git#c26b1bc2bac17010081455e3127a90fb2eafcec9",
-          "dev": true,
-          "from": "@types/mysql@types/mysql"
-        }
       }
     },
     "@types/node": {
@@ -52171,7 +52139,7 @@
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-node": "^1.0.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/express": "^4.17.21",
+        "@types/express": "^4.17.13",
         "axios": "^0.21.1",
         "cross-env": "^7.0.3",
         "express": "^4.17.1",
@@ -55822,7 +55790,7 @@
     "koa-example": {
       "version": "file:plugins/node/opentelemetry-instrumentation-koa/examples",
       "requires": {
-        "@koa/router": "^12.0.1",
+        "@koa/router": "^12.0.0",
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/exporter-jaeger": "^1.0.0",
         "@opentelemetry/exporter-zipkin": "^1.0.0",
@@ -55831,7 +55799,7 @@
         "@opentelemetry/instrumentation-koa": "^0.31.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-node": "^1.0.0",
-        "@types/koa": "^2.13.11",
+        "@types/koa": "^2.13.5",
         "axios": "^0.21.1",
         "cross-env": "^7.0.0",
         "koa": "^2.13.0",
@@ -58683,7 +58651,7 @@
         "@opentelemetry/instrumentation-mysql": "^0.31.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-node": "^1.0.0",
-        "@types/mysql": "^2.15.24",
+        "@types/mysql": "^2.15.21",
         "cross-env": "^7.0.0",
         "mysql": "^2.18.1",
         "ts-node": "^10.6.0",
@@ -61917,7 +61885,7 @@
         "@opentelemetry/instrumentation-redis": "^0.32.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-node": "^1.0.0",
-        "@types/express": "^4.17.21",
+        "@types/express": "^4.17.14",
         "axios": "^0.21.1",
         "cross-env": "^7.0.0",
         "express": "^4.17.1",

--- a/plugins/node/opentelemetry-instrumentation-mysql2/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/package.json
@@ -49,7 +49,6 @@
     "@opentelemetry/contrib-test-utils": "^0.34.3",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@types/mocha": "7.0.2",
-    "@types/mysql2": "github:types/mysql2",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.3",
     "mocha": "7.2.0",


### PR DESCRIPTION
Types are included in 'mysql2' now (as of some 2.x release).

The github:types/mysql2 dependency is problematic for dependabot version updates.
See: https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1806#issuecomment-1816889209