### PR TITLE
chore(examples/web): use exported strings for attributes

### DIFF
--- a/examples/web/examples/document-load/index.js
+++ b/examples/web/examples/document-load/index.js
@@ -9,11 +9,11 @@ import { B3Propagator } from '@opentelemetry/propagator-b3';
 import { CompositePropagator, W3CTraceContextPropagator } from '@opentelemetry/core';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { Resource } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 
 const provider = new WebTracerProvider({
   resource: new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: 'web-service-dl',
+    [SEMRESATTRS_SERVICE_NAME]: 'web-service-dl',
   }),
 });
 

--- a/examples/web/examples/meta/index.js
+++ b/examples/web/examples/meta/index.js
@@ -6,11 +6,11 @@ import { B3Propagator } from '@opentelemetry/propagator-b3';
 import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { Resource } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 
 const providerWithZone = new WebTracerProvider({
   resource: new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: 'web-service-meta',
+    [SEMRESATTRS_SERVICE_NAME]: 'web-service-meta',
   }),
 });
 

--- a/examples/web/examples/user-interaction/index.js
+++ b/examples/web/examples/user-interaction/index.js
@@ -7,11 +7,11 @@ import { B3Propagator } from '@opentelemetry/propagator-b3';
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { Resource } from '@opentelemetry/resources';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 
 const providerWithZone = new WebTracerProvider({
   resource: new Resource({
-    [SemanticResourceAttributes.SERVICE_NAME]: 'web-service-ui',
+    [SEMRESATTRS_SERVICE_NAME]: 'web-service-ui',
   }),
 });
 

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -46,7 +46,7 @@
     "@opentelemetry/instrumentation-xml-http-request": "^0.39.1",
     "@opentelemetry/propagator-b3": "^1.13.0",
     "@opentelemetry/sdk-trace-web": "^1.13.0",
-    "@opentelemetry/semantic-conventions": "^1.13.0"
+    "@opentelemetry/semantic-conventions": "^1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib#readme"
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- Part Of #2025 

## Short description of the changes

On package `examples/web`:
- Update `@opentelemetry/semantic-conventions` `^1.23.0`
- Use exported strings for Semantic Attributes.