### PR TITLE
refactor(instr-router): use exported strings for attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38645,7 +38645,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.50.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -46968,7 +46968,7 @@
         "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.6.5",
         "mocha": "7.2.0",

--- a/plugins/node/opentelemetry-instrumentation-router/README.md
+++ b/plugins/node/opentelemetry-instrumentation-router/README.md
@@ -40,6 +40,16 @@ registerInstrumentations({
 
 See [examples/router](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/examples/router) for a short example.
 
+## Semantic Conventions
+
+This package uses `@opentelemetry/semantic-conventions` version `1.22+`, which implements Semantic Convention [Version 1.7.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/semantic_conventions/README.md)
+
+Attributes collected:
+
+| Attribute    | Short Description                  |
+| ------------ | ---------------------------------- |
+| `http.route` | The matched route (path template). |
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/plugins/node/opentelemetry-instrumentation-router/package.json
+++ b/plugins/node/opentelemetry-instrumentation-router/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.50.0",
-    "@opentelemetry/semantic-conventions": "^1.0.0"
+    "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-router#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-router/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-router/src/instrumentation.ts
@@ -22,7 +22,7 @@ import {
   InstrumentationNodeModuleFile,
   isWrapped,
 } from '@opentelemetry/instrumentation';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
 
 import * as http from 'http';
 import type * as Router from 'router';
@@ -182,7 +182,7 @@ export default class RouterInstrumentation extends InstrumentationBase<any> {
       [AttributeNames.NAME]: fnName,
       [AttributeNames.VERSION]: this._moduleVersion,
       [AttributeNames.TYPE]: type,
-      [SemanticAttributes.HTTP_ROUTE]: route,
+      [SEMATTRS_HTTP_ROUTE]: route,
     };
 
     const parent = api.context.active();


### PR DESCRIPTION
## Which problem is this PR solving?

- Updates #2025 

## Short description of the changes

- Update @opentelemetry/semantic-conventions to ^1.22
- Replace `SemanticAttributes.HTTP_ROUTE` with exported string `SEMATTRS_HTTP_ROUTE`
- Update README with new semantic convention package version and key
