### PR TITLE
fix(instr-aws-sdk): ensure that instrumentation does not crash on bogus SQS.sendMessageBatch input

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sqs.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sqs.ts
@@ -110,13 +110,16 @@ export class SqsServiceExtension implements ServiceExtension {
 
       case 'SendMessageBatch':
         {
-          request.commandInput?.Entries?.forEach(
-            (messageParams: SQS.SendMessageBatchRequestEntry) => {
-              messageParams.MessageAttributes = injectPropagationContext(
-                messageParams.MessageAttributes ?? {}
-              );
-            }
-          );
+          const entries = request.commandInput?.Entries;
+          if (Array.isArray(entries)) {
+            entries.forEach(
+              (messageParams: SQS.SendMessageBatchRequestEntry) => {
+                messageParams.MessageAttributes = injectPropagationContext(
+                  messageParams.MessageAttributes ?? {}
+                );
+              }
+            );
+          }
         }
         break;
     }

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/sqs.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/sqs.test.ts
@@ -494,6 +494,28 @@ describe('SQS', () => {
       expect(processSpans[0].status.code).toStrictEqual(SpanStatusCode.UNSET);
       expect(processSpans[1].status.code).toStrictEqual(SpanStatusCode.UNSET);
     });
+
+    it('bogus sendMessageBatch input should not crash', async () => {
+      const region = 'us-east-1';
+      const sqs = new AWS.SQS();
+      sqs.config.update({ region });
+
+      const QueueName = 'unittest';
+      const params = {
+        QueueUrl: `queue/url/for/${QueueName}`,
+        Entries: { Key1: { MessageBody: 'This is the first message' } },
+      };
+
+      await sqs.sendMessageBatch(params).promise();
+
+      const spans = getTestSpans();
+      expect(spans.length).toBe(1);
+
+      // Spot check a single attribute as a sanity check.
+      expect(spans[0].attributes[SemanticAttributes.RPC_METHOD]).toEqual(
+        'SendMessageBatch'
+      );
+    });
   });
 
   describe('extract payload', () => {

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/sqs.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/sqs.test.ts
@@ -23,6 +23,7 @@ const instrumentation = registerInstrumentationTesting(
 );
 import * as AWS from 'aws-sdk';
 import { AWSError } from 'aws-sdk';
+import type { SQS } from 'aws-sdk';
 
 import {
   MessagingDestinationKindValues,
@@ -505,8 +506,9 @@ describe('SQS', () => {
         QueueUrl: `queue/url/for/${QueueName}`,
         Entries: { Key1: { MessageBody: 'This is the first message' } },
       };
-
-      await sqs.sendMessageBatch(params).promise();
+      await sqs
+        .sendMessageBatch(params as unknown as SQS.SendMessageBatchRequest)
+        .promise();
 
       const spans = getTestSpans();
       expect(spans.length).toBe(1);


### PR DESCRIPTION
Fixes: #1975
