### PR TITLE
refactor(instr-mongoose): use exported strings for attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37027,7 +37027,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.50.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -46598,7 +46598,7 @@
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.6.5",
         "expect": "29.2.0",

--- a/plugins/node/instrumentation-mongoose/README.md
+++ b/plugins/node/instrumentation-mongoose/README.md
@@ -52,6 +52,23 @@ The instrumentation's config `responseHook` functions signature changed, so the 
 
 The `moduleVersionAttributeName` config option is removed. To add the mongoose package version to spans, use the `moduleVersion` attribute in hook info for `responseHook` function.
 
+## Semantic Conventions
+
+This package uses `@opentelemetry/semantic-conventions` version `1.22+`, which implements Semantic Convention [Version 1.7.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/semantic_conventions/README.md)
+
+Attributes collected:
+
+| Attribute               | Short Description                                                           |
+| ----------------------- | --------------------------------------------------------------------------- |
+| `db.mongodb.collection` | The collection being accessed within the database stated in `db.name`.      |
+| `db.name`               | This attribute is used to report the name of the database being accessed.   |
+| `db.operation`          | The name of the operation being executed, or the SQL keyword.               |
+| `db.statement`          | The database statement being executed.                                      |
+| `db.system`             | An identifier for the database management system (DBMS) product being used. |
+| `db.user`               | Username for accessing the database.                                        |
+| `net.peer.name`         | Remote hostname or similar.                                                 |
+| `net.peer.port`         | Remote port number.                                                         |
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/plugins/node/instrumentation-mongoose/package.json
+++ b/plugins/node/instrumentation-mongoose/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.50.0",
-    "@opentelemetry/semantic-conventions": "^1.0.0"
+    "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-mongoose#readme"
 }

--- a/plugins/node/instrumentation-mongoose/src/mongoose.ts
+++ b/plugins/node/instrumentation-mongoose/src/mongoose.ts
@@ -13,13 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  context,
-  Span,
-  trace,
-  SpanAttributes,
-  SpanKind,
-} from '@opentelemetry/api';
+import { context, Span, trace, Attributes, SpanKind } from '@opentelemetry/api';
 import { suppressTracing } from '@opentelemetry/core';
 import type * as mongoose from 'mongoose';
 import { MongooseInstrumentationConfig, SerializerPayload } from './types';
@@ -34,7 +28,11 @@ import {
   InstrumentationNodeModuleDefinition,
 } from '@opentelemetry/instrumentation';
 import { VERSION } from './version';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMATTRS_DB_OPERATION,
+  SEMATTRS_DB_STATEMENT,
+  SEMATTRS_DB_SYSTEM,
+} from '@opentelemetry/semantic-conventions';
 
 const contextCaptureFunctions = [
   'remove',
@@ -155,9 +153,9 @@ export class MongooseInstrumentation extends InstrumentationBase<any> {
         }
 
         const parentSpan = this[_STORED_PARENT_SPAN];
-        const attributes: SpanAttributes = {};
+        const attributes: Attributes = {};
         if (self._config.dbStatementSerializer) {
-          attributes[SemanticAttributes.DB_STATEMENT] =
+          attributes[SEMATTRS_DB_STATEMENT] =
             self._config.dbStatementSerializer('aggregate', {
               options: this.options,
               aggregatePipeline: this._pipeline,
@@ -197,9 +195,9 @@ export class MongooseInstrumentation extends InstrumentationBase<any> {
         }
 
         const parentSpan = this[_STORED_PARENT_SPAN];
-        const attributes: SpanAttributes = {};
+        const attributes: Attributes = {};
         if (self._config.dbStatementSerializer) {
-          attributes[SemanticAttributes.DB_STATEMENT] =
+          attributes[SEMATTRS_DB_STATEMENT] =
             self._config.dbStatementSerializer(this.op, {
               condition: this._conditions,
               updates: this._update,
@@ -243,9 +241,9 @@ export class MongooseInstrumentation extends InstrumentationBase<any> {
         if (options && !(options instanceof Function)) {
           serializePayload.options = options;
         }
-        const attributes: SpanAttributes = {};
+        const attributes: Attributes = {};
         if (self._config.dbStatementSerializer) {
-          attributes[SemanticAttributes.DB_STATEMENT] =
+          attributes[SEMATTRS_DB_STATEMENT] =
             self._config.dbStatementSerializer(op, serializePayload);
         }
         const span = self._startSpan(
@@ -308,7 +306,7 @@ export class MongooseInstrumentation extends InstrumentationBase<any> {
     collection: mongoose.Collection,
     modelName: string,
     operation: string,
-    attributes: SpanAttributes,
+    attributes: Attributes,
     parentSpan?: Span
   ): Span {
     return this.tracer.startSpan(
@@ -318,8 +316,8 @@ export class MongooseInstrumentation extends InstrumentationBase<any> {
         attributes: {
           ...attributes,
           ...getAttributesFromCollection(collection),
-          [SemanticAttributes.DB_OPERATION]: operation,
-          [SemanticAttributes.DB_SYSTEM]: 'mongoose',
+          [SEMATTRS_DB_OPERATION]: operation,
+          [SEMATTRS_DB_SYSTEM]: 'mongoose',
         },
       },
       parentSpan ? trace.setSpan(context.active(), parentSpan) : undefined

--- a/plugins/node/instrumentation-mongoose/src/utils.ts
+++ b/plugins/node/instrumentation-mongoose/src/utils.ts
@@ -13,21 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { SpanAttributes, SpanStatusCode, diag, Span } from '@opentelemetry/api';
+import { Attributes, SpanStatusCode, diag, Span } from '@opentelemetry/api';
 import type { Collection } from 'mongoose';
 import { MongooseResponseCustomAttributesFunction } from './types';
 import { safeExecuteInTheMiddle } from '@opentelemetry/instrumentation';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMATTRS_DB_MONGODB_COLLECTION,
+  SEMATTRS_DB_NAME,
+  SEMATTRS_DB_USER,
+  SEMATTRS_NET_PEER_NAME,
+  SEMATTRS_NET_PEER_PORT,
+} from '@opentelemetry/semantic-conventions';
 
 export function getAttributesFromCollection(
   collection: Collection
-): SpanAttributes {
+): Attributes {
   return {
-    [SemanticAttributes.DB_MONGODB_COLLECTION]: collection.name,
-    [SemanticAttributes.DB_NAME]: collection.conn.name,
-    [SemanticAttributes.DB_USER]: collection.conn.user,
-    [SemanticAttributes.NET_PEER_NAME]: collection.conn.host,
-    [SemanticAttributes.NET_PEER_PORT]: collection.conn.port,
+    [SEMATTRS_DB_MONGODB_COLLECTION]: collection.name,
+    [SEMATTRS_DB_NAME]: collection.conn.name,
+    [SEMATTRS_DB_USER]: collection.conn.user,
+    [SEMATTRS_NET_PEER_NAME]: collection.conn.host,
+    [SEMATTRS_NET_PEER_PORT]: collection.conn.port,
   };
 }
 

--- a/plugins/node/instrumentation-mongoose/test/asserts.ts
+++ b/plugins/node/instrumentation-mongoose/test/asserts.ts
@@ -15,21 +15,26 @@
  */
 import { expect } from 'expect';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMATTRS_DB_MONGODB_COLLECTION,
+  SEMATTRS_DB_NAME,
+  SEMATTRS_DB_STATEMENT,
+  SEMATTRS_DB_SYSTEM,
+  SEMATTRS_NET_PEER_NAME,
+  SEMATTRS_NET_PEER_PORT,
+} from '@opentelemetry/semantic-conventions';
 import { SpanStatusCode } from '@opentelemetry/api';
 import { SerializerPayload } from '../src';
 import { DB_NAME, MONGO_HOST, MONGO_PORT } from './config';
 
 export const assertSpan = (span: ReadableSpan) => {
   expect(span.status.code).toBe(SpanStatusCode.UNSET);
-  expect(span.attributes[SemanticAttributes.DB_SYSTEM]).toEqual('mongoose');
-  expect(span.attributes[SemanticAttributes.DB_MONGODB_COLLECTION]).toEqual(
-    'users'
-  );
-  expect(span.attributes[SemanticAttributes.DB_NAME]).toEqual(DB_NAME);
-  expect(span.attributes[SemanticAttributes.NET_PEER_NAME]).toEqual(MONGO_HOST);
-  expect(span.attributes[SemanticAttributes.NET_PEER_PORT]).toEqual(MONGO_PORT);
+  expect(span.attributes[SEMATTRS_DB_SYSTEM]).toEqual('mongoose');
+  expect(span.attributes[SEMATTRS_DB_MONGODB_COLLECTION]).toEqual('users');
+  expect(span.attributes[SEMATTRS_DB_NAME]).toEqual(DB_NAME);
+  expect(span.attributes[SEMATTRS_NET_PEER_NAME]).toEqual(MONGO_HOST);
+  expect(span.attributes[SEMATTRS_NET_PEER_PORT]).toEqual(MONGO_PORT);
 };
 
 export const getStatement = (span: ReadableSpan): SerializerPayload =>
-  JSON.parse(span.attributes[SemanticAttributes.DB_STATEMENT] as string);
+  JSON.parse(span.attributes[SEMATTRS_DB_STATEMENT] as string);

--- a/plugins/node/instrumentation-mongoose/test/mongoose.test.ts
+++ b/plugins/node/instrumentation-mongoose/test/mongoose.test.ts
@@ -16,7 +16,10 @@
 import 'mocha';
 import { expect } from 'expect';
 import { context, ROOT_CONTEXT } from '@opentelemetry/api';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMATTRS_DB_OPERATION,
+  SEMATTRS_DB_STATEMENT,
+} from '@opentelemetry/semantic-conventions';
 import { MongooseInstrumentation } from '../src';
 import {
   getTestSpans,
@@ -89,7 +92,7 @@ describe('mongoose instrumentation', () => {
     const spans = getTestSpans();
     expect(spans.length).toBe(1);
     assertSpan(spans[0] as ReadableSpan);
-    expect(spans[0].attributes[SemanticAttributes.DB_OPERATION]).toBe('save');
+    expect(spans[0].attributes[SEMATTRS_DB_OPERATION]).toBe('save');
     const statement = getStatement(spans[0] as ReadableSpan);
     expect(statement.document).toEqual(expect.objectContaining(document));
   });
@@ -107,7 +110,7 @@ describe('mongoose instrumentation', () => {
 
       expect(spans.length).toBe(1);
       assertSpan(spans[0] as ReadableSpan);
-      expect(spans[0].attributes[SemanticAttributes.DB_OPERATION]).toBe('save');
+      expect(spans[0].attributes[SEMATTRS_DB_OPERATION]).toBe('save');
       const statement = getStatement(spans[0] as ReadableSpan);
       expect(statement.document).toEqual(expect.objectContaining(document));
       done();
@@ -120,7 +123,7 @@ describe('mongoose instrumentation', () => {
     const spans = getTestSpans();
     expect(spans.length).toBe(1);
     assertSpan(spans[0] as ReadableSpan);
-    expect(spans[0].attributes[SemanticAttributes.DB_OPERATION]).toBe('find');
+    expect(spans[0].attributes[SEMATTRS_DB_OPERATION]).toBe('find');
     const statement = getStatement(spans[0] as ReadableSpan);
     expect(statement.condition).toEqual({ id: '_test' });
   });
@@ -135,12 +138,12 @@ describe('mongoose instrumentation', () => {
     expect(spans.length).toBe(2);
     assertSpan(spans[0] as ReadableSpan);
     assertSpan(spans[1] as ReadableSpan);
-    expect(spans[0].attributes[SemanticAttributes.DB_OPERATION]).toBe('find');
-    expect(spans[0].attributes[SemanticAttributes.DB_STATEMENT]).toMatch(
+    expect(spans[0].attributes[SEMATTRS_DB_OPERATION]).toBe('find');
+    expect(spans[0].attributes[SEMATTRS_DB_STATEMENT]).toMatch(
       /.*{"id":"_test[1-2]"}.*/g
     );
-    expect(spans[1].attributes[SemanticAttributes.DB_OPERATION]).toBe('find');
-    expect(spans[1].attributes[SemanticAttributes.DB_STATEMENT]).toMatch(
+    expect(spans[1].attributes[SEMATTRS_DB_OPERATION]).toBe('find');
+    expect(spans[1].attributes[SEMATTRS_DB_STATEMENT]).toMatch(
       /.*{"id":"_test[1-2]"}.*/g
     );
   });
@@ -151,7 +154,7 @@ describe('mongoose instrumentation', () => {
     const spans = getTestSpans();
     expect(spans.length).toBe(1);
     assertSpan(spans[0] as ReadableSpan);
-    expect(spans[0].attributes[SemanticAttributes.DB_OPERATION]).toBe('find');
+    expect(spans[0].attributes[SEMATTRS_DB_OPERATION]).toBe('find');
     const statement = getStatement(spans[0] as ReadableSpan);
     expect(statement.condition).toEqual({ id: '_test' });
     expect(statement.options).toEqual({
@@ -168,7 +171,7 @@ describe('mongoose instrumentation', () => {
     const spans = getTestSpans();
     expect(spans.length).toBe(2);
     assertSpan(spans[1] as ReadableSpan);
-    expect(spans[1].attributes[SemanticAttributes.DB_OPERATION]).toBe('remove');
+    expect(spans[1].attributes[SEMATTRS_DB_OPERATION]).toBe('remove');
   });
 
   it('instrumenting remove operation with callbacks [deprecated]', done => {
@@ -177,9 +180,7 @@ describe('mongoose instrumentation', () => {
         const spans = getTestSpans();
         expect(spans.length).toBe(2);
         assertSpan(spans[1] as ReadableSpan);
-        expect(spans[1].attributes[SemanticAttributes.DB_OPERATION]).toBe(
-          'remove'
-        );
+        expect(spans[1].attributes[SEMATTRS_DB_OPERATION]).toBe('remove');
         expect(getStatement(spans[1] as ReadableSpan).options).toEqual({
           overwrite: true,
         });
@@ -194,9 +195,7 @@ describe('mongoose instrumentation', () => {
     const spans = getTestSpans();
     expect(spans.length).toBe(1);
     assertSpan(spans[0] as ReadableSpan);
-    expect(spans[0].attributes[SemanticAttributes.DB_OPERATION]).toBe(
-      'deleteOne'
-    );
+    expect(spans[0].attributes[SEMATTRS_DB_OPERATION]).toBe('deleteOne');
   });
 
   it('instrumenting updateOne operation on models', async () => {
@@ -206,9 +205,7 @@ describe('mongoose instrumentation', () => {
     const spans = getTestSpans();
     expect(spans.length).toBe(2);
     assertSpan(spans[1] as ReadableSpan);
-    expect(spans[1].attributes[SemanticAttributes.DB_OPERATION]).toBe(
-      'updateOne'
-    );
+    expect(spans[1].attributes[SEMATTRS_DB_OPERATION]).toBe('updateOne');
 
     const statement = getStatement(spans[1] as ReadableSpan);
     expect(statement.options).toEqual({ skip: 0 });
@@ -226,9 +223,7 @@ describe('mongoose instrumentation', () => {
     const spans = getTestSpans();
     expect(spans.length).toBe(1);
     assertSpan(spans[0] as ReadableSpan);
-    expect(spans[0].attributes[SemanticAttributes.DB_OPERATION]).toBe(
-      'updateOne'
-    );
+    expect(spans[0].attributes[SEMATTRS_DB_OPERATION]).toBe('updateOne');
 
     const statement = getStatement(spans[0] as ReadableSpan);
     expect(statement.options).toEqual({ skip: 0 });
@@ -242,7 +237,7 @@ describe('mongoose instrumentation', () => {
     const spans = getTestSpans();
     expect(spans.length).toBe(1);
     assertSpan(spans[0] as ReadableSpan);
-    expect(spans[0].attributes[SemanticAttributes.DB_OPERATION]).toBe('count');
+    expect(spans[0].attributes[SEMATTRS_DB_OPERATION]).toBe('count');
     const statement = getStatement(spans[0] as ReadableSpan);
     expect(statement.options).toEqual({});
     expect(statement.condition).toEqual({});
@@ -254,9 +249,7 @@ describe('mongoose instrumentation', () => {
     const spans = getTestSpans();
     expect(spans.length).toBe(1);
     assertSpan(spans[0] as ReadableSpan);
-    expect(spans[0].attributes[SemanticAttributes.DB_OPERATION]).toBe(
-      'countDocuments'
-    );
+    expect(spans[0].attributes[SEMATTRS_DB_OPERATION]).toBe('countDocuments');
     const statement = getStatement(spans[0] as ReadableSpan);
     expect(statement.options).toEqual({});
     expect(statement.condition).toEqual({ email: 'john.doe@example.com' });
@@ -268,7 +261,7 @@ describe('mongoose instrumentation', () => {
     const spans = getTestSpans();
     expect(spans.length).toBe(1);
     assertSpan(spans[0] as ReadableSpan);
-    expect(spans[0].attributes[SemanticAttributes.DB_OPERATION]).toBe(
+    expect(spans[0].attributes[SEMATTRS_DB_OPERATION]).toBe(
       'estimatedDocumentCount'
     );
     const statement = getStatement(spans[0] as ReadableSpan);
@@ -282,9 +275,7 @@ describe('mongoose instrumentation', () => {
     const spans = getTestSpans();
     expect(spans.length).toBe(1);
     assertSpan(spans[0] as ReadableSpan);
-    expect(spans[0].attributes[SemanticAttributes.DB_OPERATION]).toBe(
-      'deleteMany'
-    );
+    expect(spans[0].attributes[SEMATTRS_DB_OPERATION]).toBe('deleteMany');
     const statement = getStatement(spans[0] as ReadableSpan);
     expect(statement.options).toEqual({});
     expect(statement.condition).toEqual({});
@@ -296,9 +287,7 @@ describe('mongoose instrumentation', () => {
     const spans = getTestSpans();
     expect(spans.length).toBe(1);
     assertSpan(spans[0] as ReadableSpan);
-    expect(spans[0].attributes[SemanticAttributes.DB_OPERATION]).toBe(
-      'findOne'
-    );
+    expect(spans[0].attributes[SEMATTRS_DB_OPERATION]).toBe('findOne');
     const statement = getStatement(spans[0] as ReadableSpan);
     expect(statement.options).toEqual({});
     expect(statement.condition).toEqual({ email: 'john.doe@example.com' });
@@ -313,7 +302,7 @@ describe('mongoose instrumentation', () => {
     const spans = getTestSpans();
     expect(spans.length).toBe(1);
     assertSpan(spans[0] as ReadableSpan);
-    expect(spans[0].attributes[SemanticAttributes.DB_OPERATION]).toBe('update');
+    expect(spans[0].attributes[SEMATTRS_DB_OPERATION]).toBe('update');
     const statement = getStatement(spans[0] as ReadableSpan);
     expect(statement.options).toEqual({});
     expect(statement.condition).toEqual({ email: 'john.doe@example.com' });
@@ -326,9 +315,7 @@ describe('mongoose instrumentation', () => {
     const spans = getTestSpans();
     expect(spans.length).toBe(1);
     assertSpan(spans[0] as ReadableSpan);
-    expect(spans[0].attributes[SemanticAttributes.DB_OPERATION]).toBe(
-      'updateOne'
-    );
+    expect(spans[0].attributes[SEMATTRS_DB_OPERATION]).toBe('updateOne');
     const statement = getStatement(spans[0] as ReadableSpan);
     expect(statement.options).toEqual({});
     expect(statement.condition).toEqual({ email: 'john.doe@example.com' });
@@ -341,9 +328,7 @@ describe('mongoose instrumentation', () => {
     const spans = getTestSpans();
     expect(spans.length).toBe(1);
     assertSpan(spans[0] as ReadableSpan);
-    expect(spans[0].attributes[SemanticAttributes.DB_OPERATION]).toBe(
-      'updateMany'
-    );
+    expect(spans[0].attributes[SEMATTRS_DB_OPERATION]).toBe('updateMany');
     const statement = getStatement(spans[0] as ReadableSpan);
     expect(statement.options).toEqual({});
     expect(statement.condition).toEqual({ age: 18 });
@@ -356,9 +341,7 @@ describe('mongoose instrumentation', () => {
     const spans = getTestSpans();
     expect(spans.length).toBe(1);
     assertSpan(spans[0] as ReadableSpan);
-    expect(spans[0].attributes[SemanticAttributes.DB_OPERATION]).toBe(
-      'findOneAndDelete'
-    );
+    expect(spans[0].attributes[SEMATTRS_DB_OPERATION]).toBe('findOneAndDelete');
     const statement = getStatement(spans[0] as ReadableSpan);
     expect(statement.options).toEqual({});
     expect(statement.condition).toEqual({ email: 'john.doe@example.com' });
@@ -374,12 +357,8 @@ describe('mongoose instrumentation', () => {
     expect(spans.length).toBe(2);
     assertSpan(spans[0] as ReadableSpan);
     assertSpan(spans[1] as ReadableSpan);
-    expect(spans[0].attributes[SemanticAttributes.DB_OPERATION]).toBe(
-      'findOne'
-    );
-    expect(spans[1].attributes[SemanticAttributes.DB_OPERATION]).toBe(
-      'findOneAndUpdate'
-    );
+    expect(spans[0].attributes[SEMATTRS_DB_OPERATION]).toBe('findOne');
+    expect(spans[1].attributes[SEMATTRS_DB_OPERATION]).toBe('findOneAndUpdate');
     const statement = getStatement(spans[1] as ReadableSpan);
     expect(statement.options).toEqual({});
     expect(statement.condition).toEqual({ email: 'john.doe@example.com' });
@@ -392,9 +371,7 @@ describe('mongoose instrumentation', () => {
     const spans = getTestSpans();
     expect(spans.length).toBe(1);
     assertSpan(spans[0] as ReadableSpan);
-    expect(spans[0].attributes[SemanticAttributes.DB_OPERATION]).toBe(
-      'findOneAndRemove'
-    );
+    expect(spans[0].attributes[SEMATTRS_DB_OPERATION]).toBe('findOneAndRemove');
     const statement = getStatement(spans[0] as ReadableSpan);
     expect(statement.options).toEqual({});
     expect(statement.condition).toEqual({ email: 'john.doe@example.com' });
@@ -411,7 +388,7 @@ describe('mongoose instrumentation', () => {
     const spans = getTestSpans();
     expect(spans.length).toBe(1);
     assertSpan(spans[0] as ReadableSpan);
-    expect(spans[0].attributes[SemanticAttributes.DB_OPERATION]).toBe('save');
+    expect(spans[0].attributes[SEMATTRS_DB_OPERATION]).toBe('save');
     const statement = getStatement(spans[0] as ReadableSpan);
     expect(statement.options).toEqual({});
     expect(statement.document).toEqual(expect.objectContaining(document));
@@ -426,9 +403,7 @@ describe('mongoose instrumentation', () => {
     const spans = getTestSpans();
     expect(spans.length).toBe(1);
     assertSpan(spans[0] as ReadableSpan);
-    expect(spans[0].attributes[SemanticAttributes.DB_OPERATION]).toBe(
-      'aggregate'
-    );
+    expect(spans[0].attributes[SEMATTRS_DB_OPERATION]).toBe('aggregate');
     const statement = getStatement(spans[0] as ReadableSpan);
     expect(statement.aggregatePipeline).toEqual([
       { $match: { firstName: 'John' } },
@@ -446,9 +421,7 @@ describe('mongoose instrumentation', () => {
         const spans = getTestSpans();
         expect(spans.length).toBe(1);
         assertSpan(spans[0] as ReadableSpan);
-        expect(spans[0].attributes[SemanticAttributes.DB_OPERATION]).toBe(
-          'aggregate'
-        );
+        expect(spans[0].attributes[SEMATTRS_DB_OPERATION]).toBe('aggregate');
         const statement = getStatement(spans[0] as ReadableSpan);
         expect(statement.aggregatePipeline).toEqual([
           { $match: { firstName: 'John' } },
@@ -483,9 +456,7 @@ describe('mongoose instrumentation', () => {
     const spans = getTestSpans();
     expect(spans.length).toBe(1);
     assertSpan(spans[0] as ReadableSpan);
-    expect(spans[0].attributes[SemanticAttributes.DB_STATEMENT]).toBe(
-      undefined
-    );
+    expect(spans[0].attributes[SEMATTRS_DB_STATEMENT]).toBe(undefined);
   });
 
   it('projection is sent to serializer', async () => {
@@ -503,7 +474,7 @@ describe('mongoose instrumentation', () => {
     expect(spans.length).toBe(1);
     assertSpan(spans[0] as ReadableSpan);
     const reqPayload = JSON.parse(
-      spans[0].attributes[SemanticAttributes.DB_STATEMENT] as string
+      spans[0].attributes[SEMATTRS_DB_STATEMENT] as string
     );
     expect(reqPayload.fields).toStrictEqual(projection);
   });


### PR DESCRIPTION
## Which problem is this PR solving?

- Updates #2025 

## Short description of the changes

- Update @opentelemetry/semantic-conventions to ^1.22
- Replace `SemanticAttributes.*` with exported strings `SEMATTRS_*`
- Update README with new semantic convention package version and key
