### PR TITLE
fix: Add @opentelemetry/api as peerDependencies in @opentelemetry/resource-detector-azure

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-azure/package.json
+++ b/detectors/node/opentelemetry-resource-detector-azure/package.json
@@ -43,6 +43,9 @@
     "ts-mocha": "10.0.0",
     "typescript": "4.4.4"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.0.0"
+  },
   "dependencies": {
     "@opentelemetry/resources": "^1.10.1",
     "@opentelemetry/semantic-conventions": "^1.0.0"


### PR DESCRIPTION
## Which problem is this PR solving?

Although @opentelemetry/api is in devDependencies, @opentelemetry/api is missing in @opentelemetry/resource-detector-azure's peerDependencies. This cause failures in strict installation layout for some package managers. 

## Short description of the changes

Add @opentelemetry/api as peerDependencies in @opentelemetry/resource-detector-azure
