### PR TITLE
chore(resource-detector-container): use exported strings for attributes

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-container/package.json
+++ b/detectors/node/opentelemetry-resource-detector-container/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@opentelemetry/resources": "^1.0.0",
-    "@opentelemetry/semantic-conventions": "^1.0.0"
+    "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-container#readme"
 }

--- a/detectors/node/opentelemetry-resource-detector-container/src/detectors/ContainerDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-container/src/detectors/ContainerDetector.ts
@@ -19,7 +19,7 @@ import {
   ResourceDetectionConfig,
 } from '@opentelemetry/resources';
 
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_CONTAINER_ID } from '@opentelemetry/semantic-conventions';
 
 import * as fs from 'fs';
 import * as util from 'util';
@@ -40,7 +40,7 @@ export class ContainerDetector implements Detector {
       return !containerId
         ? Resource.empty()
         : new Resource({
-            [SemanticResourceAttributes.CONTAINER_ID]: containerId,
+            [SEMRESATTRS_CONTAINER_ID]: containerId,
           });
     } catch (e) {
       diag.info(

--- a/package-lock.json
+++ b/package-lock.json
@@ -146,7 +146,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
@@ -47897,7 +47897,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
         "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.18",


### PR DESCRIPTION
## Which problem is this PR solving?

- Part Of #2025 

## Short description of the changes

On package `opentelemetry-resource-detector-container`:
- Update `@opentelemetry/semantic-conventions` from `^1.0.0` to `^1.22.0`
- Use exported strings for Semantic Resource Attributes.