### PR TITLE
perf(instrumentation-pg): reduce temp objects allocations

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-pg/src/enums/SpanNames.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/enums/SpanNames.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-export * from './instrumentation';
-export * from './types';
-export * from './enums/AttributeNames';
-export * from './enums/SpanNames';
+// Contains span names produced by instrumentation
+export enum SpanNames {
+  QUERY_PREFIX = 'pg.query',
+  CONNECT = 'pg.connect',
+  POOL_CONNECT = 'pg-pool.connect',
+}

--- a/plugins/node/opentelemetry-instrumentation-pg/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/index.ts
@@ -17,4 +17,3 @@
 export * from './instrumentation';
 export * from './types';
 export * from './enums/AttributeNames';
-export * from './enums/SpanNames';

--- a/plugins/node/opentelemetry-instrumentation-pg/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/instrumentation.ts
@@ -38,13 +38,11 @@ import {
 } from './internal-types';
 import { PgInstrumentationConfig } from './types';
 import * as utils from './utils';
-import { AttributeNames } from './enums/AttributeNames';
 import { addSqlCommenterComment } from '@opentelemetry/sql-common';
 import { VERSION } from './version';
+import { SpanNames } from './enums/SpanNames';
 
 export class PgInstrumentation extends InstrumentationBase {
-  static readonly BASE_SPAN_NAME = 'pg.query';
-
   constructor(config: PgInstrumentationConfig = {}) {
     super(
       '@opentelemetry/instrumentation-pg',
@@ -141,7 +139,7 @@ export class PgInstrumentation extends InstrumentationBase {
           return original.call(this, callback);
         }
 
-        const span = plugin.tracer.startSpan('pg.connect', {
+        const span = plugin.tracer.startSpan(SpanNames.CONNECT, {
           kind: SpanKind.CLIENT,
           attributes: utils.getSemanticAttributesFromConnection(this),
         });
@@ -351,16 +349,10 @@ export class PgInstrumentation extends InstrumentationBase {
         }
 
         // setup span
-        const span = plugin.tracer.startSpan('pg-pool.connect', {
+        const span = plugin.tracer.startSpan(SpanNames.POOL_CONNECT, {
           kind: SpanKind.CLIENT,
-          attributes: utils.getSemanticAttributesFromConnection(this.options),
+          attributes: utils.getSemanticAttributesFromPool(this.options),
         });
-
-        span.setAttribute(
-          AttributeNames.IDLE_TIMEOUT_MILLIS,
-          this.options.idleTimeoutMillis
-        );
-        span.setAttribute(AttributeNames.MAX_CLIENT, this.options.maxClient);
 
         if (callback) {
           const parentSpan = trace.getSpan(context.active());

--- a/plugins/node/opentelemetry-instrumentation-pg/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/utils.ts
@@ -109,6 +109,7 @@ export function getSemanticAttributesFromConnection(
   params: PgParsedConnectionParams
 ) {
   return {
+    [SemanticAttributes.DB_SYSTEM]: DbSystemValues.POSTGRESQL,
     [SemanticAttributes.DB_NAME]: params.database, // required
     [SemanticAttributes.DB_CONNECTION_STRING]: getConnectionString(params), // required
     [SemanticAttributes.NET_PEER_NAME]: params.host, // required
@@ -141,10 +142,7 @@ export function handleConfigQuery(
   const spanName = getQuerySpanName(dbName, queryConfig);
   const span = tracer.startSpan(spanName, {
     kind: SpanKind.CLIENT,
-    attributes: {
-      [SemanticAttributes.DB_SYSTEM]: DbSystemValues.POSTGRESQL, // required
-      ...getSemanticAttributesFromConnection(connectionParameters),
-    },
+    attributes: getSemanticAttributesFromConnection(connectionParameters),
   });
 
   if (!queryConfig) {

--- a/plugins/node/opentelemetry-instrumentation-pg/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/utils.ts
@@ -34,11 +34,12 @@ import {
   PgPoolCallback,
   PgPoolExtended,
   PgParsedConnectionParams,
+  PgPoolOptionsParams,
 } from './internal-types';
 import { PgInstrumentationConfig } from './types';
 import type * as pgTypes from 'pg';
-import { PgInstrumentation } from './';
 import { safeExecuteInTheMiddle } from '@opentelemetry/instrumentation';
+import { SpanNames } from './enums/SpanNames';
 
 /**
  * Helper function to get a low cardinality span name from whatever info we have
@@ -66,7 +67,7 @@ export function getQuerySpanName(
   // NB: when the query config is invalid, we omit the dbName too, so that
   // someone (or some tool) reading the span name doesn't misinterpret the
   // dbName as being a prepared statement or sql commit name.
-  if (!queryConfig) return PgInstrumentation.BASE_SPAN_NAME;
+  if (!queryConfig) return SpanNames.QUERY_PREFIX;
 
   // Either the name of a prepared statement; or an attempted parse
   // of the SQL command, normalized to uppercase; or unknown.
@@ -75,9 +76,7 @@ export function getQuerySpanName(
       ? queryConfig.name
       : parseNormalizedOperationName(queryConfig.text);
 
-  return `${PgInstrumentation.BASE_SPAN_NAME}:${command}${
-    dbName ? ` ${dbName}` : ''
-  }`;
+  return `${SpanNames.QUERY_PREFIX}:${command}${dbName ? ` ${dbName}` : ''}`;
 }
 
 function parseNormalizedOperationName(queryText: string) {
@@ -115,6 +114,19 @@ export function getSemanticAttributesFromConnection(
     [SemanticAttributes.NET_PEER_NAME]: params.host, // required
     [SemanticAttributes.NET_PEER_PORT]: getPort(params.port),
     [SemanticAttributes.DB_USER]: params.user,
+  };
+}
+
+export function getSemanticAttributesFromPool(params: PgPoolOptionsParams) {
+  return {
+    [SemanticAttributes.DB_SYSTEM]: DbSystemValues.POSTGRESQL,
+    [SemanticAttributes.DB_NAME]: params.database, // required
+    [SemanticAttributes.DB_CONNECTION_STRING]: getConnectionString(params), // required
+    [SemanticAttributes.NET_PEER_NAME]: params.host, // required
+    [SemanticAttributes.NET_PEER_PORT]: getPort(params.port),
+    [SemanticAttributes.DB_USER]: params.user,
+    [AttributeNames.IDLE_TIMEOUT_MILLIS]: params.idleTimeoutMillis,
+    [AttributeNames.MAX_CLIENT]: params.maxClient,
   };
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?

The amount of allocations that opentelemetry produces is too high

## Short description of the changes

Replaced attributes passed on span creation with span.setAttirbutes to avoid multiple remapping inside startSpan function, reused kind by providing constant and replaced string interpolation with constants
