### PR TITLE
test: fix redis-4 TAV tests with Node.js v14

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-redis-4/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-redis-4/.tav.yml
@@ -1,8 +1,7 @@
 redis:
-
   jobs:
-    - versions: "^4.0.0"
+    # The latest minor releases in the range "^4.0.0", excluding
+    # "4.6.9", which was a bad release that accidentally broke
+    # node v14 support.
+    - versions: "4.0.0 || 4.0.6 || 4.1.1 || 4.2.0 || 4.3.1 || 4.4.0 || 4.5.1 || ^4.6.11"
       commands: npm run test
-
-  # Fix missing `contrib-test-utils` package
-  pretest: npm run --prefix ../../../ lerna:link


### PR DESCRIPTION
redis@4.6.9 was a bad release that accidentally broken v14 support. This updates the versions test to skip that release, and also reduces the number of versions tested from 27 to 8 by selecting just the current latest minor releases.

Also, drop the pretest config that (a) was never used because of the wrong indentation and (b) is no longer valid since the move to npm workspaces.

Refs: #1860

---

**Note**: The redis-4 TAV tests still fail with Node v18 and v16 (sometimes, I think). That is a separate issue to what this one is fixing.
