### PR TITLE
refactor(instr-restify): use exported strings for attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38579,7 +38579,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.50.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -46919,7 +46919,7 @@
         "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.6.5",
         "@types/restify": "4.3.10",

--- a/plugins/node/opentelemetry-instrumentation-restify/README.md
+++ b/plugins/node/opentelemetry-instrumentation-restify/README.md
@@ -62,6 +62,16 @@ const restifyInstrumentation = new RestifyInstrumentation({
 });
 ```
 
+## Semantic Conventions
+
+This package uses `@opentelemetry/semantic-conventions` version `1.22+`, which implements Semantic Convention [Version 1.7.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/semantic_conventions/README.md)
+
+Attributes collected:
+
+| Attribute    | Short Description                  |
+| ------------ | ---------------------------------- |
+| `http.route` | The matched route (path template). |
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/plugins/node/opentelemetry-instrumentation-restify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-restify/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.50.0",
-    "@opentelemetry/semantic-conventions": "^1.0.0"
+    "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-restify#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-restify/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/src/instrumentation.ts
@@ -20,7 +20,7 @@ import type * as restify from 'restify';
 import * as api from '@opentelemetry/api';
 import type { Server } from 'restify';
 import { LayerType } from './types';
-import * as AttributeNames from './enums/AttributeNames';
+import { AttributeNames } from './enums/AttributeNames';
 import { VERSION } from './version';
 import * as constants from './constants';
 import {
@@ -30,7 +30,7 @@ import {
   isWrapped,
   safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
 import { isPromise, isAsyncFunction } from './utils';
 import { getRPCMetadata, RPCType } from '@opentelemetry/core';
 import type { RestifyInstrumentationConfig } from './types';
@@ -185,11 +185,11 @@ export class RestifyInstrumentation extends InstrumentationBase<any> {
             ? `request handler - ${route}`
             : `middleware - ${fnName || 'anonymous'}`;
         const attributes = {
-          [AttributeNames.AttributeNames.NAME]: fnName,
-          [AttributeNames.AttributeNames.VERSION]: this._moduleVersion || 'n/a',
-          [AttributeNames.AttributeNames.TYPE]: metadata.type,
-          [AttributeNames.AttributeNames.METHOD]: metadata.methodName,
-          [SemanticAttributes.HTTP_ROUTE]: route,
+          [AttributeNames.NAME]: fnName,
+          [AttributeNames.VERSION]: this._moduleVersion || 'n/a',
+          [AttributeNames.TYPE]: metadata.type,
+          [AttributeNames.METHOD]: metadata.methodName,
+          [SEMATTRS_HTTP_ROUTE]: route,
         };
         const span = this.tracer.startSpan(
           spanName,

--- a/plugins/node/opentelemetry-instrumentation-restify/test/restify.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/test/restify.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { context, trace, Span } from '@opentelemetry/api';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_HTTP_METHOD } from '@opentelemetry/semantic-conventions';
 import { RPCMetadata, RPCType, setRPCMetadata } from '@opentelemetry/core';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
@@ -494,7 +494,7 @@ describe('Restify Instrumentation', () => {
       it('calls requestHook provided function when set in config', async () => {
         const requestHook = (span: Span, info: RestifyRequestInfo) => {
           span.setAttribute(
-            SemanticAttributes.HTTP_METHOD,
+            SEMATTRS_HTTP_METHOD,
             info.request.method
           );
           span.setAttribute('restify.layer', info.layerType);
@@ -519,7 +519,7 @@ describe('Restify Instrumentation', () => {
               const span = memoryExporter.getFinishedSpans()[2];
               assert.notStrictEqual(span, undefined);
               assert.strictEqual(
-                span.attributes[SemanticAttributes.HTTP_METHOD],
+                span.attributes[SEMATTRS_HTTP_METHOD],
                 'GET'
               );
               assert.strictEqual(
@@ -534,7 +534,7 @@ describe('Restify Instrumentation', () => {
       it('does not propagate an error from a requestHook that throws exception', async () => {
         const requestHook = (span: Span, info: RestifyRequestInfo) => {
           span.setAttribute(
-            SemanticAttributes.HTTP_METHOD,
+            SEMATTRS_HTTP_METHOD,
             info.request.method
           );
 
@@ -560,7 +560,7 @@ describe('Restify Instrumentation', () => {
               const span = memoryExporter.getFinishedSpans()[2];
               assert.notStrictEqual(span, undefined);
               assert.strictEqual(
-                span.attributes[SemanticAttributes.HTTP_METHOD],
+                span.attributes[SEMATTRS_HTTP_METHOD],
                 'GET'
               );
             }

--- a/plugins/node/opentelemetry-instrumentation-restify/test/restify.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/test/restify.test.ts
@@ -493,10 +493,7 @@ describe('Restify Instrumentation', () => {
     describe('using requestHook in config', () => {
       it('calls requestHook provided function when set in config', async () => {
         const requestHook = (span: Span, info: RestifyRequestInfo) => {
-          span.setAttribute(
-            SEMATTRS_HTTP_METHOD,
-            info.request.method
-          );
+          span.setAttribute(SEMATTRS_HTTP_METHOD, info.request.method);
           span.setAttribute('restify.layer', info.layerType);
         };
 
@@ -518,10 +515,7 @@ describe('Restify Instrumentation', () => {
               // span from get
               const span = memoryExporter.getFinishedSpans()[2];
               assert.notStrictEqual(span, undefined);
-              assert.strictEqual(
-                span.attributes[SEMATTRS_HTTP_METHOD],
-                'GET'
-              );
+              assert.strictEqual(span.attributes[SEMATTRS_HTTP_METHOD], 'GET');
               assert.strictEqual(
                 span.attributes['restify.layer'],
                 'request_handler'
@@ -533,10 +527,7 @@ describe('Restify Instrumentation', () => {
 
       it('does not propagate an error from a requestHook that throws exception', async () => {
         const requestHook = (span: Span, info: RestifyRequestInfo) => {
-          span.setAttribute(
-            SEMATTRS_HTTP_METHOD,
-            info.request.method
-          );
+          span.setAttribute(SEMATTRS_HTTP_METHOD, info.request.method);
 
           throw Error('error thrown in requestHook');
         };
@@ -559,10 +550,7 @@ describe('Restify Instrumentation', () => {
               // span from get
               const span = memoryExporter.getFinishedSpans()[2];
               assert.notStrictEqual(span, undefined);
-              assert.strictEqual(
-                span.attributes[SEMATTRS_HTTP_METHOD],
-                'GET'
-              );
+              assert.strictEqual(span.attributes[SEMATTRS_HTTP_METHOD], 'GET');
             }
           }
         );


### PR DESCRIPTION
## Which problem is this PR solving?

- Updates #2025 

## Short description of the changes

- Update @opentelemetry/semantic-conventions to ^1.22
- Replace `SemanticAttributes.HTTP_ROUTE` with exported string `SEMATTRS_HTTP_ROUTE`
- Update README with new semantic convention package version and key
