### PR TITLE
chore(opentelemetry-instrumentation-pg): use exported strings 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38293,7 +38293,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.49.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
         "@opentelemetry/sql-common": "^0.40.0",
         "@types/pg": "8.6.1",
         "@types/pg-pool": "2.0.4"
@@ -46679,7 +46679,7 @@
         "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
         "@opentelemetry/sql-common": "^0.40.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.6.5",

--- a/plugins/node/opentelemetry-instrumentation-pg/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pg/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.49.1",
-    "@opentelemetry/semantic-conventions": "^1.0.0",
+    "@opentelemetry/semantic-conventions": "^1.22.0",
     "@opentelemetry/sql-common": "^0.40.0",
     "@types/pg": "8.6.1",
     "@types/pg-pool": "2.0.4"

--- a/plugins/node/opentelemetry-instrumentation-pg/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/utils.ts
@@ -25,8 +25,14 @@ import {
 } from '@opentelemetry/api';
 import { AttributeNames } from './enums/AttributeNames';
 import {
-  SemanticAttributes,
-  DbSystemValues,
+  SEMATTRS_DB_SYSTEM,
+  SEMATTRS_DB_NAME,
+  SEMATTRS_DB_CONNECTION_STRING,
+  SEMATTRS_NET_PEER_NAME,
+  SEMATTRS_NET_PEER_PORT,
+  SEMATTRS_DB_USER,
+  SEMATTRS_DB_STATEMENT,
+  DBSYSTEMVALUES_POSTGRESQL,
 } from '@opentelemetry/semantic-conventions';
 import {
   PgClientExtended,
@@ -108,23 +114,23 @@ export function getSemanticAttributesFromConnection(
   params: PgParsedConnectionParams
 ) {
   return {
-    [SemanticAttributes.DB_SYSTEM]: DbSystemValues.POSTGRESQL,
-    [SemanticAttributes.DB_NAME]: params.database, // required
-    [SemanticAttributes.DB_CONNECTION_STRING]: getConnectionString(params), // required
-    [SemanticAttributes.NET_PEER_NAME]: params.host, // required
-    [SemanticAttributes.NET_PEER_PORT]: getPort(params.port),
-    [SemanticAttributes.DB_USER]: params.user,
+    [SEMATTRS_DB_SYSTEM]: DBSYSTEMVALUES_POSTGRESQL,
+    [SEMATTRS_DB_NAME]: params.database, // required
+    [SEMATTRS_DB_CONNECTION_STRING]: getConnectionString(params), // required
+    [SEMATTRS_NET_PEER_NAME]: params.host, // required
+    [SEMATTRS_NET_PEER_PORT]: getPort(params.port),
+    [SEMATTRS_DB_USER]: params.user,
   };
 }
 
 export function getSemanticAttributesFromPool(params: PgPoolOptionsParams) {
   return {
-    [SemanticAttributes.DB_SYSTEM]: DbSystemValues.POSTGRESQL,
-    [SemanticAttributes.DB_NAME]: params.database, // required
-    [SemanticAttributes.DB_CONNECTION_STRING]: getConnectionString(params), // required
-    [SemanticAttributes.NET_PEER_NAME]: params.host, // required
-    [SemanticAttributes.NET_PEER_PORT]: getPort(params.port),
-    [SemanticAttributes.DB_USER]: params.user,
+    [SEMATTRS_DB_SYSTEM]: DBSYSTEMVALUES_POSTGRESQL,
+    [SEMATTRS_DB_NAME]: params.database, // required
+    [SEMATTRS_DB_CONNECTION_STRING]: getConnectionString(params), // required
+    [SEMATTRS_NET_PEER_NAME]: params.host, // required
+    [SEMATTRS_NET_PEER_PORT]: getPort(params.port),
+    [SEMATTRS_DB_USER]: params.user,
     [AttributeNames.IDLE_TIMEOUT_MILLIS]: params.idleTimeoutMillis,
     [AttributeNames.MAX_CLIENT]: params.maxClient,
   };
@@ -163,7 +169,7 @@ export function handleConfigQuery(
 
   // Set attributes
   if (queryConfig.text) {
-    span.setAttribute(SemanticAttributes.DB_STATEMENT, queryConfig.text);
+    span.setAttribute(SEMATTRS_DB_STATEMENT, queryConfig.text);
   }
 
   if (

--- a/plugins/node/opentelemetry-instrumentation-pg/test/pg-pool.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/test/pg-pool.test.ts
@@ -41,8 +41,14 @@ import * as pgPool from 'pg-pool';
 import { AttributeNames } from '../src/enums/AttributeNames';
 import { TimedEvent } from './types';
 import {
-  SemanticAttributes,
-  DbSystemValues,
+  DBSYSTEMVALUES_POSTGRESQL,
+  SEMATTRS_DB_SYSTEM,
+  SEMATTRS_DB_NAME,
+  SEMATTRS_NET_PEER_NAME,
+  SEMATTRS_DB_CONNECTION_STRING,
+  SEMATTRS_NET_PEER_PORT,
+  SEMATTRS_DB_USER,
+  SEMATTRS_DB_STATEMENT,
 } from '@opentelemetry/semantic-conventions';
 
 const memoryExporter = new InMemorySpanExporter();
@@ -60,23 +66,23 @@ const CONFIG = {
 };
 
 const DEFAULT_PGPOOL_ATTRIBUTES = {
-  [SemanticAttributes.DB_SYSTEM]: DbSystemValues.POSTGRESQL,
-  [SemanticAttributes.DB_NAME]: CONFIG.database,
-  [SemanticAttributes.NET_PEER_NAME]: CONFIG.host,
-  [SemanticAttributes.DB_CONNECTION_STRING]: `postgresql://${CONFIG.host}:${CONFIG.port}/${CONFIG.database}`,
-  [SemanticAttributes.NET_PEER_PORT]: CONFIG.port,
-  [SemanticAttributes.DB_USER]: CONFIG.user,
+  [SEMATTRS_DB_SYSTEM]: DBSYSTEMVALUES_POSTGRESQL,
+  [SEMATTRS_DB_NAME]: CONFIG.database,
+  [SEMATTRS_NET_PEER_NAME]: CONFIG.host,
+  [SEMATTRS_DB_CONNECTION_STRING]: `postgresql://${CONFIG.host}:${CONFIG.port}/${CONFIG.database}`,
+  [SEMATTRS_NET_PEER_PORT]: CONFIG.port,
+  [SEMATTRS_DB_USER]: CONFIG.user,
   [AttributeNames.MAX_CLIENT]: CONFIG.maxClient,
   [AttributeNames.IDLE_TIMEOUT_MILLIS]: CONFIG.idleTimeoutMillis,
 };
 
 const DEFAULT_PG_ATTRIBUTES = {
-  [SemanticAttributes.DB_SYSTEM]: DbSystemValues.POSTGRESQL,
-  [SemanticAttributes.DB_NAME]: CONFIG.database,
-  [SemanticAttributes.NET_PEER_NAME]: CONFIG.host,
-  [SemanticAttributes.DB_CONNECTION_STRING]: `postgresql://${CONFIG.host}:${CONFIG.port}/${CONFIG.database}`,
-  [SemanticAttributes.NET_PEER_PORT]: CONFIG.port,
-  [SemanticAttributes.DB_USER]: CONFIG.user,
+  [SEMATTRS_DB_SYSTEM]: DBSYSTEMVALUES_POSTGRESQL,
+  [SEMATTRS_DB_NAME]: CONFIG.database,
+  [SEMATTRS_NET_PEER_NAME]: CONFIG.host,
+  [SEMATTRS_DB_CONNECTION_STRING]: `postgresql://${CONFIG.host}:${CONFIG.port}/${CONFIG.database}`,
+  [SEMATTRS_NET_PEER_PORT]: CONFIG.port,
+  [SEMATTRS_DB_USER]: CONFIG.user,
 };
 
 const unsetStatus: SpanStatus = {
@@ -179,7 +185,7 @@ describe('pg-pool', () => {
       };
       const pgAttributes = {
         ...DEFAULT_PG_ATTRIBUTES,
-        [SemanticAttributes.DB_STATEMENT]: 'SELECT NOW()',
+        [SEMATTRS_DB_STATEMENT]: 'SELECT NOW()',
       };
       const events: TimedEvent[] = [];
       const span = provider.getTracer('test-pg-pool').startSpan('test span');
@@ -211,7 +217,7 @@ describe('pg-pool', () => {
       };
       const pgAttributes = {
         ...DEFAULT_PG_ATTRIBUTES,
-        [SemanticAttributes.DB_STATEMENT]: 'SELECT NOW()',
+        [SEMATTRS_DB_STATEMENT]: 'SELECT NOW()',
       };
       const events: TimedEvent[] = [];
       const parentSpan = provider
@@ -284,7 +290,7 @@ describe('pg-pool', () => {
       };
       const pgAttributes = {
         ...DEFAULT_PG_ATTRIBUTES,
-        [SemanticAttributes.DB_STATEMENT]: 'SELECT NOW()',
+        [SEMATTRS_DB_STATEMENT]: 'SELECT NOW()',
       };
       const events: TimedEvent[] = [];
       const span = provider.getTracer('test-pg-pool').startSpan('test span');
@@ -303,7 +309,7 @@ describe('pg-pool', () => {
       };
       const pgAttributes = {
         ...DEFAULT_PG_ATTRIBUTES,
-        [SemanticAttributes.DB_STATEMENT]: 'SELECT NOW()',
+        [SEMATTRS_DB_STATEMENT]: 'SELECT NOW()',
       };
       const events: TimedEvent[] = [];
       const parentSpan = provider
@@ -340,7 +346,7 @@ describe('pg-pool', () => {
         };
         const pgAttributes = {
           ...DEFAULT_PG_ATTRIBUTES,
-          [SemanticAttributes.DB_STATEMENT]: query,
+          [SEMATTRS_DB_STATEMENT]: query,
           [dataAttributeName]: '{"rowCount":1}',
         };
 
@@ -422,7 +428,7 @@ describe('pg-pool', () => {
         };
         const pgAttributes = {
           ...DEFAULT_PG_ATTRIBUTES,
-          [SemanticAttributes.DB_STATEMENT]: query,
+          [SEMATTRS_DB_STATEMENT]: query,
         };
 
         beforeEach(async () => {

--- a/plugins/node/opentelemetry-instrumentation-pg/test/pg.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/test/pg.test.ts
@@ -42,8 +42,14 @@ import {
 import { AttributeNames } from '../src/enums/AttributeNames';
 import { TimedEvent } from './types';
 import {
-  SemanticAttributes,
-  DbSystemValues,
+  SEMATTRS_DB_STATEMENT,
+  SEMATTRS_DB_SYSTEM,
+  SEMATTRS_DB_NAME,
+  SEMATTRS_NET_PEER_NAME,
+  SEMATTRS_DB_CONNECTION_STRING,
+  SEMATTRS_NET_PEER_PORT,
+  SEMATTRS_DB_USER,
+  DBSYSTEMVALUES_POSTGRESQL,
 } from '@opentelemetry/semantic-conventions';
 import { addSqlCommenterComment } from '@opentelemetry/sql-common';
 
@@ -60,12 +66,12 @@ const CONFIG = {
 };
 
 const DEFAULT_ATTRIBUTES = {
-  [SemanticAttributes.DB_SYSTEM]: DbSystemValues.POSTGRESQL,
-  [SemanticAttributes.DB_NAME]: CONFIG.database,
-  [SemanticAttributes.NET_PEER_NAME]: CONFIG.host,
-  [SemanticAttributes.DB_CONNECTION_STRING]: `postgresql://${CONFIG.host}:${CONFIG.port}/${CONFIG.database}`,
-  [SemanticAttributes.NET_PEER_PORT]: CONFIG.port,
-  [SemanticAttributes.DB_USER]: CONFIG.user,
+  [SEMATTRS_DB_SYSTEM]: DBSYSTEMVALUES_POSTGRESQL,
+  [SEMATTRS_DB_NAME]: CONFIG.database,
+  [SEMATTRS_NET_PEER_NAME]: CONFIG.host,
+  [SEMATTRS_DB_CONNECTION_STRING]: `postgresql://${CONFIG.host}:${CONFIG.port}/${CONFIG.database}`,
+  [SEMATTRS_NET_PEER_PORT]: CONFIG.port,
+  [SEMATTRS_DB_USER]: CONFIG.user,
 };
 
 const unsetStatus: SpanStatus = {
@@ -348,7 +354,7 @@ describe('pg', () => {
     it('should intercept client.query(text, callback)', done => {
       const attributes = {
         ...DEFAULT_ATTRIBUTES,
-        [SemanticAttributes.DB_STATEMENT]: 'SELECT NOW()',
+        [SEMATTRS_DB_STATEMENT]: 'SELECT NOW()',
       };
       const events: TimedEvent[] = [];
       const span = tracer.startSpan('test span');
@@ -368,7 +374,7 @@ describe('pg', () => {
       const values = ['0'];
       const attributes = {
         ...DEFAULT_ATTRIBUTES,
-        [SemanticAttributes.DB_STATEMENT]: query,
+        [SEMATTRS_DB_STATEMENT]: query,
       };
       const events: TimedEvent[] = [];
       const span = tracer.startSpan('test span');
@@ -387,7 +393,7 @@ describe('pg', () => {
       const query = 'SELECT NOW()';
       const attributes = {
         ...DEFAULT_ATTRIBUTES,
-        [SemanticAttributes.DB_STATEMENT]: query,
+        [SEMATTRS_DB_STATEMENT]: query,
       };
       const events: TimedEvent[] = [];
       const span = tracer.startSpan('test span');
@@ -409,7 +415,7 @@ describe('pg', () => {
       const query = 'SELECT NOW()';
       const attributes = {
         ...DEFAULT_ATTRIBUTES,
-        [SemanticAttributes.DB_STATEMENT]: query,
+        [SEMATTRS_DB_STATEMENT]: query,
       };
       const events: TimedEvent[] = [];
       const span = tracer.startSpan('test span');
@@ -429,7 +435,7 @@ describe('pg', () => {
       const values = ['0'];
       const attributes = {
         ...DEFAULT_ATTRIBUTES,
-        [SemanticAttributes.DB_STATEMENT]: query,
+        [SEMATTRS_DB_STATEMENT]: query,
       };
       const events: TimedEvent[] = [];
       const span = tracer.startSpan('test span');
@@ -449,7 +455,7 @@ describe('pg', () => {
       const values = ['0'];
       const attributes = {
         ...DEFAULT_ATTRIBUTES,
-        [SemanticAttributes.DB_STATEMENT]: query,
+        [SEMATTRS_DB_STATEMENT]: query,
       };
       const events: TimedEvent[] = [];
       const span = tracer.startSpan('test span');
@@ -474,7 +480,7 @@ describe('pg', () => {
       const attributes = {
         ...DEFAULT_ATTRIBUTES,
         [AttributeNames.PG_PLAN]: name,
-        [SemanticAttributes.DB_STATEMENT]: query,
+        [SEMATTRS_DB_STATEMENT]: query,
       };
       const events: TimedEvent[] = [];
       const span = tracer.startSpan('test span');
@@ -498,7 +504,7 @@ describe('pg', () => {
       const query = 'SELECT NOW()';
       const attributes = {
         ...DEFAULT_ATTRIBUTES,
-        [SemanticAttributes.DB_STATEMENT]: query,
+        [SEMATTRS_DB_STATEMENT]: query,
       };
       const events: TimedEvent[] = [];
       const span = tracer.startSpan('test span');
@@ -537,7 +543,7 @@ describe('pg', () => {
 
       const attributes = {
         ...DEFAULT_ATTRIBUTES,
-        [SemanticAttributes.DB_STATEMENT]: query,
+        [SEMATTRS_DB_STATEMENT]: query,
         [AttributeNames.PG_VALUES]: [
           'Hello,World',
           'abc',
@@ -576,7 +582,7 @@ describe('pg', () => {
       // span if there is no requestHook.
       const attributes = {
         ...DEFAULT_ATTRIBUTES,
-        [SemanticAttributes.DB_STATEMENT]: query,
+        [SEMATTRS_DB_STATEMENT]: query,
       };
 
       // These are the attributes we expect on the span after the requestHook
@@ -669,7 +675,7 @@ describe('pg', () => {
       describe('AND valid responseHook', () => {
         const attributes = {
           ...DEFAULT_ATTRIBUTES,
-          [SemanticAttributes.DB_STATEMENT]: query,
+          [SEMATTRS_DB_STATEMENT]: query,
           [dataAttributeName]: '{"rowCount":1}',
         };
         beforeEach(async () => {
@@ -702,7 +708,7 @@ describe('pg', () => {
         it('should attach response hook data to resulting spans for query returning a Promise', async () => {
           const attributes = {
             ...DEFAULT_ATTRIBUTES,
-            [SemanticAttributes.DB_STATEMENT]: query,
+            [SEMATTRS_DB_STATEMENT]: query,
             [dataAttributeName]: '{"rowCount":1}',
           };
 
@@ -727,7 +733,7 @@ describe('pg', () => {
       describe('AND invalid responseHook', () => {
         const attributes = {
           ...DEFAULT_ATTRIBUTES,
-          [SemanticAttributes.DB_STATEMENT]: query,
+          [SEMATTRS_DB_STATEMENT]: query,
         };
 
         beforeEach(async () => {

--- a/plugins/node/opentelemetry-instrumentation-pg/test/utils.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/test/utils.test.ts
@@ -28,7 +28,7 @@ import { PgInstrumentationConfig } from '../src';
 import { AttributeNames } from '../src/enums/AttributeNames';
 import { PgClientExtended } from '../src/internal-types';
 import * as utils from '../src/utils';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_NET_PEER_PORT } from '@opentelemetry/semantic-conventions';
 
 const memoryExporter = new InMemorySpanExporter();
 
@@ -200,25 +200,25 @@ describe('utils.ts', () => {
       assert.strictEqual(
         utils.getSemanticAttributesFromConnection({
           port: Infinity,
-        })[SemanticAttributes.NET_PEER_PORT],
+        })[SEMATTRS_NET_PEER_PORT],
         undefined
       );
       assert.strictEqual(
         utils.getSemanticAttributesFromConnection({
           port: -Infinity,
-        })[SemanticAttributes.NET_PEER_PORT],
+        })[SEMATTRS_NET_PEER_PORT],
         undefined
       );
       assert.strictEqual(
         utils.getSemanticAttributesFromConnection({
           port: NaN,
-        })[SemanticAttributes.NET_PEER_PORT],
+        })[SEMATTRS_NET_PEER_PORT],
         undefined
       );
       assert.strictEqual(
         utils.getSemanticAttributesFromConnection({
           port: 1.234,
-        })[SemanticAttributes.NET_PEER_PORT],
+        })[SEMATTRS_NET_PEER_PORT],
         undefined
       );
     });
@@ -227,13 +227,13 @@ describe('utils.ts', () => {
       assert.strictEqual(
         utils.getSemanticAttributesFromConnection({
           port: 1234,
-        })[SemanticAttributes.NET_PEER_PORT],
+        })[SEMATTRS_NET_PEER_PORT],
         1234
       );
       assert.strictEqual(
         utils.getSemanticAttributesFromConnection({
           port: Number.MAX_VALUE,
-        })[SemanticAttributes.NET_PEER_PORT],
+        })[SEMATTRS_NET_PEER_PORT],
         Number.MAX_VALUE
       );
     });


### PR DESCRIPTION
## Which problem is this PR solving?

- Part Of #2025 

## Short description of the changes

On package `opentelemetry-instrumentation-pg`:
- Update `@opentelemetry/semantic-conventions` from `^1.0.0` to `^1.22.0`
- Use exported strings for Semantic Attributes