### PR TITLE
feat(winston-transport): Serialize nested objects passed as additional attributes

### DIFF
--- a/packages/winston-transport/src/OpenTelemetryTransportV3.ts
+++ b/packages/winston-transport/src/OpenTelemetryTransportV3.ts
@@ -27,6 +27,7 @@ export class OpenTelemetryTransportV3 extends TransportStream {
     this._logger = logs.getLogger('@opentelemetry/winston-transport', VERSION);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public override log(info: any, next: () => void) {
     try {
       emitLogRecord(info, this._logger);

--- a/packages/winston-transport/src/utils.ts
+++ b/packages/winston-transport/src/utils.ts
@@ -60,6 +60,7 @@ function getSeverityNumber(level: string): SeverityNumber | undefined {
 }
 
 export function emitLogRecord(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   record: Record<string, any>,
   logger: Logger
 ): void {

--- a/packages/winston-transport/src/utils.ts
+++ b/packages/winston-transport/src/utils.ts
@@ -65,10 +65,8 @@ export function emitLogRecord(
 ): void {
   const { message, level, ...splat } = record;
   const attributes: LogAttributes = {};
-  for (const key in splat) {
-    if (Object.prototype.hasOwnProperty.call(splat, key)) {
-      attributes[key] = splat[key];
-    }
+  for (const [key, value] of Object.entries(splat)) {
+    attributes[key] = typeof value === 'object' ? JSON.stringify(value) : value;
   }
   const logRecord: LogRecord = {
     severityNumber: getSeverityNumber(level),

--- a/packages/winston-transport/test/openTelemetryTransport.test.ts
+++ b/packages/winston-transport/test/openTelemetryTransport.test.ts
@@ -71,6 +71,25 @@ describe('OpenTelemetryTransportV3', () => {
     );
   });
 
+  it('emit LogRecord with nested objects', () => {
+    const errorMsg = 'test error';
+    const transport = new OpenTelemetryTransportV3();
+    const errorEvent = {
+      message: errorMsg,
+      meta: { error: 'test error' },
+      level: 'error',
+    };
+    const parameters = Object.assign({ message: kMessage }, errorEvent);
+    transport.log(parameters, () => {});
+    const logRecords = memoryLogExporter.getFinishedLogRecords();
+    assert.strictEqual(logRecords.length, 1);
+    assert.strictEqual(logRecords[0].body, errorMsg);
+    assert.strictEqual(
+      logRecords[0].attributes['meta'],
+      JSON.stringify(errorEvent.meta)
+    );
+  });
+
   describe('emit logRecord severity', () => {
     it('npm levels', () => {
       const callback = () => {};


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- If nested objects are passed as additional attributes to be logged by Winston, they will not be properly serialized and output as `[object Object]`.

## Short description of the changes

- Runs `JSON.stringify()` on the contents of nested objects so they can be parsed before being emitted. If `JSON.stringify() throws an error it will be caught by exception handling in the `OpenTelemetryTransportV3` class.
