### PR TITLE
docs(instrumentation-graphql): gql supported versions

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-graphql/README.md
+++ b/plugins/node/opentelemetry-instrumentation-graphql/README.md
@@ -21,7 +21,7 @@ npm install @opentelemetry/instrumentation-graphql
 
 ### Supported Versions
 
-`>=14 <16`
+`^14.0 | ^15.0 | ^16.0`
 
 ## Usage
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Fix outdated documentation about supported graphql deps versions

## Short description of the changes

- README update supported versions by the instrumentation (PR https://github.com/open-telemetry/opentelemetry-js-contrib/pull/998 should allow to also use GQL version 16, but doc still mentioned only <16).