### PR TITLE
refactor(instr-redis-4): use exported strings for attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38531,7 +38531,7 @@
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/redis-common": "^0.36.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -46881,7 +46881,7 @@
         "@opentelemetry/redis-common": "^0.36.1",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.6.5",
         "cross-env": "7.0.3",

--- a/plugins/node/opentelemetry-instrumentation-redis-4/README.md
+++ b/plugins/node/opentelemetry-instrumentation-redis-4/README.md
@@ -71,6 +71,20 @@ const redisInstrumentation = new RedisInstrumentation({
 });
 ```
 
+## Semantic Conventions
+
+This package uses `@opentelemetry/semantic-conventions` version `1.22+`, which implements Semantic Convention [Version 1.7.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/semantic_conventions/README.md)
+
+Attributes collected:
+
+| Attribute              | Short Description                                                            |
+| ---------------------- | ---------------------------------------------------------------------------- |
+| `db.statement`         | The database statement being executed.                                       |
+| `db.system`            | An identifier for the database management system (DBMS) product being used.  |
+| `db.connection_string` | The connection string used to connect to the database (without credentials). |
+| `net.peer.name`        | Remote hostname or similar, see note below.                                  |
+| `net.peer.port`        | Remote port number.                                                          |
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/plugins/node/opentelemetry-instrumentation-redis-4/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis-4/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/redis-common": "^0.36.1",
-    "@opentelemetry/semantic-conventions": "^1.0.0"
+    "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-redis-4#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-redis-4/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-redis-4/src/instrumentation.ts
@@ -32,7 +32,7 @@ import { getClientAttributes } from './utils';
 import { defaultDbStatementSerializer } from '@opentelemetry/redis-common';
 import { RedisInstrumentationConfig } from './types';
 import { VERSION } from './version';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_DB_STATEMENT } from '@opentelemetry/semantic-conventions';
 import type { MultiErrorReply } from './internal-types';
 
 const OTEL_OPEN_SPANS = Symbol(
@@ -405,7 +405,7 @@ export class RedisInstrumentation extends InstrumentationBase<any> {
     try {
       const dbStatement = dbStatementSerializer(commandName, commandArgs);
       if (dbStatement != null) {
-        attributes[SemanticAttributes.DB_STATEMENT] = dbStatement;
+        attributes[SEMATTRS_DB_STATEMENT] = dbStatement;
       }
     } catch (e) {
       this._diag.error('dbStatementSerializer throw an exception', e, {

--- a/plugins/node/opentelemetry-instrumentation-redis-4/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-redis-4/src/utils.ts
@@ -15,8 +15,11 @@
  */
 import { Attributes, DiagLogger } from '@opentelemetry/api';
 import {
-  DbSystemValues,
-  SemanticAttributes,
+  SEMATTRS_DB_SYSTEM,
+  SEMATTRS_DB_CONNECTION_STRING,
+  SEMATTRS_NET_PEER_NAME,
+  SEMATTRS_NET_PEER_PORT,
+  DBSYSTEMVALUES_REDIS,
 } from '@opentelemetry/semantic-conventions';
 
 export function getClientAttributes(
@@ -24,10 +27,10 @@ export function getClientAttributes(
   options: any
 ): Attributes {
   return {
-    [SemanticAttributes.DB_SYSTEM]: DbSystemValues.REDIS,
-    [SemanticAttributes.NET_PEER_NAME]: options?.socket?.host,
-    [SemanticAttributes.NET_PEER_PORT]: options?.socket?.port,
-    [SemanticAttributes.DB_CONNECTION_STRING]:
+    [SEMATTRS_DB_SYSTEM]: DBSYSTEMVALUES_REDIS,
+    [SEMATTRS_NET_PEER_NAME]: options?.socket?.host,
+    [SEMATTRS_NET_PEER_PORT]: options?.socket?.port,
+    [SEMATTRS_DB_CONNECTION_STRING]:
       removeCredentialsFromDBConnectionStringAttribute(diag, options?.url),
   };
 }

--- a/plugins/node/opentelemetry-instrumentation-redis-4/test/redis.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-redis-4/test/redis.test.ts
@@ -41,7 +41,14 @@ import {
   trace,
   context,
 } from '@opentelemetry/api';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMATTRS_DB_CONNECTION_STRING,
+  SEMATTRS_DB_STATEMENT,
+  SEMATTRS_DB_SYSTEM,
+  SEMATTRS_EXCEPTION_MESSAGE,
+  SEMATTRS_NET_PEER_NAME,
+  SEMATTRS_NET_PEER_PORT,
+} from '@opentelemetry/semantic-conventions';
 import { RedisResponseCustomAttributeFunction } from '../src/types';
 import { hrTimeToMilliseconds, suppressTracing } from '@opentelemetry/core';
 
@@ -94,24 +101,21 @@ describe('redis@^4.0.0', () => {
       assert.ok(setSpan);
       assert.strictEqual(setSpan?.kind, SpanKind.CLIENT);
       assert.strictEqual(setSpan?.name, 'redis-SET');
+      assert.strictEqual(setSpan?.attributes[SEMATTRS_DB_SYSTEM], 'redis');
       assert.strictEqual(
-        setSpan?.attributes[SemanticAttributes.DB_SYSTEM],
-        'redis'
-      );
-      assert.strictEqual(
-        setSpan?.attributes[SemanticAttributes.DB_STATEMENT],
+        setSpan?.attributes[SEMATTRS_DB_STATEMENT],
         'SET key [1 other arguments]'
       );
       assert.strictEqual(
-        setSpan?.attributes[SemanticAttributes.NET_PEER_NAME],
+        setSpan?.attributes[SEMATTRS_NET_PEER_NAME],
         redisTestConfig.host
       );
       assert.strictEqual(
-        setSpan?.attributes[SemanticAttributes.NET_PEER_PORT],
+        setSpan?.attributes[SEMATTRS_NET_PEER_PORT],
         redisTestConfig.port
       );
       assert.strictEqual(
-        setSpan?.attributes[SemanticAttributes.DB_CONNECTION_STRING],
+        setSpan?.attributes[SEMATTRS_DB_CONNECTION_STRING],
         redisTestUrl
       );
 
@@ -119,24 +123,18 @@ describe('redis@^4.0.0', () => {
       assert.ok(getSpan);
       assert.strictEqual(getSpan?.kind, SpanKind.CLIENT);
       assert.strictEqual(getSpan?.name, 'redis-GET');
+      assert.strictEqual(getSpan?.attributes[SEMATTRS_DB_SYSTEM], 'redis');
+      assert.strictEqual(getSpan?.attributes[SEMATTRS_DB_STATEMENT], 'GET key');
       assert.strictEqual(
-        getSpan?.attributes[SemanticAttributes.DB_SYSTEM],
-        'redis'
-      );
-      assert.strictEqual(
-        getSpan?.attributes[SemanticAttributes.DB_STATEMENT],
-        'GET key'
-      );
-      assert.strictEqual(
-        getSpan?.attributes[SemanticAttributes.NET_PEER_NAME],
+        getSpan?.attributes[SEMATTRS_NET_PEER_NAME],
         redisTestConfig.host
       );
       assert.strictEqual(
-        getSpan?.attributes[SemanticAttributes.NET_PEER_PORT],
+        getSpan?.attributes[SEMATTRS_NET_PEER_PORT],
         redisTestConfig.port
       );
       assert.strictEqual(
-        getSpan?.attributes[SemanticAttributes.DB_CONNECTION_STRING],
+        getSpan?.attributes[SEMATTRS_DB_CONNECTION_STRING],
         redisTestUrl
       );
     });
@@ -149,15 +147,15 @@ describe('redis@^4.0.0', () => {
 
       assert.ok(setSpan);
       assert.strictEqual(
-        setSpan?.attributes[SemanticAttributes.DB_STATEMENT],
+        setSpan?.attributes[SEMATTRS_DB_STATEMENT],
         'SET key [1 other arguments]'
       );
       assert.strictEqual(
-        setSpan?.attributes[SemanticAttributes.NET_PEER_NAME],
+        setSpan?.attributes[SEMATTRS_NET_PEER_NAME],
         redisTestConfig.host
       );
       assert.strictEqual(
-        setSpan?.attributes[SemanticAttributes.NET_PEER_PORT],
+        setSpan?.attributes[SEMATTRS_NET_PEER_PORT],
         redisTestConfig.port
       );
     });
@@ -180,7 +178,7 @@ describe('redis@^4.0.0', () => {
       );
       assert.strictEqual(exceptions.length, 1);
       assert.strictEqual(
-        exceptions?.[0].attributes?.[SemanticAttributes.EXCEPTION_MESSAGE],
+        exceptions?.[0].attributes?.[SEMATTRS_EXCEPTION_MESSAGE],
         'ERR value is not an integer or out of range'
       );
     });
@@ -202,20 +200,17 @@ describe('redis@^4.0.0', () => {
 
       assert.strictEqual(span.name, 'redis-connect');
 
+      assert.strictEqual(span.attributes[SEMATTRS_DB_SYSTEM], 'redis');
       assert.strictEqual(
-        span.attributes[SemanticAttributes.DB_SYSTEM],
-        'redis'
-      );
-      assert.strictEqual(
-        span.attributes[SemanticAttributes.NET_PEER_NAME],
+        span.attributes[SEMATTRS_NET_PEER_NAME],
         redisTestConfig.host
       );
       assert.strictEqual(
-        span.attributes[SemanticAttributes.NET_PEER_PORT],
+        span.attributes[SEMATTRS_NET_PEER_PORT],
         redisTestConfig.port
       );
       assert.strictEqual(
-        span.attributes[SemanticAttributes.DB_CONNECTION_STRING],
+        span.attributes[SEMATTRS_DB_CONNECTION_STRING],
         redisTestUrl
       );
     });
@@ -235,7 +230,7 @@ describe('redis@^4.0.0', () => {
       assert.strictEqual(span.name, 'redis-connect');
       assert.strictEqual(span.status.code, SpanStatusCode.ERROR);
       assert.strictEqual(
-        span.attributes[SemanticAttributes.DB_CONNECTION_STRING],
+        span.attributes[SEMATTRS_DB_CONNECTION_STRING],
         redisURL
       );
     });
@@ -258,11 +253,11 @@ describe('redis@^4.0.0', () => {
       assert.strictEqual(span.name, 'redis-connect');
       assert.strictEqual(span.status.code, SpanStatusCode.ERROR);
       assert.strictEqual(
-        span.attributes[SemanticAttributes.NET_PEER_NAME],
+        span.attributes[SEMATTRS_NET_PEER_NAME],
         redisTestConfig.host
       );
       assert.strictEqual(
-        span.attributes[SemanticAttributes.DB_CONNECTION_STRING],
+        span.attributes[SEMATTRS_DB_CONNECTION_STRING],
         expectAttributeConnString
       );
     });
@@ -285,11 +280,11 @@ describe('redis@^4.0.0', () => {
       assert.strictEqual(span.name, 'redis-connect');
       assert.strictEqual(span.status.code, SpanStatusCode.ERROR);
       assert.strictEqual(
-        span.attributes[SemanticAttributes.NET_PEER_NAME],
+        span.attributes[SEMATTRS_NET_PEER_NAME],
         redisTestConfig.host
       );
       assert.strictEqual(
-        span.attributes[SemanticAttributes.DB_CONNECTION_STRING],
+        span.attributes[SEMATTRS_DB_CONNECTION_STRING],
         expectAttributeConnString
       );
     });
@@ -314,38 +309,38 @@ describe('redis@^4.0.0', () => {
       assert.ok(multiSetSpan);
       assert.strictEqual(multiSetSpan.name, 'redis-SET');
       assert.strictEqual(
-        multiSetSpan.attributes[SemanticAttributes.DB_STATEMENT],
+        multiSetSpan.attributes[SEMATTRS_DB_STATEMENT],
         'SET key [1 other arguments]'
       );
       assert.strictEqual(
-        multiSetSpan?.attributes[SemanticAttributes.NET_PEER_NAME],
+        multiSetSpan?.attributes[SEMATTRS_NET_PEER_NAME],
         redisTestConfig.host
       );
       assert.strictEqual(
-        multiSetSpan?.attributes[SemanticAttributes.NET_PEER_PORT],
+        multiSetSpan?.attributes[SEMATTRS_NET_PEER_PORT],
         redisTestConfig.port
       );
       assert.strictEqual(
-        multiSetSpan?.attributes[SemanticAttributes.DB_CONNECTION_STRING],
+        multiSetSpan?.attributes[SEMATTRS_DB_CONNECTION_STRING],
         redisTestUrl
       );
 
       assert.ok(multiGetSpan);
       assert.strictEqual(multiGetSpan.name, 'redis-GET');
       assert.strictEqual(
-        multiGetSpan.attributes[SemanticAttributes.DB_STATEMENT],
+        multiGetSpan.attributes[SEMATTRS_DB_STATEMENT],
         'GET another-key'
       );
       assert.strictEqual(
-        multiGetSpan?.attributes[SemanticAttributes.NET_PEER_NAME],
+        multiGetSpan?.attributes[SEMATTRS_NET_PEER_NAME],
         redisTestConfig.host
       );
       assert.strictEqual(
-        multiGetSpan?.attributes[SemanticAttributes.NET_PEER_PORT],
+        multiGetSpan?.attributes[SEMATTRS_NET_PEER_PORT],
         redisTestConfig.port
       );
       assert.strictEqual(
-        multiGetSpan?.attributes[SemanticAttributes.DB_CONNECTION_STRING],
+        multiGetSpan?.attributes[SEMATTRS_DB_CONNECTION_STRING],
         redisTestUrl
       );
     });
@@ -360,19 +355,19 @@ describe('redis@^4.0.0', () => {
       const [multiSetSpan] = getTestSpans();
       assert.ok(multiSetSpan);
       assert.strictEqual(
-        multiSetSpan.attributes[SemanticAttributes.DB_STATEMENT],
+        multiSetSpan.attributes[SEMATTRS_DB_STATEMENT],
         'SET key [1 other arguments]'
       );
       assert.strictEqual(
-        multiSetSpan?.attributes[SemanticAttributes.NET_PEER_NAME],
+        multiSetSpan?.attributes[SEMATTRS_NET_PEER_NAME],
         redisTestConfig.host
       );
       assert.strictEqual(
-        multiSetSpan?.attributes[SemanticAttributes.NET_PEER_PORT],
+        multiSetSpan?.attributes[SEMATTRS_NET_PEER_PORT],
         redisTestConfig.port
       );
       assert.strictEqual(
-        multiSetSpan?.attributes[SemanticAttributes.DB_CONNECTION_STRING],
+        multiSetSpan?.attributes[SEMATTRS_DB_CONNECTION_STRING],
         redisTestUrl
       );
     });
@@ -513,7 +508,7 @@ describe('redis@^4.0.0', () => {
         await client.set('key', 'value');
         const [span] = getTestSpans();
         assert.strictEqual(
-          span.attributes[SemanticAttributes.DB_STATEMENT],
+          span.attributes[SEMATTRS_DB_STATEMENT],
           'SET key value'
         );
       });
@@ -527,7 +522,7 @@ describe('redis@^4.0.0', () => {
         await client.set('key', 'value');
         const [span] = getTestSpans();
         assert.ok(span);
-        assert.ok(!(SemanticAttributes.DB_STATEMENT in span.attributes));
+        assert.ok(!(SEMATTRS_DB_STATEMENT in span.attributes));
       });
     });
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Updates #2025 

## Short description of the changes

- Update @opentelemetry/semantic-conventions to ^1.22
- Replace `SemanticAttributes.*` with exported strings `SEMATTRS_*`
- Update README with new semantic convention package version and key
