### PR TITLE
chore(instr-mongodb): drop obsolete 'pretest' step from TAV run

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-mongodb/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/.tav.yml
@@ -9,6 +9,3 @@ mongodb:
     - versions: ">=6 <7"
       node: '>=15.0.0'
       commands: npm run test-v5-v6
-
-  # Fix missing `contrib-test-utils` package
-  pretest: npm run --prefix ../../../ lerna:link


### PR DESCRIPTION
Since the move to npm workspaces in #1771 this pretest step is
no longer needed for TAV test runs.

* * *

I had removed most `pretest: ...` entries from .tav.yml files in #1771, but I missed a couple.