### PR TITLE
fix(instrumentation-aws-sdk): Add traceparent to AWS SDK unsignableHeaders

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.ts
@@ -222,6 +222,12 @@ export class AwsInstrumentation extends InstrumentationBase<any> {
       this._getRequestPromisePatch.bind(this, moduleVersion)
     );
 
+    const unsignableHeaders =
+      moduleExports?.Signers.V4.prototype.unsignableHeaders;
+    if (!unsignableHeaders.includes('traceparent')) {
+      unsignableHeaders.push('traceparent');
+    }
+
     return moduleExports;
   }
 
@@ -231,6 +237,12 @@ export class AwsInstrumentation extends InstrumentationBase<any> {
     }
     if (isWrapped(moduleExports?.Request.prototype.promise)) {
       this._unwrap(moduleExports!.Request.prototype, 'promise');
+    }
+
+    const unsignableHeaders =
+      moduleExports?.Signers.V4.prototype.unsignableHeaders;
+    if (unsignableHeaders.includes('traceparent')) {
+      unsignableHeaders.splice(unsignableHeaders.indexOf('traceparent'), 1);
     }
   }
 


### PR DESCRIPTION
## Which problem is this PR solving?

This is an attempt to address the issue of a signature mismatch when a request fails and is retried. This happens because the instrumentation adds the `traceparent` header to outgoing headers. When a request fails, the value of the header changes, but the signature does not; and this results in an error.

Fixes https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1609 and https://github.com/open-telemetry/opentelemetry-js/issues/3922

## Short description of the changes

This change adds the `traceparent` header to the list of unsignable headers, so that it is excluded from creating the signature.
