### PR TITLE
fix(instrumentaiton-runtime-node)!: rename exported instrumentation to match package name

### DIFF
--- a/plugins/node/instrumentation-runtime-node/README.md
+++ b/plugins/node/instrumentation-runtime-node/README.md
@@ -16,7 +16,7 @@ npm install --save @opentelemetry/instrumentation-runtime-node
 ```js
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
-import { PerfHooksInstrumentation } from '@opentelemetry/instrumentation-runtime-node';
+import { RuntimeNodeInstrumentation } from '@opentelemetry/instrumentation-runtime-node';
 
 const prometheusExporter = new PrometheusExporter({
   port: 9464,
@@ -25,7 +25,7 @@ const prometheusExporter = new PrometheusExporter({
 
 const sdk = new NodeSDK({
   metricReader: prometheusExporter,
-  instrumentations: [new PerfHooksInstrumentation({
+  instrumentations: [new RuntimeNodeInstrumentation({
     eventLoopUtilizationMeasurementInterval: 5000,
   })],
 });
@@ -44,7 +44,7 @@ Go to [`localhost:9464/metrics`](http://localhost:9464/metrics), and you should 
 nodejs_performance_event_loop_utilization 0.010140079547955264
 ```
 
-> Metrics will only be exported after it has collected two ELU readings (at least approximately `PerfHooksInstrumentationConfig.eventLoopUtilizationMeasurementInterval` milliseconds after initialization). Otherwise, you may see:
+> Metrics will only be exported after it has collected two ELU readings (at least approximately `RuntimeNodeInstrumentationConfig.eventLoopUtilizationMeasurementInterval` milliseconds after initialization). Otherwise, you may see:
 >
 > ```txt
 > # no registered metrics
@@ -52,7 +52,7 @@ nodejs_performance_event_loop_utilization 0.010140079547955264
 
 ### Options
 
-`PerfHooksInstrumentation`'s constructor accepts the following options:
+`RuntimeNodeInstrumentation`'s constructor accepts the following options:
 
 | name | type | unit | default | description |
 |---|---|---|---|---|

--- a/plugins/node/instrumentation-runtime-node/src/index.ts
+++ b/plugins/node/instrumentation-runtime-node/src/index.ts
@@ -13,5 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './instrumentation';
-export * from './types';
+export { RuntimeNodeInstrumentation } from './instrumentation';
+export { RuntimeNodeInstrumentationConfig } from './types';

--- a/plugins/node/instrumentation-runtime-node/src/instrumentation.ts
+++ b/plugins/node/instrumentation-runtime-node/src/instrumentation.ts
@@ -20,18 +20,18 @@ const { eventLoopUtilization } = performance;
 import { InstrumentationBase } from '@opentelemetry/instrumentation';
 
 import { VERSION } from './version';
-import { PerfHooksInstrumentationConfig } from './types';
+import { RuntimeNodeInstrumentationConfig } from './types';
 
 const ELUS_LENGTH = 2;
-const DEFAULT_CONFIG: PerfHooksInstrumentationConfig = {
+const DEFAULT_CONFIG: RuntimeNodeInstrumentationConfig = {
   eventLoopUtilizationMeasurementInterval: 5000,
 };
 
-export class PerfHooksInstrumentation extends InstrumentationBase {
+export class RuntimeNodeInstrumentation extends InstrumentationBase {
   private _ELUs: EventLoopUtilization[] = [];
   private _interval: NodeJS.Timeout | undefined;
 
-  constructor(config: PerfHooksInstrumentationConfig = DEFAULT_CONFIG) {
+  constructor(config: RuntimeNodeInstrumentationConfig = DEFAULT_CONFIG) {
     super('@opentelemetry/instrumentation-runtime-node', VERSION, config);
   }
 
@@ -76,7 +76,7 @@ export class PerfHooksInstrumentation extends InstrumentationBase {
     clearInterval(this._interval);
     this._interval = setInterval(
       () => this._addELU(),
-      (this._config as PerfHooksInstrumentationConfig)
+      (this._config as RuntimeNodeInstrumentationConfig)
         .eventLoopUtilizationMeasurementInterval
     );
   }

--- a/plugins/node/instrumentation-runtime-node/src/types.ts
+++ b/plugins/node/instrumentation-runtime-node/src/types.ts
@@ -15,7 +15,7 @@
  */
 import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 
-export interface PerfHooksInstrumentationConfig extends InstrumentationConfig {
+export interface RuntimeNodeInstrumentationConfig extends InstrumentationConfig {
   /**
    * The approximate number of milliseconds for which to calculate event loop utilization averages.
    * A larger value will result in more accurate averages at the expense of less granular data.

--- a/plugins/node/instrumentation-runtime-node/src/types.ts
+++ b/plugins/node/instrumentation-runtime-node/src/types.ts
@@ -15,7 +15,8 @@
  */
 import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 
-export interface RuntimeNodeInstrumentationConfig extends InstrumentationConfig {
+export interface RuntimeNodeInstrumentationConfig
+  extends InstrumentationConfig {
   /**
    * The approximate number of milliseconds for which to calculate event loop utilization averages.
    * A larger value will result in more accurate averages at the expense of less granular data.

--- a/plugins/node/instrumentation-runtime-node/test/event_loop_utilization.test.ts
+++ b/plugins/node/instrumentation-runtime-node/test/event_loop_utilization.test.ts
@@ -21,7 +21,7 @@ import {
   PeriodicExportingMetricReader,
 } from '@opentelemetry/sdk-metrics';
 
-import { PerfHooksInstrumentation } from '../src';
+import { RuntimeNodeInstrumentation } from '../src';
 import * as assert from 'assert';
 
 const MEASUREMENT_INTERVAL = 10;
@@ -34,7 +34,7 @@ const metricReader = new PeriodicExportingMetricReader({
 const meterProvider = new MeterProvider();
 meterProvider.addMetricReader(metricReader);
 
-const instrumentation = new PerfHooksInstrumentation({
+const instrumentation = new RuntimeNodeInstrumentation({
   eventLoopUtilizationMeasurementInterval: MEASUREMENT_INTERVAL,
 });
 
@@ -69,7 +69,7 @@ describe('nodejs.event_loop.utilization', () => {
 
   it('can use default eventLoopUtilizationMeasurementInterval', async () => {
     // Repeat of 'should not export immediately after enable' but with defaults
-    const localInstrumentation = new PerfHooksInstrumentation();
+    const localInstrumentation = new RuntimeNodeInstrumentation();
     localInstrumentation.setMeterProvider(meterProvider);
     localInstrumentation.disable();
     metricExporter.reset();


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1970#issuecomment-1974965699
