### PR TITLE
refactor(instr-amqplib): use exported strings for attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36823,7 +36823,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.50.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -45948,7 +45948,7 @@
         "@opentelemetry/contrib-test-utils": "^0.38.0",
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.50.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/amqplib": "^0.5.17",
         "@types/lodash": "4.14.199",
         "@types/mocha": "8.2.3",

--- a/plugins/node/instrumentation-amqplib/README.md
+++ b/plugins/node/instrumentation-amqplib/README.md
@@ -87,20 +87,20 @@ This package uses `@opentelemetry/semantic-conventions` version `1.22+`, which i
 
 Attributes collected:
 
-| Attribute                        | Short Description                                                      | Notes                                          |
-| -------------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------- |
-| `messaging.destination`          | The message destination name.                                          | Key: `SEMATTRS_MESSAGING_DESTINATION`          |
-| `messaging.destination_kind`     | The kind of message destination.                                       | Key: `SEMATTRS_MESSAGING_DESTINATION_KIND`     |
-| `messaging.rabbitmq.routing_key` | RabbitMQ message routing key.                                          | Key: `SEMATTRS_MESSAGING_RABBITMQ_ROUTING_KEY` |
-| `messaging.operation`            | A string identifying the kind of message consumption.                  | Key: `SEMATTRS_MESSAGING_OPERATION`            |
-| `messaging.message_id`           | A value used by the messaging system as an identifier for the message. | Key: `SEMATTRS_MESSAGING_MESSAGE_ID`           |
-| `messaging.conversation_id`      | The ID identifying the conversation to which the message belongs.      | Key: `SEMATTRS_MESSAGING_CONVERSATION_ID`      |
-| `messaging.protocol`             | The name of the transport protocol.                                    | Key: `SEMATTRS_MESSAGING_PROTOCOL`             |
-| `messaging.protocol_version`     | The version of the transport protocol.                                 | Key: `SEMATTRS_MESSAGING_PROTOCOL_VERSION`     |
-| `messaging.system`               | A string identifying the messaging system.                             | Key: `SEMATTRS_MESSAGING_SYSTEM`               |
-| `messaging.url`                  | The connection string.                                                 | Key: `SEMATTRS_MESSAGING_URL`                  |
-| `net.peer.name`                  | Remote hostname or similar.                                            | Key: `SEMATTRS_NET_PEER_NAME`                  |
-| `net.peer.port`                  | Remote port number.                                                    | Key: `SEMATTRS_NET_PEER_PORT`                  |
+| Attribute                        | Short Description                                                      |
+| -------------------------------- | ---------------------------------------------------------------------- |
+| `messaging.destination`          | The message destination name.                                          |
+| `messaging.destination_kind`     | The kind of message destination.                                       |
+| `messaging.rabbitmq.routing_key` | RabbitMQ message routing key.                                          |
+| `messaging.operation`            | A string identifying the kind of message consumption.                  |
+| `messaging.message_id`           | A value used by the messaging system as an identifier for the message. |
+| `messaging.conversation_id`      | The ID identifying the conversation to which the message belongs.      |
+| `messaging.protocol`             | The name of the transport protocol.                                    |
+| `messaging.protocol_version`     | The version of the transport protocol.                                 |
+| `messaging.system`               | A string identifying the messaging system.                             |
+| `messaging.url`                  | The connection string.                                                 |
+| `net.peer.name`                  | Remote hostname or similar.                                            |
+| `net.peer.port`                  | Remote port number.                                                    |
 
 ## Useful links
 

--- a/plugins/node/instrumentation-amqplib/README.md
+++ b/plugins/node/instrumentation-amqplib/README.md
@@ -81,6 +81,27 @@ The instrumentation's config `publishHook`, `publishConfirmHook`, `consumeHook` 
 
 The `moduleVersionAttributeName` config option is removed. To add the amqplib package version to spans, use the `moduleVersion` attribute in hook info for `publishHook` and `consumeHook` functions.
 
+## Semantic Conventions
+
+This package uses `@opentelemetry/semantic-conventions` version `1.22+`, which implements Semantic Convention [Version 1.7.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/semantic_conventions/README.md)
+
+Attributes collected:
+
+| Attribute                        | Short Description                                                      | Notes                                          |
+| -------------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------- |
+| `messaging.destination`          | The message destination name.                                          | Key: `SEMATTRS_MESSAGING_DESTINATION`          |
+| `messaging.destination_kind`     | The kind of message destination.                                       | Key: `SEMATTRS_MESSAGING_DESTINATION_KIND`     |
+| `messaging.rabbitmq.routing_key` | RabbitMQ message routing key.                                          | Key: `SEMATTRS_MESSAGING_RABBITMQ_ROUTING_KEY` |
+| `messaging.operation`            | A string identifying the kind of message consumption.                  | Key: `SEMATTRS_MESSAGING_OPERATION`            |
+| `messaging.message_id`           | A value used by the messaging system as an identifier for the message. | Key: `SEMATTRS_MESSAGING_MESSAGE_ID`           |
+| `messaging.conversation_id`      | The ID identifying the conversation to which the message belongs.      | Key: `SEMATTRS_MESSAGING_CONVERSATION_ID`      |
+| `messaging.protocol`             | The name of the transport protocol.                                    | Key: `SEMATTRS_MESSAGING_PROTOCOL`             |
+| `messaging.protocol_version`     | The version of the transport protocol.                                 | Key: `SEMATTRS_MESSAGING_PROTOCOL_VERSION`     |
+| `messaging.system`               | A string identifying the messaging system.                             | Key: `SEMATTRS_MESSAGING_SYSTEM`               |
+| `messaging.url`                  | The connection string.                                                 | Key: `SEMATTRS_MESSAGING_URL`                  |
+| `net.peer.name`                  | Remote hostname or similar.                                            | Key: `SEMATTRS_NET_PEER_NAME`                  |
+| `net.peer.port`                  | Remote port number.                                                    | Key: `SEMATTRS_NET_PEER_PORT`                  |
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/plugins/node/instrumentation-amqplib/package.json
+++ b/plugins/node/instrumentation-amqplib/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.50.0",
-    "@opentelemetry/semantic-conventions": "^1.0.0"
+    "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",

--- a/plugins/node/instrumentation-amqplib/src/amqplib.ts
+++ b/plugins/node/instrumentation-amqplib/src/amqplib.ts
@@ -36,9 +36,14 @@ import {
   safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
 import {
-  SemanticAttributes,
-  MessagingOperationValues,
-  MessagingDestinationKindValues,
+  SEMATTRS_MESSAGING_DESTINATION,
+  SEMATTRS_MESSAGING_DESTINATION_KIND,
+  MESSAGINGDESTINATIONKINDVALUES_TOPIC,
+  SEMATTRS_MESSAGING_RABBITMQ_ROUTING_KEY,
+  SEMATTRS_MESSAGING_OPERATION,
+  MESSAGINGOPERATIONVALUES_PROCESS,
+  SEMATTRS_MESSAGING_MESSAGE_ID,
+  SEMATTRS_MESSAGING_CONVERSATION_ID,
 } from '@opentelemetry/semantic-conventions';
 import type {
   Connection,
@@ -415,16 +420,13 @@ export class AmqplibInstrumentation extends InstrumentationBase {
             kind: SpanKind.CONSUMER,
             attributes: {
               ...channel?.connection?.[CONNECTION_ATTRIBUTES],
-              [SemanticAttributes.MESSAGING_DESTINATION]: exchange,
-              [SemanticAttributes.MESSAGING_DESTINATION_KIND]:
-                MessagingDestinationKindValues.TOPIC,
-              [SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]:
-                msg.fields?.routingKey,
-              [SemanticAttributes.MESSAGING_OPERATION]:
-                MessagingOperationValues.PROCESS,
-              [SemanticAttributes.MESSAGING_MESSAGE_ID]:
-                msg?.properties.messageId,
-              [SemanticAttributes.MESSAGING_CONVERSATION_ID]:
+              [SEMATTRS_MESSAGING_DESTINATION]: exchange,
+              [SEMATTRS_MESSAGING_DESTINATION_KIND]:
+                MESSAGINGDESTINATIONKINDVALUES_TOPIC,
+              [SEMATTRS_MESSAGING_RABBITMQ_ROUTING_KEY]: msg.fields?.routingKey,
+              [SEMATTRS_MESSAGING_OPERATION]: MESSAGINGOPERATIONVALUES_PROCESS,
+              [SEMATTRS_MESSAGING_MESSAGE_ID]: msg?.properties.messageId,
+              [SEMATTRS_MESSAGING_CONVERSATION_ID]:
                 msg?.properties.correlationId,
             },
           },
@@ -636,13 +638,12 @@ export class AmqplibInstrumentation extends InstrumentationBase {
         kind: SpanKind.PRODUCER,
         attributes: {
           ...channel.connection[CONNECTION_ATTRIBUTES],
-          [SemanticAttributes.MESSAGING_DESTINATION]: exchange,
-          [SemanticAttributes.MESSAGING_DESTINATION_KIND]:
-            MessagingDestinationKindValues.TOPIC,
-          [SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY]: routingKey,
-          [SemanticAttributes.MESSAGING_MESSAGE_ID]: options?.messageId,
-          [SemanticAttributes.MESSAGING_CONVERSATION_ID]:
-            options?.correlationId,
+          [SEMATTRS_MESSAGING_DESTINATION]: exchange,
+          [SEMATTRS_MESSAGING_DESTINATION_KIND]:
+            MESSAGINGDESTINATIONKINDVALUES_TOPIC,
+          [SEMATTRS_MESSAGING_RABBITMQ_ROUTING_KEY]: routingKey,
+          [SEMATTRS_MESSAGING_MESSAGE_ID]: options?.messageId,
+          [SEMATTRS_MESSAGING_CONVERSATION_ID]: options?.correlationId,
         },
       }
     );


### PR DESCRIPTION
## Which problem is this PR solving?

- Updates #2025 

## Short description of the changes

- Update @opentelemetry/semantic-conventions to ^1.22
- Replace `SemanticAttributes.*` with exported strings `SEMATTRS_*`
- Update README with new semantic convention package version and key
