### PR TITLE
chore(resource-detector-aws): use exported strings for attributes

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-aws/package.json
+++ b/detectors/node/opentelemetry-resource-detector-aws/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.0.0",
     "@opentelemetry/resources": "^1.0.0",
-    "@opentelemetry/semantic-conventions": "^1.0.0"
+    "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-aws#readme"
 }

--- a/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsBeanstalkDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsBeanstalkDetector.ts
@@ -21,9 +21,14 @@ import {
   ResourceDetectionConfig,
 } from '@opentelemetry/resources';
 import {
-  CloudProviderValues,
-  CloudPlatformValues,
-  SemanticResourceAttributes,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CLOUD_PLATFORM,
+  SEMRESATTRS_SERVICE_NAME,
+  SEMRESATTRS_SERVICE_NAMESPACE,
+  SEMRESATTRS_SERVICE_VERSION,
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
+  CLOUDPROVIDERVALUES_AWS,
+  CLOUDPLATFORMVALUES_AWS_ELASTIC_BEANSTALK,
 } from '@opentelemetry/semantic-conventions';
 import * as fs from 'fs';
 import * as util from 'util';
@@ -69,16 +74,12 @@ export class AwsBeanstalkDetector implements Detector {
       const parsedData = JSON.parse(rawData);
 
       return new Resource({
-        [SemanticResourceAttributes.CLOUD_PROVIDER]: CloudProviderValues.AWS,
-        [SemanticResourceAttributes.CLOUD_PLATFORM]:
-          CloudPlatformValues.AWS_ELASTIC_BEANSTALK,
-        [SemanticResourceAttributes.SERVICE_NAME]:
-          CloudPlatformValues.AWS_ELASTIC_BEANSTALK,
-        [SemanticResourceAttributes.SERVICE_NAMESPACE]:
-          parsedData.environment_name,
-        [SemanticResourceAttributes.SERVICE_VERSION]: parsedData.version_label,
-        [SemanticResourceAttributes.SERVICE_INSTANCE_ID]:
-          parsedData.deployment_id,
+        [SEMRESATTRS_CLOUD_PROVIDER]: CLOUDPROVIDERVALUES_AWS,
+        [SEMRESATTRS_CLOUD_PLATFORM]: CLOUDPLATFORMVALUES_AWS_ELASTIC_BEANSTALK,
+        [SEMRESATTRS_SERVICE_NAME]: CLOUDPLATFORMVALUES_AWS_ELASTIC_BEANSTALK,
+        [SEMRESATTRS_SERVICE_NAMESPACE]: parsedData.environment_name,
+        [SEMRESATTRS_SERVICE_VERSION]: parsedData.version_label,
+        [SEMRESATTRS_SERVICE_INSTANCE_ID]: parsedData.deployment_id,
       });
     } catch (e: any) {
       diag.debug(`AwsBeanstalkDetector failed: ${e.message}`);

--- a/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsEc2Detector.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsEc2Detector.ts
@@ -20,9 +20,16 @@ import {
   ResourceDetectionConfig,
 } from '@opentelemetry/resources';
 import {
-  CloudProviderValues,
-  CloudPlatformValues,
-  SemanticResourceAttributes,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CLOUD_PLATFORM,
+  SEMRESATTRS_CLOUD_REGION,
+  SEMRESATTRS_CLOUD_ACCOUNT_ID,
+  SEMRESATTRS_CLOUD_AVAILABILITY_ZONE,
+  SEMRESATTRS_HOST_ID,
+  SEMRESATTRS_HOST_TYPE,
+  SEMRESATTRS_HOST_NAME,
+  CLOUDPROVIDERVALUES_AWS,
+  CLOUDPLATFORMVALUES_AWS_EC2,
 } from '@opentelemetry/semantic-conventions';
 import * as http from 'http';
 
@@ -62,14 +69,14 @@ class AwsEc2Detector implements Detector {
     const hostname = await this._fetchHost(token);
 
     return new Resource({
-      [SemanticResourceAttributes.CLOUD_PROVIDER]: CloudProviderValues.AWS,
-      [SemanticResourceAttributes.CLOUD_PLATFORM]: CloudPlatformValues.AWS_EC2,
-      [SemanticResourceAttributes.CLOUD_ACCOUNT_ID]: accountId,
-      [SemanticResourceAttributes.CLOUD_REGION]: region,
-      [SemanticResourceAttributes.CLOUD_AVAILABILITY_ZONE]: availabilityZone,
-      [SemanticResourceAttributes.HOST_ID]: instanceId,
-      [SemanticResourceAttributes.HOST_TYPE]: instanceType,
-      [SemanticResourceAttributes.HOST_NAME]: hostname,
+      [SEMRESATTRS_CLOUD_PROVIDER]: CLOUDPROVIDERVALUES_AWS,
+      [SEMRESATTRS_CLOUD_PLATFORM]: CLOUDPLATFORMVALUES_AWS_EC2,
+      [SEMRESATTRS_CLOUD_ACCOUNT_ID]: accountId,
+      [SEMRESATTRS_CLOUD_REGION]: region,
+      [SEMRESATTRS_CLOUD_AVAILABILITY_ZONE]: availabilityZone,
+      [SEMRESATTRS_HOST_ID]: instanceId,
+      [SEMRESATTRS_HOST_TYPE]: instanceType,
+      [SEMRESATTRS_HOST_NAME]: hostname,
     });
   }
 

--- a/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsEcsDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsEcsDetector.ts
@@ -21,9 +21,25 @@ import {
   ResourceAttributes,
 } from '@opentelemetry/resources';
 import {
-  CloudProviderValues,
-  CloudPlatformValues,
-  SemanticResourceAttributes,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CLOUD_PLATFORM,
+  SEMRESATTRS_CONTAINER_ID,
+  SEMRESATTRS_CONTAINER_NAME,
+  SEMRESATTRS_AWS_ECS_CONTAINER_ARN,
+  SEMRESATTRS_AWS_ECS_CLUSTER_ARN,
+  SEMRESATTRS_AWS_ECS_LAUNCHTYPE,
+  SEMRESATTRS_AWS_ECS_TASK_ARN,
+  SEMRESATTRS_AWS_ECS_TASK_FAMILY,
+  SEMRESATTRS_AWS_ECS_TASK_REVISION,
+  SEMRESATTRS_CLOUD_ACCOUNT_ID,
+  SEMRESATTRS_CLOUD_REGION,
+  SEMRESATTRS_CLOUD_AVAILABILITY_ZONE,
+  SEMRESATTRS_AWS_LOG_GROUP_NAMES,
+  SEMRESATTRS_AWS_LOG_GROUP_ARNS,
+  SEMRESATTRS_AWS_LOG_STREAM_NAMES,
+  SEMRESATTRS_AWS_LOG_STREAM_ARNS,
+  CLOUDPROVIDERVALUES_AWS,
+  CLOUDPLATFORMVALUES_AWS_ECS,
 } from '@opentelemetry/semantic-conventions';
 import * as http from 'http';
 import * as util from 'util';
@@ -58,8 +74,8 @@ export class AwsEcsDetector implements Detector {
     }
 
     let resource = new Resource({
-      [SemanticResourceAttributes.CLOUD_PROVIDER]: CloudProviderValues.AWS,
-      [SemanticResourceAttributes.CLOUD_PLATFORM]: CloudPlatformValues.AWS_ECS,
+      [SEMRESATTRS_CLOUD_PROVIDER]: CLOUDPROVIDERVALUES_AWS,
+      [SEMRESATTRS_CLOUD_PLATFORM]: CLOUDPLATFORMVALUES_AWS_ECS,
     }).merge(await AwsEcsDetector._getContainerIdAndHostnameResource());
 
     const metadataUrl = getEnv().ECS_CONTAINER_METADATA_URI_V4;
@@ -114,8 +130,8 @@ export class AwsEcsDetector implements Detector {
 
     if (hostName || containerId) {
       return new Resource({
-        [SemanticResourceAttributes.CONTAINER_NAME]: hostName || '',
-        [SemanticResourceAttributes.CONTAINER_ID]: containerId || '',
+        [SEMRESATTRS_CONTAINER_NAME]: hostName || '',
+        [SEMRESATTRS_CONTAINER_ID]: containerId || '',
       });
     }
 
@@ -145,23 +161,20 @@ export class AwsEcsDetector implements Detector {
 
     // https://github.com/open-telemetry/semantic-conventions/blob/main/semantic_conventions/resource/cloud_provider/aws/ecs.yaml
     const attributes: ResourceAttributes = {
-      [SemanticResourceAttributes.AWS_ECS_CONTAINER_ARN]: containerArn,
-      [SemanticResourceAttributes.AWS_ECS_CLUSTER_ARN]: clusterArn,
-      [SemanticResourceAttributes.AWS_ECS_LAUNCHTYPE]:
-        launchType?.toLowerCase(),
-      [SemanticResourceAttributes.AWS_ECS_TASK_ARN]: taskArn,
-      [SemanticResourceAttributes.AWS_ECS_TASK_FAMILY]: taskMetadata['Family'],
-      [SemanticResourceAttributes.AWS_ECS_TASK_REVISION]:
-        taskMetadata['Revision'],
+      [SEMRESATTRS_AWS_ECS_CONTAINER_ARN]: containerArn,
+      [SEMRESATTRS_AWS_ECS_CLUSTER_ARN]: clusterArn,
+      [SEMRESATTRS_AWS_ECS_LAUNCHTYPE]: launchType?.toLowerCase(),
+      [SEMRESATTRS_AWS_ECS_TASK_ARN]: taskArn,
+      [SEMRESATTRS_AWS_ECS_TASK_FAMILY]: taskMetadata['Family'],
+      [SEMRESATTRS_AWS_ECS_TASK_REVISION]: taskMetadata['Revision'],
 
-      [SemanticResourceAttributes.CLOUD_ACCOUNT_ID]: accountId,
-      [SemanticResourceAttributes.CLOUD_REGION]: region,
+      [SEMRESATTRS_CLOUD_ACCOUNT_ID]: accountId,
+      [SEMRESATTRS_CLOUD_REGION]: region,
     };
 
     // The availability zone is not available in all Fargate runtimes
     if (availabilityZone) {
-      attributes[SemanticResourceAttributes.CLOUD_AVAILABILITY_ZONE] =
-        availabilityZone;
+      attributes[SEMRESATTRS_CLOUD_AVAILABILITY_ZONE] = availabilityZone;
     }
 
     return new Resource(attributes);
@@ -192,10 +205,10 @@ export class AwsEcsDetector implements Detector {
     const logsStreamArn = `arn:aws:logs:${logsRegion}:${awsAccount}:log-group:${logsGroupName}:log-stream:${logsStreamName}`;
 
     return new Resource({
-      [SemanticResourceAttributes.AWS_LOG_GROUP_NAMES]: [logsGroupName],
-      [SemanticResourceAttributes.AWS_LOG_GROUP_ARNS]: [logsGroupArn],
-      [SemanticResourceAttributes.AWS_LOG_STREAM_NAMES]: [logsStreamName],
-      [SemanticResourceAttributes.AWS_LOG_STREAM_ARNS]: [logsStreamArn],
+      [SEMRESATTRS_AWS_LOG_GROUP_NAMES]: [logsGroupName],
+      [SEMRESATTRS_AWS_LOG_GROUP_ARNS]: [logsGroupArn],
+      [SEMRESATTRS_AWS_LOG_STREAM_NAMES]: [logsStreamName],
+      [SEMRESATTRS_AWS_LOG_STREAM_ARNS]: [logsStreamArn],
     });
   }
 

--- a/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsEksDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsEksDetector.ts
@@ -20,9 +20,12 @@ import {
   ResourceDetectionConfig,
 } from '@opentelemetry/resources';
 import {
-  CloudProviderValues,
-  CloudPlatformValues,
-  SemanticResourceAttributes,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CLOUD_PLATFORM,
+  SEMRESATTRS_K8S_CLUSTER_NAME,
+  SEMRESATTRS_CONTAINER_ID,
+  CLOUDPROVIDERVALUES_AWS,
+  CLOUDPLATFORMVALUES_AWS_EKS,
 } from '@opentelemetry/semantic-conventions';
 import * as https from 'https';
 import * as fs from 'fs';
@@ -79,12 +82,10 @@ export class AwsEksDetector implements Detector {
       return !containerId && !clusterName
         ? Resource.empty()
         : new Resource({
-            [SemanticResourceAttributes.CLOUD_PROVIDER]:
-              CloudProviderValues.AWS,
-            [SemanticResourceAttributes.CLOUD_PLATFORM]:
-              CloudPlatformValues.AWS_EKS,
-            [SemanticResourceAttributes.K8S_CLUSTER_NAME]: clusterName || '',
-            [SemanticResourceAttributes.CONTAINER_ID]: containerId || '',
+            [SEMRESATTRS_CLOUD_PROVIDER]: CLOUDPROVIDERVALUES_AWS,
+            [SEMRESATTRS_CLOUD_PLATFORM]: CLOUDPLATFORMVALUES_AWS_EKS,
+            [SEMRESATTRS_K8S_CLUSTER_NAME]: clusterName || '',
+            [SEMRESATTRS_CONTAINER_ID]: containerId || '',
           });
     } catch (e) {
       diag.warn('Process is not running on K8S', e);

--- a/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsLambdaDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsLambdaDetector.ts
@@ -21,9 +21,13 @@ import {
   ResourceDetectionConfig,
 } from '@opentelemetry/resources';
 import {
-  CloudProviderValues,
-  CloudPlatformValues,
-  SemanticResourceAttributes,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CLOUD_PLATFORM,
+  SEMRESATTRS_CLOUD_REGION,
+  SEMRESATTRS_FAAS_VERSION,
+  SEMRESATTRS_FAAS_NAME,
+  CLOUDPROVIDERVALUES_AWS,
+  CLOUDPLATFORMVALUES_AWS_LAMBDA,
 } from '@opentelemetry/semantic-conventions';
 
 /**
@@ -42,22 +46,18 @@ export class AwsLambdaDetector implements Detector {
     const region = process.env.AWS_REGION;
 
     const attributes: ResourceAttributes = {
-      [SemanticResourceAttributes.CLOUD_PROVIDER]: String(
-        CloudProviderValues.AWS
-      ),
-      [SemanticResourceAttributes.CLOUD_PLATFORM]: String(
-        CloudPlatformValues.AWS_LAMBDA
-      ),
+      [SEMRESATTRS_CLOUD_PROVIDER]: String(CLOUDPROVIDERVALUES_AWS),
+      [SEMRESATTRS_CLOUD_PLATFORM]: String(CLOUDPLATFORMVALUES_AWS_LAMBDA),
     };
     if (region) {
-      attributes[SemanticResourceAttributes.CLOUD_REGION] = region;
+      attributes[SEMRESATTRS_CLOUD_REGION] = region;
     }
 
     if (functionName) {
-      attributes[SemanticResourceAttributes.FAAS_NAME] = functionName;
+      attributes[SEMRESATTRS_FAAS_NAME] = functionName;
     }
     if (functionVersion) {
-      attributes[SemanticResourceAttributes.FAAS_VERSION] = functionVersion;
+      attributes[SEMRESATTRS_FAAS_VERSION] = functionVersion;
     }
 
     return new Resource(attributes);

--- a/detectors/node/opentelemetry-resource-detector-aws/test/detectors/AwsBeanstalkDetector.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/test/detectors/AwsBeanstalkDetector.test.ts
@@ -21,7 +21,7 @@ import {
   assertEmptyResource,
   assertServiceResource,
 } from '@opentelemetry/contrib-test-utils';
-import { CloudPlatformValues } from '@opentelemetry/semantic-conventions';
+import { CLOUDPLATFORMVALUES_AWS_ELASTIC_BEANSTALK } from '@opentelemetry/semantic-conventions';
 
 describe('BeanstalkResourceDetector', () => {
   const err = new Error('failed to read config file');
@@ -58,7 +58,7 @@ describe('BeanstalkResourceDetector', () => {
     sinon.assert.calledOnce(readStub);
     assert.ok(resource);
     assertServiceResource(resource, {
-      name: CloudPlatformValues.AWS_ELASTIC_BEANSTALK,
+      name: CLOUDPLATFORMVALUES_AWS_ELASTIC_BEANSTALK,
       namespace: 'scorekeep',
       version: 'app-5a56-170119_190650-stage-170119_190650',
       instanceId: '32',
@@ -80,7 +80,7 @@ describe('BeanstalkResourceDetector', () => {
     sinon.assert.calledOnce(readStub);
     assert.ok(resource);
     assertServiceResource(resource, {
-      name: CloudPlatformValues.AWS_ELASTIC_BEANSTALK,
+      name: CLOUDPLATFORMVALUES_AWS_ELASTIC_BEANSTALK,
       namespace: 'scorekeep',
       version: 'app-5a56-170119_190650-stage-170119_190650',
       instanceId: '32',

--- a/detectors/node/opentelemetry-resource-detector-aws/test/detectors/AwsEcsDetector.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/test/detectors/AwsEcsDetector.test.ts
@@ -28,9 +28,19 @@ import {
 } from '@opentelemetry/contrib-test-utils';
 import { Resource } from '@opentelemetry/resources';
 import {
-  CloudProviderValues,
-  CloudPlatformValues,
-  SemanticResourceAttributes,
+  SEMRESATTRS_CLOUD_PLATFORM,
+  SEMRESATTRS_AWS_ECS_CONTAINER_ARN,
+  SEMRESATTRS_AWS_ECS_CLUSTER_ARN,
+  SEMRESATTRS_AWS_ECS_LAUNCHTYPE,
+  SEMRESATTRS_AWS_ECS_TASK_ARN,
+  SEMRESATTRS_AWS_ECS_TASK_REVISION,
+  SEMRESATTRS_AWS_ECS_TASK_FAMILY,
+  SEMRESATTRS_AWS_LOG_GROUP_NAMES,
+  SEMRESATTRS_AWS_LOG_GROUP_ARNS,
+  SEMRESATTRS_AWS_LOG_STREAM_NAMES,
+  SEMRESATTRS_AWS_LOG_STREAM_ARNS,
+  CLOUDPROVIDERVALUES_AWS,
+  CLOUDPLATFORMVALUES_AWS_ECS,
 } from '@opentelemetry/semantic-conventions';
 import { readFileSync } from 'fs';
 import * as os from 'os';
@@ -57,63 +67,63 @@ const assertEcsResource = (
   validations: EcsResourceAttributes
 ) => {
   assertCloudResource(resource, {
-    provider: CloudProviderValues.AWS,
+    provider: CLOUDPROVIDERVALUES_AWS,
     accountId: validations.accountId,
     region: validations.region,
     zone: validations.zone,
   });
   assert.strictEqual(
-    resource.attributes[SemanticResourceAttributes.CLOUD_PLATFORM],
-    CloudPlatformValues.AWS_ECS
+    resource.attributes[SEMRESATTRS_CLOUD_PLATFORM],
+    CLOUDPLATFORMVALUES_AWS_ECS
   );
   if (validations.containerArn)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.AWS_ECS_CONTAINER_ARN],
+      resource.attributes[SEMRESATTRS_AWS_ECS_CONTAINER_ARN],
       validations.containerArn
     );
   if (validations.clusterArn)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.AWS_ECS_CLUSTER_ARN],
+      resource.attributes[SEMRESATTRS_AWS_ECS_CLUSTER_ARN],
       validations.clusterArn
     );
   if (validations.launchType)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.AWS_ECS_LAUNCHTYPE],
+      resource.attributes[SEMRESATTRS_AWS_ECS_LAUNCHTYPE],
       validations.launchType
     );
   if (validations.taskArn)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.AWS_ECS_TASK_ARN],
+      resource.attributes[SEMRESATTRS_AWS_ECS_TASK_ARN],
       validations.taskArn
     );
   if (validations.taskFamily)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.AWS_ECS_TASK_FAMILY],
+      resource.attributes[SEMRESATTRS_AWS_ECS_TASK_FAMILY],
       validations.taskFamily
     );
   if (validations.taskRevision)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.AWS_ECS_TASK_REVISION],
+      resource.attributes[SEMRESATTRS_AWS_ECS_TASK_REVISION],
       validations.taskRevision
     );
   if (validations.logGroupNames)
     assert.deepEqual(
-      resource.attributes[SemanticResourceAttributes.AWS_LOG_GROUP_NAMES],
+      resource.attributes[SEMRESATTRS_AWS_LOG_GROUP_NAMES],
       validations.logGroupNames
     );
   if (validations.logGroupArns)
     assert.deepEqual(
-      resource.attributes[SemanticResourceAttributes.AWS_LOG_GROUP_ARNS],
+      resource.attributes[SEMRESATTRS_AWS_LOG_GROUP_ARNS],
       validations.logGroupArns
     );
   if (validations.logStreamNames)
     assert.deepEqual(
-      resource.attributes[SemanticResourceAttributes.AWS_LOG_STREAM_NAMES],
+      resource.attributes[SEMRESATTRS_AWS_LOG_STREAM_NAMES],
       validations.logStreamNames
     );
   if (validations.logStreamArns)
     assert.deepEqual(
-      resource.attributes[SemanticResourceAttributes.AWS_LOG_STREAM_ARNS],
+      resource.attributes[SEMRESATTRS_AWS_LOG_STREAM_ARNS],
       validations.logStreamArns
     );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
@@ -47625,7 +47625,7 @@
         "@opentelemetry/contrib-test-utils": "^0.37.0",
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.18",


### PR DESCRIPTION
## Which problem is this PR solving?

- Part Of #2025 

## Short description of the changes

On package `opentelemetry-resource-detector-aws`:
- Update `@opentelemetry/semantic-conventions` from `^1.0.0` to `^1.22.0`
- Use exported strings for Semantic Resource Attributes, Cloud Platform Values and Cloud Provider Values.