### PR TITLE
fix(instr-perf-hooks): avoid 'prepare' npm script because that runs on 'npm install'

### DIFF
--- a/plugins/node/instrumentation-perf-hooks/package.json
+++ b/plugins/node/instrumentation-perf-hooks/package.json
@@ -13,7 +13,7 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-perf-hooks --include-dependencies",
     "prewatch": "npm run precompile",
-    "prepare": "npm run compile",
+    "prepublishOnly": "npm run compile",
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "version:update": "node ../../../scripts/version-update.js"
   },


### PR DESCRIPTION
Having a prepare script in the monorepo means that it runs during 'npm ci' which can break if some needed deps for that script haven't yet been installed.

# details

This is the same change that was part of https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1771
From that PR's description:

> s/prepare/prepublishOnly/g is to avoid running the compile step in packages before npm install for all packages has completed. It resulted in various build errors. Using prepublishOnly is recommended (https://docs.npmjs.com/cli/v10/using-npm/scripts#prepare-and-prepublish) and is what the core repo was already doing.

I hit a breakage in `npm ci` in a separate PR (https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1938). A few of the checks started failing:

<img width="863" alt="Screenshot 2024-02-23 at 11 44 43 AM" src="https://github.com/open-telemetry/opentelemetry-js-contrib/assets/46866/f9ad07c0-d409-4973-a519-c608ee0956f7">

E.g.:  https://github.com/open-telemetry/opentelemetry-js-contrib/actions/runs/8023208091/job/21919224572?pr=1938 shows that `instrumentation-perf-hooks`'s prepare and compile scripts were running during `npm ci`:

```
npm ERR! > @opentelemetry/instrumentation-perf-hooks@0.1.0 compile
npm ERR! > tsc -p .
npm ERR! 
npm ERR! node_modules/@types/node/ts4.8/globals.d.ts:6:76 - error TS2307: Cannot find module 'undici-types' or its corresponding type declarations.
npm ERR! 
npm ERR! 6 type _Request = typeof globalThis extends { onmessage: any } ? {} : import("undici-types").Request;
npm ERR!                                                                              ~~~~~~~~~~~~~~
npm ERR! 
...
```

I don't fully understand the type issue here. I think a contributing factor is that the instrumentation-perf-hooks package has a dependency on a *newer* version of `@types/node` than is used in all other packages in this repo:

```
...
plugins/node/opentelemetry-instrumentation-graphql/package.json
51:    "@types/node": "18.6.5",

plugins/node/instrumentation-perf-hooks/package.json
48:    "@types/node": "^20.11.2",

plugins/node/opentelemetry-instrumentation-redis/package.json
58:    "@types/node": "18.6.5",
...
```

@d4nyll Do you happen to know if the newer `@types/node` is required for the types used in instrumentation-perf-hooks?

