### PR TITLE
fix(instrumentation-runtime-node): mixin default config in constructor

### DIFF
--- a/plugins/node/instrumentation-runtime-node/src/instrumentation.ts
+++ b/plugins/node/instrumentation-runtime-node/src/instrumentation.ts
@@ -30,8 +30,12 @@ export class RuntimeNodeInstrumentation extends InstrumentationBase {
   private _ELUs: EventLoopUtilization[] = [];
   private _interval: NodeJS.Timeout | undefined;
 
-  constructor(config: RuntimeNodeInstrumentationConfig = DEFAULT_CONFIG) {
-    super('@opentelemetry/instrumentation-runtime-node', VERSION, config);
+  constructor(config: RuntimeNodeInstrumentationConfig = {}) {
+    super(
+      '@opentelemetry/instrumentation-runtime-node',
+      VERSION,
+      Object.assign({}, DEFAULT_CONFIG, config)
+    );
   }
 
   private _addELU() {


### PR DESCRIPTION
## Which problem is this PR solving?

The constructor of the instrumentation runtime node does not mixin the default config. This means that if I pass an empty object, the `eventLoopUtilizationMeasurementInterval` will be undefined, which has the side-effect of the configured interval to be near 0.

## Short description of the changes

Similarly to all other instrumentations, I've mixed in the default config to make sure default objects are always defined. Please note that the instrumentation file itself didn't have tests, so I haven't added any.
