### PR TITLE
feat(instrumentation-koa): identify middleware functions inside route handlers

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-koa/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/src/instrumentation.ts
@@ -123,7 +123,9 @@ export class KoaInstrumentation extends InstrumentationBase<typeof koa> {
       const pathStack = pathLayer.stack;
       for (let j = 0; j < pathStack.length; j++) {
         const routedMiddleware: KoaMiddleware = pathStack[j];
-        pathStack[j] = this._patchLayer(routedMiddleware, true, path);
+        const isRouter = !routedMiddleware.name || j === pathStack.length - 1;
+
+        pathStack[j] = this._patchLayer(routedMiddleware, isRouter, path);
       }
     }
 


### PR DESCRIPTION
## Which problem is this PR solving?

Considering the following route handler:


```JS
const someMiddleware = () => async function some(ctx, next) => {
  await next();
});

router.get('/post/:id', someMiddleware(), (ctx) => {
  ctx.body = `Post id: ${ctx.params.id}`;
});
```

...will generate two spans with the same name: `router - /post/:id`, even though the first handler is actually a named middleware (`some`).

Ideally, it would generate two different spans:

- `middleware - some`
-  `router - /post/:id`
 
## Short description of the changes

The changes are quite simple: when iterating these handlers, we assume they are a middleware if it's not the last handler on the stack and if it has a name.
