### PR TITLE
chore(test-utils): update semantic resource attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36772,7 +36772,7 @@
         "@opentelemetry/sdk-node": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -45796,7 +45796,7 @@
         "@opentelemetry/sdk-node": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/node": "18.6.5",
         "typescript": "4.4.4"
       }

--- a/packages/opentelemetry-test-utils/README.md
+++ b/packages/opentelemetry-test-utils/README.md
@@ -69,37 +69,37 @@ That's it - supper short and easy.
 
 This package uses `@opentelemetry/semantic-conventions` version `1.22+`, which implements Semantic Convention [Version 1.7.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/semantic_conventions/README.md)
 
-| Attributes              | Description                                                                                   | Notes                                     |
-| ------------------------| --------------------------------------------------------------------------------------------- | ----------------------------------------- |
-| cloud.account.id        | The cloud account ID the resource is assigned to.                                             | Key: `SEMRESATTRS_CLOUD_ACCOUNT_ID`       |
-| cloud.availability_zone | Availability zone represents the zone where the resource is running.                          | Key: `SEMRESATTRS_CLOUD_AVAILABILITY_ZONE`|
-| cloud.provider          | Name of the cloud provider.                                                                   | Key: `SEMRESATTRS_CLOUD_PROVIDER`         |
-| cloud.region            | The geographical region the resource is running.                                              | Key: `SEMRESATTRS_CLOUD_REGION`           |
-| container.id            | Container ID. Usually a UUID.                                                                 | Key: `SEMRESATTRS_CONTAINER_ID`           |
-| container.image.name    | Name of the image the container was built on.                                                 | Key: `SEMRESATTRS_CONTAINER_IMAGE_NAME`   |
-| container.image.tag     | Container image tag.                                                                          | Key: `SEMRESATTRS_CONTAINER_IMAGE_TAG`    |
-| container.name          | Container name.                                                                               | Key: `SEMRESATTRS_CONTAINER_NAME`         |
-| host.id                 | Unique host ID.                                                                               | Key: `SEMRESATTRS_HOST_ID`                |
-| host.image.id           | VM image ID.                                                                                  | Key: `SEMRESATTRS_HOST_IMAGE_ID`          |
-| host.image.name         | Name of the VM image or OS install the host was instantiated from.                            | Key: `SEMRESATTRS_HOST_IMAGE_NAME`        |
-| host.image.version      | The version string of the VM image.                                                           | Key: `SEMRESATTRS_HOST_IMAGE_VERSION`     |
-| host.name               | Name of the host.                                                                             | Key: `SEMRESATTRS_HOST_NAME`              |
-| host.type               | Type of host.                                                                                 | Key: `SEMRESATTRS_HOST_TYPE`              |
-| k8s.cluster.name        | The name of the cluster.                                                                      | Key: `SEMRESATTRS_K8S_CLUSTER_NAME`       |
-| k8s.deployment.name     | The name of the Deployment.                                                                   | Key: `SEMRESATTRS_K8S_DEPLOYMENT_NAME`    |
-| k8s.namespace.name      | The name of the namespace that the pod is running in.                                         | Key: `SEMRESATTRS_K8S_NAMESPACE_NAME`     |
-| k8s.pod.name            | The name of the Pod.                                                                          | Key: `SEMRESATTRS_K8S_POD_NAME`           |
-| process.command         | The command used to launch the process (i.e. the command name).                               | Key: `SEMRESATTRS_PROCESS_COMMAND`        |
-| process.command_line    | The full command used to launch the process as a single string representing the full command. | Key: `SEMRESATTRS_PROCESS_COMMAND_LINE`   |
-| process.executable.name | The name of the process executable.                                                           | Key: `SEMRESATTRS_PROCESS_EXECUTABLE_NAME`|
-| process.pid             | Process identifier (PID).                                                                     | Key: `SEMRESATTRS_PROCESS_PID`            |
-| service.instance.id     | The string ID of the service instance.                                                        | Key: `SEMRESATTRS_SERVICE_INSTANCE_ID`    |
-| service.name            | Logical name of the service.                                                                  | Key: `SEMRESATTRS_SERVICE_NAME`           |
-| service.namespace       | A namespace for `service.name`.                                                               | Key: `SEMRESATTRS_SERVICE_NAMESPACE`      |
-| service.version         | The version string of the service API or implementation.                                      | Key: `SEMRESATTRS_SERVICE_VERSION`        |
-| telemetry.sdk.language  | The language of the telemetry SDK.                                                            | Key: `SEMRESATTRS_TELEMETRY_SDK_LANGUAGE` |
-| telemetry.sdk.name      | The name of the telemetry SDK.                                                                | Key: `SEMRESATTRS_TELEMETRY_SDK_NAME`     |
-| telemetry.sdk.version   | The version string of the telemetry SDK.                                                      | Key: `SEMRESATTRS_TELEMETRY_SDK_VERSION`  |
+| Attributes              | Description                                                                                   |
+| ------------------------| --------------------------------------------------------------------------------------------- |
+| cloud.account.id        | The cloud account ID the resource is assigned to.                                             |
+| cloud.availability_zone | Availability zone represents the zone where the resource is running.                          |
+| cloud.provider          | Name of the cloud provider.                                                                   |
+| cloud.region            | The geographical region the resource is running.                                              |
+| container.id            | Container ID. Usually a UUID.                                                                 |
+| container.image.name    | Name of the image the container was built on.                                                 |
+| container.image.tag     | Container image tag.                                                                          |
+| container.name          | Container name.                                                                               |
+| host.id                 | Unique host ID.                                                                               |
+| host.image.id           | VM image ID.                                                                                  |
+| host.image.name         | Name of the VM image or OS install the host was instantiated from.                            |
+| host.image.version      | The version string of the VM image.                                                           |
+| host.name               | Name of the host.                                                                             |
+| host.type               | Type of host.                                                                                 |
+| k8s.cluster.name        | The name of the cluster.                                                                      |
+| k8s.deployment.name     | The name of the Deployment.                                                                   |
+| k8s.namespace.name      | The name of the namespace that the pod is running in.                                         |
+| k8s.pod.name            | The name of the Pod.                                                                          |
+| process.command         | The command used to launch the process (i.e. the command name).                               |
+| process.command_line    | The full command used to launch the process as a single string representing the full command. |
+| process.executable.name | The name of the process executable.                                                           |
+| process.pid             | Process identifier (PID).                                                                     |
+| service.instance.id     | The string ID of the service instance.                                                        |
+| service.name            | Logical name of the service.                                                                  |
+| service.namespace       | A namespace for `service.name`.                                                               |
+| service.version         | The version string of the service API or implementation.                                      |
+| telemetry.sdk.language  | The language of the telemetry SDK.                                                            |
+| telemetry.sdk.name      | The name of the telemetry SDK.                                                                |
+| telemetry.sdk.version   | The version string of the telemetry SDK.                                                      |
 
 ## Useful links
 

--- a/packages/opentelemetry-test-utils/README.md
+++ b/packages/opentelemetry-test-utils/README.md
@@ -65,6 +65,42 @@ it('some test', () => {
 
 That's it - supper short and easy.
 
+## Semantic Conventions
+
+This package uses `@opentelemetry/semantic-conventions` version `1.22+`, which implements Semantic Convention [Version 1.7.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/semantic_conventions/README.md)
+
+| Attributes              | Description                                                                                   | Notes                                     |
+| ------------------------| --------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| cloud.account.id        | The cloud account ID the resource is assigned to.                                             | Key: `SEMRESATTRS_CLOUD_ACCOUNT_ID`       |
+| cloud.availability_zone | Availability zone represents the zone where the resource is running.                          | Key: `SEMRESATTRS_CLOUD_AVAILABILITY_ZONE`|
+| cloud.provider          | Name of the cloud provider.                                                                   | Key: `SEMRESATTRS_CLOUD_PROVIDER`         |
+| cloud.region            | The geographical region the resource is running.                                              | Key: `SEMRESATTRS_CLOUD_REGION`           |
+| container.id            | Container ID. Usually a UUID.                                                                 | Key: `SEMRESATTRS_CONTAINER_ID`           |
+| container.image.name    | Name of the image the container was built on.                                                 | Key: `SEMRESATTRS_CONTAINER_IMAGE_NAME`   |
+| container.image.tag     | Container image tag.                                                                          | Key: `SEMRESATTRS_CONTAINER_IMAGE_TAG`    |
+| container.name          | Container name.                                                                               | Key: `SEMRESATTRS_CONTAINER_NAME`         |
+| host.id                 | Unique host ID.                                                                               | Key: `SEMRESATTRS_HOST_ID`                |
+| host.image.id           | VM image ID.                                                                                  | Key: `SEMRESATTRS_HOST_IMAGE_ID`          |
+| host.image.name         | Name of the VM image or OS install the host was instantiated from.                            | Key: `SEMRESATTRS_HOST_IMAGE_NAME`        |
+| host.image.version      | The version string of the VM image.                                                           | Key: `SEMRESATTRS_HOST_IMAGE_VERSION`     |
+| host.name               | Name of the host.                                                                             | Key: `SEMRESATTRS_HOST_NAME`              |
+| host.type               | Type of host.                                                                                 | Key: `SEMRESATTRS_HOST_TYPE`              |
+| k8s.cluster.name        | The name of the cluster.                                                                      | Key: `SEMRESATTRS_K8S_CLUSTER_NAME`       |
+| k8s.deployment.name     | The name of the Deployment.                                                                   | Key: `SEMRESATTRS_K8S_DEPLOYMENT_NAME`    |
+| k8s.namespace.name      | The name of the namespace that the pod is running in.                                         | Key: `SEMRESATTRS_K8S_NAMESPACE_NAME`     |
+| k8s.pod.name            | The name of the Pod.                                                                          | Key: `SEMRESATTRS_K8S_POD_NAME`           |
+| process.command         | The command used to launch the process (i.e. the command name).                               | Key: `SEMRESATTRS_PROCESS_COMMAND`        |
+| process.command_line    | The full command used to launch the process as a single string representing the full command. | Key: `SEMRESATTRS_PROCESS_COMMAND_LINE`   |
+| process.executable.name | The name of the process executable.                                                           | Key: `SEMRESATTRS_PROCESS_EXECUTABLE_NAME`|
+| process.pid             | Process identifier (PID).                                                                     | Key: `SEMRESATTRS_PROCESS_PID`            |
+| service.instance.id     | The string ID of the service instance.                                                        | Key: `SEMRESATTRS_SERVICE_INSTANCE_ID`    |
+| service.name            | Logical name of the service.                                                                  | Key: `SEMRESATTRS_SERVICE_NAME`           |
+| service.namespace       | A namespace for `service.name`.                                                               | Key: `SEMRESATTRS_SERVICE_NAMESPACE`      |
+| service.version         | The version string of the service API or implementation.                                      | Key: `SEMRESATTRS_SERVICE_VERSION`        |
+| telemetry.sdk.language  | The language of the telemetry SDK.                                                            | Key: `SEMRESATTRS_TELEMETRY_SDK_LANGUAGE` |
+| telemetry.sdk.name      | The name of the telemetry SDK.                                                                | Key: `SEMRESATTRS_TELEMETRY_SDK_NAME`     |
+| telemetry.sdk.version   | The version string of the telemetry SDK.                                                      | Key: `SEMRESATTRS_TELEMETRY_SDK_VERSION`  |
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/packages/opentelemetry-test-utils/README.md
+++ b/packages/opentelemetry-test-utils/README.md
@@ -69,38 +69,6 @@ That's it - supper short and easy.
 
 This package uses `@opentelemetry/semantic-conventions` version `1.22+`, which implements Semantic Convention [Version 1.7.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/semantic_conventions/README.md)
 
-| Attributes              | Description                                                                                   |
-| ------------------------| --------------------------------------------------------------------------------------------- |
-| cloud.account.id        | The cloud account ID the resource is assigned to.                                             |
-| cloud.availability_zone | Availability zone represents the zone where the resource is running.                          |
-| cloud.provider          | Name of the cloud provider.                                                                   |
-| cloud.region            | The geographical region the resource is running.                                              |
-| container.id            | Container ID. Usually a UUID.                                                                 |
-| container.image.name    | Name of the image the container was built on.                                                 |
-| container.image.tag     | Container image tag.                                                                          |
-| container.name          | Container name.                                                                               |
-| host.id                 | Unique host ID.                                                                               |
-| host.image.id           | VM image ID.                                                                                  |
-| host.image.name         | Name of the VM image or OS install the host was instantiated from.                            |
-| host.image.version      | The version string of the VM image.                                                           |
-| host.name               | Name of the host.                                                                             |
-| host.type               | Type of host.                                                                                 |
-| k8s.cluster.name        | The name of the cluster.                                                                      |
-| k8s.deployment.name     | The name of the Deployment.                                                                   |
-| k8s.namespace.name      | The name of the namespace that the pod is running in.                                         |
-| k8s.pod.name            | The name of the Pod.                                                                          |
-| process.command         | The command used to launch the process (i.e. the command name).                               |
-| process.command_line    | The full command used to launch the process as a single string representing the full command. |
-| process.executable.name | The name of the process executable.                                                           |
-| process.pid             | Process identifier (PID).                                                                     |
-| service.instance.id     | The string ID of the service instance.                                                        |
-| service.name            | Logical name of the service.                                                                  |
-| service.namespace       | A namespace for `service.name`.                                                               |
-| service.version         | The version string of the service API or implementation.                                      |
-| telemetry.sdk.language  | The language of the telemetry SDK.                                                            |
-| telemetry.sdk.name      | The name of the telemetry SDK.                                                                |
-| telemetry.sdk.version   | The version string of the telemetry SDK.                                                      |
-
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/packages/opentelemetry-test-utils/package.json
+++ b/packages/opentelemetry-test-utils/package.json
@@ -51,6 +51,6 @@
     "@opentelemetry/sdk-node": "^0.50.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
-    "@opentelemetry/semantic-conventions": "^1.0.0"
+    "@opentelemetry/semantic-conventions": "^1.22.0"
   }
 }

--- a/packages/opentelemetry-test-utils/src/instrumentations/index.ts
+++ b/packages/opentelemetry-test-utils/src/instrumentations/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Resource } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import { getInstrumentation } from './instrumentation-singleton';
 import { registerInstrumentationTestingProvider } from './otel-default-provider';
 import { resetMemoryExporter } from './otel-provider-api';
@@ -40,7 +40,7 @@ export const mochaHooks = {
     }
     const provider = registerInstrumentationTestingProvider({
       resource: new Resource({
-        [SemanticResourceAttributes.SERVICE_NAME]: serviceName,
+        [SEMRESATTRS_SERVICE_NAME]: serviceName,
       }),
     });
     getInstrumentation()?.setTracerProvider(provider);

--- a/packages/opentelemetry-test-utils/src/resource-assertions.ts
+++ b/packages/opentelemetry-test-utils/src/resource-assertions.ts
@@ -19,6 +19,32 @@ import * as assert from 'assert';
 import { Resource } from '@opentelemetry/resources';
 import {
   SemanticResourceAttributes,
+  SEMRESATTRS_CLOUD_ACCOUNT_ID,
+  SEMRESATTRS_CLOUD_AVAILABILITY_ZONE,
+  SEMRESATTRS_CLOUD_PROVIDER,
+  SEMRESATTRS_CLOUD_REGION,
+  SEMRESATTRS_CONTAINER_ID,
+  SEMRESATTRS_CONTAINER_IMAGE_NAME,
+  SEMRESATTRS_CONTAINER_IMAGE_TAG,
+  SEMRESATTRS_CONTAINER_NAME,
+  SEMRESATTRS_HOST_ID,
+  SEMRESATTRS_HOST_IMAGE_ID,
+  SEMRESATTRS_HOST_IMAGE_NAME,
+  SEMRESATTRS_HOST_IMAGE_VERSION,
+  SEMRESATTRS_HOST_NAME,
+  SEMRESATTRS_HOST_TYPE,
+  SEMRESATTRS_K8S_CLUSTER_NAME,
+  SEMRESATTRS_K8S_DEPLOYMENT_NAME,
+  SEMRESATTRS_K8S_NAMESPACE_NAME,
+  SEMRESATTRS_K8S_POD_NAME,
+  SEMRESATTRS_PROCESS_COMMAND,
+  SEMRESATTRS_PROCESS_COMMAND_LINE,
+  SEMRESATTRS_PROCESS_EXECUTABLE_NAME,
+  SEMRESATTRS_PROCESS_PID,
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
+  SEMRESATTRS_SERVICE_NAME,
+  SEMRESATTRS_SERVICE_NAMESPACE,
+  SEMRESATTRS_SERVICE_VERSION,
   SEMRESATTRS_TELEMETRY_SDK_LANGUAGE,
   SEMRESATTRS_TELEMETRY_SDK_NAME,
   SEMRESATTRS_TELEMETRY_SDK_VERSION,
@@ -42,22 +68,22 @@ export const assertCloudResource = (
   assertHasOneLabel('CLOUD', resource);
   if (validations.provider)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CLOUD_PROVIDER],
+      resource.attributes[SEMRESATTRS_CLOUD_PROVIDER],
       validations.provider
     );
   if (validations.accountId)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CLOUD_ACCOUNT_ID],
+      resource.attributes[SEMRESATTRS_CLOUD_ACCOUNT_ID],
       validations.accountId
     );
   if (validations.region)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CLOUD_REGION],
+      resource.attributes[SEMRESATTRS_CLOUD_REGION],
       validations.region
     );
   if (validations.zone)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CLOUD_AVAILABILITY_ZONE],
+      resource.attributes[SEMRESATTRS_CLOUD_AVAILABILITY_ZONE],
       validations.zone
     );
 };
@@ -80,22 +106,22 @@ export const assertContainerResource = (
   assertHasOneLabel('CONTAINER', resource);
   if (validations.name)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CONTAINER_NAME],
+      resource.attributes[SEMRESATTRS_CONTAINER_NAME],
       validations.name
     );
   if (validations.id)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CONTAINER_ID],
+      resource.attributes[SEMRESATTRS_CONTAINER_ID],
       validations.id
     );
   if (validations.imageName)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CONTAINER_IMAGE_NAME],
+      resource.attributes[SEMRESATTRS_CONTAINER_IMAGE_NAME],
       validations.imageName
     );
   if (validations.imageTag)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.CONTAINER_IMAGE_TAG],
+      resource.attributes[SEMRESATTRS_CONTAINER_IMAGE_TAG],
       validations.imageTag
     );
 };
@@ -120,32 +146,32 @@ export const assertHostResource = (
   assertHasOneLabel('HOST', resource);
   if (validations.id)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_ID],
+      resource.attributes[SEMRESATTRS_HOST_ID],
       validations.id
     );
   if (validations.name)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_NAME],
+      resource.attributes[SEMRESATTRS_HOST_NAME],
       validations.name
     );
   if (validations.hostType)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_TYPE],
+      resource.attributes[SEMRESATTRS_HOST_TYPE],
       validations.hostType
     );
   if (validations.imageName)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_IMAGE_NAME],
+      resource.attributes[SEMRESATTRS_HOST_IMAGE_NAME],
       validations.imageName
     );
   if (validations.imageId)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_IMAGE_ID],
+      resource.attributes[SEMRESATTRS_HOST_IMAGE_ID],
       validations.imageId
     );
   if (validations.imageVersion)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.HOST_IMAGE_VERSION],
+      resource.attributes[SEMRESATTRS_HOST_IMAGE_VERSION],
       validations.imageVersion
     );
 };
@@ -168,22 +194,22 @@ export const assertK8sResource = (
   assertHasOneLabel('K8S', resource);
   if (validations.clusterName)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.K8S_CLUSTER_NAME],
+      resource.attributes[SEMRESATTRS_K8S_CLUSTER_NAME],
       validations.clusterName
     );
   if (validations.namespaceName)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.K8S_NAMESPACE_NAME],
+      resource.attributes[SEMRESATTRS_K8S_NAMESPACE_NAME],
       validations.namespaceName
     );
   if (validations.podName)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.K8S_POD_NAME],
+      resource.attributes[SEMRESATTRS_K8S_POD_NAME],
       validations.podName
     );
   if (validations.deploymentName)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.K8S_DEPLOYMENT_NAME],
+      resource.attributes[SEMRESATTRS_K8S_DEPLOYMENT_NAME],
       validations.deploymentName
     );
 };
@@ -211,17 +237,17 @@ export const assertTelemetrySDKResource = (
 
   if (validations.name)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.TELEMETRY_SDK_NAME],
+      resource.attributes[SEMRESATTRS_TELEMETRY_SDK_NAME],
       validations.name
     );
   if (validations.language)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.TELEMETRY_SDK_LANGUAGE],
+      resource.attributes[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE],
       validations.language
     );
   if (validations.version)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.TELEMETRY_SDK_VERSION],
+      resource.attributes[SEMRESATTRS_TELEMETRY_SDK_VERSION],
       validations.version
     );
 };
@@ -242,21 +268,21 @@ export const assertServiceResource = (
   }
 ) => {
   assert.strictEqual(
-    resource.attributes[SemanticResourceAttributes.SERVICE_NAME],
+    resource.attributes[SEMRESATTRS_SERVICE_NAME],
     validations.name
   );
   assert.strictEqual(
-    resource.attributes[SemanticResourceAttributes.SERVICE_INSTANCE_ID],
+    resource.attributes[SEMRESATTRS_SERVICE_INSTANCE_ID],
     validations.instanceId
   );
   if (validations.namespace)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.SERVICE_NAMESPACE],
+      resource.attributes[SEMRESATTRS_SERVICE_NAMESPACE],
       validations.namespace
     );
   if (validations.version)
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.SERVICE_VERSION],
+      resource.attributes[SEMRESATTRS_SERVICE_VERSION],
       validations.version
     );
 };
@@ -277,24 +303,24 @@ export const assertProcessResource = (
   }
 ) => {
   assert.strictEqual(
-    resource.attributes[SemanticResourceAttributes.PROCESS_PID],
+    resource.attributes[SEMRESATTRS_PROCESS_PID],
     validations.pid
   );
   if (validations.name) {
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.PROCESS_EXECUTABLE_NAME],
+      resource.attributes[SEMRESATTRS_PROCESS_EXECUTABLE_NAME],
       validations.name
     );
   }
   if (validations.command) {
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.PROCESS_COMMAND],
+      resource.attributes[SEMRESATTRS_PROCESS_COMMAND],
       validations.command
     );
   }
   if (validations.commandLine) {
     assert.strictEqual(
-      resource.attributes[SemanticResourceAttributes.PROCESS_COMMAND_LINE],
+      resource.attributes[SEMRESATTRS_PROCESS_COMMAND_LINE],
       validations.commandLine
     );
   }


### PR DESCRIPTION
## Which problem is this PR solving?

- Part Of #2025

## Short description of the changes

- Update @opentelemetry/semantic-conventions from ^1.0.0 to ^1.22.0
- Use exported strings for Semantic Resource Attributes
