### PR TITLE
feat(deps): update otel-js experimental to 0.50.0

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-instana/package.json
+++ b/detectors/node/opentelemetry-resource-detector-instana/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/contrib-test-utils": "^0.37.0",
-    "@opentelemetry/sdk-node": "^0.49.1",
+    "@opentelemetry/sdk-node": "^0.50.0",
     "@types/mocha": "8.2.3",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.3",

--- a/metapackages/auto-instrumentations-node/package.json
+++ b/metapackages/auto-instrumentations-node/package.json
@@ -49,7 +49,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/instrumentation-amqplib": "^0.35.0",
     "@opentelemetry/instrumentation-aws-lambda": "^0.39.0",
     "@opentelemetry/instrumentation-aws-sdk": "^0.39.1",
@@ -64,9 +64,9 @@
     "@opentelemetry/instrumentation-fs": "^0.10.0",
     "@opentelemetry/instrumentation-generic-pool": "^0.34.0",
     "@opentelemetry/instrumentation-graphql": "^0.38.1",
-    "@opentelemetry/instrumentation-grpc": "^0.49.1",
+    "@opentelemetry/instrumentation-grpc": "^0.50.0",
     "@opentelemetry/instrumentation-hapi": "^0.35.0",
-    "@opentelemetry/instrumentation-http": "^0.49.1",
+    "@opentelemetry/instrumentation-http": "^0.50.0",
     "@opentelemetry/instrumentation-ioredis": "^0.38.0",
     "@opentelemetry/instrumentation-knex": "^0.34.0",
     "@opentelemetry/instrumentation-koa": "^0.38.0",
@@ -92,7 +92,7 @@
     "@opentelemetry/resource-detector-container": "^0.3.7",
     "@opentelemetry/resource-detector-gcp": "^0.29.7",
     "@opentelemetry/resources": "^1.12.0",
-    "@opentelemetry/sdk-node": "^0.49.1"
+    "@opentelemetry/sdk-node": "^0.50.0"
   },
   "files": [
     "build/src/**/*.js",

--- a/metapackages/auto-instrumentations-web/package.json
+++ b/metapackages/auto-instrumentations-web/package.json
@@ -61,11 +61,11 @@
     "webpack-merge": "5.8.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/instrumentation-document-load": "^0.36.0",
-    "@opentelemetry/instrumentation-fetch": "^0.49.1",
+    "@opentelemetry/instrumentation-fetch": "^0.50.0",
     "@opentelemetry/instrumentation-user-interaction": "^0.36.0",
-    "@opentelemetry/instrumentation-xml-http-request": "^0.49.1"
+    "@opentelemetry/instrumentation-xml-http-request": "^0.50.0"
   },
   "files": [
     "build/src/**/*.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -255,7 +255,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
-        "@opentelemetry/sdk-node": "^0.49.1",
+        "@opentelemetry/sdk-node": "^0.50.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.3",
@@ -284,7 +284,7 @@
       "version": "0.43.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/instrumentation-amqplib": "^0.35.0",
         "@opentelemetry/instrumentation-aws-lambda": "^0.39.0",
         "@opentelemetry/instrumentation-aws-sdk": "^0.39.1",
@@ -299,9 +299,9 @@
         "@opentelemetry/instrumentation-fs": "^0.10.0",
         "@opentelemetry/instrumentation-generic-pool": "^0.34.0",
         "@opentelemetry/instrumentation-graphql": "^0.38.1",
-        "@opentelemetry/instrumentation-grpc": "^0.49.1",
+        "@opentelemetry/instrumentation-grpc": "^0.50.0",
         "@opentelemetry/instrumentation-hapi": "^0.35.0",
-        "@opentelemetry/instrumentation-http": "^0.49.1",
+        "@opentelemetry/instrumentation-http": "^0.50.0",
         "@opentelemetry/instrumentation-ioredis": "^0.38.0",
         "@opentelemetry/instrumentation-knex": "^0.34.0",
         "@opentelemetry/instrumentation-koa": "^0.38.0",
@@ -327,7 +327,7 @@
         "@opentelemetry/resource-detector-container": "^0.3.7",
         "@opentelemetry/resource-detector-gcp": "^0.29.7",
         "@opentelemetry/resources": "^1.12.0",
-        "@opentelemetry/sdk-node": "^0.49.1"
+        "@opentelemetry/sdk-node": "^0.50.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.4.1",
@@ -353,11 +353,11 @@
       "version": "0.37.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/instrumentation-document-load": "^0.36.0",
-        "@opentelemetry/instrumentation-fetch": "^0.49.1",
+        "@opentelemetry/instrumentation-fetch": "^0.50.0",
         "@opentelemetry/instrumentation-user-interaction": "^0.36.0",
-        "@opentelemetry/instrumentation-xml-http-request": "^0.49.1"
+        "@opentelemetry/instrumentation-xml-http-request": "^0.50.0"
       },
       "devDependencies": {
         "@babel/core": "7.22.17",
@@ -8197,9 +8197,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.49.1.tgz",
-      "integrity": "sha512-kaNl/T7WzyMUQHQlVq7q0oV4Kev6+0xFwqzofryC66jgGMacd0QH5TwfpbUwSTby+SdAdprAe5UKMvBw4tKS5Q==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.50.0.tgz",
+      "integrity": "sha512-JdZuKrhOYggqOpUljAq4WWNi5nB10PmgoF0y2CvedLGXd0kSawb/UBnWT8gg1ND3bHCNHStAIVT0ELlxJJRqrA==",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
@@ -8216,9 +8216,9 @@
       "link": true
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.22.0.tgz",
-      "integrity": "sha512-Nfdxyg8YtWqVWkyrCukkundAjPhUXi93JtVQmqDT1mZRVKqA7e2r7eJCrI+F651XUBMp0hsOJSGiFk3QSpaIJw==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.23.0.tgz",
+      "integrity": "sha512-wazGJZDRevibOJ+VgyrT+9+8sybZAxpZx2G7vy30OAtk92OpZCg7HgNxT11NUx0VBDWcRx1dOatMYGOVplQ7QA==",
       "engines": {
         "node": ">=14"
       },
@@ -8227,11 +8227,11 @@
       }
     },
     "node_modules/@opentelemetry/context-zone": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-1.22.0.tgz",
-      "integrity": "sha512-ukPkASKUt9l4P3g7Dggntb3jG3dVL4dPXfDc8FUZ6pOCiLa5NRrRPQPbDdCumytbw5Yor9paiXCg/oQgMyYMHw==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-1.23.0.tgz",
+      "integrity": "sha512-7piNTrpH+gZNMDDOHIJXCSwp0Xslh3R96HWH5HwXw+4PykR4+jVoXvd6jziQxudX9rFAfu2B64A10DHs4ZWrfA==",
       "dependencies": {
-        "@opentelemetry/context-zone-peer-dep": "1.22.0",
+        "@opentelemetry/context-zone-peer-dep": "1.23.0",
         "zone.js": "^0.11.0 || ^0.13.0 || ^0.14.0"
       },
       "engines": {
@@ -8239,9 +8239,9 @@
       }
     },
     "node_modules/@opentelemetry/context-zone-peer-dep": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.22.0.tgz",
-      "integrity": "sha512-kQ0K6syNQQYj4Pd5Q4yiUAsuthpzWDmVPPqMUSACh9ArRYLq8ZY9JdnkqkT1RyeecpSDh5uG+x5dbx6drpJ79g==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.23.0.tgz",
+      "integrity": "sha512-3ia5w2y3CGHIhMSggttliGbeRBWclIyMMXdfRCcit1NHg1ocieA9qYxyUEetbOvPrQpoti3O3k+5eyQUv7r8nw==",
       "engines": {
         "node": ">=14"
       },
@@ -8255,11 +8255,11 @@
       "link": true
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.22.0.tgz",
-      "integrity": "sha512-0VoAlT6x+Xzik1v9goJ3pZ2ppi6+xd3aUfg4brfrLkDBHRIVjMP0eBHrKrhB+NKcDyMAg8fAbGL3Npg/F6AwWA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+      "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -8269,13 +8269,13 @@
       }
     },
     "node_modules/@opentelemetry/exporter-jaeger": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.22.0.tgz",
-      "integrity": "sha512-8kDUmx0nMgh+kLPi9hpQFS/bT0nrLYXKGoXTjsCQ24lbIEOanWAyA/lQFFu1Y/mZKsws/h3fBb1b9JSicNCWBw==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.23.0.tgz",
+      "integrity": "sha512-9GjZPS9kR4nC0ApOFQtj2xwYAGhQ3bO6KPx27DLqCOiso27OlJVUgvAtB3i+1On23OTcjfPtKbNo4a2npmV27A==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "jaeger-client": "^3.15.0"
       },
       "engines": {
@@ -8286,16 +8286,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.49.1.tgz",
-      "integrity": "sha512-Zbd7f3zF7fI2587MVhBizaW21cO/SordyrZGtMtvhoxU6n4Qb02Gx71X4+PzXH620e0+JX+Pcr9bYb1HTeVyJA==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.50.0.tgz",
+      "integrity": "sha512-w/NF4TrwHxx+Uz1M0rCOSVr6KgcoQPv3zF9JRqcebY2euD7ddWnLP0hE8JavyA1uq4UchnMp9faAk9n7hTCePw==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -8305,15 +8305,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.49.1.tgz",
-      "integrity": "sha512-KOLtZfZvIrpGZLVvblKsiVQT7gQUZNKcUUH24Zz6Xbi7LJb9Vt6xtUZFYdR5IIjvt47PIqBKDWUQlU0o1wAsRw==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.50.0.tgz",
+      "integrity": "sha512-L7OtIMT7MsFqkmhbQlPBGRXt7152VN5esHpQEJYIBFedOEo3Da+yHpu5ojMZtPzpIvSpB5Xr5lnJUjJCbkttCA==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -8323,16 +8323,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.49.1.tgz",
-      "integrity": "sha512-n8ON/c9pdMyYAfSFWKkgsPwjYoxnki+6Olzo+klKfW7KqLWoyEkryNkbcMIYnGGNXwdkMIrjoaP0VxXB26Oxcg==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.50.0.tgz",
+      "integrity": "sha512-vavD9Ow6yOLiD+ocuS/oeciCsXNdsN41aYUrEljNaLXogvnkfMhJ+JLAhOnRSpzlVtRp7Ciw2BYGdYSebR0OsA==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-proto-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -8342,14 +8342,14 @@
       }
     },
     "node_modules/@opentelemetry/exporter-zipkin": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.22.0.tgz",
-      "integrity": "sha512-XcFs6rGvcTz0qW5uY7JZDYD0yNEXdekXAb6sFtnZgY/cHY6BQ09HMzOjv9SX+iaXplRDcHr1Gta7VQKM1XXM6g==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.23.0.tgz",
+      "integrity": "sha512-2LOGvNUGONuIcWhynFaJorVyqv03uZkURScciLmOxvBf2lWTNPEj77br1dCpShIWBM+YlrH7Tc+JXAs+GC7DqA==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -8367,11 +8367,11 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.49.1.tgz",
-      "integrity": "sha512-0DLtWtaIppuNNRRllSD4bjU8ZIiLp1cDXvJEbp752/Zf+y3gaLNaoGRGIlX4UHhcsrmtL+P2qxi3Hodi8VuKiQ==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.50.0.tgz",
+      "integrity": "sha512-bhGhbJiZKpuu7wTaSak4hyZcFPlnDeuSF/2vglze8B4w2LubcSbbOnkVTzTs5SXtzh4Xz8eRjaNnAm+u2GYufQ==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.49.1",
+        "@opentelemetry/api-logs": "0.50.0",
         "@types/shimmer": "^1.0.2",
         "import-in-the-middle": "1.7.1",
         "require-in-the-middle": "^7.1.1",
@@ -8434,14 +8434,14 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-fetch": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.49.1.tgz",
-      "integrity": "sha512-hizhULZXlq02y8YC0vPQ4WtUWiXcwxPdEqHBy8p75jzF9rAuP/ldrVr0Oxvz5Xr9qQcdEOFLvEl0ZxbVL76WKw==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.50.0.tgz",
+      "integrity": "sha512-CayteluGJbrfDvzEFQ0EWqLFkNAcO9H7nfDHptZjtonBpJRWF170XZoMkJVC2bxp0lIVwyuw6WlnGVRSNwEtKA==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/sdk-trace-web": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/sdk-trace-web": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -8463,12 +8463,12 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-grpc": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.49.1.tgz",
-      "integrity": "sha512-f8mQjFi5/PiP4SK3VDU1/3sUUgs6exMtBgcnNycgCKgN40htiPT+MuDRwdRnRMNI/4vNQ7p1/5r4Q5oN0GuRBw==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.50.0.tgz",
+      "integrity": "sha512-/ZFuvHtrHyxfRJX5CJ8yPKokAIcvTbIJAoR4AN+gBq1YqecWuCr4XG52p5YU5qDrbwOBtShOrC8d4GdFZOky6Q==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -8482,13 +8482,13 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.49.1.tgz",
-      "integrity": "sha512-Yib5zrW2s0V8wTeUK/B3ZtpyP4ldgXj9L3Ws/axXrW1dW0/mEFKifK50MxMQK9g5NNJQS9dWH7rvcEGZdWdQDA==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.50.0.tgz",
+      "integrity": "sha512-bsd6Nv0FtN9C6M6vX/kgPzvJY9UhJc4CZZNvqDbsfVQv3/MWvPrYgthf41AhrehqeDnpfn/QGzNKtdWUduGanQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -8591,14 +8591,14 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-xml-http-request": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.49.1.tgz",
-      "integrity": "sha512-gCPd2o1geRXc1urJoLxWRnMKAF6Akbwlp1nfe+xg2akSUenlt4wopmq1gEIrJva4bXLsNSModVLrEVCTt5/fDA==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.50.0.tgz",
+      "integrity": "sha512-o9z6SDQByqc3GvmUcy6Npt/SAIrv2Pk0Hm0Hl54B3Ny8WUrTsrlt6MULx8d+EjuifE4uVo8op8DekmvKJ1FHoQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/sdk-trace-web": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/sdk-trace-web": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -8608,11 +8608,11 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.49.1.tgz",
-      "integrity": "sha512-z6sHliPqDgJU45kQatAettY9/eVF58qVPaTuejw9YWfSRqid9pXPYeegDCSdyS47KAUgAtm+nC28K3pfF27HWg==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.50.0.tgz",
+      "integrity": "sha512-JUmjmrCmE1/fc4LjCQMqLfudgSl5OpUkzx7iA94b4jgeODM7zWxUoVXL7/CT7fWf47Cn+pmKjMvTCSESqZZ3mA==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0"
+        "@opentelemetry/core": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -8622,13 +8622,13 @@
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.49.1.tgz",
-      "integrity": "sha512-DNDNUWmOqtKTFJAyOyHHKotVox0NQ/09ETX8fUOeEtyNVHoGekAVtBbvIA3AtK+JflP7LC0PTjlLfruPM3Wy6w==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.50.0.tgz",
+      "integrity": "sha512-J500AczSD7xEsjXpwNzSh5HQqxW73PT3CCNsi1VEWCE+8UPgVfkHYIGRHGoch35DV+CMe1svbi7gAk3e5eCSVA==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
         "protobufjs": "^7.2.3"
       },
       "engines": {
@@ -8639,12 +8639,12 @@
       }
     },
     "node_modules/@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.49.1.tgz",
-      "integrity": "sha512-x1qB4EUC7KikUl2iNuxCkV8yRzrSXSyj4itfpIO674H7dhI7Zv37SFaOJTDN+8Z/F50gF2ISFH9CWQ4KCtGm2A==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.50.0.tgz",
+      "integrity": "sha512-hlbn3eZbhxoK79Sq1ddj1f7qcx+PzsPQC/SFpJvaWgTaqacCbqJmpzWDKfRRCAC7iGX2Hj/sgpf8vysazqyMOw==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
         "protobufjs": "^7.2.3"
       },
       "engines": {
@@ -8655,16 +8655,16 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.49.1.tgz",
-      "integrity": "sha512-Z+koA4wp9L9e3jkFacyXTGphSWTbOKjwwXMpb0CxNb0kjTHGUxhYRN8GnkLFsFo5NbZPjP07hwAqeEG/uCratQ==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.50.0.tgz",
+      "integrity": "sha512-s0sl1Yfqd5q1Kjrf6DqXPWzErL+XHhrXOfejh4Vc/SMTNqC902xDsC8JQxbjuramWt/+hibfguIvi7Ns8VLolA==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.49.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-logs": "0.49.1",
-        "@opentelemetry/sdk-metrics": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0"
+        "@opentelemetry/api-logs": "0.50.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-logs": "0.50.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -8686,11 +8686,11 @@
       "link": true
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.22.0.tgz",
-      "integrity": "sha512-qBItJm9ygg/jCB5rmivyGz1qmKZPsL/sX715JqPMFgq++Idm0x+N9sLQvWFHFt2+ZINnCSojw7FVBgFW6izcXA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.23.0.tgz",
+      "integrity": "sha512-cZ6rl8y2bdxYQ4e+zP2CQ+QmuPebaLBLO1skjFpj3eEu7zar+6hBzUP3llMOUupkQeQSwXz+4c8dZ26OhYfG/g==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0"
+        "@opentelemetry/core": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -8708,11 +8708,11 @@
       "link": true
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.22.0.tgz",
-      "integrity": "sha512-pMLgst3QIwrUfepraH5WG7xfpJ8J3CrPKrtINK0t7kBkuu96rn+HDYQ8kt3+0FXvrZI8YJE77MCQwnJWXIrgpA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.23.0.tgz",
+      "integrity": "sha512-6iArixfgIl3ZgzeltQ5jyiKbjZygM+MbM84pXi1HL0Qs4x4Ck5rM6wEtjhZffFnlDMWEkEqrnM0xF6bTfbiMAQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0"
+        "@opentelemetry/core": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -8758,12 +8758,12 @@
       "link": true
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.22.0.tgz",
-      "integrity": "sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.23.0.tgz",
+      "integrity": "sha512-iPRLfVfcEQynYGo7e4Di+ti+YQTAY0h5mQEUJcHlU9JOqpb4x965O6PZ+wMcwYVY63G96KtdS86YCM1BF1vQZg==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -8773,12 +8773,12 @@
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.49.1.tgz",
-      "integrity": "sha512-gCzYWsJE0h+3cuh3/cK+9UwlVFyHvj3PReIOCDOmdeXOp90ZjKRoDOJBc3mvk1LL6wyl1RWIivR8Rg9OToyesw==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.50.0.tgz",
+      "integrity": "sha512-PeUEupBB29p9nlPNqXoa1PUWNLsZnxG0DCDj3sHqzae+8y76B/A5hvZjg03ulWdnvBLYpnJslqzylG9E0IL87g==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -8789,12 +8789,12 @@
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.22.0.tgz",
-      "integrity": "sha512-k6iIx6H3TZ+BVMr2z8M16ri2OxWaljg5h8ihGJxi/KQWcjign6FEaEzuigXt5bK9wVEhqAcWLCfarSftaNWkkg==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.23.0.tgz",
+      "integrity": "sha512-4OkvW6+wST4h6LFG23rXSTf6nmTf201h9dzq7bE0z5R9ESEVLERZz6WXwE7PSgg1gdjlaznm1jLJf8GttypFDg==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
         "lodash.merge": "^4.6.2"
       },
       "engines": {
@@ -8805,23 +8805,23 @@
       }
     },
     "node_modules/@opentelemetry/sdk-node": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.49.1.tgz",
-      "integrity": "sha512-feBIT85ndiSHXsQ2gfGpXC/sNeX4GCHLksC4A9s/bfpUbbgbCSl0RvzZlmEpCHarNrkZMwFRi4H0xFfgvJEjrg==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.50.0.tgz",
+      "integrity": "sha512-LhIXHnvcnhRYcPwG9VG4G6lJ7x4ElYF6UYHHmXA7e4ZWzSUEFmAPfR1IBWv358aD1KwffcEBu7J6zeAR7lPZag==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.49.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-http": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.49.1",
-        "@opentelemetry/exporter-zipkin": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-logs": "0.49.1",
-        "@opentelemetry/sdk-metrics": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/sdk-trace-node": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/api-logs": "0.50.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.50.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.50.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.50.0",
+        "@opentelemetry/exporter-zipkin": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-logs": "0.50.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/sdk-trace-node": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -8831,13 +8831,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.22.0.tgz",
-      "integrity": "sha512-pfTuSIpCKONC6vkTpv6VmACxD+P1woZf4q0K46nSUvXFvOFqjBYKFaAMkKD3M1mlKUUh0Oajwj35qNjMl80m1Q==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.23.0.tgz",
+      "integrity": "sha512-PzBmZM8hBomUqvCddF/5Olyyviayka44O5nDWq673np3ctnvwMOvNrsUORZjKja1zJbwEuD9niAGbnVrz3jwRQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -8847,15 +8847,15 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.22.0.tgz",
-      "integrity": "sha512-gTGquNz7ue8uMeiWPwp3CU321OstQ84r7PCDtOaCicjbJxzvO8RZMlEC4geOipTeiF88kss5n6w+//A0MhP1lQ==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.23.0.tgz",
+      "integrity": "sha512-dwnin5Go2r6VzJZkVc9JBPupssWp7j2EFto+S7qRkwQ00WDykWeq3x2Skk7I1Jr448FeBSvGCQVPgV5e6s6O3w==",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.22.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/propagator-b3": "1.22.0",
-        "@opentelemetry/propagator-jaeger": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/context-async-hooks": "1.23.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/propagator-b3": "1.23.0",
+        "@opentelemetry/propagator-jaeger": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -8866,13 +8866,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-web": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.22.0.tgz",
-      "integrity": "sha512-id5bUhWYg475xbm4hjwWA4PnWM4duNK1EyFRkZxa3BZNuCITwiKCLvDkVhlE9RK2kvuDOPmcRxgSbU1apF9/1w==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.23.0.tgz",
+      "integrity": "sha512-tx9N3hIkd6k567BeujBnpXYdhu3ptYVk0ZkhdcjyQ3I8ZDJ+/JkVtaVNLAuf8hp1buTqNDmxSipALMxEmK2fnw==",
       "dependencies": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       },
       "engines": {
         "node": ">=14"
@@ -8882,9 +8882,9 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.22.0.tgz",
-      "integrity": "sha512-CAOgFOKLybd02uj/GhCdEeeBjOS0yeoDeo/CA7ASBSmenpZHAKGB3iDm/rv3BQLcabb/OprDEsSQ1y0P8A7Siw==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.23.0.tgz",
+      "integrity": "sha512-MiqFvfOzfR31t8cc74CTP1OZfz7MbqpAnLCra8NqQoaHJX6ncIRTdYOQYBDQ2uFISDq0WY8Y9dDTWvsgzzBYRg==",
       "engines": {
         "node": ">=14"
       }
@@ -36703,9 +36703,9 @@
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/exporter-jaeger": "^1.3.1",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/resources": "^1.8.0",
-        "@opentelemetry/sdk-node": "^0.49.1",
+        "@opentelemetry/sdk-node": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
@@ -36727,7 +36727,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.49.1",
+        "@opentelemetry/api-logs": "^0.50.0",
         "winston-transport": "4.*"
       },
       "devDependencies": {
@@ -36758,7 +36758,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "devDependencies": {
@@ -36797,7 +36797,7 @@
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "devDependencies": {
@@ -36864,7 +36864,7 @@
       "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1"
+        "@opentelemetry/instrumentation": "^0.50.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -36894,7 +36894,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "devDependencies": {
@@ -36925,7 +36925,7 @@
       "version": "0.35.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1"
+        "@opentelemetry/instrumentation": "^0.50.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -36961,7 +36961,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "devDependencies": {
@@ -36997,7 +36997,7 @@
       "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1"
+        "@opentelemetry/instrumentation": "^0.50.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37037,7 +37037,7 @@
       "version": "0.37.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "devDependencies": {
@@ -37286,7 +37286,7 @@
       "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/tedious": "^4.0.10"
       },
@@ -37317,7 +37317,7 @@
       "version": "0.39.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/propagator-aws-xray": "^1.3.1",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -37350,7 +37350,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/propagation-utils": "^0.30.7",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
@@ -37397,14 +37397,14 @@
       "version": "0.36.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.49.1",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/api-logs": "^0.50.0",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@types/bunyan": "1.8.9"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/resources": "^1.8.0",
-        "@opentelemetry/sdk-logs": "^0.49.1",
+        "@opentelemetry/sdk-logs": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -37440,7 +37440,7 @@
       "version": "0.36.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "devDependencies": {
@@ -37474,7 +37474,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/connect": "3.4.36"
       },
@@ -37512,7 +37512,7 @@
       "version": "0.34.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "semver": "^7.5.4"
       },
@@ -37546,7 +37546,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
@@ -37581,7 +37581,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "devDependencies": {
@@ -37589,7 +37589,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
-        "@opentelemetry/instrumentation-http": "^0.49.1",
+        "@opentelemetry/instrumentation-http": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/express": "4.17.18",
@@ -37629,7 +37629,7 @@
       "version": "0.34.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "devDependencies": {
@@ -37694,7 +37694,7 @@
       "version": "0.38.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1"
+        "@opentelemetry/instrumentation": "^0.50.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37729,7 +37729,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/hapi__hapi": "20.0.13"
       },
@@ -37760,7 +37760,7 @@
       "version": "0.38.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/redis-common": "^0.36.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/ioredis4": "npm:@types/ioredis@^4.28.10"
@@ -37796,7 +37796,7 @@
       "version": "0.34.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "devDependencies": {
@@ -37827,7 +37827,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/koa": "2.14.0",
         "@types/koa__router": "12.0.3"
@@ -37837,7 +37837,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
-        "@opentelemetry/instrumentation-http": "^0.49.1",
+        "@opentelemetry/instrumentation-http": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
@@ -37864,7 +37864,7 @@
       "version": "0.34.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/memcached": "^2.2.6"
       },
@@ -37896,7 +37896,7 @@
       "version": "0.41.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-metrics": "^1.9.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
@@ -38090,7 +38090,7 @@
       "version": "0.36.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mysql": "2.15.22"
       },
@@ -38123,7 +38123,7 @@
       "version": "0.36.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@opentelemetry/sql-common": "^0.40.0"
       },
@@ -38189,7 +38189,7 @@
       "version": "0.35.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "devDependencies": {
@@ -38262,7 +38262,7 @@
       "version": "0.34.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "devDependencies": {
@@ -38292,7 +38292,7 @@
       "version": "0.39.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
         "@opentelemetry/sql-common": "^0.40.0",
         "@types/pg": "8.6.1",
@@ -38331,7 +38331,7 @@
       "version": "0.36.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1"
+        "@opentelemetry/instrumentation": "^0.50.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -38398,7 +38398,7 @@
       "version": "0.37.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/redis-common": "^0.36.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
@@ -38432,7 +38432,7 @@
       "version": "0.37.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/redis-common": "^0.36.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
@@ -38481,7 +38481,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "devDependencies": {
@@ -38547,7 +38547,7 @@
       "version": "0.35.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "devDependencies": {
@@ -38576,7 +38576,7 @@
       "version": "0.35.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.49.1"
+        "@opentelemetry/instrumentation": "^0.50.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -38611,7 +38611,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-web": "^1.15.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
@@ -38652,7 +38652,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-web": "^1.8.0"
       },
       "devDependencies": {
@@ -38698,7 +38698,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-web": "^1.8.0"
       },
       "devDependencies": {
@@ -38706,7 +38706,7 @@
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-zone-peer-dep": "^1.8.0",
-        "@opentelemetry/instrumentation-xml-http-request": "^0.49.1",
+        "@opentelemetry/instrumentation-xml-http-request": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@types/jquery": "3.5.20",
         "@types/mocha": "7.0.2",
@@ -45396,9 +45396,9 @@
       "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w=="
     },
     "@opentelemetry/api-logs": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.49.1.tgz",
-      "integrity": "sha512-kaNl/T7WzyMUQHQlVq7q0oV4Kev6+0xFwqzofryC66jgGMacd0QH5TwfpbUwSTby+SdAdprAe5UKMvBw4tKS5Q==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.50.0.tgz",
+      "integrity": "sha512-JdZuKrhOYggqOpUljAq4WWNi5nB10PmgoF0y2CvedLGXd0kSawb/UBnWT8gg1ND3bHCNHStAIVT0ELlxJJRqrA==",
       "requires": {
         "@opentelemetry/api": "^1.0.0"
       }
@@ -45407,7 +45407,7 @@
       "version": "file:metapackages/auto-instrumentations-node",
       "requires": {
         "@opentelemetry/api": "^1.4.1",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/instrumentation-amqplib": "^0.35.0",
         "@opentelemetry/instrumentation-aws-lambda": "^0.39.0",
         "@opentelemetry/instrumentation-aws-sdk": "^0.39.1",
@@ -45422,9 +45422,9 @@
         "@opentelemetry/instrumentation-fs": "^0.10.0",
         "@opentelemetry/instrumentation-generic-pool": "^0.34.0",
         "@opentelemetry/instrumentation-graphql": "^0.38.1",
-        "@opentelemetry/instrumentation-grpc": "^0.49.1",
+        "@opentelemetry/instrumentation-grpc": "^0.50.0",
         "@opentelemetry/instrumentation-hapi": "^0.35.0",
-        "@opentelemetry/instrumentation-http": "^0.49.1",
+        "@opentelemetry/instrumentation-http": "^0.50.0",
         "@opentelemetry/instrumentation-ioredis": "^0.38.0",
         "@opentelemetry/instrumentation-knex": "^0.34.0",
         "@opentelemetry/instrumentation-koa": "^0.38.0",
@@ -45450,7 +45450,7 @@
         "@opentelemetry/resource-detector-container": "^0.3.7",
         "@opentelemetry/resource-detector-gcp": "^0.29.7",
         "@opentelemetry/resources": "^1.12.0",
-        "@opentelemetry/sdk-node": "^0.49.1",
+        "@opentelemetry/sdk-node": "^0.50.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.18",
@@ -45468,11 +45468,11 @@
         "@babel/core": "7.22.17",
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/instrumentation-document-load": "^0.36.0",
-        "@opentelemetry/instrumentation-fetch": "^0.49.1",
+        "@opentelemetry/instrumentation-fetch": "^0.50.0",
         "@opentelemetry/instrumentation-user-interaction": "^0.36.0",
-        "@opentelemetry/instrumentation-xml-http-request": "^0.49.1",
+        "@opentelemetry/instrumentation-xml-http-request": "^0.50.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.18",
@@ -45505,24 +45505,24 @@
       }
     },
     "@opentelemetry/context-async-hooks": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.22.0.tgz",
-      "integrity": "sha512-Nfdxyg8YtWqVWkyrCukkundAjPhUXi93JtVQmqDT1mZRVKqA7e2r7eJCrI+F651XUBMp0hsOJSGiFk3QSpaIJw==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.23.0.tgz",
+      "integrity": "sha512-wazGJZDRevibOJ+VgyrT+9+8sybZAxpZx2G7vy30OAtk92OpZCg7HgNxT11NUx0VBDWcRx1dOatMYGOVplQ7QA==",
       "requires": {}
     },
     "@opentelemetry/context-zone": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-1.22.0.tgz",
-      "integrity": "sha512-ukPkASKUt9l4P3g7Dggntb3jG3dVL4dPXfDc8FUZ6pOCiLa5NRrRPQPbDdCumytbw5Yor9paiXCg/oQgMyYMHw==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-1.23.0.tgz",
+      "integrity": "sha512-7piNTrpH+gZNMDDOHIJXCSwp0Xslh3R96HWH5HwXw+4PykR4+jVoXvd6jziQxudX9rFAfu2B64A10DHs4ZWrfA==",
       "requires": {
-        "@opentelemetry/context-zone-peer-dep": "1.22.0",
+        "@opentelemetry/context-zone-peer-dep": "1.23.0",
         "zone.js": "^0.11.0 || ^0.13.0 || ^0.14.0"
       }
     },
     "@opentelemetry/context-zone-peer-dep": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.22.0.tgz",
-      "integrity": "sha512-kQ0K6syNQQYj4Pd5Q4yiUAsuthpzWDmVPPqMUSACh9ArRYLq8ZY9JdnkqkT1RyeecpSDh5uG+x5dbx6drpJ79g==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.23.0.tgz",
+      "integrity": "sha512-3ia5w2y3CGHIhMSggttliGbeRBWclIyMMXdfRCcit1NHg1ocieA9qYxyUEetbOvPrQpoti3O3k+5eyQUv7r8nw==",
       "requires": {}
     },
     "@opentelemetry/contrib-test-utils": {
@@ -45531,9 +45531,9 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/exporter-jaeger": "^1.3.1",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/resources": "^1.8.0",
-        "@opentelemetry/sdk-node": "^0.49.1",
+        "@opentelemetry/sdk-node": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -45542,71 +45542,71 @@
       }
     },
     "@opentelemetry/core": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.22.0.tgz",
-      "integrity": "sha512-0VoAlT6x+Xzik1v9goJ3pZ2ppi6+xd3aUfg4brfrLkDBHRIVjMP0eBHrKrhB+NKcDyMAg8fAbGL3Npg/F6AwWA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.23.0.tgz",
+      "integrity": "sha512-hdQ/a9TMzMQF/BO8Cz1juA43/L5YGtCSiKoOHmrTEf7VMDAZgy8ucpWx3eQTnQ3gBloRcWtzvcrMZABC3PTSKQ==",
       "requires": {
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/semantic-conventions": "1.23.0"
       }
     },
     "@opentelemetry/exporter-jaeger": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.22.0.tgz",
-      "integrity": "sha512-8kDUmx0nMgh+kLPi9hpQFS/bT0nrLYXKGoXTjsCQ24lbIEOanWAyA/lQFFu1Y/mZKsws/h3fBb1b9JSicNCWBw==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.23.0.tgz",
+      "integrity": "sha512-9GjZPS9kR4nC0ApOFQtj2xwYAGhQ3bO6KPx27DLqCOiso27OlJVUgvAtB3i+1On23OTcjfPtKbNo4a2npmV27A==",
       "requires": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "jaeger-client": "^3.15.0"
       }
     },
     "@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.49.1.tgz",
-      "integrity": "sha512-Zbd7f3zF7fI2587MVhBizaW21cO/SordyrZGtMtvhoxU6n4Qb02Gx71X4+PzXH620e0+JX+Pcr9bYb1HTeVyJA==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.50.0.tgz",
+      "integrity": "sha512-w/NF4TrwHxx+Uz1M0rCOSVr6KgcoQPv3zF9JRqcebY2euD7ddWnLP0hE8JavyA1uq4UchnMp9faAk9n7hTCePw==",
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
       }
     },
     "@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.49.1.tgz",
-      "integrity": "sha512-KOLtZfZvIrpGZLVvblKsiVQT7gQUZNKcUUH24Zz6Xbi7LJb9Vt6xtUZFYdR5IIjvt47PIqBKDWUQlU0o1wAsRw==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.50.0.tgz",
+      "integrity": "sha512-L7OtIMT7MsFqkmhbQlPBGRXt7152VN5esHpQEJYIBFedOEo3Da+yHpu5ojMZtPzpIvSpB5Xr5lnJUjJCbkttCA==",
       "requires": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
       }
     },
     "@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.49.1.tgz",
-      "integrity": "sha512-n8ON/c9pdMyYAfSFWKkgsPwjYoxnki+6Olzo+klKfW7KqLWoyEkryNkbcMIYnGGNXwdkMIrjoaP0VxXB26Oxcg==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.50.0.tgz",
+      "integrity": "sha512-vavD9Ow6yOLiD+ocuS/oeciCsXNdsN41aYUrEljNaLXogvnkfMhJ+JLAhOnRSpzlVtRp7Ciw2BYGdYSebR0OsA==",
       "requires": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-proto-exporter-base": "0.49.1",
-        "@opentelemetry/otlp-transformer": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.50.0",
+        "@opentelemetry/otlp-transformer": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
       }
     },
     "@opentelemetry/exporter-zipkin": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.22.0.tgz",
-      "integrity": "sha512-XcFs6rGvcTz0qW5uY7JZDYD0yNEXdekXAb6sFtnZgY/cHY6BQ09HMzOjv9SX+iaXplRDcHr1Gta7VQKM1XXM6g==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.23.0.tgz",
+      "integrity": "sha512-2LOGvNUGONuIcWhynFaJorVyqv03uZkURScciLmOxvBf2lWTNPEj77br1dCpShIWBM+YlrH7Tc+JXAs+GC7DqA==",
       "requires": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       }
     },
     "@opentelemetry/host-metrics": {
@@ -45669,11 +45669,11 @@
       }
     },
     "@opentelemetry/instrumentation": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.49.1.tgz",
-      "integrity": "sha512-0DLtWtaIppuNNRRllSD4bjU8ZIiLp1cDXvJEbp752/Zf+y3gaLNaoGRGIlX4UHhcsrmtL+P2qxi3Hodi8VuKiQ==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.50.0.tgz",
+      "integrity": "sha512-bhGhbJiZKpuu7wTaSak4hyZcFPlnDeuSF/2vglze8B4w2LubcSbbOnkVTzTs5SXtzh4Xz8eRjaNnAm+u2GYufQ==",
       "requires": {
-        "@opentelemetry/api-logs": "0.49.1",
+        "@opentelemetry/api-logs": "0.50.0",
         "@types/shimmer": "^1.0.2",
         "import-in-the-middle": "1.7.1",
         "require-in-the-middle": "^7.1.1",
@@ -45687,7 +45687,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/amqplib": "^0.5.17",
         "@types/lodash": "4.14.199",
@@ -45718,7 +45718,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/propagator-aws-xray": "^1.3.1",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/sdk-metrics": "^1.8.0",
@@ -45747,7 +45747,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/propagation-utils": "^0.30.7",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -45779,10 +45779,10 @@
       "version": "file:plugins/node/opentelemetry-instrumentation-bunyan",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/api-logs": "^0.49.1",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/api-logs": "^0.50.0",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/resources": "^1.8.0",
-        "@opentelemetry/sdk-logs": "^0.49.1",
+        "@opentelemetry/sdk-logs": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -45816,7 +45816,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -45839,7 +45839,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -45870,7 +45870,7 @@
         "@cucumber/cucumber": "^9.0.0",
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/core": "^1.3.1",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.3.1",
         "@opentelemetry/sdk-trace-node": "^1.3.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -45919,7 +45919,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
@@ -45938,7 +45938,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -45963,7 +45963,7 @@
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-web": "^1.15.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -45996,7 +45996,7 @@
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -46022,8 +46022,8 @@
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
-        "@opentelemetry/instrumentation-http": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
+        "@opentelemetry/instrumentation-http": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -46056,14 +46056,14 @@
       }
     },
     "@opentelemetry/instrumentation-fetch": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.49.1.tgz",
-      "integrity": "sha512-hizhULZXlq02y8YC0vPQ4WtUWiXcwxPdEqHBy8p75jzF9rAuP/ldrVr0Oxvz5Xr9qQcdEOFLvEl0ZxbVL76WKw==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.50.0.tgz",
+      "integrity": "sha512-CayteluGJbrfDvzEFQ0EWqLFkNAcO9H7nfDHptZjtonBpJRWF170XZoMkJVC2bxp0lIVwyuw6WlnGVRSNwEtKA==",
       "requires": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/sdk-trace-web": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/sdk-trace-web": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       }
     },
     "@opentelemetry/instrumentation-fs": {
@@ -46072,7 +46072,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
@@ -46093,7 +46093,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -46140,7 +46140,7 @@
       "version": "file:plugins/node/opentelemetry-instrumentation-graphql",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.3.1",
         "@types/mocha": "8.2.3",
@@ -46163,12 +46163,12 @@
       }
     },
     "@opentelemetry/instrumentation-grpc": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.49.1.tgz",
-      "integrity": "sha512-f8mQjFi5/PiP4SK3VDU1/3sUUgs6exMtBgcnNycgCKgN40htiPT+MuDRwdRnRMNI/4vNQ7p1/5r4Q5oN0GuRBw==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.50.0.tgz",
+      "integrity": "sha512-/ZFuvHtrHyxfRJX5CJ8yPKokAIcvTbIJAoR4AN+gBq1YqecWuCr4XG52p5YU5qDrbwOBtShOrC8d4GdFZOky6Q==",
       "requires": {
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       }
     },
     "@opentelemetry/instrumentation-hapi": {
@@ -46178,7 +46178,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -46194,13 +46194,13 @@
       }
     },
     "@opentelemetry/instrumentation-http": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.49.1.tgz",
-      "integrity": "sha512-Yib5zrW2s0V8wTeUK/B3ZtpyP4ldgXj9L3Ws/axXrW1dW0/mEFKifK50MxMQK9g5NNJQS9dWH7rvcEGZdWdQDA==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.50.0.tgz",
+      "integrity": "sha512-bsd6Nv0FtN9C6M6vX/kgPzvJY9UhJc4CZZNvqDbsfVQv3/MWvPrYgthf41AhrehqeDnpfn/QGzNKtdWUduGanQ==",
       "requires": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/semantic-conventions": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/semantic-conventions": "1.23.0",
         "semver": "^7.5.2"
       }
     },
@@ -46210,7 +46210,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/redis-common": "^0.36.1",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
@@ -46235,7 +46235,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -46258,8 +46258,8 @@
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
-        "@opentelemetry/instrumentation-http": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
+        "@opentelemetry/instrumentation-http": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -46285,7 +46285,7 @@
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-web": "^1.8.0",
         "@types/jquery": "3.5.20",
@@ -46319,7 +46319,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@types/lru-cache": "7.10.9",
         "@types/mocha": "8.2.3",
         "@types/node": "18.6.5",
@@ -46347,7 +46347,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -46369,7 +46369,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-metrics": "^1.9.1",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
@@ -46499,7 +46499,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mocha": "8.2.3",
@@ -46528,7 +46528,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-metrics": "^1.8.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -46551,7 +46551,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@opentelemetry/sql-common": "^0.40.0",
@@ -46604,7 +46604,7 @@
         "@nestjs/websockets": "9.4.3",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -46655,7 +46655,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -46676,7 +46676,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -46705,7 +46705,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
@@ -46755,7 +46755,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/redis-common": "^0.36.1",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
@@ -46780,7 +46780,7 @@
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/redis-common": "^0.36.1",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
@@ -46819,7 +46819,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -46868,7 +46868,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -46886,7 +46886,7 @@
       "version": "file:plugins/node/instrumentation-runtime-node",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-metrics": "^1.20.0",
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.11.2",
@@ -46919,7 +46919,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mocha": "8.2.3",
@@ -47112,7 +47112,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mocha": "7.0.2",
@@ -47135,8 +47135,8 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-zone-peer-dep": "^1.8.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
-        "@opentelemetry/instrumentation-xml-http-request": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
+        "@opentelemetry/instrumentation-xml-http-request": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-web": "^1.8.0",
         "@types/jquery": "3.5.20",
@@ -47170,7 +47170,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.21.0",
-        "@opentelemetry/instrumentation": "^0.49.1",
+        "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.21.0",
         "@opentelemetry/sdk-trace-node": "^1.21.0",
         "@opentelemetry/winston-transport": "^0.1.0",
@@ -47190,56 +47190,56 @@
       }
     },
     "@opentelemetry/instrumentation-xml-http-request": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.49.1.tgz",
-      "integrity": "sha512-gCPd2o1geRXc1urJoLxWRnMKAF6Akbwlp1nfe+xg2akSUenlt4wopmq1gEIrJva4bXLsNSModVLrEVCTt5/fDA==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.50.0.tgz",
+      "integrity": "sha512-o9z6SDQByqc3GvmUcy6Npt/SAIrv2Pk0Hm0Hl54B3Ny8WUrTsrlt6MULx8d+EjuifE4uVo8op8DekmvKJ1FHoQ==",
       "requires": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/sdk-trace-web": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/sdk-trace-web": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       }
     },
     "@opentelemetry/otlp-exporter-base": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.49.1.tgz",
-      "integrity": "sha512-z6sHliPqDgJU45kQatAettY9/eVF58qVPaTuejw9YWfSRqid9pXPYeegDCSdyS47KAUgAtm+nC28K3pfF27HWg==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.50.0.tgz",
+      "integrity": "sha512-JUmjmrCmE1/fc4LjCQMqLfudgSl5OpUkzx7iA94b4jgeODM7zWxUoVXL7/CT7fWf47Cn+pmKjMvTCSESqZZ3mA==",
       "requires": {
-        "@opentelemetry/core": "1.22.0"
+        "@opentelemetry/core": "1.23.0"
       }
     },
     "@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.49.1.tgz",
-      "integrity": "sha512-DNDNUWmOqtKTFJAyOyHHKotVox0NQ/09ETX8fUOeEtyNVHoGekAVtBbvIA3AtK+JflP7LC0PTjlLfruPM3Wy6w==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.50.0.tgz",
+      "integrity": "sha512-J500AczSD7xEsjXpwNzSh5HQqxW73PT3CCNsi1VEWCE+8UPgVfkHYIGRHGoch35DV+CMe1svbi7gAk3e5eCSVA==",
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
         "protobufjs": "^7.2.3"
       }
     },
     "@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.49.1.tgz",
-      "integrity": "sha512-x1qB4EUC7KikUl2iNuxCkV8yRzrSXSyj4itfpIO674H7dhI7Zv37SFaOJTDN+8Z/F50gF2ISFH9CWQ4KCtGm2A==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.50.0.tgz",
+      "integrity": "sha512-hlbn3eZbhxoK79Sq1ddj1f7qcx+PzsPQC/SFpJvaWgTaqacCbqJmpzWDKfRRCAC7iGX2Hj/sgpf8vysazqyMOw==",
       "requires": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/otlp-exporter-base": "0.49.1",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/otlp-exporter-base": "0.50.0",
         "protobufjs": "^7.2.3"
       }
     },
     "@opentelemetry/otlp-transformer": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.49.1.tgz",
-      "integrity": "sha512-Z+koA4wp9L9e3jkFacyXTGphSWTbOKjwwXMpb0CxNb0kjTHGUxhYRN8GnkLFsFo5NbZPjP07hwAqeEG/uCratQ==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.50.0.tgz",
+      "integrity": "sha512-s0sl1Yfqd5q1Kjrf6DqXPWzErL+XHhrXOfejh4Vc/SMTNqC902xDsC8JQxbjuramWt/+hibfguIvi7Ns8VLolA==",
       "requires": {
-        "@opentelemetry/api-logs": "0.49.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-logs": "0.49.1",
-        "@opentelemetry/sdk-metrics": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0"
+        "@opentelemetry/api-logs": "0.50.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-logs": "0.50.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0"
       }
     },
     "@opentelemetry/plugin-react-load": {
@@ -47341,11 +47341,11 @@
       }
     },
     "@opentelemetry/propagator-b3": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.22.0.tgz",
-      "integrity": "sha512-qBItJm9ygg/jCB5rmivyGz1qmKZPsL/sX715JqPMFgq++Idm0x+N9sLQvWFHFt2+ZINnCSojw7FVBgFW6izcXA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.23.0.tgz",
+      "integrity": "sha512-cZ6rl8y2bdxYQ4e+zP2CQ+QmuPebaLBLO1skjFpj3eEu7zar+6hBzUP3llMOUupkQeQSwXz+4c8dZ26OhYfG/g==",
       "requires": {
-        "@opentelemetry/core": "1.22.0"
+        "@opentelemetry/core": "1.23.0"
       }
     },
     "@opentelemetry/propagator-grpc-census-binary": {
@@ -47535,11 +47535,11 @@
       }
     },
     "@opentelemetry/propagator-jaeger": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.22.0.tgz",
-      "integrity": "sha512-pMLgst3QIwrUfepraH5WG7xfpJ8J3CrPKrtINK0t7kBkuu96rn+HDYQ8kt3+0FXvrZI8YJE77MCQwnJWXIrgpA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.23.0.tgz",
+      "integrity": "sha512-6iArixfgIl3ZgzeltQ5jyiKbjZygM+MbM84pXi1HL0Qs4x4Ck5rM6wEtjhZffFnlDMWEkEqrnM0xF6bTfbiMAQ==",
       "requires": {
-        "@opentelemetry/core": "1.22.0"
+        "@opentelemetry/core": "1.23.0"
       }
     },
     "@opentelemetry/propagator-ot-trace": {
@@ -47758,7 +47758,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.37.0",
         "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/sdk-node": "^0.49.1",
+        "@opentelemetry/sdk-node": "^0.50.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.6.5",
@@ -47780,90 +47780,90 @@
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.22.0.tgz",
-      "integrity": "sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.23.0.tgz",
+      "integrity": "sha512-iPRLfVfcEQynYGo7e4Di+ti+YQTAY0h5mQEUJcHlU9JOqpb4x965O6PZ+wMcwYVY63G96KtdS86YCM1BF1vQZg==",
       "requires": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       }
     },
     "@opentelemetry/sdk-logs": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.49.1.tgz",
-      "integrity": "sha512-gCzYWsJE0h+3cuh3/cK+9UwlVFyHvj3PReIOCDOmdeXOp90ZjKRoDOJBc3mvk1LL6wyl1RWIivR8Rg9OToyesw==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.50.0.tgz",
+      "integrity": "sha512-PeUEupBB29p9nlPNqXoa1PUWNLsZnxG0DCDj3sHqzae+8y76B/A5hvZjg03ulWdnvBLYpnJslqzylG9E0IL87g==",
       "requires": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0"
       }
     },
     "@opentelemetry/sdk-metrics": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.22.0.tgz",
-      "integrity": "sha512-k6iIx6H3TZ+BVMr2z8M16ri2OxWaljg5h8ihGJxi/KQWcjign6FEaEzuigXt5bK9wVEhqAcWLCfarSftaNWkkg==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.23.0.tgz",
+      "integrity": "sha512-4OkvW6+wST4h6LFG23rXSTf6nmTf201h9dzq7bE0z5R9ESEVLERZz6WXwE7PSgg1gdjlaznm1jLJf8GttypFDg==",
       "requires": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
         "lodash.merge": "^4.6.2"
       }
     },
     "@opentelemetry/sdk-node": {
-      "version": "0.49.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.49.1.tgz",
-      "integrity": "sha512-feBIT85ndiSHXsQ2gfGpXC/sNeX4GCHLksC4A9s/bfpUbbgbCSl0RvzZlmEpCHarNrkZMwFRi4H0xFfgvJEjrg==",
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.50.0.tgz",
+      "integrity": "sha512-LhIXHnvcnhRYcPwG9VG4G6lJ7x4ElYF6UYHHmXA7e4ZWzSUEFmAPfR1IBWv358aD1KwffcEBu7J6zeAR7lPZag==",
       "requires": {
-        "@opentelemetry/api-logs": "0.49.1",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-http": "0.49.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.49.1",
-        "@opentelemetry/exporter-zipkin": "1.22.0",
-        "@opentelemetry/instrumentation": "0.49.1",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/sdk-logs": "0.49.1",
-        "@opentelemetry/sdk-metrics": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/sdk-trace-node": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/api-logs": "0.50.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.50.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.50.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.50.0",
+        "@opentelemetry/exporter-zipkin": "1.23.0",
+        "@opentelemetry/instrumentation": "0.50.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/sdk-logs": "0.50.0",
+        "@opentelemetry/sdk-metrics": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/sdk-trace-node": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       }
     },
     "@opentelemetry/sdk-trace-base": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.22.0.tgz",
-      "integrity": "sha512-pfTuSIpCKONC6vkTpv6VmACxD+P1woZf4q0K46nSUvXFvOFqjBYKFaAMkKD3M1mlKUUh0Oajwj35qNjMl80m1Q==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.23.0.tgz",
+      "integrity": "sha512-PzBmZM8hBomUqvCddF/5Olyyviayka44O5nDWq673np3ctnvwMOvNrsUORZjKja1zJbwEuD9niAGbnVrz3jwRQ==",
       "requires": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/resources": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/resources": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       }
     },
     "@opentelemetry/sdk-trace-node": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.22.0.tgz",
-      "integrity": "sha512-gTGquNz7ue8uMeiWPwp3CU321OstQ84r7PCDtOaCicjbJxzvO8RZMlEC4geOipTeiF88kss5n6w+//A0MhP1lQ==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.23.0.tgz",
+      "integrity": "sha512-dwnin5Go2r6VzJZkVc9JBPupssWp7j2EFto+S7qRkwQ00WDykWeq3x2Skk7I1Jr448FeBSvGCQVPgV5e6s6O3w==",
       "requires": {
-        "@opentelemetry/context-async-hooks": "1.22.0",
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/propagator-b3": "1.22.0",
-        "@opentelemetry/propagator-jaeger": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
+        "@opentelemetry/context-async-hooks": "1.23.0",
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/propagator-b3": "1.23.0",
+        "@opentelemetry/propagator-jaeger": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
         "semver": "^7.5.2"
       }
     },
     "@opentelemetry/sdk-trace-web": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.22.0.tgz",
-      "integrity": "sha512-id5bUhWYg475xbm4hjwWA4PnWM4duNK1EyFRkZxa3BZNuCITwiKCLvDkVhlE9RK2kvuDOPmcRxgSbU1apF9/1w==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.23.0.tgz",
+      "integrity": "sha512-tx9N3hIkd6k567BeujBnpXYdhu3ptYVk0ZkhdcjyQ3I8ZDJ+/JkVtaVNLAuf8hp1buTqNDmxSipALMxEmK2fnw==",
       "requires": {
-        "@opentelemetry/core": "1.22.0",
-        "@opentelemetry/sdk-trace-base": "1.22.0",
-        "@opentelemetry/semantic-conventions": "1.22.0"
+        "@opentelemetry/core": "1.23.0",
+        "@opentelemetry/sdk-trace-base": "1.23.0",
+        "@opentelemetry/semantic-conventions": "1.23.0"
       }
     },
     "@opentelemetry/semantic-conventions": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.22.0.tgz",
-      "integrity": "sha512-CAOgFOKLybd02uj/GhCdEeeBjOS0yeoDeo/CA7ASBSmenpZHAKGB3iDm/rv3BQLcabb/OprDEsSQ1y0P8A7Siw=="
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.23.0.tgz",
+      "integrity": "sha512-MiqFvfOzfR31t8cc74CTP1OZfz7MbqpAnLCra8NqQoaHJX6ncIRTdYOQYBDQ2uFISDq0WY8Y9dDTWvsgzzBYRg=="
     },
     "@opentelemetry/sql-common": {
       "version": "file:packages/opentelemetry-sql-common",
@@ -47881,7 +47881,7 @@
     "@opentelemetry/winston-transport": {
       "version": "file:packages/winston-transport",
       "requires": {
-        "@opentelemetry/api-logs": "^0.49.1",
+        "@opentelemetry/api-logs": "^0.50.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.18",

--- a/packages/opentelemetry-test-utils/package.json
+++ b/packages/opentelemetry-test-utils/package.json
@@ -46,9 +46,9 @@
   "dependencies": {
     "@opentelemetry/core": "^1.0.0",
     "@opentelemetry/exporter-jaeger": "^1.3.1",
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/resources": "^1.8.0",
-    "@opentelemetry/sdk-node": "^0.49.1",
+    "@opentelemetry/sdk-node": "^0.50.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@opentelemetry/semantic-conventions": "^1.0.0"

--- a/packages/winston-transport/package.json
+++ b/packages/winston-transport/package.json
@@ -50,8 +50,8 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "^0.49.1",
-    "winston-transport" : "4.*"
+    "@opentelemetry/api-logs": "^0.50.0",
+    "winston-transport": "4.*"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/winston-transport#readme"
 }

--- a/plugins/node/instrumentation-amqplib/package.json
+++ b/plugins/node/instrumentation-amqplib/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "devDependencies": {

--- a/plugins/node/instrumentation-cucumber/package.json
+++ b/plugins/node/instrumentation-cucumber/package.json
@@ -62,7 +62,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-cucumber#readme"

--- a/plugins/node/instrumentation-dataloader/package.json
+++ b/plugins/node/instrumentation-dataloader/package.json
@@ -58,7 +58,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1"
+    "@opentelemetry/instrumentation": "^0.50.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-dataloader#readme"
 }

--- a/plugins/node/instrumentation-fs/package.json
+++ b/plugins/node/instrumentation-fs/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-fs#readme"

--- a/plugins/node/instrumentation-lru-memoizer/package.json
+++ b/plugins/node/instrumentation-lru-memoizer/package.json
@@ -57,7 +57,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1"
+    "@opentelemetry/instrumentation": "^0.50.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-lru-memoizer#readme"
 }

--- a/plugins/node/instrumentation-mongoose/package.json
+++ b/plugins/node/instrumentation-mongoose/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-mongoose#readme"

--- a/plugins/node/instrumentation-runtime-node/package.json
+++ b/plugins/node/instrumentation-runtime-node/package.json
@@ -39,7 +39,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1"
+    "@opentelemetry/instrumentation": "^0.50.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",

--- a/plugins/node/instrumentation-socket.io/package.json
+++ b/plugins/node/instrumentation-socket.io/package.json
@@ -58,7 +58,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-socket.io#readme"

--- a/plugins/node/instrumentation-tedious/package.json
+++ b/plugins/node/instrumentation-tedious/package.json
@@ -62,7 +62,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "@types/tedious": "^4.0.10"
   },

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
@@ -56,7 +56,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/propagator-aws-xray": "^1.3.1",
     "@opentelemetry/resources": "^1.8.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/propagation-utils": "^0.30.7",
     "@opentelemetry/semantic-conventions": "^1.0.0"
   },

--- a/plugins/node/opentelemetry-instrumentation-bunyan/package.json
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/resources": "^1.8.0",
-    "@opentelemetry/sdk-logs": "^0.49.1",
+    "@opentelemetry/sdk-logs": "^0.50.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
@@ -63,8 +63,8 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "^0.49.1",
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/api-logs": "^0.50.0",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@types/bunyan": "1.8.9"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-bunyan#readme"

--- a/plugins/node/opentelemetry-instrumentation-cassandra/package.json
+++ b/plugins/node/opentelemetry-instrumentation-cassandra/package.json
@@ -61,7 +61,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-cassandra#readme"

--- a/plugins/node/opentelemetry-instrumentation-connect/package.json
+++ b/plugins/node/opentelemetry-instrumentation-connect/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "@types/connect": "3.4.36"
   },

--- a/plugins/node/opentelemetry-instrumentation-dns/package.json
+++ b/plugins/node/opentelemetry-instrumentation-dns/package.json
@@ -59,7 +59,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "semver": "^7.5.4"
   },

--- a/plugins/node/opentelemetry-instrumentation-express/package.json
+++ b/plugins/node/opentelemetry-instrumentation-express/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-express#readme"

--- a/plugins/node/opentelemetry-instrumentation-fastify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-fastify/package.json
@@ -47,7 +47,7 @@
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/context-async-hooks": "^1.8.0",
     "@opentelemetry/contrib-test-utils": "^0.37.0",
-    "@opentelemetry/instrumentation-http": "^0.49.1",
+    "@opentelemetry/instrumentation-http": "^0.50.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/express": "4.17.18",
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-fastify#readme"

--- a/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
+++ b/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
@@ -59,7 +59,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-generic-pool#readme"

--- a/plugins/node/opentelemetry-instrumentation-graphql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-graphql/package.json
@@ -58,7 +58,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1"
+    "@opentelemetry/instrumentation": "^0.50.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-graphql#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-hapi/package.json
+++ b/plugins/node/opentelemetry-instrumentation-hapi/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "@types/hapi__hapi": "20.0.13"
   },

--- a/plugins/node/opentelemetry-instrumentation-ioredis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/package.json
@@ -66,7 +66,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/redis-common": "^0.36.1",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "@types/ioredis4": "npm:@types/ioredis@^4.28.10"

--- a/plugins/node/opentelemetry-instrumentation-knex/package.json
+++ b/plugins/node/opentelemetry-instrumentation-knex/package.json
@@ -57,7 +57,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-knex#readme"

--- a/plugins/node/opentelemetry-instrumentation-koa/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/package.json
@@ -49,7 +49,7 @@
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/context-async-hooks": "^1.8.0",
     "@opentelemetry/contrib-test-utils": "^0.37.0",
-    "@opentelemetry/instrumentation-http": "^0.49.1",
+    "@opentelemetry/instrumentation-http": "^0.50.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/mocha": "7.0.2",
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/semantic-conventions": "^1.22.0",
     "@types/koa": "2.14.0",
     "@types/koa__router": "12.0.3"

--- a/plugins/node/opentelemetry-instrumentation-memcached/package.json
+++ b/plugins/node/opentelemetry-instrumentation-memcached/package.json
@@ -60,7 +60,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "@types/memcached": "^2.2.6"
   },

--- a/plugins/node/opentelemetry-instrumentation-mongodb/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/package.json
@@ -66,7 +66,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/sdk-metrics": "^1.9.1",
     "@opentelemetry/semantic-conventions": "^1.0.0"
   },

--- a/plugins/node/opentelemetry-instrumentation-mysql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql/package.json
@@ -59,7 +59,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "@types/mysql": "2.15.22"
   },

--- a/plugins/node/opentelemetry-instrumentation-mysql2/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/package.json
@@ -61,7 +61,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/semantic-conventions": "^1.0.0",
     "@opentelemetry/sql-common": "^0.40.0"
   },

--- a/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
+++ b/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
@@ -70,7 +70,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-nestjs-core#readme"

--- a/plugins/node/opentelemetry-instrumentation-net/package.json
+++ b/plugins/node/opentelemetry-instrumentation-net/package.json
@@ -58,7 +58,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-net#readme"

--- a/plugins/node/opentelemetry-instrumentation-pg/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pg/package.json
@@ -71,7 +71,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/semantic-conventions": "^1.22.0",
     "@opentelemetry/sql-common": "^0.40.0",
     "@types/pg": "8.6.1",

--- a/plugins/node/opentelemetry-instrumentation-pino/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pino/package.json
@@ -64,7 +64,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1"
+    "@opentelemetry/instrumentation": "^0.50.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-pino#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-redis-4/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis-4/package.json
@@ -66,7 +66,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/redis-common": "^0.36.1",
     "@opentelemetry/semantic-conventions": "^1.0.0"
   },

--- a/plugins/node/opentelemetry-instrumentation-redis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis/package.json
@@ -66,7 +66,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/redis-common": "^0.36.1",
     "@opentelemetry/semantic-conventions": "^1.0.0"
   },

--- a/plugins/node/opentelemetry-instrumentation-restify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-restify/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-restify#readme"

--- a/plugins/node/opentelemetry-instrumentation-router/package.json
+++ b/plugins/node/opentelemetry-instrumentation-router/package.json
@@ -56,7 +56,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/semantic-conventions": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-router#readme"

--- a/plugins/node/opentelemetry-instrumentation-winston/package.json
+++ b/plugins/node/opentelemetry-instrumentation-winston/package.json
@@ -64,7 +64,7 @@
     "winston2": "npm:winston@2.4.7"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.49.1"
+    "@opentelemetry/instrumentation": "^0.50.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-winston#readme"
 }

--- a/plugins/web/opentelemetry-instrumentation-document-load/package.json
+++ b/plugins/web/opentelemetry-instrumentation-document-load/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/sdk-trace-base": "^1.0.0",
     "@opentelemetry/sdk-trace-web": "^1.15.0",
     "@opentelemetry/semantic-conventions": "^1.22.0"

--- a/plugins/web/opentelemetry-instrumentation-long-task/package.json
+++ b/plugins/web/opentelemetry-instrumentation-long-task/package.json
@@ -79,7 +79,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/sdk-trace-web": "^1.8.0"
   },
   "peerDependencies": {

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
@@ -52,7 +52,7 @@
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/context-zone-peer-dep": "^1.8.0",
-    "@opentelemetry/instrumentation-xml-http-request": "^0.49.1",
+    "@opentelemetry/instrumentation-xml-http-request": "^0.50.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@types/jquery": "3.5.20",
     "@types/mocha": "7.0.2",
@@ -81,7 +81,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.49.1",
+    "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/sdk-trace-web": "^1.8.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This PR updates core dependencies to [v0.50.0](https://github.com/open-telemetry/opentelemetry-js/releases/tag/experimental%2Fv0.50.0).
