### PR TITLE
fix(instrumentation-mysql2)!: instrumentation should not include values in db.statement

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-mysql2/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/src/instrumentation.ts
@@ -154,8 +154,16 @@ export class MySQL2Instrumentation extends InstrumentationBase<MySQL2Instrumenta
           }
           span.end();
         });
-
-        if (typeof arguments[arguments.length - 1] !== 'function') {
+        function findCallback(_arguments: IArguments) {
+          for (let i = 0; i < _arguments.length; i++) {
+            if (typeof _arguments[i] === 'function') {
+              return i;
+            }
+          }
+          return -1;
+        }
+        const cb = findCallback(arguments);
+        if (cb < 0) {
           if (typeof (query as any).onResult === 'function') {
             thisPlugin._wrap(
               query as any,
@@ -182,7 +190,7 @@ export class MySQL2Instrumentation extends InstrumentationBase<MySQL2Instrumenta
         } else {
           thisPlugin._wrap(
             arguments,
-            arguments.length - 1,
+            cb,
             thisPlugin._patchCallbackQuery(endSpan)
           );
         }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

This PR addresses the bug in #1758 also following what emerged in https://github.com/open-telemetry/semantic-conventions/issues/436

## Short description of the changes

*This is a breaking change*

-  The DB statement will be included in the span only when placeholders are used. The rationale behind this choice is that if there are no placeholders, it is assumed that the query SQL may include sensitive data, and therefore, no DB statement is included in the telemetry.
