### PR TITLE
chore: add maryliag as CODEOWNER of opentelemetry-instrumentation-pg

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -111,6 +111,7 @@ components:
   plugins/node/opentelemetry-instrumentation-runtime-node:
     - d4nyll
   plugins/node/opentelemetry-instrumentation-pg:
+    - maryliag
     - rauno56
   plugins/node/opentelemetry-instrumentation-pino:
     - seemk


### PR DESCRIPTION
Add `maryliag` as CODEOWNER of `plugins/node/opentelemetry-instrumentation-pg` as discussed on SIG meeting of March 27.