### PR TITLE
fix(instrumentation-koa): Move @types/koa and @types/koa__router to devDependencies

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-koa/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/package.json
@@ -53,6 +53,8 @@
     "@opentelemetry/instrumentation-http": "^0.48.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
+    "@types/koa": "2.14.0",
+    "@types/koa__router": "12.0.3",
     "@types/mocha": "7.0.2",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.18",
@@ -68,9 +70,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.48.0",
-    "@opentelemetry/semantic-conventions": "^1.0.0",
-    "@types/koa": "2.14.0",
-    "@types/koa__router": "12.0.3"
+    "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-koa#readme"
 }


### PR DESCRIPTION
This pull request moves the `@types/koa` and `@types/koa__router` packages from dependencies to devDependencies in the package.json file. This change ensures that these type definitions are only required during development and not in the production build.