### PR TITLE
ci: automatically map component labels to PRs

### DIFF
--- a/.github/component-label-map.yml
+++ b/.github/component-label-map.yml
@@ -1,0 +1,174 @@
+pkg:resource-detector-alibaba-cloud:
+  - changed-files:
+      - any-glob-to-any-file: detectors/node/opentelemetry-resource-detector-alibaba-cloud/**
+pkg:resource-detector-aws:
+  - changed-files:
+      - any-glob-to-any-file: detectors/node/opentelemetry-resource-detector-aws/**
+pkg:resource-detector-azure:
+  - changed-files:
+      - any-glob-to-any-file: detectors/node/opentelemetry-resource-detector-azure/**
+pkg:resource-detector-container:
+  - changed-files:
+      - any-glob-to-any-file: detectors/node/opentelemetry-resource-detector-container/**
+pkg:resource-detector-gcp:
+  - changed-files:
+      - any-glob-to-any-file: detectors/node/opentelemetry-resource-detector-gcp/**
+pkg:resource-detector-github:
+  - changed-files:
+      - any-glob-to-any-file: detectors/node/opentelemetry-resource-detector-github/**
+pkg:resource-detector-instana:
+  - changed-files:
+      - any-glob-to-any-file: detectors/node/opentelemetry-resource-detector-instana/**
+pkg:auto-instrumentations-node:
+  - changed-files:
+      - any-glob-to-any-file: metapackages/auto-instrumentations-node/**
+pkg:auto-instrumentations-web:
+  - changed-files:
+      - any-glob-to-any-file: metapackages/auto-instrumentations-web/**
+pkg:host-metrics:
+  - changed-files:
+      - any-glob-to-any-file: packages/opentelemetry-host-metrics/**
+pkg:id-generator-aws-xray:
+  - changed-files:
+      - any-glob-to-any-file: packages/opentelemetry-id-generator-aws-xray/**
+pkg:sampler-aws-xray:
+  - changed-files:
+      - any-glob-to-any-file: packages/opentelemetry-sampler-aws-xray/**
+pkg:propagation-utils:
+  - changed-files:
+      - any-glob-to-any-file: packages/opentelemetry-propagation-utils/**
+pkg:redis-common:
+  - changed-files:
+      - any-glob-to-any-file: packages/opentelemetry-redis-common/**
+pkg:test-utils:
+  - changed-files:
+      - any-glob-to-any-file: packages/opentelemetry-test-utils/**
+pkg:instrumentation-amqplib:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/instrumentation-amqplib/**
+pkg:instrumentation-cucumber:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/instrumentation-cucumber/**
+pkg:instrumentation-dataloader:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/instrumentation-dataloader/**
+pkg:instrumentation-fs:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/instrumentation-fs/**
+pkg:instrumentation-lru-memoizer:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/instrumentation-lru-memoizer/**
+pkg:instrumentation-mongoose:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/instrumentation-mongoose/**
+pkg:instrumentation-socket.io:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/instrumentation-socket.io/**
+pkg:instrumentation-tedious:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/instrumentation-tedious/**
+pkg:instrumentation-aws-lambda:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-aws-lambda/**
+pkg:instrumentation-aws-sdk:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-aws-sdk/**
+pkg:instrumentation-bunyan:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-bunyan/**
+pkg:instrumentation-cassandra:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-cassandra/**
+pkg:instrumentation-connect:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-connect/**
+pkg:instrumentation-dns:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-dns/**
+pkg:instrumentation-express:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-express/**
+pkg:instrumentation-fastify:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-fastify/**
+pkg:instrumentation-generic-pool:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-generic-pool/**
+pkg:instrumentation-graphql:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-graphql/**
+pkg:instrumentation-hapi:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-hapi/**
+pkg:instrumentation-ioredis:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-ioredis/**
+pkg:instrumentation-knex:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-knex/**
+pkg:instrumentation-koa:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-koa/**
+pkg:instrumentation-memcached:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-memcached/**
+pkg:instrumentation-mongodb:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-mongodb/**
+pkg:instrumentation-mysql:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-mysql/**
+pkg:instrumentation-mysql2:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-mysql2/**
+pkg:instrumentation-nestjs-core:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-nestjs-core/**
+pkg:instrumentation-net:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-net/**
+pkg:instrumentation-pg:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-pg/**
+pkg:instrumentation-pino:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-pino/**
+pkg:instrumentation-redis-4:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-redis-4/**
+pkg:instrumentation-redis:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-redis/**
+pkg:instrumentation-restify:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-restify/**
+pkg:instrumentation-router:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-router/**
+pkg:instrumentation-winston:
+  - changed-files:
+      - any-glob-to-any-file: plugins/node/opentelemetry-instrumentation-winston/**
+pkg:instrumentation-document-load:
+  - changed-files:
+      - any-glob-to-any-file: plugins/web/opentelemetry-instrumentation-document-load/**
+pkg:instrumentation-long-task:
+  - changed-files:
+      - any-glob-to-any-file: plugins/web/opentelemetry-instrumentation-long-task/**
+pkg:instrumentation-user-interaction:
+  - changed-files:
+      - any-glob-to-any-file: plugins/web/opentelemetry-instrumentation-user-interaction/**
+pkg:plugin-react-load:
+  - changed-files:
+      - any-glob-to-any-file: plugins/web/opentelemetry-plugin-react-load/**
+pkg:propagator-aws-xray:
+  - changed-files:
+      - any-glob-to-any-file: propagators/opentelemetry-propagator-aws-xray/**
+pkg:propagator-grpc-census-binary:
+  - changed-files:
+      - any-glob-to-any-file: propagators/opentelemetry-propagator-grpc-census-binary/**
+pkg:propagator-instana:
+  - changed-files:
+      - any-glob-to-any-file: propagators/opentelemetry-propagator-instana/**
+pkg:propagator-ot-trace:
+  - changed-files:
+      - any-glob-to-any-file: propagators/opentelemetry-propagator-ot-trace/**

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -1,0 +1,16 @@
+name: "Label PR"
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    name: 'Add component labels'
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: '.github/component-label-map.yml'


### PR DESCRIPTION
## Which problem is this PR solving?

Currently approvers/maintainers need to add labels manually to PRs to get TAV to run. This PR adds a workflow that adds these labels based on the files that were changed.
