### PR TITLE
feat(koa): Use exported strings for attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37966,7 +37966,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.49.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/koa": "2.14.0",
         "@types/koa__router": "12.0.3"
       },
@@ -46481,7 +46481,7 @@
         "@opentelemetry/instrumentation-http": "^0.49.1",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/koa": "2.14.0",
         "@types/koa__router": "12.0.3",
         "@types/mocha": "7.0.2",

--- a/plugins/node/opentelemetry-instrumentation-koa/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.49.1",
-    "@opentelemetry/semantic-conventions": "^1.0.0",
+    "@opentelemetry/semantic-conventions": "^1.22.0",
     "@types/koa": "2.14.0",
     "@types/koa__router": "12.0.3"
   },

--- a/plugins/node/opentelemetry-instrumentation-koa/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/src/utils.ts
@@ -17,7 +17,7 @@ import { KoaContext, KoaLayerType, KoaInstrumentationConfig } from './types';
 import { KoaMiddleware } from './internal-types';
 import { AttributeNames } from './enums/AttributeNames';
 import { Attributes } from '@opentelemetry/api';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
 
 export const getMiddlewareMetadata = (
   context: KoaContext,
@@ -33,7 +33,7 @@ export const getMiddlewareMetadata = (
       attributes: {
         [AttributeNames.KOA_NAME]: layerPath?.toString(),
         [AttributeNames.KOA_TYPE]: KoaLayerType.ROUTER,
-        [SemanticAttributes.HTTP_ROUTE]: layerPath?.toString(),
+        [SEMATTRS_HTTP_ROUTE]: layerPath?.toString(),
       },
       name: context._matchedRouteName || `router - ${layerPath}`,
     };

--- a/plugins/node/opentelemetry-instrumentation-koa/test/koa.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/test/koa.test.ts
@@ -23,7 +23,11 @@ import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMATTRS_EXCEPTION_MESSAGE,
+  SEMATTRS_HTTP_METHOD,
+  SEMATTRS_HTTP_ROUTE,
+} from '@opentelemetry/semantic-conventions';
 
 import { KoaInstrumentation } from '../src';
 const plugin = new KoaInstrumentation();
@@ -175,7 +179,7 @@ describe('Koa Instrumentation', () => {
           );
 
           assert.strictEqual(
-            requestHandlerSpan?.attributes[SemanticAttributes.HTTP_ROUTE],
+            requestHandlerSpan?.attributes[SEMATTRS_HTTP_ROUTE],
             '/post/:id'
           );
 
@@ -226,7 +230,7 @@ describe('Koa Instrumentation', () => {
           );
 
           assert.strictEqual(
-            requestHandlerSpan?.attributes[SemanticAttributes.HTTP_ROUTE],
+            requestHandlerSpan?.attributes[SEMATTRS_HTTP_ROUTE],
             '/^\\/post/'
           );
 
@@ -273,7 +277,7 @@ describe('Koa Instrumentation', () => {
           );
 
           assert.strictEqual(
-            requestHandlerSpan?.attributes[SemanticAttributes.HTTP_ROUTE],
+            requestHandlerSpan?.attributes[SEMATTRS_HTTP_ROUTE],
             '/post/:id'
           );
 
@@ -322,7 +326,7 @@ describe('Koa Instrumentation', () => {
           );
 
           assert.strictEqual(
-            requestHandlerSpan?.attributes[SemanticAttributes.HTTP_ROUTE],
+            requestHandlerSpan?.attributes[SEMATTRS_HTTP_ROUTE],
             '/:first/post/:id'
           );
 
@@ -369,7 +373,7 @@ describe('Koa Instrumentation', () => {
           );
 
           assert.strictEqual(
-            requestHandlerSpan?.attributes[SemanticAttributes.HTTP_ROUTE],
+            requestHandlerSpan?.attributes[SEMATTRS_HTTP_ROUTE],
             '/:first/post/:id'
           );
 
@@ -570,7 +574,7 @@ describe('Koa Instrumentation', () => {
       assert.ok(exceptionEvent, 'There should be an exception event recorded');
       assert.deepStrictEqual(exceptionEvent.name, 'exception');
       assert.deepStrictEqual(
-        exceptionEvent.attributes![SemanticAttributes.EXCEPTION_MESSAGE],
+        exceptionEvent.attributes![SEMATTRS_EXCEPTION_MESSAGE],
         'I failed!'
       );
     });
@@ -591,10 +595,7 @@ describe('Koa Instrumentation', () => {
       );
 
       const requestHook = sinon.spy((span: Span, info: KoaRequestInfo) => {
-        span.setAttribute(
-          SemanticAttributes.HTTP_METHOD,
-          info.context.request.method
-        );
+        span.setAttribute(SEMATTRS_HTTP_METHOD, info.context.request.method);
 
         throw Error('error thrown in requestHook');
       });


### PR DESCRIPTION
## Which problem is this PR solving?

* Updates [Update usage of semantic conventions to new exported strings #2025](https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2025)


## Short description of the changes

In koa instrumentation package:
* Update `@opentelemetry/semantic-conventions` to `^1.22`
* Replace `SemanticAttributes.HTTP_ROUTE` with exported string `SEMATTRS_HTTP_ROUTE`

