### PR TITLE
chore(resource-detector-alibaba): use exported strings for attributes

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-alibaba-cloud/package.json
+++ b/detectors/node/opentelemetry-resource-detector-alibaba-cloud/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@opentelemetry/resources": "^1.0.0",
-    "@opentelemetry/semantic-conventions": "^1.0.0"
+    "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-alibaba-cloud#readme"
 }

--- a/detectors/node/opentelemetry-resource-detector-alibaba-cloud/src/detectors/AlibabaCloudEcsDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-alibaba-cloud/src/detectors/AlibabaCloudEcsDetector.ts
@@ -20,9 +20,16 @@ import {
   ResourceDetectionConfig,
 } from '@opentelemetry/resources';
 import {
-  CloudPlatformValues,
-  CloudProviderValues,
-  SemanticResourceAttributes,
+  CLOUDPLATFORMVALUES_ALIBABA_CLOUD_ECS,
+  CLOUDPROVIDERVALUES_ALIBABA_CLOUD,
+  SEMRESATTRS_CLOUD_ACCOUNT_ID,
+  SEMRESATTRS_CLOUD_AVAILABILITY_ZONE,
+  SEMRESATTRS_CLOUD_PLATFORM,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CLOUD_REGION,
+  SEMRESATTRS_HOST_ID,
+  SEMRESATTRS_HOST_NAME,
+  SEMRESATTRS_HOST_TYPE,
 } from '@opentelemetry/semantic-conventions';
 import * as http from 'http';
 
@@ -61,16 +68,14 @@ class AlibabaCloudEcsDetector implements Detector {
     const hostname = await this._fetchHost();
 
     return new Resource({
-      [SemanticResourceAttributes.CLOUD_PROVIDER]:
-        CloudProviderValues.ALIBABA_CLOUD,
-      [SemanticResourceAttributes.CLOUD_PLATFORM]:
-        CloudPlatformValues.ALIBABA_CLOUD_ECS,
-      [SemanticResourceAttributes.CLOUD_ACCOUNT_ID]: accountId,
-      [SemanticResourceAttributes.CLOUD_REGION]: region,
-      [SemanticResourceAttributes.CLOUD_AVAILABILITY_ZONE]: availabilityZone,
-      [SemanticResourceAttributes.HOST_ID]: instanceId,
-      [SemanticResourceAttributes.HOST_TYPE]: instanceType,
-      [SemanticResourceAttributes.HOST_NAME]: hostname,
+      [SEMRESATTRS_CLOUD_PROVIDER]: CLOUDPROVIDERVALUES_ALIBABA_CLOUD,
+      [SEMRESATTRS_CLOUD_PLATFORM]: CLOUDPLATFORMVALUES_ALIBABA_CLOUD_ECS,
+      [SEMRESATTRS_CLOUD_ACCOUNT_ID]: accountId,
+      [SEMRESATTRS_CLOUD_REGION]: region,
+      [SEMRESATTRS_CLOUD_AVAILABILITY_ZONE]: availabilityZone,
+      [SEMRESATTRS_HOST_ID]: instanceId,
+      [SEMRESATTRS_HOST_TYPE]: instanceType,
+      [SEMRESATTRS_HOST_NAME]: hostname,
     });
   }
 

--- a/detectors/node/opentelemetry-resource-detector-alibaba-cloud/test/detectors/AlibabaCloudEcsDetector.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-alibaba-cloud/test/detectors/AlibabaCloudEcsDetector.test.ts
@@ -17,7 +17,7 @@
 import * as nock from 'nock';
 import * as assert from 'assert';
 import { Resource } from '@opentelemetry/resources';
-import { CloudProviderValues } from '@opentelemetry/semantic-conventions';
+import { CLOUDPROVIDERVALUES_ALIBABA_CLOUD } from '@opentelemetry/semantic-conventions';
 import { alibabaCloudEcsDetector } from '../../src';
 import {
   assertCloudResource,
@@ -70,7 +70,7 @@ describe('alibabaCloudEcsDetector', () => {
       assert.ok(resource);
 
       assertCloudResource(resource, {
-        provider: CloudProviderValues.ALIBABA_CLOUD,
+        provider: CLOUDPROVIDERVALUES_ALIBABA_CLOUD,
         accountId: 'my-owner-account-id',
         region: 'my-region-id',
         zone: 'my-zone-id',

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
@@ -47597,7 +47597,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
         "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.18",


### PR DESCRIPTION
## Which problem is this PR solving?

- Part Of #2025 

## Short description of the changes

On package `opentelemetry-resource-detector-alibaba-cloud`:
- Update `@opentelemetry/semantic-conventions` from `^1.0.0` to `^1.22.0`
- Use exported strings for Semantic Resource Attributes, Cloud Platform Values and Cloud Provider Values.

