### PR TITLE
fix: Fix Azure Fns Detector When Running with App Service Detector

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-azure/src/detectors/AzureAppServiceDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-azure/src/detectors/AzureAppServiceDetector.ts
@@ -26,6 +26,7 @@ import {
   WEBSITE_SITE_NAME,
   WEBSITE_SLOT_NAME,
   CLOUD_RESOURCE_ID_RESOURCE_ATTRIBUTE,
+  FUNCTIONS_VERSION
 } from '../types';
 import {
   CloudProviderValues,
@@ -49,7 +50,8 @@ class AzureAppServiceDetector implements DetectorSync {
   detect(): IResource {
     let attributes = {};
     const websiteSiteName = process.env[WEBSITE_SITE_NAME];
-    if (websiteSiteName) {
+    const isAzureFunction = !!process.env[FUNCTIONS_VERSION];
+    if (websiteSiteName && !isAzureFunction) {
       attributes = {
         ...attributes,
         [SemanticResourceAttributes.SERVICE_NAME]: websiteSiteName,

--- a/detectors/node/opentelemetry-resource-detector-azure/src/detectors/AzureAppServiceDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-azure/src/detectors/AzureAppServiceDetector.ts
@@ -26,7 +26,7 @@ import {
   WEBSITE_SITE_NAME,
   WEBSITE_SLOT_NAME,
   CLOUD_RESOURCE_ID_RESOURCE_ATTRIBUTE,
-  FUNCTIONS_VERSION
+  FUNCTIONS_VERSION,
 } from '../types';
 import {
   CloudProviderValues,

--- a/detectors/node/opentelemetry-resource-detector-azure/test/detectors/AzureAppServiceDetector.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-azure/test/detectors/AzureAppServiceDetector.test.ts
@@ -17,6 +17,8 @@
 import * as assert from 'assert';
 import { azureAppServiceDetector } from '../../src/detectors/AzureAppServiceDetector';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { azureFunctionsDetector } from '../../src';
+import { detectResourcesSync } from '@opentelemetry/resources';
 
 describe('AzureAppServiceDetector', () => {
   let originalEnv: NodeJS.ProcessEnv;
@@ -38,7 +40,9 @@ describe('AzureAppServiceDetector', () => {
     process.env.WEBSITE_RESOURCE_GROUP = 'test-resource-group';
     process.env.WEBSITE_OWNER_NAME = 'test-owner-name';
 
-    const resource = azureAppServiceDetector.detect();
+    const resource = detectResourcesSync({
+      detectors: [azureFunctionsDetector, azureAppServiceDetector],
+    });
     assert.ok(resource);
     const attributes = resource.attributes;
     assert.strictEqual(
@@ -88,7 +92,9 @@ describe('AzureAppServiceDetector', () => {
     process.env.WEBSITE_HOME_STAMPNAME = 'test-home-stamp';
     process.env.WEBSITE_OWNER_NAME = 'test-owner-name';
 
-    const resource = azureAppServiceDetector.detect();
+    const resource = detectResourcesSync({
+      detectors: [azureFunctionsDetector, azureAppServiceDetector],
+    });
     assert.ok(resource);
     const attributes = resource.attributes;
     assert.strictEqual(
@@ -123,7 +129,9 @@ describe('AzureAppServiceDetector', () => {
     process.env.WEBSITE_RESOURCE_GROUP = 'test-resource-group';
     delete process.env.WEBSITE_OWNER_NAME;
 
-    const resource = azureAppServiceDetector.detect();
+    const resource = detectResourcesSync({
+      detectors: [azureFunctionsDetector, azureAppServiceDetector],
+    });
     assert.ok(resource);
     const attributes = resource.attributes;
     assert.strictEqual(

--- a/detectors/node/opentelemetry-resource-detector-azure/test/detectors/AzureFunctionsDetector.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-azure/test/detectors/AzureFunctionsDetector.test.ts
@@ -16,7 +16,9 @@
 
 import * as assert from 'assert';
 import { azureFunctionsDetector } from '../../src/detectors/AzureFunctionsDetector';
+import { azureAppServiceDetector } from '../../src/detectors/AzureAppServiceDetector';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { detectResourcesSync } from '@opentelemetry/resources';
 
 describe('AzureFunctionsDetector', () => {
   let originalEnv: NodeJS.ProcessEnv;
@@ -35,7 +37,51 @@ describe('AzureFunctionsDetector', () => {
     process.env.FUNCTIONS_EXTENSION_VERSION = '~4';
     process.env.WEBSITE_MEMORY_LIMIT_MB = '1000';
 
-    const resource = azureFunctionsDetector.detect();
+    const resource = detectResourcesSync({
+      detectors: [azureFunctionsDetector, azureAppServiceDetector],
+    });
+    assert.ok(resource);
+    const attributes = resource.attributes;
+    assert.strictEqual(
+      attributes[SemanticResourceAttributes.FAAS_NAME],
+      'test-function'
+    );
+    assert.strictEqual(
+      attributes[SemanticResourceAttributes.CLOUD_PROVIDER],
+      'azure'
+    );
+    assert.strictEqual(
+      attributes[SemanticResourceAttributes.CLOUD_PLATFORM],
+      'azure_functions'
+    );
+    assert.strictEqual(
+      attributes[SemanticResourceAttributes.CLOUD_REGION],
+      'test-region'
+    );
+    assert.strictEqual(
+      attributes[SemanticResourceAttributes.FAAS_INSTANCE],
+      'test-instance-id'
+    );
+    assert.strictEqual(
+      attributes[SemanticResourceAttributes.FAAS_MAX_MEMORY],
+      '1000'
+    );
+    assert.strictEqual(
+      attributes[SemanticResourceAttributes.FAAS_VERSION],
+      '~4'
+    );
+  });
+  
+  it('should not detect azure app service values', () => {
+    process.env.WEBSITE_SITE_NAME = 'test-function';
+    process.env.REGION_NAME = 'test-region';
+    process.env.WEBSITE_INSTANCE_ID = 'test-instance-id';
+    process.env.FUNCTIONS_EXTENSION_VERSION = '~4';
+    process.env.WEBSITE_MEMORY_LIMIT_MB = '1000';
+
+    const resource = detectResourcesSync({
+      detectors: [azureFunctionsDetector, azureAppServiceDetector],
+    });
     assert.ok(resource);
     const attributes = resource.attributes;
     assert.strictEqual(

--- a/detectors/node/opentelemetry-resource-detector-azure/test/detectors/AzureFunctionsDetector.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-azure/test/detectors/AzureFunctionsDetector.test.ts
@@ -19,6 +19,7 @@ import { azureFunctionsDetector } from '../../src/detectors/AzureFunctionsDetect
 import { azureAppServiceDetector } from '../../src/detectors/AzureAppServiceDetector';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { detectResourcesSync } from '@opentelemetry/resources';
+import { AZURE_APP_SERVICE_STAMP_RESOURCE_ATTRIBUTE } from '../../src/types';
 
 describe('AzureFunctionsDetector', () => {
   let originalEnv: NodeJS.ProcessEnv;
@@ -70,47 +71,16 @@ describe('AzureFunctionsDetector', () => {
       attributes[SemanticResourceAttributes.FAAS_VERSION],
       '~4'
     );
-  });
 
-  it('should not detect azure app service values', () => {
-    process.env.WEBSITE_SITE_NAME = 'test-function';
-    process.env.REGION_NAME = 'test-region';
-    process.env.WEBSITE_INSTANCE_ID = 'test-instance-id';
-    process.env.FUNCTIONS_EXTENSION_VERSION = '~4';
-    process.env.WEBSITE_MEMORY_LIMIT_MB = '1000';
+    // Should not detect app service values
+    assert.strictEqual(
+      attributes[SemanticResourceAttributes.SERVICE_INSTANCE_ID],
+      undefined
+    );
 
-    const resource = detectResourcesSync({
-      detectors: [azureFunctionsDetector, azureAppServiceDetector],
-    });
-    assert.ok(resource);
-    const attributes = resource.attributes;
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.FAAS_NAME],
-      'test-function'
-    );
-    assert.strictEqual(
-      attributes[SemanticResourceAttributes.CLOUD_PROVIDER],
-      'azure'
-    );
-    assert.strictEqual(
-      attributes[SemanticResourceAttributes.CLOUD_PLATFORM],
-      'azure_functions'
-    );
-    assert.strictEqual(
-      attributes[SemanticResourceAttributes.CLOUD_REGION],
-      'test-region'
-    );
-    assert.strictEqual(
-      attributes[SemanticResourceAttributes.FAAS_INSTANCE],
-      'test-instance-id'
-    );
-    assert.strictEqual(
-      attributes[SemanticResourceAttributes.FAAS_MAX_MEMORY],
-      '1000'
-    );
-    assert.strictEqual(
-      attributes[SemanticResourceAttributes.FAAS_VERSION],
-      '~4'
+      attributes[AZURE_APP_SERVICE_STAMP_RESOURCE_ATTRIBUTE],
+      undefined
     );
   });
 });

--- a/detectors/node/opentelemetry-resource-detector-azure/test/detectors/AzureFunctionsDetector.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-azure/test/detectors/AzureFunctionsDetector.test.ts
@@ -71,7 +71,7 @@ describe('AzureFunctionsDetector', () => {
       '~4'
     );
   });
-  
+
   it('should not detect azure app service values', () => {
     process.env.WEBSITE_SITE_NAME = 'test-function';
     process.env.REGION_NAME = 'test-region';


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

When running inside of an Azure Function and in the case where both the Azure Functions and Azure App Services detector were being run in the same application, because the Azure App Service check was not exclusive of the Azure Functions check, the application would incorrectly be identified as running inside of Azure App Services.

This PR also adds tests for both Azure Functions and Azure App Services detectors to ensure that they function as expected when running in the same application.
