### PR TITLE
chore(instr-express): use exported strings for attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37494,7 +37494,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.49.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -46003,7 +46003,7 @@
         "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/express": "4.17.18",
         "@types/mocha": "7.0.2",
         "@types/node": "18.6.5",

--- a/plugins/node/opentelemetry-instrumentation-express/README.md
+++ b/plugins/node/opentelemetry-instrumentation-express/README.md
@@ -144,13 +144,13 @@ const expressInstrumentation = new ExpressInstrumentation({
 
 ## Semantic Conventions
 
-This package uses `@opentelemetry/semantic-conventions` version `1.0+`, which implements Semantic Convention [Version 1.7.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/semantic_conventions/README.md)
+This package uses `@opentelemetry/semantic-conventions` version `1.22+`, which implements Semantic Convention [Version 1.7.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/semantic_conventions/README.md)
 
 Attributes collected:
 
-| Attribute    | Short Description                  | Notes             |
-| ------------ | ---------------------------------- | ----------------- |
-| `http.route` | The matched route (path template). | Key: `HTTP_ROUTE` |
+| Attribute    | Short Description                  | Notes                      |
+| ------------ | ---------------------------------- | -------------------------- |
+| `http.route` | The matched route (path template). | Key: `SEMATTRS_HTTP_ROUTE` |
 
 ## Useful links
 

--- a/plugins/node/opentelemetry-instrumentation-express/package.json
+++ b/plugins/node/opentelemetry-instrumentation-express/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.49.1",
-    "@opentelemetry/semantic-conventions": "^1.0.0"
+    "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-express#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-express/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-express/src/instrumentation.ts
@@ -39,7 +39,7 @@ import {
   isWrapped,
   safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
 import {
   ExpressLayer,
   ExpressRouter,
@@ -202,7 +202,7 @@ export class ExpressInstrumentation extends InstrumentationBase<
           .replace(/\/{2,}/g, '/');
 
         const attributes: Attributes = {
-          [SemanticAttributes.HTTP_ROUTE]: route.length > 0 ? route : '/',
+          [SEMATTRS_HTTP_ROUTE]: route.length > 0 ? route : '/',
         };
         const metadata = getLayerMetadata(layer, layerPath);
         const type = metadata.attributes[

--- a/plugins/node/opentelemetry-instrumentation-express/test/custom-config.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-express/test/custom-config.test.ts
@@ -21,7 +21,7 @@ import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
 import * as assert from 'assert';
 import { RPCMetadata, RPCType, setRPCMetadata } from '@opentelemetry/core';
 import { ExpressLayerType } from '../src/enums/ExpressLayerType';
@@ -145,7 +145,7 @@ describe('ExpressInstrumentation', () => {
             .find(span => span.name.includes('request handler'));
           assert.notStrictEqual(requestHandlerSpan, undefined);
           assert.strictEqual(
-            requestHandlerSpan?.attributes[SemanticAttributes.HTTP_ROUTE],
+            requestHandlerSpan?.attributes[SEMATTRS_HTTP_ROUTE],
             '/mw'
           );
 
@@ -196,7 +196,7 @@ describe('ExpressInstrumentation', () => {
             .find(span => span.name.includes('request handler'));
           assert.notStrictEqual(requestHandlerSpan, undefined);
           assert.strictEqual(
-            requestHandlerSpan?.attributes[SemanticAttributes.HTTP_ROUTE],
+            requestHandlerSpan?.attributes[SEMATTRS_HTTP_ROUTE],
             '/'
           );
 

--- a/plugins/node/opentelemetry-instrumentation-express/test/express.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-express/test/express.test.ts
@@ -25,7 +25,7 @@ import * as assert from 'assert';
 import { AttributeNames } from '../src/enums/AttributeNames';
 import { ExpressInstrumentation } from '../src';
 import { createServer, httpRequest, serverWithMiddleware } from './utils';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
 import * as testUtils from '@opentelemetry/contrib-test-utils';
 
 const instrumentation = new ExpressInstrumentation();
@@ -114,7 +114,7 @@ describe('ExpressInstrumentation', () => {
             .find(span => span.name.includes('request handler'));
           assert.notStrictEqual(requestHandlerSpan, undefined);
           assert.strictEqual(
-            requestHandlerSpan?.attributes[SemanticAttributes.HTTP_ROUTE],
+            requestHandlerSpan?.attributes[SEMATTRS_HTTP_ROUTE],
             '/toto/:id'
           );
           assert.strictEqual(
@@ -481,7 +481,7 @@ describe('ExpressInstrumentation', () => {
             .getFinishedSpans()
             .find(span => span.name.includes('request handler'));
           assert.strictEqual(
-            requestHandlerSpan?.attributes[SemanticAttributes.HTTP_ROUTE],
+            requestHandlerSpan?.attributes[SEMATTRS_HTTP_ROUTE],
             '/double-slashes/:id'
           );
           assert.strictEqual(rpcMetadata?.route, '/double-slashes/:id');

--- a/plugins/node/opentelemetry-instrumentation-express/test/hooks.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-express/test/hooks.test.ts
@@ -27,7 +27,7 @@ import * as sinon from 'sinon';
 import { ExpressInstrumentation } from '../src';
 import { ExpressRequestInfo, SpanNameHook } from '../src/types';
 import { ExpressLayerType } from '../src/enums/ExpressLayerType';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_HTTP_METHOD } from '@opentelemetry/semantic-conventions';
 
 const instrumentation = new ExpressInstrumentation();
 instrumentation.enable();
@@ -178,7 +178,7 @@ describe('ExpressInstrumentation hooks', () => {
 
     it('should call requestHook when set in config', async () => {
       const requestHook = sinon.spy((span: Span, info: ExpressRequestInfo) => {
-        span.setAttribute(SemanticAttributes.HTTP_METHOD, info.request.method);
+        span.setAttribute(SEMATTRS_HTTP_METHOD, info.request.method);
 
         if (info.layerType) {
           span.setAttribute('express.layer_type', info.layerType);


### PR DESCRIPTION
## Which problem is this PR solving?

- updates #2025 

## Short description of the changes

In express instrumentation package:

- Update `@opentelemetry/semantic-conventions` to `^1.22`
- Replace `SemanticAttributes.HTTP_ROUTE` with exported string `SEMATTRS_HTTP_ROUTE`
- Update `README` with new semantic convention package version and key
