### PR TITLE
fix(ci): use opentelemetrybot to sync package-lock.json on release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,17 +20,51 @@ jobs:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Build Packages
+      - name: Install packages
         run: |
           npm ci
-          npm run compile
 
       - uses: google-github-actions/release-please-action@v3
         id: release
         with:
           command: manifest
-          token: ${{secrets.RELEASE_PR_TOKEN}}
+          token: ${{secrets.OPENTELEMETRYBOT_GITHUB_TOKEN}}
           default-branch: main
+
+      # get release PR as we're currently on main
+      - name: Checkout release PR
+        # only update if a PR has been created, otherwise this will fail
+        if: ${{ steps.release.outputs.pr }}
+        uses: actions/checkout@v4
+        with:
+          ref: release-please--branches--main
+          # use a token so that workflows on the PR run when we push later
+          token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+
+      # release-please does not do this on its own, so we do it here instead
+      - name: Update package-lock.json in PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+        # only update if a PR has been created
+        if: ${{ steps.release.outputs.pr }}
+        run: |
+          npm install --ignore-scripts --package-lock-only
+          git add package-lock.json
+          git config user.name opentelemetrybot
+          git config user.email 107717825+opentelemetrybot@users.noreply.github.com
+          git commit -m "chore: sync package-lock.json"
+          git push
+
+      # get main again
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Rebuild Packages
+        run: |
+          npm ci
+          npm run compile
 
       # Release Please has already incremented versions and published tags, so we just
       # need to publish all unpublished versions to npm here

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,7 +28,7 @@ jobs:
         id: release
         with:
           command: manifest
-          token: ${{secrets.OPENTELEMETRYBOT_GITHUB_TOKEN}}
+          token: ${{secrets.RELEASE_PR_TOKEN}}
           default-branch: main
 
       # get release PR as we're currently on main
@@ -39,12 +39,12 @@ jobs:
         with:
           ref: release-please--branches--main
           # use a token so that workflows on the PR run when we push later
-          token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PR_TOKEN }}
 
       # release-please does not do this on its own, so we do it here instead
       - name: Update package-lock.json in PR
         env:
-          GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PR_TOKEN }}
         # only update if a PR has been created
         if: ${{ steps.release.outputs.pr }}
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,7 +33,7 @@ jobs:
 
       # get release PR as we're currently on main
       - name: Checkout release PR
-        # only update if a PR has been created, otherwise this will fail
+        # only checkout if a PR has been created, otherwise this will fail
         if: ${{ steps.release.outputs.pr }}
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Which problem is this PR solving?

- see #1798, release-please is not updating package-lock.json with the new versions, so currently we'd need to do this manually - however release please force-pushes on each merge to main, so this is tedious.
- we currently do not use the opentelemetrybot account to create release PRs
  - [link to community repo issue to get the required access to @opentelemetrybot](https://github.com/open-telemetry/community/issues/1814)

## Short description of the changes

- uses opentelemetrybot credentials to create release PRs via release please
- adds a commit as opentelemetrybot, which syncs the package-lock.json (@opentelemetrybot has signed the CLA) 
