### PR TITLE
refactor(instr-mongodb): use exported strings for attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38125,7 +38125,7 @@
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-metrics": "^1.9.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -46633,7 +46633,7 @@
         "@opentelemetry/sdk-metrics": "^1.9.1",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/bson": "4.0.5",
         "@types/mocha": "7.0.2",
         "@types/mongodb": "3.6.20",

--- a/plugins/node/opentelemetry-instrumentation-mongodb/README.md
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/README.md
@@ -55,6 +55,22 @@ Mongodb instrumentation has few options available to choose from. You can set th
 | `responseHook` | `MongoDBInstrumentationExecutionResponseHook` (function) | Function for adding custom attributes from db response |
 | `dbStatementSerializer` | `DbStatementSerializer` (function) | Custom serializer function for the db.statement tag |
 
+## Semantic Conventions
+
+This package uses `@opentelemetry/semantic-conventions` version `1.22+`, which implements Semantic Convention [Version 1.7.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/semantic_conventions/README.md)
+
+Attributes collected:
+
+| Attribute               | Short Description                                                              | Notes                                 |
+| ----------------------- | ------------------------------------------------------------------------------ | ------------------------------------- |
+| `db.system`             | An identifier for the database management system (DBMS) product being used.    | Key: `SEMATTRS_DB_SYSTEM`             |
+| `db.connection_string`  | The connection string used to connect to the database.                         | Key: `SEMATTRS_DB_CONNECTION_STRING`  |
+| `db.name`               | This attribute is used to report the name of the database being accessed.      | Key: `SEMATTRS_DB_NAME`               |
+| `db.operation`          | The name of the operation being executed.                                      | Key: `SEMATTRS_DB_OPERATION`          |
+| `db.mongodb.collection` | The collection being accessed within the database stated in `db.name`.         | Key: `SEMATTRS_DB_MONGODB_COLLECTION` |
+| `net.peer.name`         | Remote hostname or similar.                                                    | Key: `SEMATTRS_NET_PEER_NAME`         |
+| `net.peer.port`         | Remote port number.                                                            | Key: `SEMATTRS_NET_PEER_PORT`         |
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/plugins/node/opentelemetry-instrumentation-mongodb/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/sdk-metrics": "^1.9.1",
-    "@opentelemetry/semantic-conventions": "^1.0.0"
+    "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-mongodb#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-mongodb/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/src/instrumentation.ts
@@ -29,8 +29,15 @@ import {
   safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
 import {
-  DbSystemValues,
-  SemanticAttributes,
+  DBSYSTEMVALUES_MONGODB,
+  SEMATTRS_DB_CONNECTION_STRING,
+  SEMATTRS_DB_MONGODB_COLLECTION,
+  SEMATTRS_DB_NAME,
+  SEMATTRS_DB_OPERATION,
+  SEMATTRS_DB_STATEMENT,
+  SEMATTRS_DB_SYSTEM,
+  SEMATTRS_NET_PEER_NAME,
+  SEMATTRS_NET_PEER_PORT,
 } from '@opentelemetry/semantic-conventions';
 import { MongoDBInstrumentationConfig, CommandResult } from './types';
 import {
@@ -898,18 +905,18 @@ export class MongoDBInstrumentation extends InstrumentationBase {
   ) {
     // add database related attributes
     span.setAttributes({
-      [SemanticAttributes.DB_SYSTEM]: DbSystemValues.MONGODB,
-      [SemanticAttributes.DB_NAME]: dbName,
-      [SemanticAttributes.DB_MONGODB_COLLECTION]: dbCollection,
-      [SemanticAttributes.DB_OPERATION]: operation,
-      [SemanticAttributes.DB_CONNECTION_STRING]: `mongodb://${host}:${port}/${dbName}`,
+      [SEMATTRS_DB_SYSTEM]: DBSYSTEMVALUES_MONGODB,
+      [SEMATTRS_DB_NAME]: dbName,
+      [SEMATTRS_DB_MONGODB_COLLECTION]: dbCollection,
+      [SEMATTRS_DB_OPERATION]: operation,
+      [SEMATTRS_DB_CONNECTION_STRING]: `mongodb://${host}:${port}/${dbName}`,
     });
 
     if (host && port) {
-      span.setAttribute(SemanticAttributes.NET_PEER_NAME, host);
+      span.setAttribute(SEMATTRS_NET_PEER_NAME, host);
       const portNumber = parseInt(port, 10);
       if (!isNaN(portNumber)) {
-        span.setAttribute(SemanticAttributes.NET_PEER_PORT, portNumber);
+        span.setAttribute(SEMATTRS_NET_PEER_PORT, portNumber);
       }
     }
     if (!commandObj) return;
@@ -921,7 +928,7 @@ export class MongoDBInstrumentation extends InstrumentationBase {
     safeExecuteInTheMiddle(
       () => {
         const query = dbStatementSerializer(commandObj);
-        span.setAttribute(SemanticAttributes.DB_STATEMENT, query);
+        span.setAttribute(SEMATTRS_DB_STATEMENT, query);
       },
       err => {
         if (err) {


### PR DESCRIPTION
## Which problem is this PR solving?

- Updates #2025 

## Short description of the changes

- Update @opentelemetry/semantic-conventions to ^1.22
- Replace `SemanticAttributes.*` with exported strings `SEMATTRS_*`
- Update README with new semantic convention package version and key
