### PR TITLE
test: temporarily pin Node.js 18 testing to 18.18.2

### DIFF
--- a/.github/workflows/test-all-versions.yml
+++ b/.github/workflows/test-all-versions.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ["14", "16", "18"]
+        node: ["14", "16", "18.18.2"]
     runs-on: ubuntu-latest
     services:
       mongo:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ["14", "16", "18"]
+        node: ["14", "16", "18.18.2"]
         include:
             - node: 14
               code-coverage: true


### PR DESCRIPTION
This is as a workaround for ESM testing failing with v18.19.0 due
to node's off-thread ESM loading and import-in-the-middle's limitation
with reexports.

Refs: https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1872
