### PR TITLE
feat(resource-detector-aws): add service.instance.id to resource detection

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsEc2Detector.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsEc2Detector.ts
@@ -30,7 +30,9 @@ import {
   SEMRESATTRS_HOST_NAME,
   CLOUDPROVIDERVALUES_AWS,
   CLOUDPLATFORMVALUES_AWS_EC2,
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
 } from '@opentelemetry/semantic-conventions';
+import { randomUUID } from 'crypto';
 import * as http from 'http';
 
 /**
@@ -77,6 +79,7 @@ class AwsEc2Detector implements Detector {
       [SEMRESATTRS_HOST_ID]: instanceId,
       [SEMRESATTRS_HOST_TYPE]: instanceType,
       [SEMRESATTRS_HOST_NAME]: hostname,
+      [SEMRESATTRS_SERVICE_INSTANCE_ID]: randomUUID(),
     });
   }
 

--- a/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsEcsDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsEcsDetector.ts
@@ -40,12 +40,14 @@ import {
   SEMRESATTRS_AWS_LOG_STREAM_ARNS,
   CLOUDPROVIDERVALUES_AWS,
   CLOUDPLATFORMVALUES_AWS_ECS,
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
 } from '@opentelemetry/semantic-conventions';
 import * as http from 'http';
 import * as util from 'util';
 import * as fs from 'fs';
 import * as os from 'os';
 import { getEnv } from '@opentelemetry/core';
+import { randomUUID } from 'crypto';
 
 const HTTP_TIMEOUT_IN_MS = 1000;
 
@@ -76,6 +78,7 @@ export class AwsEcsDetector implements Detector {
     let resource = new Resource({
       [SEMRESATTRS_CLOUD_PROVIDER]: CLOUDPROVIDERVALUES_AWS,
       [SEMRESATTRS_CLOUD_PLATFORM]: CLOUDPLATFORMVALUES_AWS_ECS,
+      [SEMRESATTRS_SERVICE_INSTANCE_ID]: randomUUID(),
     }).merge(await AwsEcsDetector._getContainerIdAndHostnameResource());
 
     const metadataUrl = getEnv().ECS_CONTAINER_METADATA_URI_V4;

--- a/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsEksDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsEksDetector.ts
@@ -26,11 +26,13 @@ import {
   SEMRESATTRS_CONTAINER_ID,
   CLOUDPROVIDERVALUES_AWS,
   CLOUDPLATFORMVALUES_AWS_EKS,
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
 } from '@opentelemetry/semantic-conventions';
 import * as https from 'https';
 import * as fs from 'fs';
 import * as util from 'util';
 import { diag } from '@opentelemetry/api';
+import { randomUUID } from 'crypto';
 
 /**
  * The AwsEksDetector can be used to detect if a process is running in AWS Elastic
@@ -86,6 +88,7 @@ export class AwsEksDetector implements Detector {
             [SEMRESATTRS_CLOUD_PLATFORM]: CLOUDPLATFORMVALUES_AWS_EKS,
             [SEMRESATTRS_K8S_CLUSTER_NAME]: clusterName || '',
             [SEMRESATTRS_CONTAINER_ID]: containerId || '',
+            [SEMRESATTRS_SERVICE_INSTANCE_ID]: randomUUID(),
           });
     } catch (e) {
       diag.warn('Process is not running on K8S', e);

--- a/detectors/node/opentelemetry-resource-detector-aws/test/detectors/AwsEc2Detector.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/test/detectors/AwsEc2Detector.test.ts
@@ -22,6 +22,7 @@ import {
   assertCloudResource,
   assertHostResource,
 } from '@opentelemetry/contrib-test-utils';
+import { SEMRESATTRS_SERVICE_INSTANCE_ID } from '@opentelemetry/semantic-conventions';
 
 const AWS_HOST = 'http://' + awsEc2Detector.AWS_IDMS_ENDPOINT;
 const AWS_TOKEN_PATH = awsEc2Detector.AWS_INSTANCE_TOKEN_DOCUMENT_PATH;
@@ -81,6 +82,10 @@ describe('awsEc2Detector', () => {
         hostType: 'my-instance-type',
         name: 'my-hostname',
       });
+      assert.equal(
+        resource.attributes[SEMRESATTRS_SERVICE_INSTANCE_ID]?.toString().length,
+        36
+      );
     });
   });
 

--- a/detectors/node/opentelemetry-resource-detector-aws/test/detectors/AwsEcsDetector.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/test/detectors/AwsEcsDetector.test.ts
@@ -41,6 +41,7 @@ import {
   SEMRESATTRS_AWS_LOG_STREAM_ARNS,
   CLOUDPROVIDERVALUES_AWS,
   CLOUDPLATFORMVALUES_AWS_ECS,
+  SEMRESATTRS_SERVICE_INSTANCE_ID,
 } from '@opentelemetry/semantic-conventions';
 import { readFileSync } from 'fs';
 import * as os from 'os';
@@ -126,6 +127,11 @@ const assertEcsResource = (
       resource.attributes[SEMRESATTRS_AWS_LOG_STREAM_ARNS],
       validations.logStreamArns
     );
+
+  assert.equal(
+    resource.attributes[SEMRESATTRS_SERVICE_INSTANCE_ID]?.toString().length,
+    36
+  );
 };
 
 describe('AwsEcsResourceDetector', () => {

--- a/detectors/node/opentelemetry-resource-detector-aws/test/detectors/AwsEksDetector.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/test/detectors/AwsEksDetector.test.ts
@@ -24,6 +24,7 @@ import {
   assertContainerResource,
   assertEmptyResource,
 } from '@opentelemetry/contrib-test-utils';
+import { SEMRESATTRS_SERVICE_INSTANCE_ID } from '@opentelemetry/semantic-conventions';
 
 const K8S_SVC_URL = awsEksDetector.K8S_SVC_URL;
 const AUTH_CONFIGMAP_PATH = awsEksDetector.AUTH_CONFIGMAP_PATH;
@@ -86,6 +87,10 @@ describe('awsEksDetector', () => {
       assertContainerResource(resource, {
         id: 'bcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklm',
       });
+      assert.equal(
+        resource.attributes[SEMRESATTRS_SERVICE_INSTANCE_ID]?.toString().length,
+        36
+      );
     });
 
     it('should return a resource with clusterName attribute without cgroup file', async () => {


### PR DESCRIPTION
## Which problem is this PR solving?

- Part Of #2065

## Short description of the changes

- `service.instance.id` is a recommended value.
Implements `service.instance.id` from [here](open-telemetry/semantic-conventions#312). Uses `randomUUID` as is similar implemented on other languages, such as the Java SDK.
