### PR TITLE
feat(instrumentation-aws-lambda): support ESM handlers and other less common handler patterns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,8 @@
         "lerna-changelog": "2.2.0",
         "markdownlint-cli2": "0.13.0",
         "minimatch": "^9.0.3",
-        "nx": "15.9.7",
         "mocha": "^10.7.3",
+        "nx": "15.9.7",
         "prettier": "2.8.8",
         "process": "0.11.10",
         "semver": "^7.6.0",
@@ -95,6 +95,8 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
+        "@opentelemetry/instrumentation-fs": "^0.16.0",
+        "@opentelemetry/instrumentation-http": "^0.54.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
@@ -138,6 +140,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
+        "@opentelemetry/instrumentation-http": "^0.54.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
@@ -180,7 +183,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
-        "@opentelemetry/instrumentation-fs": "*",
+        "@opentelemetry/instrumentation-fs": "^0.16.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
@@ -226,6 +229,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
+        "@opentelemetry/instrumentation-http": "^0.54.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
@@ -36913,6 +36917,7 @@
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/contrib-test-utils": "^0.40.0",
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/propagator-aws-xray": "^1.25.1",
         "@opentelemetry/propagator-aws-xray-lambda": "^0.52.1",
@@ -36924,6 +36929,72 @@
         "nyc": "15.1.0",
         "rimraf": "5.0.10",
         "typescript": "4.4.4"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/api-logs": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.1.tgz",
+      "integrity": "sha512-qnSqB2DQ9TPP96dl8cDubDvrUyWc0/sK81xHTK8eSUspzDM3bsewX903qclQFvVhgStjRWdC5bLb3kQqMkfV5A==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.25.1.tgz",
+      "integrity": "sha512-UW/ge9zjvAEmRWVapOP0qyCvPulWU6cQxGxDbWEFfGOj1VBBZAuOqTo3X6yWmDTD3Xe15ysCZChHncr2xFMIfQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/contrib-test-utils": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/contrib-test-utils/-/contrib-test-utils-0.40.0.tgz",
+      "integrity": "sha512-hsxA+i4RfM7z46yoSAza7ugE5bMRu82sZm1UlZiB9mUeBKUFyQO24Vslr1bu5jGmeu1XI25Lb1TAF95KX06K/A==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "^1.0.0",
+        "@opentelemetry/exporter-jaeger": "^1.3.1",
+        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/resources": "^1.8.0",
+        "@opentelemetry/sdk-node": "^0.52.0",
+        "@opentelemetry/sdk-trace-base": "^1.8.0",
+        "@opentelemetry/sdk-trace-node": "^1.8.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/contrib-test-utils/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.52.1.tgz",
+      "integrity": "sha512-uXJbYU/5/MBHjMp1FqrILLRuiJCs3Ofk0MeRDk8g1S1gD47U8X3JnSwcMO1rtRo1x1a7zKaQHaoYu49p/4eSKw==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.52.1",
+        "@types/shimmer": "^1.0.2",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
       },
       "engines": {
         "node": ">=14"
@@ -36956,6 +37027,146 @@
         "node": ">=14"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.52.1.tgz",
+      "integrity": "sha512-pVkSH20crBwMTqB3nIN4jpQKUEoB0Z94drIHpYyEqs7UBr+I0cpYyOR3bqjA/UasQUMROb3GX8ZX4/9cVRqGBQ==",
+      "dev": true,
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.52.1.tgz",
+      "integrity": "sha512-05HcNizx0BxcFKKnS5rwOV+2GevLTVIRA0tRgWYyw4yCgR53Ic/xk83toYKts7kbzcI+dswInUg/4s8oyA+tqg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.52.1.tgz",
+      "integrity": "sha512-pt6uX0noTQReHXNeEslQv7x311/F1gJzMnp1HD2qgypLRPbXDeMzzeTngRTUaUbP6hqWNtPxuLr4DEoZG+TcEQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/exporter-zipkin": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.25.1.tgz",
+      "integrity": "sha512-RmOwSvkimg7ETwJbUOPTMhJm9A9bG1U8s7Zo3ajDh4zM7eYcycQ0dM7FbLD6NXWbI2yj7UY4q8BKinKYBQksyw==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.52.1.tgz",
+      "integrity": "sha512-z175NXOtX5ihdlshtYBe5RpGeBoTXVCKPPLiQlD6FHvpM4Ch+p2B0yWKYSrBfLH24H9zjJiBdTrtD+hLlfnXEQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-transformer": "0.52.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.52.1.tgz",
+      "integrity": "sha512-zo/YrSDmKMjG+vPeA9aBBrsQM9Q/f2zo6N04WMB3yNldJRsgpRBeLLwvAt/Ba7dpehDLOEFBd1i2JCoaFtpCoQ==",
+      "dev": true,
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.52.1.tgz",
+      "integrity": "sha512-I88uCZSZZtVa0XniRqQWKbjAUm73I8tpEy/uJYPPYw5d7BRdVk0RfTBQw8kSUl01oVWEuqxLDa802222MYyWHg==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.52.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-logs": "0.52.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/propagator-aws-xray": {
       "version": "1.25.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.25.1.tgz",
@@ -36984,6 +37195,197 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/propagator-b3": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.25.1.tgz",
+      "integrity": "sha512-p6HFscpjrv7//kE+7L+3Vn00VEDUJB0n6ZrjkTYHrJ58QZ8B3ajSJhRbCcY6guQ3PDjTbxWklyvIN2ojVbIb1A==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/propagator-jaeger": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.25.1.tgz",
+      "integrity": "sha512-nBprRf0+jlgxks78G/xq72PipVK+4or9Ypntw0gVZYNTCSK8rg5SeaGV19tV920CMqBD/9UIOiFr23Li/Q8tiA==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.52.1.tgz",
+      "integrity": "sha512-MBYh+WcPPsN8YpRHRmK1Hsca9pVlyyKd4BxOC4SsgHACnl/bPp4Cri9hWhVm5+2tiQ9Zf4qSc1Jshw9tOLGWQA==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.52.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
+      "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/sdk-node": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.52.1.tgz",
+      "integrity": "sha512-uEG+gtEr6eKd8CVWeKMhH2olcCHM9dEK68pe0qE0be32BcCRsvYURhHaD1Srngh1SQcnQzZ4TP324euxqtBOJA==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.52.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.52.1",
+        "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
+        "@opentelemetry/exporter-zipkin": "1.25.1",
+        "@opentelemetry/instrumentation": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-logs": "0.52.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/sdk-trace-node": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.52.1.tgz",
+      "integrity": "sha512-uXJbYU/5/MBHjMp1FqrILLRuiJCs3Ofk0MeRDk8g1S1gD47U8X3JnSwcMO1rtRo1x1a7zKaQHaoYu49p/4eSKw==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.52.1",
+        "@types/shimmer": "^1.0.2",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+      "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.25.1.tgz",
+      "integrity": "sha512-nMcjFIKxnFqoez4gUmihdBrbpsEnAX/Xj16sGvZm+guceYE0NE00vLhpDVK6f3q8Q4VFI5xG8JjlXKMB/SkTTQ==",
+      "dev": true,
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "1.25.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/propagator-b3": "1.25.1",
+        "@opentelemetry/propagator-jaeger": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "semver": "^7.5.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@types/node": {
@@ -47469,6 +47871,7 @@
       "version": "file:plugins/node/opentelemetry-instrumentation-aws-lambda",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/contrib-test-utils": "^0.40.0",
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.54.0",
         "@opentelemetry/propagator-aws-xray": "^1.25.1",
@@ -47485,6 +47888,54 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/api-logs": {
+          "version": "0.52.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.1.tgz",
+          "integrity": "sha512-qnSqB2DQ9TPP96dl8cDubDvrUyWc0/sK81xHTK8eSUspzDM3bsewX903qclQFvVhgStjRWdC5bLb3kQqMkfV5A==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/api": "^1.0.0"
+          }
+        },
+        "@opentelemetry/context-async-hooks": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.25.1.tgz",
+          "integrity": "sha512-UW/ge9zjvAEmRWVapOP0qyCvPulWU6cQxGxDbWEFfGOj1VBBZAuOqTo3X6yWmDTD3Xe15ysCZChHncr2xFMIfQ==",
+          "dev": true,
+          "requires": {}
+        },
+        "@opentelemetry/contrib-test-utils": {
+          "version": "0.40.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/contrib-test-utils/-/contrib-test-utils-0.40.0.tgz",
+          "integrity": "sha512-hsxA+i4RfM7z46yoSAza7ugE5bMRu82sZm1UlZiB9mUeBKUFyQO24Vslr1bu5jGmeu1XI25Lb1TAF95KX06K/A==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "^1.0.0",
+            "@opentelemetry/exporter-jaeger": "^1.3.1",
+            "@opentelemetry/instrumentation": "^0.52.0",
+            "@opentelemetry/resources": "^1.8.0",
+            "@opentelemetry/sdk-node": "^0.52.0",
+            "@opentelemetry/sdk-trace-base": "^1.8.0",
+            "@opentelemetry/sdk-trace-node": "^1.8.0",
+            "@opentelemetry/semantic-conventions": "^1.22.0"
+          },
+          "dependencies": {
+            "@opentelemetry/instrumentation": {
+              "version": "0.52.1",
+              "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.52.1.tgz",
+              "integrity": "sha512-uXJbYU/5/MBHjMp1FqrILLRuiJCs3Ofk0MeRDk8g1S1gD47U8X3JnSwcMO1rtRo1x1a7zKaQHaoYu49p/4eSKw==",
+              "dev": true,
+              "requires": {
+                "@opentelemetry/api-logs": "0.52.1",
+                "@types/shimmer": "^1.0.2",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
+              }
+            }
+          }
+        },
         "@opentelemetry/core": {
           "version": "1.25.1",
           "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
@@ -47500,6 +47951,103 @@
               "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
               "dev": true
             }
+          }
+        },
+        "@opentelemetry/exporter-trace-otlp-grpc": {
+          "version": "0.52.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.52.1.tgz",
+          "integrity": "sha512-pVkSH20crBwMTqB3nIN4jpQKUEoB0Z94drIHpYyEqs7UBr+I0cpYyOR3bqjA/UasQUMROb3GX8ZX4/9cVRqGBQ==",
+          "dev": true,
+          "requires": {
+            "@grpc/grpc-js": "^1.7.1",
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/otlp-grpc-exporter-base": "0.52.1",
+            "@opentelemetry/otlp-transformer": "0.52.1",
+            "@opentelemetry/resources": "1.25.1",
+            "@opentelemetry/sdk-trace-base": "1.25.1"
+          }
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "version": "0.52.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.52.1.tgz",
+          "integrity": "sha512-05HcNizx0BxcFKKnS5rwOV+2GevLTVIRA0tRgWYyw4yCgR53Ic/xk83toYKts7kbzcI+dswInUg/4s8oyA+tqg==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/otlp-exporter-base": "0.52.1",
+            "@opentelemetry/otlp-transformer": "0.52.1",
+            "@opentelemetry/resources": "1.25.1",
+            "@opentelemetry/sdk-trace-base": "1.25.1"
+          }
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "version": "0.52.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.52.1.tgz",
+          "integrity": "sha512-pt6uX0noTQReHXNeEslQv7x311/F1gJzMnp1HD2qgypLRPbXDeMzzeTngRTUaUbP6hqWNtPxuLr4DEoZG+TcEQ==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/otlp-exporter-base": "0.52.1",
+            "@opentelemetry/otlp-transformer": "0.52.1",
+            "@opentelemetry/resources": "1.25.1",
+            "@opentelemetry/sdk-trace-base": "1.25.1"
+          }
+        },
+        "@opentelemetry/exporter-zipkin": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.25.1.tgz",
+          "integrity": "sha512-RmOwSvkimg7ETwJbUOPTMhJm9A9bG1U8s7Zo3ajDh4zM7eYcycQ0dM7FbLD6NXWbI2yj7UY4q8BKinKYBQksyw==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "@opentelemetry/sdk-trace-base": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          },
+          "dependencies": {
+            "@opentelemetry/semantic-conventions": {
+              "version": "1.25.1",
+              "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+              "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+              "dev": true
+            }
+          }
+        },
+        "@opentelemetry/otlp-exporter-base": {
+          "version": "0.52.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.52.1.tgz",
+          "integrity": "sha512-z175NXOtX5ihdlshtYBe5RpGeBoTXVCKPPLiQlD6FHvpM4Ch+p2B0yWKYSrBfLH24H9zjJiBdTrtD+hLlfnXEQ==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/otlp-transformer": "0.52.1"
+          }
+        },
+        "@opentelemetry/otlp-grpc-exporter-base": {
+          "version": "0.52.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.52.1.tgz",
+          "integrity": "sha512-zo/YrSDmKMjG+vPeA9aBBrsQM9Q/f2zo6N04WMB3yNldJRsgpRBeLLwvAt/Ba7dpehDLOEFBd1i2JCoaFtpCoQ==",
+          "dev": true,
+          "requires": {
+            "@grpc/grpc-js": "^1.7.1",
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/otlp-exporter-base": "0.52.1",
+            "@opentelemetry/otlp-transformer": "0.52.1"
+          }
+        },
+        "@opentelemetry/otlp-transformer": {
+          "version": "0.52.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.52.1.tgz",
+          "integrity": "sha512-I88uCZSZZtVa0XniRqQWKbjAUm73I8tpEy/uJYPPYw5d7BRdVk0RfTBQw8kSUl01oVWEuqxLDa802222MYyWHg==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/api-logs": "0.52.1",
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "@opentelemetry/sdk-logs": "0.52.1",
+            "@opentelemetry/sdk-metrics": "1.25.1",
+            "@opentelemetry/sdk-trace-base": "1.25.1",
+            "protobufjs": "^7.3.0"
           }
         },
         "@opentelemetry/propagator-aws-xray": {
@@ -47518,6 +48066,140 @@
           "dev": true,
           "requires": {
             "@opentelemetry/propagator-aws-xray": "1.25.1"
+          }
+        },
+        "@opentelemetry/propagator-b3": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.25.1.tgz",
+          "integrity": "sha512-p6HFscpjrv7//kE+7L+3Vn00VEDUJB0n6ZrjkTYHrJ58QZ8B3ajSJhRbCcY6guQ3PDjTbxWklyvIN2ojVbIb1A==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1"
+          }
+        },
+        "@opentelemetry/propagator-jaeger": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.25.1.tgz",
+          "integrity": "sha512-nBprRf0+jlgxks78G/xq72PipVK+4or9Ypntw0gVZYNTCSK8rg5SeaGV19tV920CMqBD/9UIOiFr23Li/Q8tiA==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+          "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          },
+          "dependencies": {
+            "@opentelemetry/semantic-conventions": {
+              "version": "1.25.1",
+              "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+              "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+              "dev": true
+            }
+          }
+        },
+        "@opentelemetry/sdk-logs": {
+          "version": "0.52.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.52.1.tgz",
+          "integrity": "sha512-MBYh+WcPPsN8YpRHRmK1Hsca9pVlyyKd4BxOC4SsgHACnl/bPp4Cri9hWhVm5+2tiQ9Zf4qSc1Jshw9tOLGWQA==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/api-logs": "0.52.1",
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1"
+          }
+        },
+        "@opentelemetry/sdk-metrics": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
+          "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "lodash.merge": "^4.6.2"
+          }
+        },
+        "@opentelemetry/sdk-node": {
+          "version": "0.52.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.52.1.tgz",
+          "integrity": "sha512-uEG+gtEr6eKd8CVWeKMhH2olcCHM9dEK68pe0qE0be32BcCRsvYURhHaD1Srngh1SQcnQzZ4TP324euxqtBOJA==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/api-logs": "0.52.1",
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/exporter-trace-otlp-grpc": "0.52.1",
+            "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
+            "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
+            "@opentelemetry/exporter-zipkin": "1.25.1",
+            "@opentelemetry/instrumentation": "0.52.1",
+            "@opentelemetry/resources": "1.25.1",
+            "@opentelemetry/sdk-logs": "0.52.1",
+            "@opentelemetry/sdk-metrics": "1.25.1",
+            "@opentelemetry/sdk-trace-base": "1.25.1",
+            "@opentelemetry/sdk-trace-node": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          },
+          "dependencies": {
+            "@opentelemetry/instrumentation": {
+              "version": "0.52.1",
+              "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.52.1.tgz",
+              "integrity": "sha512-uXJbYU/5/MBHjMp1FqrILLRuiJCs3Ofk0MeRDk8g1S1gD47U8X3JnSwcMO1rtRo1x1a7zKaQHaoYu49p/4eSKw==",
+              "dev": true,
+              "requires": {
+                "@opentelemetry/api-logs": "0.52.1",
+                "@types/shimmer": "^1.0.2",
+                "import-in-the-middle": "^1.8.1",
+                "require-in-the-middle": "^7.1.1",
+                "semver": "^7.5.2",
+                "shimmer": "^1.2.1"
+              }
+            },
+            "@opentelemetry/semantic-conventions": {
+              "version": "1.25.1",
+              "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+              "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+              "dev": true
+            }
+          }
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+          "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/resources": "1.25.1",
+            "@opentelemetry/semantic-conventions": "1.25.1"
+          },
+          "dependencies": {
+            "@opentelemetry/semantic-conventions": {
+              "version": "1.25.1",
+              "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+              "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+              "dev": true
+            }
+          }
+        },
+        "@opentelemetry/sdk-trace-node": {
+          "version": "1.25.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.25.1.tgz",
+          "integrity": "sha512-nMcjFIKxnFqoez4gUmihdBrbpsEnAX/Xj16sGvZm+guceYE0NE00vLhpDVK6f3q8Q4VFI5xG8JjlXKMB/SkTTQ==",
+          "dev": true,
+          "requires": {
+            "@opentelemetry/context-async-hooks": "1.25.1",
+            "@opentelemetry/core": "1.25.1",
+            "@opentelemetry/propagator-b3": "1.25.1",
+            "@opentelemetry/propagator-jaeger": "1.25.1",
+            "@opentelemetry/sdk-trace-base": "1.25.1",
+            "semver": "^7.5.2"
           }
         },
         "@types/node": {
@@ -50512,6 +51194,8 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
         "@opentelemetry/core": "^1.0.0",
+        "@opentelemetry/instrumentation-fs": "^0.16.0",
+        "@opentelemetry/instrumentation-http": "^0.54.0",
         "@opentelemetry/resources": "^1.10.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
@@ -50547,6 +51231,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
         "@opentelemetry/core": "^1.25.1",
+        "@opentelemetry/instrumentation-http": "^0.54.0",
         "@opentelemetry/resources": "^1.10.1",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
@@ -50581,7 +51266,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
         "@opentelemetry/core": "^1.26.0",
-        "@opentelemetry/instrumentation-fs": "*",
+        "@opentelemetry/instrumentation-fs": "^0.16.0",
         "@opentelemetry/resources": "^1.10.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
@@ -50618,6 +51303,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
         "@opentelemetry/core": "^1.0.0",
+        "@opentelemetry/instrumentation-http": "^0.54.0",
         "@opentelemetry/resources": "^1.10.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/README.md
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/README.md
@@ -35,6 +35,9 @@ const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 const provider = new NodeTracerProvider();
 provider.register();
 
+// Note that this needs to appear after the tracer provider is registered,
+// otherwise the instrumentation will not properly flush data after each
+// lambda invocation.
 registerInstrumentations({
   instrumentations: [
     new AwsLambdaInstrumentation({
@@ -46,7 +49,7 @@ registerInstrumentations({
 
 In your Lambda function configuration, add or update the `NODE_OPTIONS` environment variable to require the wrapper, e.g.,
 
-`NODE_OPTIONS=--require lambda-wrapper`
+`NODE_OPTIONS=--require lambda-wrapper --experimental-loader @opentelemetry/instrumentation/hook.mjs`
 
 ## AWS Lambda Instrumentation Options
 

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
+    "@opentelemetry/contrib-test-utils": "^0.40.0",
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/propagator-aws-xray": "^1.25.1",
     "@opentelemetry/propagator-aws-xray-lambda": "^0.52.1",

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/user-function.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/user-function.ts
@@ -1,4 +1,20 @@
-/**
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
  * Adapted from https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/blob/v3.1.0/src/UserFunction.js
  */
 

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/user-function.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/user-function.ts
@@ -1,0 +1,107 @@
+/**
+ * Adapted from https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/blob/v3.1.0/src/UserFunction.js
+ */
+
+import * as path from 'path';
+import * as fs from 'fs';
+import { LambdaModule } from './internal-types';
+
+const FUNCTION_EXPR = /^([^.]*)\.(.*)$/;
+const RELATIVE_PATH_SUBSTRING = '..';
+
+/**
+ * Break the full handler string into two pieces, the module root and the actual
+ * handler string.
+ * Given './somepath/something/module.nestedobj.handler' this returns
+ * ['./somepath/something', 'module.nestedobj.handler']
+ */
+export function moduleRootAndHandler(
+  fullHandlerString: string
+): [moduleRoot: string, handler: string] {
+  const handlerString = path.basename(fullHandlerString);
+  const moduleRoot = fullHandlerString.substring(
+    0,
+    fullHandlerString.indexOf(handlerString)
+  );
+  return [moduleRoot, handlerString];
+}
+
+/**
+ * Split the handler string into two pieces: the module name and the path to
+ * the handler function.
+ */
+export function splitHandlerString(
+  handler: string
+): [module: string | undefined, functionPath: string | undefined] {
+  const match = handler.match(FUNCTION_EXPR);
+  if (match && match.length === 3) {
+    return [match[1], match[2]];
+  } else {
+    return [undefined, undefined];
+  }
+}
+
+/**
+ * Resolve the user's handler function key and its containing object from the module.
+ */
+export function resolveHandler(
+  object: object,
+  nestedProperty: string
+): [container: LambdaModule | undefined, handlerKey: string | undefined] {
+  const nestedPropertyKeys = nestedProperty.split('.');
+  const handlerKey = nestedPropertyKeys.pop();
+
+  const container = nestedPropertyKeys.reduce<object | undefined>(
+    (nested, key) => {
+      return nested && (nested as Partial<Record<string, object>>)[key];
+    },
+    object
+  );
+
+  if (container) {
+    return [container as LambdaModule, handlerKey];
+  } else {
+    return [undefined, undefined];
+  }
+}
+
+/**
+ * Attempt to determine the user's module path.
+ */
+export function tryPath(
+  appRoot: string,
+  moduleRoot: string,
+  module: string
+): string | undefined {
+  const lambdaStylePath = path.resolve(appRoot, moduleRoot, module);
+
+  const extensionless = fs.existsSync(lambdaStylePath);
+  if (extensionless) {
+    return lambdaStylePath;
+  }
+
+  const extensioned =
+    (fs.existsSync(lambdaStylePath + '.js') && lambdaStylePath + '.js') ||
+    (fs.existsSync(lambdaStylePath + '.mjs') && lambdaStylePath + '.mjs') ||
+    (fs.existsSync(lambdaStylePath + '.cjs') && lambdaStylePath + '.cjs');
+  if (extensioned) {
+    return extensioned;
+  }
+
+  try {
+    const nodeStylePath = require.resolve(module, {
+      paths: [appRoot, moduleRoot],
+    });
+    return nodeStylePath;
+  } catch {
+    return undefined;
+  }
+}
+
+export function isInvalidHandler(fullHandlerString: string): boolean {
+  if (fullHandlerString.includes(RELATIVE_PATH_SUBSTRING)) {
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler.force-flush.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler.force-flush.test.ts
@@ -20,6 +20,7 @@
 import * as path from 'path';
 
 import { AwsLambdaInstrumentation } from '../../src';
+import { load } from '../vendor/UserFunction';
 import {
   BatchSpanProcessor,
   InMemorySpanExporter,
@@ -71,8 +72,8 @@ describe('force flush', () => {
     instrumentation.setMeterProvider(provider);
   };
 
-  const lambdaRequire = (module: string) =>
-    require(path.resolve(__dirname, '..', module));
+  const lambdaLoadHandler = (handler: string = process.env._HANDLER!) =>
+    load(process.env.LAMBDA_TASK_ROOT!, handler);
 
   beforeEach(() => {
     oldEnv = { ...process.env };
@@ -100,18 +101,15 @@ describe('force flush', () => {
     provider.forceFlush = forceFlush;
     initializeHandlerTracing('lambda-test/sync.handler', provider);
 
+    const handler = await lambdaLoadHandler();
     await new Promise((resolve, reject) => {
-      lambdaRequire('lambda-test/sync').handler(
-        'arg',
-        ctx,
-        (err: Error, res: any) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(res);
-          }
+      handler('arg', ctx, (err: Error, res: any) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(res);
         }
-      );
+      });
     });
 
     assert.strictEqual(forceFlushed, true);
@@ -134,18 +132,15 @@ describe('force flush', () => {
     nodeTracerProvider.forceFlush = forceFlush;
     initializeHandlerTracing('lambda-test/sync.handler', provider);
 
+    const handler = await lambdaLoadHandler();
     await new Promise((resolve, reject) => {
-      lambdaRequire('lambda-test/sync').handler(
-        'arg',
-        ctx,
-        (err: Error, res: any) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(res);
-          }
+      handler('arg', ctx, (err: Error, res: any) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(res);
         }
-      );
+      });
     });
 
     assert.strictEqual(forceFlushed, true);
@@ -165,18 +160,15 @@ describe('force flush', () => {
     provider.forceFlush = forceFlush;
     initializeHandlerMetrics('lambda-test/sync.handler', provider);
 
+    const handler = await lambdaLoadHandler();
     await new Promise((resolve, reject) => {
-      lambdaRequire('lambda-test/sync').handler(
-        'arg',
-        ctx,
-        (err: Error, res: any) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(res);
-          }
+      handler('arg', ctx, (err: Error, res: any) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(res);
         }
-      );
+      });
     });
 
     assert.strictEqual(forceFlushed, true);
@@ -217,19 +209,16 @@ describe('force flush', () => {
     instrumentation.setMeterProvider(meterProvider);
 
     let callbackCount = 0;
+    const handler = await lambdaLoadHandler();
     await new Promise((resolve, reject) => {
-      lambdaRequire('lambda-test/sync').handler(
-        'arg',
-        ctx,
-        (err: Error, res: any) => {
-          callbackCount++;
-          if (err) {
-            reject(err);
-          } else {
-            resolve(res);
-          }
+      handler('arg', ctx, (err: Error, res: any) => {
+        callbackCount++;
+        if (err) {
+          reject(err);
+        } else {
+          resolve(res);
         }
-      );
+      });
     });
 
     assert.strictEqual(tracerForceFlushed, true);

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler.test.ts
@@ -540,7 +540,7 @@ describe('lambda handler', () => {
       initializeHandler('lambda-test/async.handler');
 
       const handler = await lambdaLoadHandler();
-      const result = handler('arg', ctx);
+      const result = await handler('arg', ctx);
 
       assert.strictEqual(result, 'ok');
       const spans = memoryExporter.getFinishedSpans();

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler.test.ts
@@ -842,6 +842,19 @@ describe('lambda handler', () => {
     });
   });
 
+  describe('non-existent handler module', () => {
+    it('should skip instrumentation', async () => {
+      initializeHandler('lambda-test/callback.handle');
+
+      const handler = await lambdaLoadHandler('lambda-test/async.handler');
+      const result = await handler('arg', ctx);
+
+      assert.strictEqual(result, 'ok');
+      const spans = memoryExporter.getFinishedSpans();
+      assert.strictEqual(spans.length, 0);
+    });
+  });
+
   describe('non-existent handler function', () => {
     it('should skip instrumentation', async () => {
       initializeHandler('lambda-test/async.handle');

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/lambda-test/async.js
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/lambda-test/async.js
@@ -19,19 +19,29 @@ exports.handler = async function (event, context) {
   return 'ok';
 };
 
+exports.deeply = {
+  nested: {
+    handler: async function (event, context) {
+      return 'ok';
+    },
+  },
+};
+
 exports.error = async function (event, context) {
   throw new Error('handler error');
-}
+};
 
 exports.stringerror = async function (event, context) {
   throw 'handler error';
-}
+};
 
 exports.context = async function (event, context) {
   return api.trace.getSpan(api.context.active()).spanContext().traceId;
 };
 
 exports.handler_return_baggage = async function (event, context) {
-  const [baggageEntryKey, baggageEntryValue] =  api.propagation.getBaggage(api.context.active()).getAllEntries()[0];
+  const [baggageEntryKey, baggageEntryValue] = api.propagation
+    .getBaggage(api.context.active())
+    .getAllEntries()[0];
   return `${baggageEntryKey}=${baggageEntryValue.value}`;
-}
+};

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/lambda-test/extensionless
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/lambda-test/extensionless
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 exports.handler = async function (event, context) {
   return 'ok';
 };

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/lambda-test/module.mjs
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/lambda-test/module.mjs
@@ -1,0 +1,3 @@
+export async function handler(event, context) {
+  return 'ok';
+}

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/lambda-test/sync.js
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/lambda-test/sync.js
@@ -19,21 +19,29 @@ exports.handler = function (event, context, callback) {
   callback(null, 'ok');
 };
 
+exports.deeply = {
+  nested: {
+    handler: function (event, context, callback) {
+      callback(null, 'ok');
+    },
+  },
+};
+
 exports.error = function (event, context, callback) {
   throw new Error('handler error');
-}
+};
 
 exports.callbackerror = function (event, context, callback) {
   callback(new Error('handler error'));
-}
+};
 
 exports.stringerror = function (event, context, callback) {
   throw 'handler error';
-}
+};
 
 exports.callbackstringerror = function (event, context, callback) {
   callback('handler error');
-}
+};
 
 exports.context = function (event, context, callback) {
   callback(null, api.trace.getSpan(api.context.active()).spanContext().traceId);

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/lambda-test/use-lambda.mjs
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/lambda-test/use-lambda.mjs
@@ -1,0 +1,26 @@
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+import { trace } from '@opentelemetry/api';
+import { createTestNodeSdk } from '@opentelemetry/contrib-test-utils';
+
+import { AwsLambdaInstrumentation } from '../../build/src/index.js';
+import { load } from '../vendor/UserFunction.js';
+
+process.env.LAMBDA_TASK_ROOT = path.dirname(fileURLToPath(import.meta.url));
+process.env._HANDLER = 'module.handler';
+
+const instrumentation = new AwsLambdaInstrumentation();
+const sdk = createTestNodeSdk({
+  serviceName: 'use-lambda',
+  instrumentations: [instrumentation],
+});
+sdk.start();
+instrumentation.setTracerProvider(trace.getTracerProvider());
+
+const handler = await load(process.env.LAMBDA_TASK_ROOT, process.env._HANDLER);
+await handler('arg', {
+  functionName: 'my_function',
+  invokedFunctionArn: 'my_arn',
+  awsRequestId: 'aws_request_id',
+});

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/vendor/Errors.js
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/vendor/Errors.js
@@ -1,0 +1,123 @@
+// https://raw.githubusercontent.com/aws/aws-lambda-nodejs-runtime-interface-client/v3.1.0/src/Errors.js
+
+/**
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Defines custom error types throwable by the runtime.
+ */
+
+'use strict';
+
+const util = require('util');
+
+function _isError(obj) {
+  return (
+    obj &&
+    obj.name &&
+    obj.message &&
+    obj.stack &&
+    typeof obj.name === 'string' &&
+    typeof obj.message === 'string' &&
+    typeof obj.stack === 'string'
+  );
+}
+
+function intoError(err) {
+  if (err instanceof Error) {
+    return err;
+  } else {
+    return new Error(err);
+  }
+}
+
+module.exports.intoError = intoError;
+
+/**
+ * Attempt to convert an object into a response object.
+ * This method accounts for failures when serializing the error object.
+ */
+function toRapidResponse(error) {
+  try {
+    if (util.types.isNativeError(error) || _isError(error)) {
+      return {
+        errorType: error.name,
+        errorMessage: error.message,
+        trace: error.stack.split('\n'),
+      };
+    } else {
+      return {
+        errorType: typeof error,
+        errorMessage: error.toString(),
+        trace: [],
+      };
+    }
+  } catch (_err) {
+    return {
+      errorType: 'handled',
+      errorMessage:
+        'callback called with Error argument, but there was a problem while retrieving one or more of its message, name, and stack',
+    };
+  }
+}
+
+module.exports.toRapidResponse = toRapidResponse;
+
+/**
+ * Format an error with the expected properties.
+ * For compatability, the error string always starts with a tab.
+ */
+module.exports.toFormatted = error => {
+  try {
+    return (
+      '\t' + JSON.stringify(error, (_k, v) => _withEnumerableProperties(v))
+    );
+  } catch (err) {
+    return '\t' + JSON.stringify(toRapidResponse(error));
+  }
+};
+
+/**
+ * Error name, message, code, and stack are all members of the superclass, which
+ * means they aren't enumerable and don't normally show up in JSON.stringify.
+ * This method ensures those interesting properties are available along with any
+ * user-provided enumerable properties.
+ */
+function _withEnumerableProperties(error) {
+  if (error instanceof Error) {
+    let ret = Object.assign(
+      {
+        errorType: error.name,
+        errorMessage: error.message,
+        code: error.code,
+      },
+      error
+    );
+    if (typeof error.stack == 'string') {
+      ret.stack = error.stack.split('\n');
+    }
+    return ret;
+  } else {
+    return error;
+  }
+}
+
+const errorClasses = [
+  class ImportModuleError extends Error {},
+  class HandlerNotFound extends Error {},
+  class MalformedHandlerName extends Error {},
+  class UserCodeSyntaxError extends Error {},
+  class MalformedStreamingHandler extends Error {},
+  class InvalidStreamingOperation extends Error {},
+  class UnhandledPromiseRejection extends Error {
+    constructor(reason, promise) {
+      super(reason);
+      this.reason = reason;
+      this.promise = promise;
+    }
+  },
+];
+
+errorClasses.forEach(e => {
+  module.exports[e.name] = e;
+  e.prototype.name = `Runtime.${e.name}`;
+});

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/vendor/HttpResponseStream.js
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/vendor/HttpResponseStream.js
@@ -1,0 +1,35 @@
+// https://raw.githubusercontent.com/aws/aws-lambda-nodejs-runtime-interface-client/v3.1.0/src/HttpResponseStream.js
+
+/**
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * HttpResponseStream is NOT used by the runtime.
+ * It is only exposed in the `awslambda` variable for customers to use.
+ */
+
+'use strict';
+
+const METADATA_PRELUDE_CONTENT_TYPE =
+  'application/vnd.awslambda.http-integration-response';
+const DELIMITER_LEN = 8;
+
+// Implements the application/vnd.awslambda.http-integration-response content type.
+class HttpResponseStream {
+  static from(underlyingStream, prelude) {
+    underlyingStream.setContentType(METADATA_PRELUDE_CONTENT_TYPE);
+
+    // JSON.stringify is required. NULL byte is not allowed in metadataPrelude.
+    const metadataPrelude = JSON.stringify(prelude);
+
+    underlyingStream._onBeforeFirstWrite = write => {
+      write(metadataPrelude);
+
+      // Write 8 null bytes after the JSON prelude.
+      write(new Uint8Array(DELIMITER_LEN));
+    };
+
+    return underlyingStream;
+  }
+}
+
+module.exports.HttpResponseStream = HttpResponseStream;

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/vendor/UserFunction.d.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/vendor/UserFunction.d.ts
@@ -1,0 +1,4 @@
+export declare function load(
+  appRoot: string,
+  fullHandlerString: string
+): Promise<Function>;

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/vendor/UserFunction.d.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/vendor/UserFunction.d.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export declare function load(
   appRoot: string,
   fullHandlerString: string

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/tsconfig.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/tsconfig.json
@@ -4,8 +4,5 @@
     "rootDir": ".",
     "outDir": "build"
   },
-  "include": [
-    "src/**/*.ts",
-    "test/**/*.ts"
-  ]
+  "include": ["src/**/*.ts", "test/**/*.ts", "test/vendor/**/*"]
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

The Lambda instrumentation doesn't currently support instrumenting ESM handlers, which are now the default, and other less common handler patterns supported by Lambda such as extensionless handler modules and nested handler functions.

## Short description of the changes

The previous logic to determine the handler to patch is replaced with an implementation based on [the one present in the Lambda runtime](https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/blob/v3.1.0/src/UserFunction.js). I tried to keep the function names and structure as close to possible to the original to make it easier to cross-reference.

The tests also now use code copied from the Lambda runtime to load handlers, as opposed to just calling `require` which doesn't properly reflect a real-world scenario and doesn't work at all for ESM.

I also updated the notes about absolute path support in the patching infrastructure. The instrumentation keeps using the same hack but it would probably be a good idea to fix the issue upstream, which is that while [absolute paths are taken into account while registering hooks](https://github.com/open-telemetry/opentelemetry-js/blob/experimental/v0.52.1/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts#L304-L309), they are not when matching against the module name within the hook function, [which ignores the `baseDir`](https://github.com/open-telemetry/opentelemetry-js/blob/experimental/v0.52.1/experimental/packages/opentelemetry-instrumentation/src/platform/node/instrumentation.ts#L209).
