### PR TITLE
refactor: replace deprecated string and use new exported strings

### DIFF
--- a/archive/opentelemetry-browser-extension-autoinjection/src/instrumentation/index.ts
+++ b/archive/opentelemetry-browser-extension-autoinjection/src/instrumentation/index.ts
@@ -23,7 +23,7 @@ import {
 } from '../types';
 import { WebInstrumentation } from './WebInstrumentation';
 import { Resource } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 
 const configTag = document.getElementById(DomElements['CONFIG_TAG']);
 const { exporters }: Settings = configTag
@@ -48,7 +48,7 @@ new WebInstrumentation(
   },
   new WebTracerProvider({
     resource: new Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]: window.location.hostname,
+      [SEMRESATTRS_SERVICE_NAME]: window.location.hostname,
     }),
   })
 ).register();

--- a/detectors/node/opentelemetry-resource-detector-alibaba-cloud/CHANGELOG.md
+++ b/detectors/node/opentelemetry-resource-detector-alibaba-cloud/CHANGELOG.md
@@ -72,6 +72,10 @@
   * devDependencies
     * @opentelemetry/contrib-test-utils bumped from ^0.36.0 to ^0.37.0
 
+### Enhancement
+
+* refactor: use exported strings for Semantic Resource Attributes, Cloud Platform Values and Cloud Provider Values
+
 ## [0.28.1](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/resource-detector-alibaba-cloud-v0.28.0...resource-detector-alibaba-cloud-v0.28.1) (2023-08-14)
 
 

--- a/detectors/node/opentelemetry-resource-detector-alibaba-cloud/src/detectors/AlibabaCloudEcsDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-alibaba-cloud/src/detectors/AlibabaCloudEcsDetector.ts
@@ -20,9 +20,16 @@ import {
   ResourceDetectionConfig,
 } from '@opentelemetry/resources';
 import {
-  CloudPlatformValues,
-  CloudProviderValues,
-  SemanticResourceAttributes,
+  CLOUDPLATFORMVALUES_ALIBABA_CLOUD_ECS,
+  CLOUDPROVIDERVALUES_ALIBABA_CLOUD,
+  SEMRESATTRS_CLOUD_ACCOUNT_ID,
+  SEMRESATTRS_CLOUD_AVAILABILITY_ZONE,
+  SEMRESATTRS_CLOUD_PLATFORM,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CLOUD_REGION,
+  SEMRESATTRS_HOST_ID,
+  SEMRESATTRS_HOST_NAME,
+  SEMRESATTRS_HOST_TYPE,
 } from '@opentelemetry/semantic-conventions';
 import * as http from 'http';
 
@@ -61,16 +68,16 @@ class AlibabaCloudEcsDetector implements Detector {
     const hostname = await this._fetchHost();
 
     return new Resource({
-      [SemanticResourceAttributes.CLOUD_PROVIDER]:
-        CloudProviderValues.ALIBABA_CLOUD,
-      [SemanticResourceAttributes.CLOUD_PLATFORM]:
-        CloudPlatformValues.ALIBABA_CLOUD_ECS,
-      [SemanticResourceAttributes.CLOUD_ACCOUNT_ID]: accountId,
-      [SemanticResourceAttributes.CLOUD_REGION]: region,
-      [SemanticResourceAttributes.CLOUD_AVAILABILITY_ZONE]: availabilityZone,
-      [SemanticResourceAttributes.HOST_ID]: instanceId,
-      [SemanticResourceAttributes.HOST_TYPE]: instanceType,
-      [SemanticResourceAttributes.HOST_NAME]: hostname,
+      [SEMRESATTRS_CLOUD_PROVIDER]:
+        CLOUDPROVIDERVALUES_ALIBABA_CLOUD,
+      [SEMRESATTRS_CLOUD_PLATFORM]:
+        CLOUDPLATFORMVALUES_ALIBABA_CLOUD_ECS,
+      [SEMRESATTRS_CLOUD_ACCOUNT_ID]: accountId,
+      [SEMRESATTRS_CLOUD_REGION]: region,
+      [SEMRESATTRS_CLOUD_AVAILABILITY_ZONE]: availabilityZone,
+      [SEMRESATTRS_HOST_ID]: instanceId,
+      [SEMRESATTRS_HOST_TYPE]: instanceType,
+      [SEMRESATTRS_HOST_NAME]: hostname,
     });
   }
 

--- a/detectors/node/opentelemetry-resource-detector-alibaba-cloud/test/detectors/AlibabaCloudEcsDetector.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-alibaba-cloud/test/detectors/AlibabaCloudEcsDetector.test.ts
@@ -17,7 +17,7 @@
 import * as nock from 'nock';
 import * as assert from 'assert';
 import { Resource } from '@opentelemetry/resources';
-import { CloudProviderValues } from '@opentelemetry/semantic-conventions';
+import { CLOUDPROVIDERVALUES_ALIBABA_CLOUD } from '@opentelemetry/semantic-conventions';
 import { alibabaCloudEcsDetector } from '../../src';
 import {
   assertCloudResource,
@@ -70,7 +70,7 @@ describe('alibabaCloudEcsDetector', () => {
       assert.ok(resource);
 
       assertCloudResource(resource, {
-        provider: CloudProviderValues.ALIBABA_CLOUD,
+        provider: CLOUDPROVIDERVALUES_ALIBABA_CLOUD,
         accountId: 'my-owner-account-id',
         region: 'my-region-id',
         zone: 'my-zone-id',

--- a/detectors/node/opentelemetry-resource-detector-aws/CHANGELOG.md
+++ b/detectors/node/opentelemetry-resource-detector-aws/CHANGELOG.md
@@ -66,6 +66,10 @@
   * devDependencies
     * @opentelemetry/contrib-test-utils bumped from ^0.35.1 to ^0.36.0
 
+### Enhancement
+
+* refactor: use exported strings for Semantic Resource Attributes, Cloud Platform Values and Cloud Provider Values
+
 ## [1.4.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/resource-detector-aws-v1.3.6...resource-detector-aws-v1.4.0) (2024-03-06)
 
 

--- a/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsBeanstalkDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsBeanstalkDetector.ts
@@ -21,9 +21,14 @@ import {
   ResourceDetectionConfig,
 } from '@opentelemetry/resources';
 import {
-  CloudProviderValues,
-  CloudPlatformValues,
-  SemanticResourceAttributes,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CLOUD_PLATFORM,
+  SEMRESATTRS_SERVICE_NAME,
+  SEMRESATTRS_SERVICE_NAMESPACE,
+  SEMRESATTRS_SERVICE_VERSION,
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
+  CLOUDPROVIDERVALUES_AWS,
+  CLOUDPLATFORMVALUES_AWS_ELASTIC_BEANSTALK,
 } from '@opentelemetry/semantic-conventions';
 import * as fs from 'fs';
 import * as util from 'util';
@@ -69,15 +74,15 @@ export class AwsBeanstalkDetector implements Detector {
       const parsedData = JSON.parse(rawData);
 
       return new Resource({
-        [SemanticResourceAttributes.CLOUD_PROVIDER]: CloudProviderValues.AWS,
-        [SemanticResourceAttributes.CLOUD_PLATFORM]:
-          CloudPlatformValues.AWS_ELASTIC_BEANSTALK,
-        [SemanticResourceAttributes.SERVICE_NAME]:
-          CloudPlatformValues.AWS_ELASTIC_BEANSTALK,
-        [SemanticResourceAttributes.SERVICE_NAMESPACE]:
+        [SEMRESATTRS_CLOUD_PROVIDER]: CLOUDPROVIDERVALUES_AWS,
+        [SEMRESATTRS_CLOUD_PLATFORM]:
+          CLOUDPLATFORMVALUES_AWS_ELASTIC_BEANSTALK,
+        [SEMRESATTRS_SERVICE_NAME]:
+          CLOUDPLATFORMVALUES_AWS_ELASTIC_BEANSTALK,
+        [SEMRESATTRS_SERVICE_NAMESPACE]:
           parsedData.environment_name,
-        [SemanticResourceAttributes.SERVICE_VERSION]: parsedData.version_label,
-        [SemanticResourceAttributes.SERVICE_INSTANCE_ID]:
+        [SEMRESATTRS_SERVICE_VERSION]: parsedData.version_label,
+        [SEMRESATTRS_SERVICE_INSTANCE_ID]:
           parsedData.deployment_id,
       });
     } catch (e: any) {

--- a/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsEc2Detector.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsEc2Detector.ts
@@ -20,9 +20,16 @@ import {
   ResourceDetectionConfig,
 } from '@opentelemetry/resources';
 import {
-  CloudProviderValues,
-  CloudPlatformValues,
-  SemanticResourceAttributes,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CLOUD_PLATFORM,
+  SEMRESATTRS_CLOUD_REGION,
+  SEMRESATTRS_CLOUD_ACCOUNT_ID,
+  SEMRESATTRS_CLOUD_AVAILABILITY_ZONE,
+  SEMRESATTRS_HOST_ID,
+  SEMRESATTRS_HOST_TYPE,
+  SEMRESATTRS_HOST_NAME,
+  CLOUDPROVIDERVALUES_AWS,
+  CLOUDPLATFORMVALUES_AWS_EC2,
 } from '@opentelemetry/semantic-conventions';
 import * as http from 'http';
 
@@ -62,14 +69,14 @@ class AwsEc2Detector implements Detector {
     const hostname = await this._fetchHost(token);
 
     return new Resource({
-      [SemanticResourceAttributes.CLOUD_PROVIDER]: CloudProviderValues.AWS,
-      [SemanticResourceAttributes.CLOUD_PLATFORM]: CloudPlatformValues.AWS_EC2,
-      [SemanticResourceAttributes.CLOUD_ACCOUNT_ID]: accountId,
-      [SemanticResourceAttributes.CLOUD_REGION]: region,
-      [SemanticResourceAttributes.CLOUD_AVAILABILITY_ZONE]: availabilityZone,
-      [SemanticResourceAttributes.HOST_ID]: instanceId,
-      [SemanticResourceAttributes.HOST_TYPE]: instanceType,
-      [SemanticResourceAttributes.HOST_NAME]: hostname,
+      [SEMRESATTRS_CLOUD_PROVIDER]: CLOUDPROVIDERVALUES_AWS,
+      [SEMRESATTRS_CLOUD_PLATFORM]: CLOUDPLATFORMVALUES_AWS_EC2,
+      [SEMRESATTRS_CLOUD_ACCOUNT_ID]: accountId,
+      [SEMRESATTRS_CLOUD_REGION]: region,
+      [SEMRESATTRS_CLOUD_AVAILABILITY_ZONE]: availabilityZone,
+      [SEMRESATTRS_HOST_ID]: instanceId,
+      [SEMRESATTRS_HOST_TYPE]: instanceType,
+      [SEMRESATTRS_HOST_NAME]: hostname,
     });
   }
 

--- a/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsEcsDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsEcsDetector.ts
@@ -21,9 +21,25 @@ import {
   ResourceAttributes,
 } from '@opentelemetry/resources';
 import {
-  CloudProviderValues,
-  CloudPlatformValues,
-  SemanticResourceAttributes,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CLOUD_PLATFORM,
+  SEMRESATTRS_CONTAINER_ID,
+  SEMRESATTRS_CONTAINER_NAME,
+  SEMRESATTRS_AWS_ECS_CONTAINER_ARN,
+  SEMRESATTRS_AWS_ECS_CLUSTER_ARN,
+  SEMRESATTRS_AWS_ECS_LAUNCHTYPE,
+  SEMRESATTRS_AWS_ECS_TASK_ARN,
+  SEMRESATTRS_AWS_ECS_TASK_FAMILY,
+  SEMRESATTRS_AWS_ECS_TASK_REVISION,
+  SEMRESATTRS_CLOUD_ACCOUNT_ID,
+  SEMRESATTRS_CLOUD_REGION,
+  SEMRESATTRS_CLOUD_AVAILABILITY_ZONE,
+  SEMRESATTRS_AWS_LOG_GROUP_NAMES,
+  SEMRESATTRS_AWS_LOG_GROUP_ARNS,
+  SEMRESATTRS_AWS_LOG_STREAM_NAMES,
+  SEMRESATTRS_AWS_LOG_STREAM_ARNS,
+  CLOUDPROVIDERVALUES_AWS,
+  CLOUDPLATFORMVALUES_AWS_ECS,
 } from '@opentelemetry/semantic-conventions';
 import * as http from 'http';
 import * as util from 'util';
@@ -58,8 +74,8 @@ export class AwsEcsDetector implements Detector {
     }
 
     let resource = new Resource({
-      [SemanticResourceAttributes.CLOUD_PROVIDER]: CloudProviderValues.AWS,
-      [SemanticResourceAttributes.CLOUD_PLATFORM]: CloudPlatformValues.AWS_ECS,
+      [SEMRESATTRS_CLOUD_PROVIDER]: CLOUDPROVIDERVALUES_AWS,
+      [SEMRESATTRS_CLOUD_PLATFORM]: CLOUDPLATFORMVALUES_AWS_ECS,
     }).merge(await AwsEcsDetector._getContainerIdAndHostnameResource());
 
     const metadataUrl = getEnv().ECS_CONTAINER_METADATA_URI_V4;
@@ -114,8 +130,8 @@ export class AwsEcsDetector implements Detector {
 
     if (hostName || containerId) {
       return new Resource({
-        [SemanticResourceAttributes.CONTAINER_NAME]: hostName || '',
-        [SemanticResourceAttributes.CONTAINER_ID]: containerId || '',
+        [SEMRESATTRS_CONTAINER_NAME]: hostName || '',
+        [SEMRESATTRS_CONTAINER_ID]: containerId || '',
       });
     }
 
@@ -145,22 +161,22 @@ export class AwsEcsDetector implements Detector {
 
     // https://github.com/open-telemetry/semantic-conventions/blob/main/semantic_conventions/resource/cloud_provider/aws/ecs.yaml
     const attributes: ResourceAttributes = {
-      [SemanticResourceAttributes.AWS_ECS_CONTAINER_ARN]: containerArn,
-      [SemanticResourceAttributes.AWS_ECS_CLUSTER_ARN]: clusterArn,
-      [SemanticResourceAttributes.AWS_ECS_LAUNCHTYPE]:
+      [SEMRESATTRS_AWS_ECS_CONTAINER_ARN]: containerArn,
+      [SEMRESATTRS_AWS_ECS_CLUSTER_ARN]: clusterArn,
+      [SEMRESATTRS_AWS_ECS_LAUNCHTYPE]:
         launchType?.toLowerCase(),
-      [SemanticResourceAttributes.AWS_ECS_TASK_ARN]: taskArn,
-      [SemanticResourceAttributes.AWS_ECS_TASK_FAMILY]: taskMetadata['Family'],
-      [SemanticResourceAttributes.AWS_ECS_TASK_REVISION]:
+      [SEMRESATTRS_AWS_ECS_TASK_ARN]: taskArn,
+      [SEMRESATTRS_AWS_ECS_TASK_FAMILY]: taskMetadata['Family'],
+      [SEMRESATTRS_AWS_ECS_TASK_REVISION]:
         taskMetadata['Revision'],
 
-      [SemanticResourceAttributes.CLOUD_ACCOUNT_ID]: accountId,
-      [SemanticResourceAttributes.CLOUD_REGION]: region,
+      [SEMRESATTRS_CLOUD_ACCOUNT_ID]: accountId,
+      [SEMRESATTRS_CLOUD_REGION]: region,
     };
 
     // The availability zone is not available in all Fargate runtimes
     if (availabilityZone) {
-      attributes[SemanticResourceAttributes.CLOUD_AVAILABILITY_ZONE] =
+      attributes[SEMRESATTRS_CLOUD_AVAILABILITY_ZONE] =
         availabilityZone;
     }
 
@@ -192,10 +208,10 @@ export class AwsEcsDetector implements Detector {
     const logsStreamArn = `arn:aws:logs:${logsRegion}:${awsAccount}:log-group:${logsGroupName}:log-stream:${logsStreamName}`;
 
     return new Resource({
-      [SemanticResourceAttributes.AWS_LOG_GROUP_NAMES]: [logsGroupName],
-      [SemanticResourceAttributes.AWS_LOG_GROUP_ARNS]: [logsGroupArn],
-      [SemanticResourceAttributes.AWS_LOG_STREAM_NAMES]: [logsStreamName],
-      [SemanticResourceAttributes.AWS_LOG_STREAM_ARNS]: [logsStreamArn],
+      [SEMRESATTRS_AWS_LOG_GROUP_NAMES]: [logsGroupName],
+      [SEMRESATTRS_AWS_LOG_GROUP_ARNS]: [logsGroupArn],
+      [SEMRESATTRS_AWS_LOG_STREAM_NAMES]: [logsStreamName],
+      [SEMRESATTRS_AWS_LOG_STREAM_ARNS]: [logsStreamArn],
     });
   }
 

--- a/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsEksDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsEksDetector.ts
@@ -20,9 +20,12 @@ import {
   ResourceDetectionConfig,
 } from '@opentelemetry/resources';
 import {
-  CloudProviderValues,
-  CloudPlatformValues,
-  SemanticResourceAttributes,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CLOUD_PLATFORM,
+  SEMRESATTRS_K8S_CLUSTER_NAME,
+  SEMRESATTRS_CONTAINER_ID,
+  CLOUDPROVIDERVALUES_AWS,
+  CLOUDPLATFORMVALUES_AWS_EKS,
 } from '@opentelemetry/semantic-conventions';
 import * as https from 'https';
 import * as fs from 'fs';
@@ -79,12 +82,12 @@ export class AwsEksDetector implements Detector {
       return !containerId && !clusterName
         ? Resource.empty()
         : new Resource({
-            [SemanticResourceAttributes.CLOUD_PROVIDER]:
-              CloudProviderValues.AWS,
-            [SemanticResourceAttributes.CLOUD_PLATFORM]:
-              CloudPlatformValues.AWS_EKS,
-            [SemanticResourceAttributes.K8S_CLUSTER_NAME]: clusterName || '',
-            [SemanticResourceAttributes.CONTAINER_ID]: containerId || '',
+            [SEMRESATTRS_CLOUD_PROVIDER]:
+              CLOUDPROVIDERVALUES_AWS,
+            [SEMRESATTRS_CLOUD_PLATFORM]:
+              CLOUDPLATFORMVALUES_AWS_EKS,
+            [SEMRESATTRS_K8S_CLUSTER_NAME]: clusterName || '',
+            [SEMRESATTRS_CONTAINER_ID]: containerId || '',
           });
     } catch (e) {
       diag.warn('Process is not running on K8S', e);

--- a/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsLambdaDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsLambdaDetector.ts
@@ -21,9 +21,13 @@ import {
   ResourceDetectionConfig,
 } from '@opentelemetry/resources';
 import {
-  CloudProviderValues,
-  CloudPlatformValues,
-  SemanticResourceAttributes,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CLOUD_PLATFORM,
+  SEMRESATTRS_CLOUD_REGION,
+  SEMRESATTRS_FAAS_VERSION,
+  SEMRESATTRS_FAAS_NAME,
+  CLOUDPROVIDERVALUES_AWS,
+  CLOUDPLATFORMVALUES_AWS_LAMBDA,
 } from '@opentelemetry/semantic-conventions';
 
 /**
@@ -42,22 +46,22 @@ export class AwsLambdaDetector implements Detector {
     const region = process.env.AWS_REGION;
 
     const attributes: ResourceAttributes = {
-      [SemanticResourceAttributes.CLOUD_PROVIDER]: String(
-        CloudProviderValues.AWS
+      [SEMRESATTRS_CLOUD_PROVIDER]: String(
+        CLOUDPROVIDERVALUES_AWS
       ),
-      [SemanticResourceAttributes.CLOUD_PLATFORM]: String(
-        CloudPlatformValues.AWS_LAMBDA
+      [SEMRESATTRS_CLOUD_PLATFORM]: String(
+        CLOUDPLATFORMVALUES_AWS_LAMBDA
       ),
     };
     if (region) {
-      attributes[SemanticResourceAttributes.CLOUD_REGION] = region;
+      attributes[SEMRESATTRS_CLOUD_REGION] = region;
     }
 
     if (functionName) {
-      attributes[SemanticResourceAttributes.FAAS_NAME] = functionName;
+      attributes[SEMRESATTRS_FAAS_NAME] = functionName;
     }
     if (functionVersion) {
-      attributes[SemanticResourceAttributes.FAAS_VERSION] = functionVersion;
+      attributes[SEMRESATTRS_FAAS_VERSION] = functionVersion;
     }
 
     return new Resource(attributes);

--- a/detectors/node/opentelemetry-resource-detector-aws/test/detectors/AwsBeanstalkDetector.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/test/detectors/AwsBeanstalkDetector.test.ts
@@ -21,7 +21,7 @@ import {
   assertEmptyResource,
   assertServiceResource,
 } from '@opentelemetry/contrib-test-utils';
-import { CloudPlatformValues } from '@opentelemetry/semantic-conventions';
+import { CLOUDPLATFORMVALUES_AWS_ELASTIC_BEANSTALK } from '@opentelemetry/semantic-conventions';
 
 describe('BeanstalkResourceDetector', () => {
   const err = new Error('failed to read config file');
@@ -58,7 +58,7 @@ describe('BeanstalkResourceDetector', () => {
     sinon.assert.calledOnce(readStub);
     assert.ok(resource);
     assertServiceResource(resource, {
-      name: CloudPlatformValues.AWS_ELASTIC_BEANSTALK,
+      name: CLOUDPLATFORMVALUES_AWS_ELASTIC_BEANSTALK,
       namespace: 'scorekeep',
       version: 'app-5a56-170119_190650-stage-170119_190650',
       instanceId: '32',
@@ -80,7 +80,7 @@ describe('BeanstalkResourceDetector', () => {
     sinon.assert.calledOnce(readStub);
     assert.ok(resource);
     assertServiceResource(resource, {
-      name: CloudPlatformValues.AWS_ELASTIC_BEANSTALK,
+      name: CLOUDPLATFORMVALUES_AWS_ELASTIC_BEANSTALK,
       namespace: 'scorekeep',
       version: 'app-5a56-170119_190650-stage-170119_190650',
       instanceId: '32',

--- a/detectors/node/opentelemetry-resource-detector-aws/test/detectors/AwsEcsDetector.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/test/detectors/AwsEcsDetector.test.ts
@@ -28,9 +28,19 @@ import {
 } from '@opentelemetry/contrib-test-utils';
 import { Resource } from '@opentelemetry/resources';
 import {
-  CloudProviderValues,
-  CloudPlatformValues,
-  SemanticResourceAttributes,
+  SEMRESATTRS_CLOUD_PLATFORM,
+  SEMRESATTRS_AWS_ECS_CONTAINER_ARN,
+  SEMRESATTRS_AWS_ECS_CLUSTER_ARN,
+  SEMRESATTRS_AWS_ECS_LAUNCHTYPE,
+  SEMRESATTRS_AWS_ECS_TASK_ARN,
+  SEMRESATTRS_AWS_ECS_TASK_REVISION,
+  SEMRESATTRS_AWS_ECS_TASK_FAMILY,
+  SEMRESATTRS_AWS_LOG_GROUP_NAMES,
+  SEMRESATTRS_AWS_LOG_GROUP_ARNS,
+  SEMRESATTRS_AWS_LOG_STREAM_NAMES,
+  SEMRESATTRS_AWS_LOG_STREAM_ARNS,
+  CLOUDPROVIDERVALUES_AWS,
+  CLOUDPLATFORMVALUES_AWS_ECS,
 } from '@opentelemetry/semantic-conventions';
 import { readFileSync } from 'fs';
 import * as os from 'os';
@@ -57,63 +67,63 @@ const assertEcsResource = (
   validations: EcsResourceAttributes
 ) => {
   assertCloudResource(resource, {
-    provider: CloudProviderValues.AWS,
+    provider: CLOUDPROVIDERVALUES_AWS,
     accountId: validations.accountId,
     region: validations.region,
     zone: validations.zone,
   });
   assert.strictEqual(
-    resource.attributes[SemanticResourceAttributes.CLOUD_PLATFORM],
-    CloudPlatformValues.AWS_ECS
+    resource.attributes[SEMRESATTRS_CLOUD_PLATFORM],
+    CLOUDPLATFORMVALUES_AWS_ECS
   );
   if (validations.containerArn)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.AWS_ECS_CONTAINER_ARN],
+      resource.attributes[SEMRESATTRS_AWS_ECS_CONTAINER_ARN],
       validations.containerArn
     );
   if (validations.clusterArn)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.AWS_ECS_CLUSTER_ARN],
+      resource.attributes[SEMRESATTRS_AWS_ECS_CLUSTER_ARN],
       validations.clusterArn
     );
   if (validations.launchType)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.AWS_ECS_LAUNCHTYPE],
+      resource.attributes[SEMRESATTRS_AWS_ECS_LAUNCHTYPE],
       validations.launchType
     );
   if (validations.taskArn)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.AWS_ECS_TASK_ARN],
+      resource.attributes[SEMRESATTRS_AWS_ECS_TASK_ARN],
       validations.taskArn
     );
   if (validations.taskFamily)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.AWS_ECS_TASK_FAMILY],
+      resource.attributes[SEMRESATTRS_AWS_ECS_TASK_FAMILY],
       validations.taskFamily
     );
   if (validations.taskRevision)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.AWS_ECS_TASK_REVISION],
+      resource.attributes[SEMRESATTRS_AWS_ECS_TASK_REVISION],
       validations.taskRevision
     );
   if (validations.logGroupNames)
     assert.deepEqual(
-      resource.attributes[SemanticResourceAttributes.AWS_LOG_GROUP_NAMES],
+      resource.attributes[SEMRESATTRS_AWS_LOG_GROUP_NAMES],
       validations.logGroupNames
     );
   if (validations.logGroupArns)
     assert.deepEqual(
-      resource.attributes[SemanticResourceAttributes.AWS_LOG_GROUP_ARNS],
+      resource.attributes[SEMRESATTRS_AWS_LOG_GROUP_ARNS],
       validations.logGroupArns
     );
   if (validations.logStreamNames)
     assert.deepEqual(
-      resource.attributes[SemanticResourceAttributes.AWS_LOG_STREAM_NAMES],
+      resource.attributes[SEMRESATTRS_AWS_LOG_STREAM_NAMES],
       validations.logStreamNames
     );
   if (validations.logStreamArns)
     assert.deepEqual(
-      resource.attributes[SemanticResourceAttributes.AWS_LOG_STREAM_ARNS],
+      resource.attributes[SEMRESATTRS_AWS_LOG_STREAM_ARNS],
       validations.logStreamArns
     );
 };

--- a/detectors/node/opentelemetry-resource-detector-azure/CHANGELOG.md
+++ b/detectors/node/opentelemetry-resource-detector-azure/CHANGELOG.md
@@ -12,6 +12,10 @@
   * devDependencies
     * @opentelemetry/contrib-test-utils bumped from ^0.36.0 to ^0.37.0
 
+### Enhancement
+
+* refactor: use exported strings for Semantic Resource Attributes, Cloud Platform Values and Cloud Provider Values
+
 ## [0.2.3](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/resource-detector-azure-v0.2.2...resource-detector-azure-v0.2.3) (2024-01-04)
 
 

--- a/detectors/node/opentelemetry-resource-detector-azure/src/detectors/AzureAppServiceDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-azure/src/detectors/AzureAppServiceDetector.ts
@@ -29,16 +29,22 @@ import {
   FUNCTIONS_VERSION,
 } from '../types';
 import {
-  CloudProviderValues,
-  CloudPlatformValues,
-  SemanticResourceAttributes,
+  SEMRESATTRS_CLOUD_REGION,
+  SEMRESATTRS_DEPLOYMENT_ENVIRONMENT,
+  SEMRESATTRS_HOST_ID,
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
+  SEMRESATTRS_SERVICE_NAME,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CLOUD_PLATFORM,
+  CLOUDPROVIDERVALUES_AZURE,
+  CLOUDPLATFORMVALUES_AZURE_APP_SERVICE,
 } from '@opentelemetry/semantic-conventions';
 
 const APP_SERVICE_ATTRIBUTE_ENV_VARS = {
-  [SemanticResourceAttributes.CLOUD_REGION]: REGION_NAME,
-  [SemanticResourceAttributes.DEPLOYMENT_ENVIRONMENT]: WEBSITE_SLOT_NAME,
-  [SemanticResourceAttributes.HOST_ID]: WEBSITE_HOSTNAME,
-  [SemanticResourceAttributes.SERVICE_INSTANCE_ID]: WEBSITE_INSTANCE_ID,
+  [SEMRESATTRS_CLOUD_REGION]: REGION_NAME,
+  [SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]: WEBSITE_SLOT_NAME,
+  [SEMRESATTRS_HOST_ID]: WEBSITE_HOSTNAME,
+  [SEMRESATTRS_SERVICE_INSTANCE_ID]: WEBSITE_INSTANCE_ID,
   [AZURE_APP_SERVICE_STAMP_RESOURCE_ATTRIBUTE]: WEBSITE_HOME_STAMPNAME,
 };
 
@@ -54,16 +60,16 @@ class AzureAppServiceDetector implements DetectorSync {
     if (websiteSiteName && !isAzureFunction) {
       attributes = {
         ...attributes,
-        [SemanticResourceAttributes.SERVICE_NAME]: websiteSiteName,
+        [SEMRESATTRS_SERVICE_NAME]: websiteSiteName,
       };
       attributes = {
         ...attributes,
-        [SemanticResourceAttributes.CLOUD_PROVIDER]: CloudProviderValues.AZURE,
+        [SEMRESATTRS_CLOUD_PROVIDER]: CLOUDPROVIDERVALUES_AZURE,
       };
       attributes = {
         ...attributes,
-        [SemanticResourceAttributes.CLOUD_PLATFORM]:
-          CloudPlatformValues.AZURE_APP_SERVICE,
+        [SEMRESATTRS_CLOUD_PLATFORM]:
+          CLOUDPLATFORMVALUES_AZURE_APP_SERVICE,
       };
 
       const azureResourceUri = this.getAzureResourceUri(websiteSiteName);

--- a/detectors/node/opentelemetry-resource-detector-azure/src/detectors/AzureFunctionsDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-azure/src/detectors/AzureFunctionsDetector.ts
@@ -17,9 +17,15 @@
 import { DetectorSync, IResource, Resource } from '@opentelemetry/resources';
 
 import {
-  CloudProviderValues,
-  CloudPlatformValues,
-  SemanticResourceAttributes,
+  SEMRESATTRS_FAAS_NAME,
+  SEMRESATTRS_FAAS_VERSION,
+  SEMRESATTRS_FAAS_MAX_MEMORY,
+  SEMRESATTRS_FAAS_INSTANCE,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CLOUD_PLATFORM,
+  SEMRESATTRS_CLOUD_REGION,
+  CLOUDPROVIDERVALUES_AZURE,
+  CLOUDPLATFORMVALUES_AZURE_FUNCTIONS,
 } from '@opentelemetry/semantic-conventions';
 import {
   WEBSITE_SITE_NAME,
@@ -30,10 +36,10 @@ import {
 } from '../types';
 
 const AZURE_FUNCTIONS_ATTRIBUTE_ENV_VARS = {
-  [SemanticResourceAttributes.FAAS_NAME]: WEBSITE_SITE_NAME,
-  [SemanticResourceAttributes.FAAS_VERSION]: FUNCTIONS_VERSION,
-  [SemanticResourceAttributes.FAAS_INSTANCE]: WEBSITE_INSTANCE_ID,
-  [SemanticResourceAttributes.FAAS_MAX_MEMORY]: FUNCTIONS_MEM_LIMIT,
+  [SEMRESATTRS_FAAS_NAME]: WEBSITE_SITE_NAME,
+  [SEMRESATTRS_FAAS_VERSION]: FUNCTIONS_VERSION,
+  [SEMRESATTRS_FAAS_INSTANCE]: WEBSITE_INSTANCE_ID,
+  [SEMRESATTRS_FAAS_MAX_MEMORY]: FUNCTIONS_MEM_LIMIT,
 };
 
 /**
@@ -50,34 +56,34 @@ class AzureFunctionsDetector implements DetectorSync {
       const functionMemLimit = process.env[FUNCTIONS_MEM_LIMIT];
 
       attributes = {
-        [SemanticResourceAttributes.CLOUD_PROVIDER]: CloudProviderValues.AZURE,
-        [SemanticResourceAttributes.CLOUD_PLATFORM]:
-          CloudPlatformValues.AZURE_FUNCTIONS,
-        [SemanticResourceAttributes.CLOUD_REGION]: process.env[REGION_NAME],
+        [SEMRESATTRS_CLOUD_PROVIDER]: CLOUDPROVIDERVALUES_AZURE,
+        [SEMRESATTRS_CLOUD_PLATFORM]:
+          CLOUDPLATFORMVALUES_AZURE_FUNCTIONS,
+        [SEMRESATTRS_CLOUD_REGION]: process.env[REGION_NAME],
       };
 
       if (functionName) {
         attributes = {
           ...attributes,
-          [SemanticResourceAttributes.FAAS_NAME]: functionName,
+          [SEMRESATTRS_FAAS_NAME]: functionName,
         };
       }
       if (functionVersion) {
         attributes = {
           ...attributes,
-          [SemanticResourceAttributes.FAAS_VERSION]: functionVersion,
+          [SEMRESATTRS_FAAS_VERSION]: functionVersion,
         };
       }
       if (functionInstance) {
         attributes = {
           ...attributes,
-          [SemanticResourceAttributes.FAAS_INSTANCE]: functionInstance,
+          [SEMRESATTRS_FAAS_INSTANCE]: functionInstance,
         };
       }
       if (functionMemLimit) {
         attributes = {
           ...attributes,
-          [SemanticResourceAttributes.FAAS_MAX_MEMORY]: functionMemLimit,
+          [SEMRESATTRS_FAAS_MAX_MEMORY]: functionMemLimit,
         };
       }
 

--- a/detectors/node/opentelemetry-resource-detector-azure/src/detectors/AzureVmDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-azure/src/detectors/AzureVmDetector.ts
@@ -22,9 +22,15 @@ import {
   ResourceAttributes,
 } from '@opentelemetry/resources';
 import {
-  CloudPlatformValues,
-  CloudProviderValues,
-  SemanticResourceAttributes,
+  CLOUDPLATFORMVALUES_AZURE_VM,
+  CLOUDPROVIDERVALUES_AZURE,
+  SEMRESATTRS_CLOUD_PLATFORM,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CLOUD_REGION,
+  SEMRESATTRS_HOST_ID,
+  SEMRESATTRS_HOST_NAME,
+  SEMRESATTRS_HOST_TYPE,
+  SEMRESATTRS_OS_VERSION,
 } from '@opentelemetry/semantic-conventions';
 import {
   CLOUD_RESOURCE_ID_RESOURCE_ATTRIBUTE,
@@ -90,14 +96,14 @@ class AzureVmResourceDetector implements DetectorSync {
     const attributes = {
       [AZURE_VM_SCALE_SET_NAME_ATTRIBUTE]: metadata['vmScaleSetName'],
       [AZURE_VM_SKU_ATTRIBUTE]: metadata['sku'],
-      [SemanticResourceAttributes.CLOUD_PLATFORM]: CloudPlatformValues.AZURE_VM,
-      [SemanticResourceAttributes.CLOUD_PROVIDER]: CloudProviderValues.AZURE,
-      [SemanticResourceAttributes.CLOUD_REGION]: metadata['location'],
+      [SEMRESATTRS_CLOUD_PLATFORM]: CLOUDPLATFORMVALUES_AZURE_VM,
+      [SEMRESATTRS_CLOUD_PROVIDER]: CLOUDPROVIDERVALUES_AZURE,
+      [SEMRESATTRS_CLOUD_REGION]: metadata['location'],
       [CLOUD_RESOURCE_ID_RESOURCE_ATTRIBUTE]: metadata['resourceId'],
-      [SemanticResourceAttributes.HOST_ID]: metadata['vmId'],
-      [SemanticResourceAttributes.HOST_NAME]: metadata['name'],
-      [SemanticResourceAttributes.HOST_TYPE]: metadata['vmSize'],
-      [SemanticResourceAttributes.OS_VERSION]: metadata['version'],
+      [SEMRESATTRS_HOST_ID]: metadata['vmId'],
+      [SEMRESATTRS_HOST_NAME]: metadata['name'],
+      [SEMRESATTRS_HOST_TYPE]: metadata['vmSize'],
+      [SEMRESATTRS_OS_VERSION]: metadata['version'],
     };
     return attributes;
   }

--- a/detectors/node/opentelemetry-resource-detector-azure/test/detectors/AzureAppServiceDetector.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-azure/test/detectors/AzureAppServiceDetector.test.ts
@@ -16,7 +16,15 @@
 
 import * as assert from 'assert';
 import { azureAppServiceDetector } from '../../src/detectors/AzureAppServiceDetector';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { 
+  SEMRESATTRS_CLOUD_PLATFORM,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CLOUD_REGION,
+  SEMRESATTRS_DEPLOYMENT_ENVIRONMENT,
+  SEMRESATTRS_HOST_ID,
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
+  SEMRESATTRS_SERVICE_NAME
+} from '@opentelemetry/semantic-conventions';
 import { azureFunctionsDetector } from '../../src';
 import { detectResourcesSync } from '@opentelemetry/resources';
 
@@ -46,15 +54,15 @@ describe('AzureAppServiceDetector', () => {
     assert.ok(resource);
     const attributes = resource.attributes;
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.SERVICE_NAME],
+      attributes[SEMRESATTRS_SERVICE_NAME],
       'test-site'
     );
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.CLOUD_PROVIDER],
+      attributes[SEMRESATTRS_CLOUD_PROVIDER],
       'azure'
     );
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.CLOUD_PLATFORM],
+      attributes[SEMRESATTRS_CLOUD_PLATFORM],
       'azure_app_service'
     );
     assert.strictEqual(
@@ -62,19 +70,19 @@ describe('AzureAppServiceDetector', () => {
       `/subscriptions/${process.env.WEBSITE_OWNER_NAME}/resourceGroups/${process.env.WEBSITE_RESOURCE_GROUP}/providers/Microsoft.Web/sites/${process.env.WEBSITE_SITE_NAME}`
     );
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.CLOUD_REGION],
+      attributes[SEMRESATTRS_CLOUD_REGION],
       'test-region'
     );
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.DEPLOYMENT_ENVIRONMENT],
+      attributes[SEMRESATTRS_DEPLOYMENT_ENVIRONMENT],
       'test-slot'
     );
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.HOST_ID],
+      attributes[SEMRESATTRS_HOST_ID],
       'test-hostname'
     );
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.SERVICE_INSTANCE_ID],
+      attributes[SEMRESATTRS_SERVICE_INSTANCE_ID],
       'test-instance-id'
     );
     assert.strictEqual(
@@ -98,19 +106,19 @@ describe('AzureAppServiceDetector', () => {
     assert.ok(resource);
     const attributes = resource.attributes;
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.CLOUD_REGION],
+      attributes[SEMRESATTRS_CLOUD_REGION],
       'test-region'
     );
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.DEPLOYMENT_ENVIRONMENT],
+      attributes[SEMRESATTRS_DEPLOYMENT_ENVIRONMENT],
       'test-slot'
     );
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.HOST_ID],
+      attributes[SEMRESATTRS_HOST_ID],
       'test-hostname'
     );
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.SERVICE_INSTANCE_ID],
+      attributes[SEMRESATTRS_SERVICE_INSTANCE_ID],
       'test-instance-id'
     );
     assert.strictEqual(
@@ -135,19 +143,19 @@ describe('AzureAppServiceDetector', () => {
     assert.ok(resource);
     const attributes = resource.attributes;
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.CLOUD_REGION],
+      attributes[SEMRESATTRS_CLOUD_REGION],
       'test-region'
     );
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.DEPLOYMENT_ENVIRONMENT],
+      attributes[SEMRESATTRS_DEPLOYMENT_ENVIRONMENT],
       'test-slot'
     );
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.HOST_ID],
+      attributes[SEMRESATTRS_HOST_ID],
       'test-hostname'
     );
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.SERVICE_INSTANCE_ID],
+      attributes[SEMRESATTRS_SERVICE_INSTANCE_ID],
       'test-instance-id'
     );
     assert.strictEqual(

--- a/detectors/node/opentelemetry-resource-detector-azure/test/detectors/AzureFunctionsDetector.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-azure/test/detectors/AzureFunctionsDetector.test.ts
@@ -17,7 +17,16 @@
 import * as assert from 'assert';
 import { azureFunctionsDetector } from '../../src/detectors/AzureFunctionsDetector';
 import { azureAppServiceDetector } from '../../src/detectors/AzureAppServiceDetector';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { 
+  SEMRESATTRS_CLOUD_PLATFORM,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CLOUD_REGION,
+  SEMRESATTRS_FAAS_INSTANCE,
+  SEMRESATTRS_FAAS_MAX_MEMORY,
+  SEMRESATTRS_FAAS_NAME,
+  SEMRESATTRS_FAAS_VERSION,
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
+} from '@opentelemetry/semantic-conventions';
 import { detectResourcesSync } from '@opentelemetry/resources';
 import { AZURE_APP_SERVICE_STAMP_RESOURCE_ATTRIBUTE } from '../../src/types';
 
@@ -44,37 +53,37 @@ describe('AzureFunctionsDetector', () => {
     assert.ok(resource);
     const attributes = resource.attributes;
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.FAAS_NAME],
+      attributes[SEMRESATTRS_FAAS_NAME],
       'test-function'
     );
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.CLOUD_PROVIDER],
+      attributes[SEMRESATTRS_CLOUD_PROVIDER],
       'azure'
     );
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.CLOUD_PLATFORM],
+      attributes[SEMRESATTRS_CLOUD_PLATFORM],
       'azure_functions'
     );
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.CLOUD_REGION],
+      attributes[SEMRESATTRS_CLOUD_REGION],
       'test-region'
     );
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.FAAS_INSTANCE],
+      attributes[SEMRESATTRS_FAAS_INSTANCE],
       'test-instance-id'
     );
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.FAAS_MAX_MEMORY],
+      attributes[SEMRESATTRS_FAAS_MAX_MEMORY],
       '1000'
     );
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.FAAS_VERSION],
+      attributes[SEMRESATTRS_FAAS_VERSION],
       '~4'
     );
 
     // Should not detect app service values
     assert.strictEqual(
-      attributes[SemanticResourceAttributes.SERVICE_INSTANCE_ID],
+      attributes[SEMRESATTRS_SERVICE_INSTANCE_ID],
       undefined
     );
 

--- a/detectors/node/opentelemetry-resource-detector-container/CHANGELOG.md
+++ b/detectors/node/opentelemetry-resource-detector-container/CHANGELOG.md
@@ -60,6 +60,10 @@
   * devDependencies
     * @opentelemetry/contrib-test-utils bumped from ^0.36.0 to ^0.37.0
 
+### Enhancement
+
+* refactor: use exported strings for Semantic Resource Attributes, Cloud Platform Values and Cloud Provider Values
+
 ## [0.3.2](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/resource-detector-container-v0.3.1...resource-detector-container-v0.3.2) (2023-10-10)
 
 

--- a/detectors/node/opentelemetry-resource-detector-container/src/detectors/ContainerDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-container/src/detectors/ContainerDetector.ts
@@ -19,7 +19,7 @@ import {
   ResourceDetectionConfig,
 } from '@opentelemetry/resources';
 
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_CONTAINER_ID } from '@opentelemetry/semantic-conventions';
 
 import * as fs from 'fs';
 import * as util from 'util';
@@ -40,7 +40,7 @@ export class ContainerDetector implements Detector {
       return !containerId
         ? Resource.empty()
         : new Resource({
-            [SemanticResourceAttributes.CONTAINER_ID]: containerId,
+            [SEMRESATTRS_CONTAINER_ID]: containerId,
           });
     } catch (e) {
       diag.info(

--- a/detectors/node/opentelemetry-resource-detector-gcp/CHANGELOG.md
+++ b/detectors/node/opentelemetry-resource-detector-gcp/CHANGELOG.md
@@ -60,6 +60,10 @@
   * devDependencies
     * @opentelemetry/contrib-test-utils bumped from ^0.36.0 to ^0.37.0
 
+### Enhancement
+
+* refactor: use exported strings for Semantic Resource Attributes, Cloud Platform Values and Cloud Provider Values
+
 ## [0.29.3](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/resource-detector-gcp-v0.29.2...resource-detector-gcp-v0.29.3) (2023-11-13)
 
 

--- a/detectors/node/opentelemetry-resource-detector-gcp/src/detectors/GcpDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-gcp/src/detectors/GcpDetector.ts
@@ -23,9 +23,17 @@ import {
   ResourceAttributes,
 } from '@opentelemetry/resources';
 import { getEnv } from '@opentelemetry/core';
-import {
-  CloudProviderValues,
-  SemanticResourceAttributes,
+import { 
+  CLOUDPROVIDERVALUES_GCP,
+  SEMRESATTRS_CLOUD_ACCOUNT_ID,
+  SEMRESATTRS_CLOUD_AVAILABILITY_ZONE,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CONTAINER_NAME,
+  SEMRESATTRS_HOST_ID,
+  SEMRESATTRS_HOST_NAME,
+  SEMRESATTRS_K8S_CLUSTER_NAME,
+  SEMRESATTRS_K8S_NAMESPACE_NAME,
+  SEMRESATTRS_K8S_POD_NAME,
 } from '@opentelemetry/semantic-conventions';
 
 /**
@@ -58,12 +66,12 @@ class GcpDetector implements Detector {
       ]);
 
     const attributes: ResourceAttributes = {};
-    attributes[SemanticResourceAttributes.CLOUD_ACCOUNT_ID] = projectId;
-    attributes[SemanticResourceAttributes.HOST_ID] = instanceId;
-    attributes[SemanticResourceAttributes.HOST_NAME] = hostname;
-    attributes[SemanticResourceAttributes.CLOUD_AVAILABILITY_ZONE] = zoneId;
-    attributes[SemanticResourceAttributes.CLOUD_PROVIDER] =
-      CloudProviderValues.GCP;
+    attributes[SEMRESATTRS_CLOUD_ACCOUNT_ID] = projectId;
+    attributes[SEMRESATTRS_HOST_ID] = instanceId;
+    attributes[SEMRESATTRS_HOST_NAME] = hostname;
+    attributes[SEMRESATTRS_CLOUD_AVAILABILITY_ZONE] = zoneId;
+    attributes[SEMRESATTRS_CLOUD_PROVIDER] =
+      CLOUDPROVIDERVALUES_GCP;
 
     if (getEnv().KUBERNETES_SERVICE_HOST)
       this._addK8sAttributes(attributes, clusterName);
@@ -78,10 +86,10 @@ class GcpDetector implements Detector {
   ): void {
     const env = getEnv();
 
-    attributes[SemanticResourceAttributes.K8S_CLUSTER_NAME] = clusterName;
-    attributes[SemanticResourceAttributes.K8S_NAMESPACE_NAME] = env.NAMESPACE;
-    attributes[SemanticResourceAttributes.K8S_POD_NAME] = env.HOSTNAME;
-    attributes[SemanticResourceAttributes.CONTAINER_NAME] = env.CONTAINER_NAME;
+    attributes[SEMRESATTRS_K8S_CLUSTER_NAME] = clusterName;
+    attributes[SEMRESATTRS_K8S_NAMESPACE_NAME] = env.NAMESPACE;
+    attributes[SEMRESATTRS_K8S_POD_NAME] = env.HOSTNAME;
+    attributes[SEMRESATTRS_CONTAINER_NAME] = env.CONTAINER_NAME;
   }
 
   /** Gets project id from GCP project metadata. */

--- a/detectors/node/opentelemetry-resource-detector-instana/CHANGELOG.md
+++ b/detectors/node/opentelemetry-resource-detector-instana/CHANGELOG.md
@@ -6,6 +6,10 @@
   * devDependencies
     * @opentelemetry/contrib-test-utils bumped from ^0.34.3 to ^0.35.0
 
+### Enhancement
+
+* refactor: use exported strings for Semantic Resource Attributes, Cloud Platform Values and Cloud Provider Values
+
 ## [0.7.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/resource-detector-instana-v0.6.0...resource-detector-instana-v0.7.0) (2024-03-06)
 
 

--- a/detectors/node/opentelemetry-resource-detector-instana/README.md
+++ b/detectors/node/opentelemetry-resource-detector-instana/README.md
@@ -31,7 +31,7 @@ import { NodeSDK } from "@opentelemetry/sdk-node";
 import { instanaAgentDetector } from "@opentelemetry/resource-detector-instana";
 
 const globalResource = new Resource({
-   [SemanticResourceAttributes.SERVICE_NAME]: "TestService",
+   [SEMRESATTRS_SERVICE_NAME]: "TestService",
 });
 
 const sdk = new NodeSDK({

--- a/detectors/node/opentelemetry-resource-detector-instana/src/detectors/InstanaAgentDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-instana/src/detectors/InstanaAgentDetector.ts
@@ -15,7 +15,10 @@
  */
 import { Detector, Resource, IResource } from '@opentelemetry/resources';
 import { diag } from '@opentelemetry/api';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { 
+  SEMRESATTRS_PROCESS_PID,
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
+} from '@opentelemetry/semantic-conventions';
 import * as http from 'http';
 
 class InstanaAgentDetector implements Detector {
@@ -32,8 +35,8 @@ class InstanaAgentDetector implements Detector {
     const data = await this._retryHandler(host, port, 0);
 
     return new Resource({
-      [SemanticResourceAttributes.PROCESS_PID]: data.pid,
-      [SemanticResourceAttributes.SERVICE_INSTANCE_ID]: data.agentUuid,
+      [SEMRESATTRS_PROCESS_PID]: data.pid,
+      [SEMRESATTRS_SERVICE_INSTANCE_ID]: data.agentUuid,
     });
   }
 

--- a/detectors/node/opentelemetry-resource-detector-instana/test/InstanaAgentDetectorIntegrationTest.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-instana/test/InstanaAgentDetectorIntegrationTest.test.ts
@@ -21,7 +21,7 @@ import {
   processDetector,
   envDetector,
 } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { instanaAgentDetector } from '../src';
 
@@ -54,7 +54,7 @@ describe('[Integration] instanaAgentDetector', () => {
 
     const serviceName = 'TestService';
     const globalResource = new Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
+      [SEMRESATTRS_SERVICE_NAME]: serviceName,
     });
 
     const sdk = new NodeSDK({
@@ -93,7 +93,7 @@ describe('[Integration] instanaAgentDetector', () => {
 
     const serviceName = 'TestService';
     const globalResource = new Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
+      [SEMRESATTRS_SERVICE_NAME]: serviceName,
     });
 
     const sdk = new NodeSDK({

--- a/examples/connect/tracing.js
+++ b/examples/connect/tracing.js
@@ -24,7 +24,7 @@ function log() {
 module.exports = (serviceName) => {
   const provider = new NodeTracerProvider({
     resource: new Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
+      [SEMRESATTRS_SERVICE_NAME]: serviceName,
     }),
   });
   const connectInstrumentation = new ConnectInstrumentation();

--- a/examples/graphql/tracer.js
+++ b/examples/graphql/tracer.js
@@ -8,11 +8,10 @@ const { OTLPTraceExporter } = require('@opentelemetry/exporter-otlp-http');
 const { HttpInstrumentation } = require('@opentelemetry/instrumentation-http');
 const { ExpressInstrumentation } = require('@opentelemetry/instrumentation-express');
 const { Resource } = require('@opentelemetry/resources');
-const { SemanticResourceAttributes } = require('@opentelemetry/semantic-conventions');
 
 const provider = new NodeTracerProvider({
   resource: new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: 'graphql-service',
+    [SEMRESATTRS_SERVICE_NAME]: 'graphql-service',
   }),
 });
 

--- a/examples/koa/src/tracer.ts
+++ b/examples/koa/src/tracer.ts
@@ -10,14 +10,14 @@ import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { JaegerExporter } from '@opentelemetry/exporter-jaeger';
 import { ZipkinExporter } from '@opentelemetry/exporter-zipkin';
 import { Resource } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
 
 const EXPORTER = process.env.EXPORTER || '';
 
 export const setupTracing = (serviceName: string) => {
   const provider = new NodeTracerProvider({
     resource: new Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]: serviceName
+      [SEMRESATTRS_SERVICE_NAME]: serviceName
     })
   });
 

--- a/examples/memcached/tracer.js
+++ b/examples/memcached/tracer.js
@@ -9,14 +9,13 @@ const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
 const { SimpleSpanProcessor, ConsoleSpanExporter } = require('@opentelemetry/sdk-trace-base');
 const { Resource } = require('@opentelemetry/resources');
-const { SemanticResourceAttributes } = require('@opentelemetry/semantic-conventions');
 
 const { MemcachedInstrumentation } = require('@opentelemetry/instrumentation-memcached');
 
 module.exports = (serviceName) => {
   const provider = new NodeTracerProvider({
     resource: new Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
+      [SEMRESATTRS_SERVICE_NAME]: serviceName,
     }),
   });
   registerInstrumentations({

--- a/examples/mongodb/src/tracer.ts
+++ b/examples/mongodb/src/tracer.ts
@@ -8,13 +8,13 @@ import { ZipkinExporter } from '@opentelemetry/exporter-zipkin';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { MongoDBInstrumentation } from '@opentelemetry/instrumentation-mongodb';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 
 
 export const setupTracing = (serviceName: string): api.Tracer => {
   const provider = new NodeTracerProvider({
     resource: new Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]: serviceName
+      [SEMRESATTRS_SERVICE_NAME]: serviceName
     })
   });
 

--- a/examples/mysql/src/tracer.ts
+++ b/examples/mysql/src/tracer.ts
@@ -9,7 +9,7 @@ import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { MySQLInstrumentation } from '@opentelemetry/instrumentation-mysql';
 import { Resource } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import {
   MeterProvider,
   PeriodicExportingMetricReader,
@@ -33,7 +33,7 @@ export const setupTracing = (serviceName: string) => {
   //traces:
   const tracerProvider = new NodeTracerProvider({
     resource: new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
+    [SEMRESATTRS_SERVICE_NAME]: serviceName,
   }),});
 
   if (EXPORTER.toLowerCase().startsWith('z')) {

--- a/examples/react-load/react/src/web-tracer.js
+++ b/examples/react-load/react/src/web-tracer.js
@@ -5,12 +5,12 @@ import { ZoneContextManager } from '@opentelemetry/context-zone';
 import { CollectorTraceExporter } from '@opentelemetry/exporter-collector';
 import { diag, DiagConsoleLogger } from '@opentelemetry/api';
 import { Resource } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
 
 export default (serviceName) => {
   const provider = new WebTracerProvider({
     resource: new Resource({
-        [SemanticResourceAttributes.SERVICE_NAME]: "react-load-example"
+        [SEMRESATTRS_SERVICE_NAME]: "react-load-example"
     }),
   });
 

--- a/examples/redis/src/tracer.ts
+++ b/examples/redis/src/tracer.ts
@@ -9,14 +9,14 @@ import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { RedisInstrumentation } from '@opentelemetry/instrumentation-redis';
 import { Resource } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 
 const EXPORTER = process.env.EXPORTER || '';
 
 export const setupTracing = (serviceName: string) => {
   const provider = new NodeTracerProvider({
     resource: new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
+    [SEMRESATTRS_SERVICE_NAME]: serviceName,
   }),});
 
   let exporter;

--- a/examples/web/examples/document-load/index.js
+++ b/examples/web/examples/document-load/index.js
@@ -9,11 +9,11 @@ import { B3Propagator } from '@opentelemetry/propagator-b3';
 import { CompositePropagator, W3CTraceContextPropagator } from '@opentelemetry/core';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { Resource } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 
 const provider = new WebTracerProvider({
   resource: new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: 'web-service-dl',
+    [SEMRESATTRS_SERVICE_NAME]: 'web-service-dl',
   }),
 });
 

--- a/examples/web/examples/meta/index.js
+++ b/examples/web/examples/meta/index.js
@@ -6,11 +6,11 @@ import { B3Propagator } from '@opentelemetry/propagator-b3';
 import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { Resource } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 
 const providerWithZone = new WebTracerProvider({
   resource: new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: 'web-service-meta',
+    [SEMRESATTRS_SERVICE_NAME]: 'web-service-meta',
   }),
 });
 

--- a/examples/web/examples/user-interaction/index.js
+++ b/examples/web/examples/user-interaction/index.js
@@ -7,11 +7,11 @@ import { B3Propagator } from '@opentelemetry/propagator-b3';
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { Resource } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 
 const providerWithZone = new WebTracerProvider({
   resource: new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: 'web-service-ui',
+    [SEMRESATTRS_SERVICE_NAME]: 'web-service-ui',
   }),
 });
 

--- a/incubator/opentelemetry-sampler-aws-xray/README.md
+++ b/incubator/opentelemetry-sampler-aws-xray/README.md
@@ -21,7 +21,7 @@ const { AWSXRayIdGenerator } = require("@opentelemetry/id-generator-aws-xray");
 
 // Initialize resource, trace exporter, span processor, and ID generator
 const _resource = Resource.default().merge(new Resource({
-        [SemanticResourceAttributes.SERVICE_NAME]: "remote-sampler-app",
+        [SEMRESATTRS_SERVICE_NAME]: "remote-sampler-app",
     }));
 const _traceExporter = new OTLPTraceExporter();
 const _spanProcessor = new BatchSpanProcessor(_traceExporter);

--- a/metapackages/auto-instrumentations-node/README.md
+++ b/metapackages/auto-instrumentations-node/README.md
@@ -124,7 +124,7 @@ const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 const exporter = new CollectorTraceExporter();
 const provider = new NodeTracerProvider({
   resource: new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: 'basic-service',
+    [SEMRESATTRS_SERVICE_NAME]: 'basic-service',
   }),
 });
 provider.addSpanProcessor(new SimpleSpanProcessor(exporter));

--- a/packages/opentelemetry-test-utils/src/instrumentations/index.ts
+++ b/packages/opentelemetry-test-utils/src/instrumentations/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Resource } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import { getInstrumentation } from './instrumentation-singleton';
 import { registerInstrumentationTestingProvider } from './otel-default-provider';
 import { resetMemoryExporter } from './otel-provider-api';
@@ -40,7 +40,7 @@ export const mochaHooks = {
     }
     const provider = registerInstrumentationTestingProvider({
       resource: new Resource({
-        [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
+        [SEMRESATTRS_SERVICE_NAME]: serviceName,
       }),
     });
     getInstrumentation()?.setTracerProvider(provider);

--- a/packages/opentelemetry-test-utils/src/resource-assertions.ts
+++ b/packages/opentelemetry-test-utils/src/resource-assertions.ts
@@ -19,6 +19,32 @@ import * as assert from 'assert';
 import { Resource } from '@opentelemetry/resources';
 import {
   SemanticResourceAttributes,
+  SEMRESATTRS_CLOUD_ACCOUNT_ID,
+  SEMRESATTRS_CLOUD_AVAILABILITY_ZONE,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CLOUD_REGION,
+  SEMRESATTRS_CONTAINER_ID,
+  SEMRESATTRS_CONTAINER_IMAGE_NAME,
+  SEMRESATTRS_CONTAINER_IMAGE_TAG,
+  SEMRESATTRS_CONTAINER_NAME,
+  SEMRESATTRS_HOST_ID,
+  SEMRESATTRS_HOST_IMAGE_ID,
+  SEMRESATTRS_HOST_IMAGE_NAME,
+  SEMRESATTRS_HOST_IMAGE_VERSION,
+  SEMRESATTRS_HOST_NAME,
+  SEMRESATTRS_HOST_TYPE,
+  SEMRESATTRS_K8S_CLUSTER_NAME,
+  SEMRESATTRS_K8S_DEPLOYMENT_NAME,
+  SEMRESATTRS_K8S_NAMESPACE_NAME,
+  SEMRESATTRS_K8S_POD_NAME,
+  SEMRESATTRS_PROCESS_COMMAND,
+  SEMRESATTRS_PROCESS_COMMAND_LINE,
+  SEMRESATTRS_PROCESS_EXECUTABLE_NAME,
+  SEMRESATTRS_PROCESS_PID,
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
+  SEMRESATTRS_SERVICE_NAME,
+  SEMRESATTRS_SERVICE_NAMESPACE,
+  SEMRESATTRS_SERVICE_VERSION,
   SEMRESATTRS_TELEMETRY_SDK_LANGUAGE,
   SEMRESATTRS_TELEMETRY_SDK_NAME,
   SEMRESATTRS_TELEMETRY_SDK_VERSION,
@@ -42,22 +68,22 @@ export const assertCloudResource = (
   assertHasOneLabel('CLOUD', resource);
   if (validations.provider)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CLOUD_PROVIDER],
+      resource.attributes[SEMRESATTRS_CLOUD_PROVIDER],
       validations.provider
     );
   if (validations.accountId)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CLOUD_ACCOUNT_ID],
+      resource.attributes[SEMRESATTRS_CLOUD_ACCOUNT_ID],
       validations.accountId
     );
   if (validations.region)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CLOUD_REGION],
+      resource.attributes[SEMRESATTRS_CLOUD_REGION],
       validations.region
     );
   if (validations.zone)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CLOUD_AVAILABILITY_ZONE],
+      resource.attributes[SEMRESATTRS_CLOUD_AVAILABILITY_ZONE],
       validations.zone
     );
 };
@@ -80,22 +106,22 @@ export const assertContainerResource = (
   assertHasOneLabel('CONTAINER', resource);
   if (validations.name)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CONTAINER_NAME],
+      resource.attributes[SEMRESATTRS_CONTAINER_NAME],
       validations.name
     );
   if (validations.id)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CONTAINER_ID],
+      resource.attributes[SEMRESATTRS_CONTAINER_ID],
       validations.id
     );
   if (validations.imageName)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CONTAINER_IMAGE_NAME],
+      resource.attributes[SEMRESATTRS_CONTAINER_IMAGE_NAME],
       validations.imageName
     );
   if (validations.imageTag)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CONTAINER_IMAGE_TAG],
+      resource.attributes[SEMRESATTRS_CONTAINER_IMAGE_TAG],
       validations.imageTag
     );
 };
@@ -120,32 +146,32 @@ export const assertHostResource = (
   assertHasOneLabel('HOST', resource);
   if (validations.id)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_ID],
+      resource.attributes[SEMRESATTRS_HOST_ID],
       validations.id
     );
   if (validations.name)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_NAME],
+      resource.attributes[SEMRESATTRS_HOST_NAME],
       validations.name
     );
   if (validations.hostType)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_TYPE],
+      resource.attributes[SEMRESATTRS_HOST_TYPE],
       validations.hostType
     );
   if (validations.imageName)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_IMAGE_NAME],
+      resource.attributes[SEMRESATTRS_HOST_IMAGE_NAME],
       validations.imageName
     );
   if (validations.imageId)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_IMAGE_ID],
+      resource.attributes[SEMRESATTRS_HOST_IMAGE_ID],
       validations.imageId
     );
   if (validations.imageVersion)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_IMAGE_VERSION],
+      resource.attributes[SEMRESATTRS_HOST_IMAGE_VERSION],
       validations.imageVersion
     );
 };
@@ -168,22 +194,22 @@ export const assertK8sResource = (
   assertHasOneLabel('K8S', resource);
   if (validations.clusterName)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.K8S_CLUSTER_NAME],
+      resource.attributes[SEMRESATTRS_K8S_CLUSTER_NAME],
       validations.clusterName
     );
   if (validations.namespaceName)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.K8S_NAMESPACE_NAME],
+      resource.attributes[SEMRESATTRS_K8S_NAMESPACE_NAME],
       validations.namespaceName
     );
   if (validations.podName)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.K8S_POD_NAME],
+      resource.attributes[SEMRESATTRS_K8S_POD_NAME],
       validations.podName
     );
   if (validations.deploymentName)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.K8S_DEPLOYMENT_NAME],
+      resource.attributes[SEMRESATTRS_K8S_DEPLOYMENT_NAME],
       validations.deploymentName
     );
 };
@@ -211,17 +237,17 @@ export const assertTelemetrySDKResource = (
 
   if (validations.name)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.TELEMETRY_SDK_NAME],
+      resource.attributes[SEMRESATTRS_TELEMETRY_SDK_NAME],
       validations.name
     );
   if (validations.language)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.TELEMETRY_SDK_LANGUAGE],
+      resource.attributes[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE],
       validations.language
     );
   if (validations.version)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.TELEMETRY_SDK_VERSION],
+      resource.attributes[SEMRESATTRS_TELEMETRY_SDK_VERSION],
       validations.version
     );
 };
@@ -242,21 +268,21 @@ export const assertServiceResource = (
   }
 ) => {
   assert.strictEqual(
-    resource.attributes[SemanticResourceAttributes.SERVICE_NAME],
+    resource.attributes[SEMRESATTRS_SERVICE_NAME],
     validations.name
   );
   assert.strictEqual(
-    resource.attributes[SemanticResourceAttributes.SERVICE_INSTANCE_ID],
+    resource.attributes[SEMRESATTRS_SERVICE_INSTANCE_ID],
     validations.instanceId
   );
   if (validations.namespace)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.SERVICE_NAMESPACE],
+      resource.attributes[SEMRESATTRS_SERVICE_NAMESPACE],
       validations.namespace
     );
   if (validations.version)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.SERVICE_VERSION],
+      resource.attributes[SEMRESATTRS_SERVICE_VERSION],
       validations.version
     );
 };
@@ -277,24 +303,24 @@ export const assertProcessResource = (
   }
 ) => {
   assert.strictEqual(
-    resource.attributes[SemanticResourceAttributes.PROCESS_PID],
+    resource.attributes[SEMRESATTRS_PROCESS_PID],
     validations.pid
   );
   if (validations.name) {
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.PROCESS_EXECUTABLE_NAME],
+      resource.attributes[SEMRESATTRS_PROCESS_EXECUTABLE_NAME],
       validations.name
     );
   }
   if (validations.command) {
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.PROCESS_COMMAND],
+      resource.attributes[SEMRESATTRS_PROCESS_COMMAND],
       validations.command
     );
   }
   if (validations.commandLine) {
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.PROCESS_COMMAND_LINE],
+      resource.attributes[SEMRESATTRS_PROCESS_COMMAND_LINE],
       validations.commandLine
     );
   }

--- a/plugins/node/instrumentation-cucumber/test/cucumber.test.ts
+++ b/plugins/node/instrumentation-cucumber/test/cucumber.test.ts
@@ -21,9 +21,11 @@ import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { 
+  SemanticAttributes,
+  SEMRESATTRS_SERVICE_NAME
+} from '@opentelemetry/semantic-conventions';
 import { Resource } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 
 import * as path from 'path';
 import * as assert from 'assert';
@@ -50,7 +52,7 @@ import { PassThrough } from 'stream';
 describe('CucumberInstrumentation', () => {
   const provider = new NodeTracerProvider({
     resource: new Resource({
-      [SemanticResourceAttributes.SERVICE_NAME]: 'CucumberInstrumentation',
+      [SEMRESATTRS_SERVICE_NAME]: 'CucumberInstrumentation',
     }),
   });
   const memoryExporter = new InMemorySpanExporter();

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -44,8 +44,9 @@ import {
   AWSXRayPropagator,
 } from '@opentelemetry/propagator-aws-xray';
 import {
+  SEMRESATTRS_CLOUD_ACCOUNT_ID,
+  SEMRESATTRS_FAAS_ID,
   SemanticAttributes,
-  SemanticResourceAttributes,
 } from '@opentelemetry/semantic-conventions';
 
 import {
@@ -202,8 +203,8 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
           kind: SpanKind.SERVER,
           attributes: {
             [SemanticAttributes.FAAS_EXECUTION]: context.awsRequestId,
-            [SemanticResourceAttributes.FAAS_ID]: context.invokedFunctionArn,
-            [SemanticResourceAttributes.CLOUD_ACCOUNT_ID]:
+            [SEMRESATTRS_FAAS_ID]: context.invokedFunctionArn,
+            [SEMRESATTRS_CLOUD_ACCOUNT_ID]:
               AwsLambdaInstrumentation._extractAccountId(
                 context.invokedFunctionArn
               ),

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler.test.ts
@@ -33,8 +33,8 @@ import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { Context } from 'aws-lambda';
 import * as assert from 'assert';
 import {
+  SEMRESATTRS_FAAS_NAME,
   SemanticAttributes,
-  SemanticResourceAttributes,
 } from '@opentelemetry/semantic-conventions';
 import {
   Context as OtelContext,
@@ -842,7 +842,7 @@ describe('lambda handler', () => {
         initializeHandler('lambda-test/async.handler', {
           requestHook: (span, { context }) => {
             span.setAttribute(
-              SemanticResourceAttributes.FAAS_NAME,
+              SEMRESATTRS_FAAS_NAME,
               context.functionName
             );
           },
@@ -853,7 +853,7 @@ describe('lambda handler', () => {
         const [span] = spans;
         assert.strictEqual(spans.length, 1);
         assert.strictEqual(
-          span.attributes[SemanticResourceAttributes.FAAS_NAME],
+          span.attributes[SEMRESATTRS_FAAS_NAME],
           ctx.functionName
         );
         assertSpanSuccess(span);

--- a/plugins/node/opentelemetry-instrumentation-bunyan/test/bunyan.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/test/bunyan.test.ts
@@ -28,7 +28,7 @@ import {
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { isWrapped } from '@opentelemetry/instrumentation';
 import { Resource } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { Writable } from 'stream';
@@ -48,7 +48,7 @@ tracerProvider.addSpanProcessor(
 const tracer = tracerProvider.getTracer('default');
 
 const resource = new Resource({
-  [SemanticResourceAttributes.SERVICE_NAME]: 'test-instrumentation-bunyan',
+  [SEMRESATTRS_SERVICE_NAME]: 'test-instrumentation-bunyan',
 });
 const loggerProvider = new LoggerProvider({ resource });
 const memExporter = new InMemoryLogRecordExporter();


### PR DESCRIPTION
## Which problem is this PR solving?

- Replacement of deprecated strings

## Short description of the changes

- Use exported strings for Semantic Resource Attributes, Cloud Platform Values and Cloud Provider Values.
