### PR TITLE
chore(instr-amqpllib): use semconv strings in test files

### DIFF
--- a/plugins/node/instrumentation-amqplib/test/amqplib-callbacks.test.ts
+++ b/plugins/node/instrumentation-amqplib/test/amqplib-callbacks.test.ts
@@ -25,8 +25,16 @@ registerInstrumentationTesting(new AmqplibInstrumentation());
 
 import * as amqpCallback from 'amqplib/callback_api';
 import {
-  MessagingDestinationKindValues,
-  SemanticAttributes,
+  MESSAGINGDESTINATIONKINDVALUES_TOPIC,
+  SEMATTRS_MESSAGING_DESTINATION,
+  SEMATTRS_MESSAGING_DESTINATION_KIND,
+  SEMATTRS_MESSAGING_PROTOCOL,
+  SEMATTRS_MESSAGING_PROTOCOL_VERSION,
+  SEMATTRS_MESSAGING_RABBITMQ_ROUTING_KEY,
+  SEMATTRS_MESSAGING_SYSTEM,
+  SEMATTRS_MESSAGING_URL,
+  SEMATTRS_NET_PEER_NAME,
+  SEMATTRS_NET_PEER_PORT,
 } from '@opentelemetry/semantic-conventions';
 import { Baggage, context, propagation, SpanKind } from '@opentelemetry/api';
 import { asyncConfirmSend, asyncConsume, shouldTest } from './utils';
@@ -127,67 +135,63 @@ describe('amqplib instrumentation callback model', () => {
 
         // assert publish span
         expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
+        expect(publishSpan.attributes[SEMATTRS_MESSAGING_SYSTEM]).toEqual(
+          'rabbitmq'
+        );
+        expect(publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]).toEqual(
+          ''
+        ); // according to spec: "This will be an empty string if the default exchange is used"
         expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]
-        ).toEqual('rabbitmq');
+          publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]
+        ).toEqual(MESSAGINGDESTINATIONKINDVALUES_TOPIC);
         expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]
-        ).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
-        expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]
-        ).toEqual(MessagingDestinationKindValues.TOPIC);
-        expect(
-          publishSpan.attributes[
-            SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY
-          ]
+          publishSpan.attributes[SEMATTRS_MESSAGING_RABBITMQ_ROUTING_KEY]
         ).toEqual(queueName);
+        expect(publishSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL]).toEqual(
+          'AMQP'
+        );
         expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]
-        ).toEqual('AMQP');
-        expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]
+          publishSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL_VERSION]
         ).toEqual('0.9.1');
-        expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_URL]
-        ).toEqual(censoredUrl);
-        expect(
-          publishSpan.attributes[SemanticAttributes.NET_PEER_NAME]
-        ).toEqual(TEST_RABBITMQ_HOST);
-        expect(
-          publishSpan.attributes[SemanticAttributes.NET_PEER_PORT]
-        ).toEqual(TEST_RABBITMQ_PORT);
+        expect(publishSpan.attributes[SEMATTRS_MESSAGING_URL]).toEqual(
+          censoredUrl
+        );
+        expect(publishSpan.attributes[SEMATTRS_NET_PEER_NAME]).toEqual(
+          TEST_RABBITMQ_HOST
+        );
+        expect(publishSpan.attributes[SEMATTRS_NET_PEER_PORT]).toEqual(
+          TEST_RABBITMQ_PORT
+        );
 
         // assert consume span
         expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
+        expect(consumeSpan.attributes[SEMATTRS_MESSAGING_SYSTEM]).toEqual(
+          'rabbitmq'
+        );
+        expect(consumeSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]).toEqual(
+          ''
+        ); // according to spec: "This will be an empty string if the default exchange is used"
         expect(
-          consumeSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]
-        ).toEqual('rabbitmq');
+          consumeSpan.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]
+        ).toEqual(MESSAGINGDESTINATIONKINDVALUES_TOPIC);
         expect(
-          consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]
-        ).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
-        expect(
-          consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]
-        ).toEqual(MessagingDestinationKindValues.TOPIC);
-        expect(
-          consumeSpan.attributes[
-            SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY
-          ]
+          consumeSpan.attributes[SEMATTRS_MESSAGING_RABBITMQ_ROUTING_KEY]
         ).toEqual(queueName);
+        expect(consumeSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL]).toEqual(
+          'AMQP'
+        );
         expect(
-          consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]
-        ).toEqual('AMQP');
-        expect(
-          consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]
+          consumeSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL_VERSION]
         ).toEqual('0.9.1');
-        expect(
-          consumeSpan.attributes[SemanticAttributes.MESSAGING_URL]
-        ).toEqual(censoredUrl);
-        expect(
-          consumeSpan.attributes[SemanticAttributes.NET_PEER_NAME]
-        ).toEqual(TEST_RABBITMQ_HOST);
-        expect(
-          consumeSpan.attributes[SemanticAttributes.NET_PEER_PORT]
-        ).toEqual(TEST_RABBITMQ_PORT);
+        expect(consumeSpan.attributes[SEMATTRS_MESSAGING_URL]).toEqual(
+          censoredUrl
+        );
+        expect(consumeSpan.attributes[SEMATTRS_NET_PEER_NAME]).toEqual(
+          TEST_RABBITMQ_HOST
+        );
+        expect(consumeSpan.attributes[SEMATTRS_NET_PEER_PORT]).toEqual(
+          TEST_RABBITMQ_PORT
+        );
 
         // assert context propagation
         expect(consumeSpan.spanContext().traceId).toEqual(
@@ -301,75 +305,63 @@ describe('amqplib instrumentation callback model', () => {
 
           // assert publish span
           expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
+          expect(publishSpan.attributes[SEMATTRS_MESSAGING_SYSTEM]).toEqual(
+            'rabbitmq'
+          );
           expect(
-            publishSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]
-          ).toEqual('rabbitmq');
-          expect(
-            publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]
+            publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]
           ).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
           expect(
-            publishSpan.attributes[
-              SemanticAttributes.MESSAGING_DESTINATION_KIND
-            ]
-          ).toEqual(MessagingDestinationKindValues.TOPIC);
+            publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]
+          ).toEqual(MESSAGINGDESTINATIONKINDVALUES_TOPIC);
           expect(
-            publishSpan.attributes[
-              SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY
-            ]
+            publishSpan.attributes[SEMATTRS_MESSAGING_RABBITMQ_ROUTING_KEY]
           ).toEqual(queueName);
+          expect(publishSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL]).toEqual(
+            'AMQP'
+          );
           expect(
-            publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]
-          ).toEqual('AMQP');
-          expect(
-            publishSpan.attributes[
-              SemanticAttributes.MESSAGING_PROTOCOL_VERSION
-            ]
+            publishSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL_VERSION]
           ).toEqual('0.9.1');
-          expect(
-            publishSpan.attributes[SemanticAttributes.MESSAGING_URL]
-          ).toEqual(censoredUrl);
-          expect(
-            publishSpan.attributes[SemanticAttributes.NET_PEER_NAME]
-          ).toEqual(TEST_RABBITMQ_HOST);
-          expect(
-            publishSpan.attributes[SemanticAttributes.NET_PEER_PORT]
-          ).toEqual(TEST_RABBITMQ_PORT);
+          expect(publishSpan.attributes[SEMATTRS_MESSAGING_URL]).toEqual(
+            censoredUrl
+          );
+          expect(publishSpan.attributes[SEMATTRS_NET_PEER_NAME]).toEqual(
+            TEST_RABBITMQ_HOST
+          );
+          expect(publishSpan.attributes[SEMATTRS_NET_PEER_PORT]).toEqual(
+            TEST_RABBITMQ_PORT
+          );
 
           // assert consume span
           expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
+          expect(consumeSpan.attributes[SEMATTRS_MESSAGING_SYSTEM]).toEqual(
+            'rabbitmq'
+          );
           expect(
-            consumeSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]
-          ).toEqual('rabbitmq');
-          expect(
-            consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]
+            consumeSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]
           ).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
           expect(
-            consumeSpan.attributes[
-              SemanticAttributes.MESSAGING_DESTINATION_KIND
-            ]
-          ).toEqual(MessagingDestinationKindValues.TOPIC);
+            consumeSpan.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]
+          ).toEqual(MESSAGINGDESTINATIONKINDVALUES_TOPIC);
           expect(
-            consumeSpan.attributes[
-              SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY
-            ]
+            consumeSpan.attributes[SEMATTRS_MESSAGING_RABBITMQ_ROUTING_KEY]
           ).toEqual(queueName);
+          expect(consumeSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL]).toEqual(
+            'AMQP'
+          );
           expect(
-            consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]
-          ).toEqual('AMQP');
-          expect(
-            consumeSpan.attributes[
-              SemanticAttributes.MESSAGING_PROTOCOL_VERSION
-            ]
+            consumeSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL_VERSION]
           ).toEqual('0.9.1');
-          expect(
-            consumeSpan.attributes[SemanticAttributes.MESSAGING_URL]
-          ).toEqual(censoredUrl);
-          expect(
-            consumeSpan.attributes[SemanticAttributes.NET_PEER_NAME]
-          ).toEqual(TEST_RABBITMQ_HOST);
-          expect(
-            consumeSpan.attributes[SemanticAttributes.NET_PEER_PORT]
-          ).toEqual(TEST_RABBITMQ_PORT);
+          expect(consumeSpan.attributes[SEMATTRS_MESSAGING_URL]).toEqual(
+            censoredUrl
+          );
+          expect(consumeSpan.attributes[SEMATTRS_NET_PEER_NAME]).toEqual(
+            TEST_RABBITMQ_HOST
+          );
+          expect(consumeSpan.attributes[SEMATTRS_NET_PEER_PORT]).toEqual(
+            TEST_RABBITMQ_PORT
+          );
 
           // assert context propagation
           expect(consumeSpan.spanContext().traceId).toEqual(

--- a/plugins/node/instrumentation-amqplib/test/amqplib-connection.test.ts
+++ b/plugins/node/instrumentation-amqplib/test/amqplib-connection.test.ts
@@ -32,7 +32,14 @@ import {
 
 registerInstrumentationTesting(new AmqplibInstrumentation());
 import * as amqp from 'amqplib';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMATTRS_MESSAGING_PROTOCOL,
+  SEMATTRS_MESSAGING_PROTOCOL_VERSION,
+  SEMATTRS_MESSAGING_SYSTEM,
+  SEMATTRS_MESSAGING_URL,
+  SEMATTRS_NET_PEER_NAME,
+  SEMATTRS_NET_PEER_PORT,
+} from '@opentelemetry/semantic-conventions';
 
 describe('amqplib instrumentation connection', () => {
   before(function () {
@@ -60,24 +67,22 @@ describe('amqplib instrumentation connection', () => {
         );
         const [publishSpan] = getTestSpans();
 
+        expect(publishSpan.attributes[SEMATTRS_MESSAGING_SYSTEM]).toEqual(
+          'rabbitmq'
+        );
+        expect(publishSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL]).toEqual(
+          'AMQP'
+        );
         expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]
-        ).toEqual('rabbitmq');
-        expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]
-        ).toEqual('AMQP');
-        expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]
+          publishSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL_VERSION]
         ).toEqual('0.9.1');
-        expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_URL]
-        ).toBeUndefined(); // no url string if value supplied as object
-        expect(
-          publishSpan.attributes[SemanticAttributes.NET_PEER_NAME]
-        ).toEqual(TEST_RABBITMQ_HOST);
-        expect(
-          publishSpan.attributes[SemanticAttributes.NET_PEER_PORT]
-        ).toEqual(TEST_RABBITMQ_PORT);
+        expect(publishSpan.attributes[SEMATTRS_MESSAGING_URL]).toBeUndefined(); // no url string if value supplied as object
+        expect(publishSpan.attributes[SEMATTRS_NET_PEER_NAME]).toEqual(
+          TEST_RABBITMQ_HOST
+        );
+        expect(publishSpan.attributes[SEMATTRS_NET_PEER_PORT]).toEqual(
+          TEST_RABBITMQ_PORT
+        );
       } finally {
         await conn.close();
       }
@@ -99,9 +104,9 @@ describe('amqplib instrumentation connection', () => {
           Buffer.from('message created only to test connection attributes')
         );
         const [publishSpan] = getTestSpans();
-        expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]
-        ).toEqual('AMQP');
+        expect(publishSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL]).toEqual(
+          'AMQP'
+        );
       } finally {
         await conn.close();
       }
@@ -127,9 +132,9 @@ describe('amqplib instrumentation connection', () => {
           Buffer.from('message created only to test connection attributes')
         );
         const [publishSpan] = getTestSpans();
-        expect(
-          publishSpan.attributes[SemanticAttributes.NET_PEER_NAME]
-        ).toEqual(TEST_RABBITMQ_HOST);
+        expect(publishSpan.attributes[SEMATTRS_NET_PEER_NAME]).toEqual(
+          TEST_RABBITMQ_HOST
+        );
       } finally {
         await conn.close();
       }
@@ -149,24 +154,24 @@ describe('amqplib instrumentation connection', () => {
         );
         const [publishSpan] = getTestSpans();
 
+        expect(publishSpan.attributes[SEMATTRS_MESSAGING_SYSTEM]).toEqual(
+          'rabbitmq'
+        );
+        expect(publishSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL]).toEqual(
+          'AMQP'
+        );
         expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]
-        ).toEqual('rabbitmq');
-        expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]
-        ).toEqual('AMQP');
-        expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]
+          publishSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL_VERSION]
         ).toEqual('0.9.1');
-        expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_URL]
-        ).toEqual(censoredUrl);
-        expect(
-          publishSpan.attributes[SemanticAttributes.NET_PEER_NAME]
-        ).toEqual(TEST_RABBITMQ_HOST);
-        expect(
-          publishSpan.attributes[SemanticAttributes.NET_PEER_PORT]
-        ).toEqual(TEST_RABBITMQ_PORT);
+        expect(publishSpan.attributes[SEMATTRS_MESSAGING_URL]).toEqual(
+          censoredUrl
+        );
+        expect(publishSpan.attributes[SEMATTRS_NET_PEER_NAME]).toEqual(
+          TEST_RABBITMQ_HOST
+        );
+        expect(publishSpan.attributes[SEMATTRS_NET_PEER_PORT]).toEqual(
+          TEST_RABBITMQ_PORT
+        );
       } finally {
         await conn.close();
       }

--- a/plugins/node/instrumentation-amqplib/test/amqplib-promise.test.ts
+++ b/plugins/node/instrumentation-amqplib/test/amqplib-promise.test.ts
@@ -36,8 +36,16 @@ const instrumentation = registerInstrumentationTesting(
 import * as amqp from 'amqplib';
 import { ConsumeMessage } from 'amqplib';
 import {
-  MessagingDestinationKindValues,
-  SemanticAttributes,
+  MESSAGINGDESTINATIONKINDVALUES_TOPIC,
+  SEMATTRS_MESSAGING_DESTINATION,
+  SEMATTRS_MESSAGING_DESTINATION_KIND,
+  SEMATTRS_MESSAGING_PROTOCOL,
+  SEMATTRS_MESSAGING_PROTOCOL_VERSION,
+  SEMATTRS_MESSAGING_RABBITMQ_ROUTING_KEY,
+  SEMATTRS_MESSAGING_SYSTEM,
+  SEMATTRS_MESSAGING_URL,
+  SEMATTRS_NET_PEER_NAME,
+  SEMATTRS_NET_PEER_PORT,
 } from '@opentelemetry/semantic-conventions';
 import { Span, SpanKind, SpanStatusCode } from '@opentelemetry/api';
 import { asyncConfirmPublish, asyncConfirmSend, asyncConsume } from './utils';
@@ -146,65 +154,61 @@ describe('amqplib instrumentation promise model', () => {
 
       // assert publish span
       expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
+      expect(publishSpan.attributes[SEMATTRS_MESSAGING_SYSTEM]).toEqual(
+        'rabbitmq'
+      );
+      expect(publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]).toEqual(
+        ''
+      ); // according to spec: "This will be an empty string if the default exchange is used"
       expect(
-        publishSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]
-      ).toEqual('rabbitmq');
+        publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]
+      ).toEqual(MESSAGINGDESTINATIONKINDVALUES_TOPIC);
       expect(
-        publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]
-      ).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
-      expect(
-        publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]
-      ).toEqual(MessagingDestinationKindValues.TOPIC);
-      expect(
-        publishSpan.attributes[
-          SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY
-        ]
+        publishSpan.attributes[SEMATTRS_MESSAGING_RABBITMQ_ROUTING_KEY]
       ).toEqual(queueName);
+      expect(publishSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL]).toEqual(
+        'AMQP'
+      );
       expect(
-        publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]
-      ).toEqual('AMQP');
-      expect(
-        publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]
+        publishSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL_VERSION]
       ).toEqual('0.9.1');
-      expect(publishSpan.attributes[SemanticAttributes.MESSAGING_URL]).toEqual(
+      expect(publishSpan.attributes[SEMATTRS_MESSAGING_URL]).toEqual(
         censoredUrl
       );
-      expect(publishSpan.attributes[SemanticAttributes.NET_PEER_NAME]).toEqual(
+      expect(publishSpan.attributes[SEMATTRS_NET_PEER_NAME]).toEqual(
         TEST_RABBITMQ_HOST
       );
-      expect(publishSpan.attributes[SemanticAttributes.NET_PEER_PORT]).toEqual(
+      expect(publishSpan.attributes[SEMATTRS_NET_PEER_PORT]).toEqual(
         TEST_RABBITMQ_PORT
       );
 
       // assert consume span
       expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
+      expect(consumeSpan.attributes[SEMATTRS_MESSAGING_SYSTEM]).toEqual(
+        'rabbitmq'
+      );
+      expect(consumeSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]).toEqual(
+        ''
+      ); // according to spec: "This will be an empty string if the default exchange is used"
       expect(
-        consumeSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]
-      ).toEqual('rabbitmq');
+        consumeSpan.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]
+      ).toEqual(MESSAGINGDESTINATIONKINDVALUES_TOPIC);
       expect(
-        consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]
-      ).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
-      expect(
-        consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]
-      ).toEqual(MessagingDestinationKindValues.TOPIC);
-      expect(
-        consumeSpan.attributes[
-          SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY
-        ]
+        consumeSpan.attributes[SEMATTRS_MESSAGING_RABBITMQ_ROUTING_KEY]
       ).toEqual(queueName);
+      expect(consumeSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL]).toEqual(
+        'AMQP'
+      );
       expect(
-        consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]
-      ).toEqual('AMQP');
-      expect(
-        consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]
+        consumeSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL_VERSION]
       ).toEqual('0.9.1');
-      expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_URL]).toEqual(
+      expect(consumeSpan.attributes[SEMATTRS_MESSAGING_URL]).toEqual(
         censoredUrl
       );
-      expect(consumeSpan.attributes[SemanticAttributes.NET_PEER_NAME]).toEqual(
+      expect(consumeSpan.attributes[SEMATTRS_NET_PEER_NAME]).toEqual(
         TEST_RABBITMQ_HOST
       );
-      expect(consumeSpan.attributes[SemanticAttributes.NET_PEER_PORT]).toEqual(
+      expect(consumeSpan.attributes[SEMATTRS_NET_PEER_PORT]).toEqual(
         TEST_RABBITMQ_PORT
       );
 
@@ -505,48 +509,44 @@ describe('amqplib instrumentation promise model', () => {
 
         // assert publish span
         expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
+        expect(publishSpan.attributes[SEMATTRS_MESSAGING_SYSTEM]).toEqual(
+          'rabbitmq'
+        );
+        expect(publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]).toEqual(
+          exchangeName
+        );
         expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]
-        ).toEqual('rabbitmq');
+          publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]
+        ).toEqual(MESSAGINGDESTINATIONKINDVALUES_TOPIC);
         expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]
-        ).toEqual(exchangeName);
-        expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]
-        ).toEqual(MessagingDestinationKindValues.TOPIC);
-        expect(
-          publishSpan.attributes[
-            SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY
-          ]
+          publishSpan.attributes[SEMATTRS_MESSAGING_RABBITMQ_ROUTING_KEY]
         ).toEqual(routingKey);
+        expect(publishSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL]).toEqual(
+          'AMQP'
+        );
         expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]
-        ).toEqual('AMQP');
-        expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]
+          publishSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL_VERSION]
         ).toEqual('0.9.1');
 
         // assert consume span
         expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
+        expect(consumeSpan.attributes[SEMATTRS_MESSAGING_SYSTEM]).toEqual(
+          'rabbitmq'
+        );
+        expect(consumeSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]).toEqual(
+          exchangeName
+        );
         expect(
-          consumeSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]
-        ).toEqual('rabbitmq');
+          consumeSpan.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]
+        ).toEqual(MESSAGINGDESTINATIONKINDVALUES_TOPIC);
         expect(
-          consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]
-        ).toEqual(exchangeName);
-        expect(
-          consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]
-        ).toEqual(MessagingDestinationKindValues.TOPIC);
-        expect(
-          consumeSpan.attributes[
-            SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY
-          ]
+          consumeSpan.attributes[SEMATTRS_MESSAGING_RABBITMQ_ROUTING_KEY]
         ).toEqual(routingKey);
+        expect(consumeSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL]).toEqual(
+          'AMQP'
+        );
         expect(
-          consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]
-        ).toEqual('AMQP');
-        expect(
-          consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]
+          consumeSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL_VERSION]
         ).toEqual('0.9.1');
 
         // assert context propagation
@@ -689,65 +689,61 @@ describe('amqplib instrumentation promise model', () => {
 
       // assert publish span
       expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
+      expect(publishSpan.attributes[SEMATTRS_MESSAGING_SYSTEM]).toEqual(
+        'rabbitmq'
+      );
+      expect(publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]).toEqual(
+        ''
+      ); // according to spec: "This will be an empty string if the default exchange is used"
       expect(
-        publishSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]
-      ).toEqual('rabbitmq');
+        publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]
+      ).toEqual(MESSAGINGDESTINATIONKINDVALUES_TOPIC);
       expect(
-        publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]
-      ).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
-      expect(
-        publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]
-      ).toEqual(MessagingDestinationKindValues.TOPIC);
-      expect(
-        publishSpan.attributes[
-          SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY
-        ]
+        publishSpan.attributes[SEMATTRS_MESSAGING_RABBITMQ_ROUTING_KEY]
       ).toEqual(queueName);
+      expect(publishSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL]).toEqual(
+        'AMQP'
+      );
       expect(
-        publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]
-      ).toEqual('AMQP');
-      expect(
-        publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]
+        publishSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL_VERSION]
       ).toEqual('0.9.1');
-      expect(publishSpan.attributes[SemanticAttributes.MESSAGING_URL]).toEqual(
+      expect(publishSpan.attributes[SEMATTRS_MESSAGING_URL]).toEqual(
         censoredUrl
       );
-      expect(publishSpan.attributes[SemanticAttributes.NET_PEER_NAME]).toEqual(
+      expect(publishSpan.attributes[SEMATTRS_NET_PEER_NAME]).toEqual(
         TEST_RABBITMQ_HOST
       );
-      expect(publishSpan.attributes[SemanticAttributes.NET_PEER_PORT]).toEqual(
+      expect(publishSpan.attributes[SEMATTRS_NET_PEER_PORT]).toEqual(
         TEST_RABBITMQ_PORT
       );
 
       // assert consume span
       expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
+      expect(consumeSpan.attributes[SEMATTRS_MESSAGING_SYSTEM]).toEqual(
+        'rabbitmq'
+      );
+      expect(consumeSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]).toEqual(
+        ''
+      ); // according to spec: "This will be an empty string if the default exchange is used"
       expect(
-        consumeSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]
-      ).toEqual('rabbitmq');
+        consumeSpan.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]
+      ).toEqual(MESSAGINGDESTINATIONKINDVALUES_TOPIC);
       expect(
-        consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]
-      ).toEqual(''); // according to spec: "This will be an empty string if the default exchange is used"
-      expect(
-        consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]
-      ).toEqual(MessagingDestinationKindValues.TOPIC);
-      expect(
-        consumeSpan.attributes[
-          SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY
-        ]
+        consumeSpan.attributes[SEMATTRS_MESSAGING_RABBITMQ_ROUTING_KEY]
       ).toEqual(queueName);
+      expect(consumeSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL]).toEqual(
+        'AMQP'
+      );
       expect(
-        consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]
-      ).toEqual('AMQP');
-      expect(
-        consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]
+        consumeSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL_VERSION]
       ).toEqual('0.9.1');
-      expect(consumeSpan.attributes[SemanticAttributes.MESSAGING_URL]).toEqual(
+      expect(consumeSpan.attributes[SEMATTRS_MESSAGING_URL]).toEqual(
         censoredUrl
       );
-      expect(consumeSpan.attributes[SemanticAttributes.NET_PEER_NAME]).toEqual(
+      expect(consumeSpan.attributes[SEMATTRS_NET_PEER_NAME]).toEqual(
         TEST_RABBITMQ_HOST
       );
-      expect(consumeSpan.attributes[SemanticAttributes.NET_PEER_PORT]).toEqual(
+      expect(consumeSpan.attributes[SEMATTRS_NET_PEER_PORT]).toEqual(
         TEST_RABBITMQ_PORT
       );
 
@@ -1100,48 +1096,44 @@ describe('amqplib instrumentation promise model', () => {
 
         // assert publish span
         expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
+        expect(publishSpan.attributes[SEMATTRS_MESSAGING_SYSTEM]).toEqual(
+          'rabbitmq'
+        );
+        expect(publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]).toEqual(
+          exchangeName
+        );
         expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]
-        ).toEqual('rabbitmq');
+          publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]
+        ).toEqual(MESSAGINGDESTINATIONKINDVALUES_TOPIC);
         expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]
-        ).toEqual(exchangeName);
-        expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]
-        ).toEqual(MessagingDestinationKindValues.TOPIC);
-        expect(
-          publishSpan.attributes[
-            SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY
-          ]
+          publishSpan.attributes[SEMATTRS_MESSAGING_RABBITMQ_ROUTING_KEY]
         ).toEqual(routingKey);
+        expect(publishSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL]).toEqual(
+          'AMQP'
+        );
         expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]
-        ).toEqual('AMQP');
-        expect(
-          publishSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]
+          publishSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL_VERSION]
         ).toEqual('0.9.1');
 
         // assert consume span
         expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
+        expect(consumeSpan.attributes[SEMATTRS_MESSAGING_SYSTEM]).toEqual(
+          'rabbitmq'
+        );
+        expect(consumeSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]).toEqual(
+          exchangeName
+        );
         expect(
-          consumeSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]
-        ).toEqual('rabbitmq');
+          consumeSpan.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]
+        ).toEqual(MESSAGINGDESTINATIONKINDVALUES_TOPIC);
         expect(
-          consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]
-        ).toEqual(exchangeName);
-        expect(
-          consumeSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]
-        ).toEqual(MessagingDestinationKindValues.TOPIC);
-        expect(
-          consumeSpan.attributes[
-            SemanticAttributes.MESSAGING_RABBITMQ_ROUTING_KEY
-          ]
+          consumeSpan.attributes[SEMATTRS_MESSAGING_RABBITMQ_ROUTING_KEY]
         ).toEqual(routingKey);
+        expect(consumeSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL]).toEqual(
+          'AMQP'
+        );
         expect(
-          consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL]
-        ).toEqual('AMQP');
-        expect(
-          consumeSpan.attributes[SemanticAttributes.MESSAGING_PROTOCOL_VERSION]
+          consumeSpan.attributes[SEMATTRS_MESSAGING_PROTOCOL_VERSION]
         ).toEqual('0.9.1');
 
         // assert context propagation

--- a/plugins/node/instrumentation-amqplib/test/utils.test.ts
+++ b/plugins/node/instrumentation-amqplib/test/utils.test.ts
@@ -19,7 +19,14 @@ import {
   getConnectionAttributesFromServer,
   getConnectionAttributesFromUrl,
 } from '../src/utils';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMATTRS_MESSAGING_PROTOCOL,
+  SEMATTRS_MESSAGING_PROTOCOL_VERSION,
+  SEMATTRS_MESSAGING_SYSTEM,
+  SEMATTRS_MESSAGING_URL,
+  SEMATTRS_NET_PEER_NAME,
+  SEMATTRS_NET_PEER_PORT,
+} from '@opentelemetry/semantic-conventions';
 import * as amqp from 'amqplib';
 import { shouldTest } from './utils';
 import { rabbitMqUrl } from './config';
@@ -43,7 +50,7 @@ describe('utils', () => {
     it('messaging system attribute', () => {
       const attributes = getConnectionAttributesFromServer(conn.connection);
       expect(attributes).toStrictEqual({
-        [SemanticAttributes.MESSAGING_SYSTEM]: 'rabbitmq',
+        [SEMATTRS_MESSAGING_SYSTEM]: 'rabbitmq',
       });
     });
   });
@@ -54,11 +61,11 @@ describe('utils', () => {
         'amqp://user:pass@host:10000/vhost'
       );
       expect(attributes).toStrictEqual({
-        [SemanticAttributes.MESSAGING_PROTOCOL]: 'AMQP',
-        [SemanticAttributes.MESSAGING_PROTOCOL_VERSION]: '0.9.1',
-        [SemanticAttributes.NET_PEER_NAME]: 'host',
-        [SemanticAttributes.NET_PEER_PORT]: 10000,
-        [SemanticAttributes.MESSAGING_URL]: 'amqp://user:***@host:10000/vhost',
+        [SEMATTRS_MESSAGING_PROTOCOL]: 'AMQP',
+        [SEMATTRS_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
+        [SEMATTRS_NET_PEER_NAME]: 'host',
+        [SEMATTRS_NET_PEER_PORT]: 10000,
+        [SEMATTRS_MESSAGING_URL]: 'amqp://user:***@host:10000/vhost',
       });
     });
 
@@ -67,102 +74,101 @@ describe('utils', () => {
         'amqp://user%61:%61pass@ho%61st:10000/v%2fhost'
       );
       expect(attributes).toStrictEqual({
-        [SemanticAttributes.MESSAGING_PROTOCOL]: 'AMQP',
-        [SemanticAttributes.MESSAGING_PROTOCOL_VERSION]: '0.9.1',
-        [SemanticAttributes.NET_PEER_NAME]: 'ho%61st',
-        [SemanticAttributes.NET_PEER_PORT]: 10000,
-        [SemanticAttributes.MESSAGING_URL]:
-          'amqp://user%61:***@ho%61st:10000/v%2fhost',
+        [SEMATTRS_MESSAGING_PROTOCOL]: 'AMQP',
+        [SEMATTRS_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
+        [SEMATTRS_NET_PEER_NAME]: 'ho%61st',
+        [SEMATTRS_NET_PEER_PORT]: 10000,
+        [SEMATTRS_MESSAGING_URL]: 'amqp://user%61:***@ho%61st:10000/v%2fhost',
       });
     });
 
     it('only protocol', () => {
       const attributes = getConnectionAttributesFromUrl('amqp://');
       expect(attributes).toStrictEqual({
-        [SemanticAttributes.MESSAGING_PROTOCOL]: 'AMQP',
-        [SemanticAttributes.MESSAGING_PROTOCOL_VERSION]: '0.9.1',
-        [SemanticAttributes.NET_PEER_NAME]: 'localhost',
-        [SemanticAttributes.NET_PEER_PORT]: 5672,
-        [SemanticAttributes.MESSAGING_URL]: 'amqp://',
+        [SEMATTRS_MESSAGING_PROTOCOL]: 'AMQP',
+        [SEMATTRS_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
+        [SEMATTRS_NET_PEER_NAME]: 'localhost',
+        [SEMATTRS_NET_PEER_PORT]: 5672,
+        [SEMATTRS_MESSAGING_URL]: 'amqp://',
       });
     });
 
     it('empty username and password', () => {
       const attributes = getConnectionAttributesFromUrl('amqp://:@/');
       expect(attributes).toStrictEqual({
-        [SemanticAttributes.MESSAGING_PROTOCOL_VERSION]: '0.9.1',
-        [SemanticAttributes.MESSAGING_URL]: 'amqp://:***@/',
+        [SEMATTRS_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
+        [SEMATTRS_MESSAGING_URL]: 'amqp://:***@/',
       });
     });
 
     it('username and no password', () => {
       const attributes = getConnectionAttributesFromUrl('amqp://user@');
       expect(attributes).toStrictEqual({
-        [SemanticAttributes.MESSAGING_PROTOCOL_VERSION]: '0.9.1',
-        [SemanticAttributes.MESSAGING_URL]: 'amqp://user@',
+        [SEMATTRS_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
+        [SEMATTRS_MESSAGING_URL]: 'amqp://user@',
       });
     });
 
     it('username and password, no host', () => {
       const attributes = getConnectionAttributesFromUrl('amqp://user:pass@');
       expect(attributes).toStrictEqual({
-        [SemanticAttributes.MESSAGING_PROTOCOL_VERSION]: '0.9.1',
-        [SemanticAttributes.MESSAGING_URL]: 'amqp://user:***@',
+        [SEMATTRS_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
+        [SEMATTRS_MESSAGING_URL]: 'amqp://user:***@',
       });
     });
 
     it('host only', () => {
       const attributes = getConnectionAttributesFromUrl('amqp://host');
       expect(attributes).toStrictEqual({
-        [SemanticAttributes.MESSAGING_PROTOCOL]: 'AMQP',
-        [SemanticAttributes.MESSAGING_PROTOCOL_VERSION]: '0.9.1',
-        [SemanticAttributes.NET_PEER_NAME]: 'host',
-        [SemanticAttributes.NET_PEER_PORT]: 5672,
-        [SemanticAttributes.MESSAGING_URL]: 'amqp://host',
+        [SEMATTRS_MESSAGING_PROTOCOL]: 'AMQP',
+        [SEMATTRS_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
+        [SEMATTRS_NET_PEER_NAME]: 'host',
+        [SEMATTRS_NET_PEER_PORT]: 5672,
+        [SEMATTRS_MESSAGING_URL]: 'amqp://host',
       });
     });
 
     it('vhost only', () => {
       const attributes = getConnectionAttributesFromUrl('amqp:///vhost');
       expect(attributes).toStrictEqual({
-        [SemanticAttributes.MESSAGING_PROTOCOL]: 'AMQP',
-        [SemanticAttributes.MESSAGING_PROTOCOL_VERSION]: '0.9.1',
-        [SemanticAttributes.NET_PEER_NAME]: 'localhost',
-        [SemanticAttributes.NET_PEER_PORT]: 5672,
-        [SemanticAttributes.MESSAGING_URL]: 'amqp:///vhost',
+        [SEMATTRS_MESSAGING_PROTOCOL]: 'AMQP',
+        [SEMATTRS_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
+        [SEMATTRS_NET_PEER_NAME]: 'localhost',
+        [SEMATTRS_NET_PEER_PORT]: 5672,
+        [SEMATTRS_MESSAGING_URL]: 'amqp:///vhost',
       });
     });
 
     it('host only, trailing slash', () => {
       const attributes = getConnectionAttributesFromUrl('amqp://host/');
       expect(attributes).toStrictEqual({
-        [SemanticAttributes.MESSAGING_PROTOCOL]: 'AMQP',
-        [SemanticAttributes.MESSAGING_PROTOCOL_VERSION]: '0.9.1',
-        [SemanticAttributes.NET_PEER_NAME]: 'host',
-        [SemanticAttributes.NET_PEER_PORT]: 5672,
-        [SemanticAttributes.MESSAGING_URL]: 'amqp://host/',
+        [SEMATTRS_MESSAGING_PROTOCOL]: 'AMQP',
+        [SEMATTRS_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
+        [SEMATTRS_NET_PEER_NAME]: 'host',
+        [SEMATTRS_NET_PEER_PORT]: 5672,
+        [SEMATTRS_MESSAGING_URL]: 'amqp://host/',
       });
     });
 
     it('vhost encoded', () => {
       const attributes = getConnectionAttributesFromUrl('amqp://host/%2f');
       expect(attributes).toStrictEqual({
-        [SemanticAttributes.MESSAGING_PROTOCOL]: 'AMQP',
-        [SemanticAttributes.MESSAGING_PROTOCOL_VERSION]: '0.9.1',
-        [SemanticAttributes.NET_PEER_NAME]: 'host',
-        [SemanticAttributes.NET_PEER_PORT]: 5672,
-        [SemanticAttributes.MESSAGING_URL]: 'amqp://host/%2f',
+        [SEMATTRS_MESSAGING_PROTOCOL]: 'AMQP',
+        [SEMATTRS_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
+        [SEMATTRS_NET_PEER_NAME]: 'host',
+        [SEMATTRS_NET_PEER_PORT]: 5672,
+        [SEMATTRS_MESSAGING_URL]: 'amqp://host/%2f',
       });
     });
 
     it('IPv6 host', () => {
       const attributes = getConnectionAttributesFromUrl('amqp://[::1]');
       expect(attributes).toStrictEqual({
-        [SemanticAttributes.MESSAGING_PROTOCOL]: 'AMQP',
-        [SemanticAttributes.MESSAGING_PROTOCOL_VERSION]: '0.9.1',
-        [SemanticAttributes.NET_PEER_NAME]: '[::1]',
-        [SemanticAttributes.NET_PEER_PORT]: 5672,
-        [SemanticAttributes.MESSAGING_URL]: 'amqp://[::1]',
+        [SEMATTRS_MESSAGING_PROTOCOL]: 'AMQP',
+        [SEMATTRS_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
+        [SEMATTRS_NET_PEER_NAME]: '[::1]',
+        [SEMATTRS_NET_PEER_PORT]: 5672,
+        [SEMATTRS_MESSAGING_URL]: 'amqp://[::1]',
       });
     });
   });


### PR DESCRIPTION
Leftover from https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2086

Test files were not using the exported strings. Kudos to @trentm  for spotting it