### PR TITLE
refactor(instr-document-load): use exported strings for semconv

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38726,7 +38726,7 @@
         "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-web": "^1.15.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
         "@babel/core": "7.22.17",
@@ -45970,7 +45970,7 @@
         "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-web": "^1.15.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@types/chai": "^4.3.10",

--- a/plugins/web/opentelemetry-instrumentation-document-load/README.md
+++ b/plugins/web/opentelemetry-instrumentation-document-load/README.md
@@ -111,6 +111,17 @@ registerInstrumentations({
 
 See [examples/tracer-web](https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/tracer-web) for a short example.
 
+## Semantic Conventions
+
+This package uses `@opentelemetry/semantic-conventions` version `1.22+`, which implements Semantic Convention [Version 1.7.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/semantic_conventions/README.md)
+
+Attributes collected:
+
+| Attribute         | Short Description                                                              | Notes                           |
+| ----------------- | ------------------------------------------------------------------------------ | ------------------------------- |
+| `http.url`        | Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]` | Key: `SEMATTRS_HTTP_URL`        |
+| `http.user_agent` | Value of the HTTP User-Agent header sent by the client                         | Key: `SEMATTRS_HTTP_USER_AGENT` |
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/plugins/web/opentelemetry-instrumentation-document-load/package.json
+++ b/plugins/web/opentelemetry-instrumentation-document-load/package.json
@@ -72,7 +72,7 @@
     "@opentelemetry/instrumentation": "^0.49.1",
     "@opentelemetry/sdk-trace-base": "^1.0.0",
     "@opentelemetry/sdk-trace-web": "^1.15.0",
-    "@opentelemetry/semantic-conventions": "^1.0.0"
+    "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/web/opentelemetry-instrumentation-document-load#readme"
 }

--- a/plugins/web/opentelemetry-instrumentation-document-load/src/instrumentation.ts
+++ b/plugins/web/opentelemetry-instrumentation-document-load/src/instrumentation.ts
@@ -40,7 +40,10 @@ import {
 } from './types';
 import { AttributeNames } from './enums/AttributeNames';
 import { VERSION } from './version';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMATTRS_HTTP_URL,
+  SEMATTRS_HTTP_USER_AGENT,
+} from '@opentelemetry/semantic-conventions';
 import {
   addSpanPerformancePaintEvents,
   getPerformanceNavigationEntries,
@@ -115,7 +118,7 @@ export class DocumentLoadInstrumentation extends InstrumentationBase<unknown> {
           entries
         );
         if (fetchSpan) {
-          fetchSpan.setAttribute(SemanticAttributes.HTTP_URL, location.href);
+          fetchSpan.setAttribute(SEMATTRS_HTTP_URL, location.href);
           context.with(trace.setSpan(context.active(), fetchSpan), () => {
             addSpanNetworkEvents(fetchSpan, entries);
             this._addCustomAttributesOnSpan(
@@ -127,11 +130,8 @@ export class DocumentLoadInstrumentation extends InstrumentationBase<unknown> {
         }
       });
 
-      rootSpan.setAttribute(SemanticAttributes.HTTP_URL, location.href);
-      rootSpan.setAttribute(
-        SemanticAttributes.HTTP_USER_AGENT,
-        navigator.userAgent
-      );
+      rootSpan.setAttribute(SEMATTRS_HTTP_URL, location.href);
+      rootSpan.setAttribute(SEMATTRS_HTTP_USER_AGENT, navigator.userAgent);
 
       this._addResourcesSpans(rootSpan);
 
@@ -196,7 +196,7 @@ export class DocumentLoadInstrumentation extends InstrumentationBase<unknown> {
       parentSpan
     );
     if (span) {
-      span.setAttribute(SemanticAttributes.HTTP_URL, resource.name);
+      span.setAttribute(SEMATTRS_HTTP_URL, resource.name);
       addSpanNetworkEvents(span, resource);
       this._addCustomAttributesOnResourceSpan(
         span,

--- a/plugins/web/opentelemetry-instrumentation-document-load/test/documentLoad.test.ts
+++ b/plugins/web/opentelemetry-instrumentation-document-load/test/documentLoad.test.ts
@@ -39,7 +39,10 @@ import {
 import chai from 'chai/chai.js';
 import * as sinon from 'sinon';
 import { DocumentLoadInstrumentation } from '../src';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH,
+  SEMATTRS_HTTP_URL,
+} from '@opentelemetry/semantic-conventions';
 import { EventNames } from '../src/enums/EventNames';
 
 const { assert } = chai as typeof import('chai');
@@ -347,7 +350,7 @@ describe('DocumentLoad Instrumentation', () => {
         assert.strictEqual(rootSpan.name, 'documentFetch');
         assert.ok(
           (rootSpan.attributes[
-            SemanticAttributes.HTTP_RESPONSE_CONTENT_LENGTH
+            SEMATTRS_HTTP_RESPONSE_CONTENT_LENGTH
           ] as number) > 0
         );
         assert.strictEqual(fetchSpan.name, 'documentLoad');
@@ -448,11 +451,11 @@ describe('DocumentLoad Instrumentation', () => {
         const srEvents2 = spanResource2.events;
 
         assert.strictEqual(
-          spanResource1.attributes[SemanticAttributes.HTTP_URL],
+          spanResource1.attributes[SEMATTRS_HTTP_URL],
           'http://localhost:8090/bundle.js'
         );
         assert.strictEqual(
-          spanResource2.attributes[SemanticAttributes.HTTP_URL],
+          spanResource2.attributes[SEMATTRS_HTTP_URL],
           'http://localhost:8090/sockjs-node/info?t=1572620894466'
         );
 
@@ -484,7 +487,7 @@ describe('DocumentLoad Instrumentation', () => {
         const srEvents1 = spanResource1.events;
 
         assert.strictEqual(
-          spanResource1.attributes[SemanticAttributes.HTTP_URL],
+          spanResource1.attributes[SEMATTRS_HTTP_URL],
           'http://localhost:8090/bundle.js'
         );
 


### PR DESCRIPTION
## Which problem is this PR solving?

- updates #1778 
- updates #2025 

## Short description of the changes

In`@opentelemetry/instrumentation-document-load` package:

- Update `@opentelemetry/semantic-conventions` to `^1.22`
- Replace deprecated `SemanticAttributes.*` with new exported strings `SEMATTRS_*`
- Update `README` with new semantic convention package version and keys