### PR TITLE
feat(instrumentation-fs): error hook

### DIFF
--- a/plugins/node/instrumentation-fs/README.md
+++ b/plugins/node/instrumentation-fs/README.md
@@ -40,11 +40,12 @@ registerInstrumentations({
 
 You can set the following:
 
-| Options             | Type                                                                                                | Description                                                                                                     |
-| ------------------- | --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `createHook`        | `(functionName: FMember \| FPMember, info: { args: ArrayLike<unknown> }) => boolean`                | Hook called before creating the span. If `false` is returned this and all the sibling calls will not be traced. |
-| `endHook`           | `( functionName: FMember \| FPMember, info: { args: ArrayLike<unknown>; span: api.Span } ) => void` | Function called just before the span is ended. Useful for adding attributes.                                    |
-| `requireParentSpan` | `boolean`                                                                                           | Require parent to create fs span, default when unset is `false`.                                                |
+| Options             | Type                                                                                                                             | Description                                                                                                                                                                                                |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `createHook`        | `(functionName: FMember \| FPMember, info: { args: ArrayLike<unknown> }) => boolean`                                             | Hook called before creating the span. If `false` is returned this and all the sibling calls will not be traced.                                                                                            |
+| `endHook`           | `(functionName: FMember \| FPMember, info: { args: ArrayLike<unknown>; span: api.Span; error?: NodeJS.ErrnoException }  => void` | Hook called just before the span is ended. Useful for adding attributes.                                                                                                                                   |
+| `errorHook`         | `(functionName: FMember \| FPMember, error: NodeJS.ErrnoException) => boolean`                                                   | Hook called when a filesystem function throws an error. If `false` is returned no error event will be added to the span and it won't end with an error status code. The error itself is always propagated. |
+| `requireParentSpan` | `boolean`                                                                                                                        | Require parent to create fs span, default when unset is `false`.                                                                                                                                           |
 
 ## Useful links
 

--- a/plugins/node/instrumentation-fs/src/types.ts
+++ b/plugins/node/instrumentation-fs/src/types.ts
@@ -59,11 +59,20 @@ export type CreateHook = (
 ) => boolean;
 export type EndHook = (
   functionName: FMember | FPMember,
-  info: { args: ArrayLike<unknown>; span: api.Span; error?: Error }
+  info: {
+    args: ArrayLike<unknown>;
+    span: api.Span;
+    error?: NodeJS.ErrnoException;
+  }
 ) => void;
+export type ErrorHook = (
+  functionName: FMember | FPMember,
+  error: NodeJS.ErrnoException
+) => boolean;
 
 export interface FsInstrumentationConfig extends InstrumentationConfig {
   createHook?: CreateHook;
   endHook?: EndHook;
+  errorHook?: ErrorHook;
   requireParentSpan?: boolean;
 }

--- a/plugins/node/instrumentation-fs/test/error.test.ts
+++ b/plugins/node/instrumentation-fs/test/error.test.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import * as assert from 'assert';
+import Instrumentation, { CreateHook, ErrorHook } from '../src';
+import * as sinon from 'sinon';
+import type * as FSType from 'fs';
+import type { FsInstrumentationConfig } from '../src/types';
+
+const createHook = sinon.spy<CreateHook>((functionName, { args }) => {
+  // `ts-node`, which we use via `ts-mocha` also patches module loading and creates
+  // a lot of unrelated spans. Filter those out.
+  const filename = args[0];
+  if (!/test\/fixtures/.test(filename as string)) {
+    return false;
+  }
+  return true;
+});
+
+let error: Error;
+const errorHook = sinon.spy<ErrorHook>((functionName, e) => {
+  error = e;
+  if (functionName.includes('access') && e.code === 'ENOENT') {
+    return false;
+  }
+  return true;
+});
+
+const pluginConfig = {
+  createHook,
+  errorHook,
+};
+
+const provider = new BasicTracerProvider();
+const memoryExporter = new InMemorySpanExporter();
+provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+
+const assertFilteredOut = () => {
+  assert.strictEqual(memoryExporter.getFinishedSpans().length, 1);
+  const span = memoryExporter.getFinishedSpans()[0];
+  assert.strictEqual(span.events.length, 0);
+};
+
+const assertKept = () => {
+  assert.strictEqual(memoryExporter.getFinishedSpans().length, 1);
+  const span = memoryExporter.getFinishedSpans()[0];
+  assert.strictEqual(span.events.length, 1);
+  const event = span.events[0];
+  assert.strictEqual(event.name, 'exception');
+  assert.strictEqual(
+    (event.attributes || {})['exception.message'],
+    error.message
+  );
+};
+
+describe('fs instrumentation: error hook', () => {
+  let plugin: Instrumentation;
+  let fs: typeof FSType;
+
+  beforeEach(async () => {
+    plugin = new Instrumentation(pluginConfig);
+    plugin.setTracerProvider(provider);
+    plugin.setConfig(pluginConfig as FsInstrumentationConfig);
+    plugin.enable();
+    fs = require('fs');
+    createHook.resetHistory();
+    errorHook.resetHistory();
+    assert.strictEqual(memoryExporter.getFinishedSpans().length, 0);
+  });
+
+  afterEach(() => {
+    plugin.disable();
+    memoryExporter.reset();
+  });
+
+  describe('Syncronous API', () => {
+    it('should filter out errors according to hook', () => {
+      try {
+        fs.accessSync('./test/fixtures/readtest-404', fs.constants.R_OK);
+      } catch (e) {
+        assert.strictEqual(e, error);
+      }
+      assertFilteredOut();
+    });
+
+    it('should keep other error events', () => {
+      try {
+        fs.unlinkSync('./test/fixtures/readtest-404');
+      } catch (e) {
+        assert.strictEqual(e, error);
+      }
+      assertKept();
+    });
+  });
+
+  describe('Callback API', () => {
+    it('should filter out errors according to hook', done => {
+      fs.access('./test/fixtures/readtest-404', fs.constants.R_OK, e => {
+        try {
+          assert.strictEqual(e, error);
+          assertFilteredOut();
+          done();
+        } catch (e) {
+          done(e);
+        }
+      });
+    });
+
+    it('should keep other error events', done => {
+      fs.unlink('./test/fixtures/readtest-404', e => {
+        try {
+          assert.strictEqual(e, error);
+          assertKept();
+          done();
+        } catch (e) {
+          done(e);
+        }
+      });
+    });
+  });
+
+  describe('Promise API', () => {
+    it('should filter out errors according to hook', async () => {
+      try {
+        await fs.promises.access(
+          './test/fixtures/readtest-404',
+          fs.constants.R_OK
+        );
+      } catch (e) {
+        assert.strictEqual(e, error);
+      }
+      assertFilteredOut();
+    });
+
+    it('should keep other error events', async () => {
+      try {
+        await fs.promises.unlink('./test/fixtures/readtest-404');
+      } catch (e) {
+        assert.strictEqual(e, error);
+      }
+      assertKept();
+    });
+  });
+});

--- a/plugins/node/instrumentation-fs/test/fsPromisesHooks.test.ts
+++ b/plugins/node/instrumentation-fs/test/fsPromisesHooks.test.ts
@@ -32,9 +32,14 @@ const endHookError = new Error('endHook failed');
 const endHook = sinon.spy((_functionName: string) => {
   throw endHookError;
 });
+const errorHookError = new Error('errorHook failed');
+const errorHook = sinon.spy((_functionName: string) => {
+  throw errorHookError;
+});
 const pluginConfig = {
   createHook,
   endHook,
+  errorHook,
 };
 
 const provider = new BasicTracerProvider();
@@ -45,7 +50,8 @@ const assertNotHookError = (err?: Error | null) => {
   assert.ok(
     err &&
       err.message !== createHookError.message &&
-      err.message !== endHookError.message,
+      err.message !== endHookError.message &&
+      err.message !== errorHookError.message,
     'Hook error shadowed the error from the original call'
   );
 };
@@ -62,6 +68,9 @@ const assertSuccessfulCallHooks = (expectedFunctionName: string) => {
     !(endHookCall.getCall(0).args as any)[1].error,
     'Did not expect an error'
   );
+
+  const errorHookCall = errorHook.withArgs(expectedFunctionName);
+  sinon.assert.notCalled(errorHookCall);
 };
 
 const assertFailingCallHooks = (expectedFunctionName: string) => {
@@ -73,6 +82,10 @@ const assertFailingCallHooks = (expectedFunctionName: string) => {
   sinon.assert.called(endHookCall);
   sinon.assert.threw(endHookCall, endHookError);
   assert((endHookCall.getCall(0).args as any)[1].error, 'Expected an error');
+
+  const errorHookCall = errorHook.withArgs(expectedFunctionName);
+  sinon.assert.called(errorHookCall);
+  sinon.assert.threw(errorHookCall, errorHookError);
 };
 
 // This should equal `fs.constants.R_OK`.
@@ -91,6 +104,7 @@ describe('fs/promises instrumentation: hooks', () => {
     fsPromises = require('fs/promises');
     createHook.resetHistory();
     endHook.resetHistory();
+    errorHook.resetHistory();
     assert.strictEqual(memoryExporter.getFinishedSpans().length, 0);
   });
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

This adds a new error hook to the `fs` instrumentation to let users filter some errors from being reported as span events. This prevents trace data being polluted by irrelevant error events and failed spans for idiomatic filesystem access patterns where an error is expected, for instance opening a file without checking whether it exists then dealing with that case in the error handler.

## Short description of the changes

- Adds an optional `errorHook` option to the config that is called with the function name and error before reporting the error event. If the hook is present and returns `false`, the error event is not reported.
- The error is still always propagated
