### PR TITLE
fix(host-metrics): bump minimum systeminformation version to 5.21.20 (security)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29911,9 +29911,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.21.17",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.21.17.tgz",
-      "integrity": "sha512-JZYRCbIjk3WuBV59A9/rTla2rROX+aAJ9uo2Z1dI+bjieORcukClN8rlM1zE9NYKpULSbaGc+KKct/870lO0DA==",
+      "version": "5.21.20",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.21.20.tgz",
+      "integrity": "sha512-AyS1fNc+MDoAJtFknFbbo587H8h6yejJwM+H9rVusnOToIEkiMehMyD5JM7o3j55Cto20MawIZrcgNMgd4BfOQ==",
       "os": [
         "darwin",
         "linux",
@@ -33654,7 +33654,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/sdk-metrics": "^1.8.0",
-        "systeminformation": "^5.0.0"
+        "systeminformation": "^5.21.20"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -42919,7 +42919,7 @@
         "nyc": "15.1.0",
         "rimraf": "5.0.5",
         "sinon": "15.2.0",
-        "systeminformation": "^5.0.0",
+        "systeminformation": "^5.21.20",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
       }
@@ -62830,9 +62830,9 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "systeminformation": {
-      "version": "5.21.17",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.21.17.tgz",
-      "integrity": "sha512-JZYRCbIjk3WuBV59A9/rTla2rROX+aAJ9uo2Z1dI+bjieORcukClN8rlM1zE9NYKpULSbaGc+KKct/870lO0DA=="
+      "version": "5.21.20",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.21.20.tgz",
+      "integrity": "sha512-AyS1fNc+MDoAJtFknFbbo587H8h6yejJwM+H9rVusnOToIEkiMehMyD5JM7o3j55Cto20MawIZrcgNMgd4BfOQ=="
     },
     "tapable": {
       "version": "1.1.3",

--- a/packages/opentelemetry-host-metrics/package.json
+++ b/packages/opentelemetry-host-metrics/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@opentelemetry/sdk-metrics": "^1.8.0",
-    "systeminformation": "^5.0.0"
+    "systeminformation": "^5.21.20"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/opentelemetry-host-metrics#readme"
 }


### PR DESCRIPTION
…n vulnerability in systeminformation

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?
In the current version of the systeminformation library used by the host metrics package, a pretty serious vulnerability exists. That being the arbitrary command injection. This pull request addresss that by bumping the version of the library.
-

## Short description of the changes
This changes is only comprised of a version bump.
-
