### PR TITLE
docs: remove `key` column on readme

### DIFF
--- a/plugins/node/instrumentation-undici/README.md
+++ b/plugins/node/instrumentation-undici/README.md
@@ -71,21 +71,21 @@ Ref: [opentelemetry-js/issues/4235](https://github.com/open-telemetry/openteleme
 
 Attributes collected:
 
-| Attribute    | Short Description                  | Notes             |
-| ------------ | ---------------------------------- | ----------------- |
-| `http.request.method` | HTTP request method. | Key: `HTTP_REQUEST_METHOD` |
-| `http.request.method_original` | Original HTTP method sent by the client in the request line. | Key: `HTTP_REQUEST_METHOD_ORIGINAL` |
-| `url.full` | Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986). | Key: `URL_FULL` |
-| `url.path` | The [URI path](https://www.rfc-editor.org/rfc/rfc3986#section-3.3) component. | Key: `URL_PATH` |
-| `url.query` | The [URI query](https://www.rfc-editor.org/rfc/rfc3986#section-3.4) component. | Key: `URL_QUERY` |
-| `url.scheme` | HTTP request method. | Key: `URL_SCHEME` |
-| `server.address` | Server domain name, IP address or Unix domain socket name. | Key: `HTTP_REQUEST_METHOD` |
-| `server.port` | Server port number. | Key: `HTTP_REQUEST_METHOD` |
-| `user_agent.original` | Value of the HTTP User-Agent header sent by the client. | Key: `USER_AGENT_ORIGINAL` |
-| `network.peer.address` | Peer address of the network connection - IP address or Unix domain socket name. | Key: `NETWORK_PEER_ADDRESS` |
-| `network.peer.port` | Peer port number of the network connection. | Key: `NETWORK_PEER_PORT` |
-| `http.response.status_code` | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | Key: `HTTP_RESPONSE_STATUS_CODE` |
-| `error.type` | Describes a class of error the operation ended with. | Key: `ERROR_TYPE` |
+| Attribute                      | Short Description                                                                                          |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| `error.type`                   | Describes a class of error the operation ended with.                                                       |
+| `http.request.method`          | HTTP request method.                                                                                       |
+| `http.request.method_original` | Original HTTP method sent by the client in the request line.                                               |
+| `http.response.status_code`    | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).                                |
+| `network.peer.address`         | Peer address of the network connection - IP address or Unix domain socket name.                            |
+| `network.peer.port`            | Peer port number of the network connection.                                                                |
+| `server.address`               | Server domain name, IP address or Unix domain socket name.                                                 |
+| `server.port`                  | Server port number.                                                                                        |
+| `url.full`                     | Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986). |
+| `url.path`                     | The [URI path](https://www.rfc-editor.org/rfc/rfc3986#section-3.3) component.                              |
+| `url.query`                    | The [URI query](https://www.rfc-editor.org/rfc/rfc3986#section-3.4) component.                             |
+| `url.scheme`                   | HTTP request method.                                                                                       |
+| `user_agent.original`          | Value of the HTTP User-Agent header sent by the client.                                                    |
 
 ## Useful links
 

--- a/plugins/node/opentelemetry-instrumentation-express/README.md
+++ b/plugins/node/opentelemetry-instrumentation-express/README.md
@@ -148,9 +148,9 @@ This package uses `@opentelemetry/semantic-conventions` version `1.22+`, which i
 
 Attributes collected:
 
-| Attribute    | Short Description                  | Notes                      |
-| ------------ | ---------------------------------- | -------------------------- |
-| `http.route` | The matched route (path template). | Key: `SEMATTRS_HTTP_ROUTE` |
+| Attribute    | Short Description                  |
+| ------------ | ---------------------------------- |
+| `http.route` | The matched route (path template). |
 
 ## Useful links
 

--- a/plugins/node/opentelemetry-instrumentation-fastify/README.md
+++ b/plugins/node/opentelemetry-instrumentation-fastify/README.md
@@ -74,9 +74,9 @@ This package uses `@opentelemetry/semantic-conventions` version `1.22+`, which i
 
 Attributes collected:
 
-| Attribute    | Short Description                  | Notes                      |
-| ------------ | ---------------------------------- | -------------------------- |
-| `http.route` | The matched route (path template). | Key: `SEMATTRS_HTTP_ROUTE` |
+| Attribute    | Short Description                  |
+| ------------ | ---------------------------------- |
+| `http.route` | The matched route (path template). |
 
 ## Useful links
 

--- a/plugins/node/opentelemetry-instrumentation-redis/README.md
+++ b/plugins/node/opentelemetry-instrumentation-redis/README.md
@@ -80,13 +80,13 @@ This package uses `@opentelemetry/semantic-conventions` version `1.22+`, which i
 
 Attributes collected:
 
-| Attribute              | Short Description                                            | Notes                                |
-|------------------------|--------------------------------------------------------------|--------------------------------------|
-| `db.connection_string` | URL to Redis server address, of the form `redis://host:port` | Key: `SEMATTRS_DB_CONNECTION_STRING` |
-| `db.statement`         | Executed Redis statement                                     | Key: `SEMATTRS_DB_STATEMENT`         |
-| `db.system`            | Database identifier; always `redis`                          | Key: `SEMATTRS_DB_SYSTEM`            |
-| `net.peer.name`        | Hostname or IP of the connected Redis server                 | Key: `SEMATTRS_NET_PEER_NAME`        |
-| `net.peer.port`        | Port of the connected Redis server                           | Key: `SEMATTRS_NET_PORT_NAME`        |
+| Attribute              | Short Description                                            |
+|------------------------|--------------------------------------------------------------|
+| `db.connection_string` | URL to Redis server address, of the form `redis://host:port` |
+| `db.statement`         | Executed Redis statement                                     |
+| `db.system`            | Database identifier; always `redis`                          |
+| `net.peer.name`        | Hostname or IP of the connected Redis server                 |
+| `net.peer.port`        | Port of the connected Redis server                           |
 
 ## Useful links
 

--- a/plugins/web/opentelemetry-instrumentation-document-load/README.md
+++ b/plugins/web/opentelemetry-instrumentation-document-load/README.md
@@ -117,10 +117,10 @@ This package uses `@opentelemetry/semantic-conventions` version `1.22+`, which i
 
 Attributes collected:
 
-| Attribute         | Short Description                                                              | Notes                           |
-| ----------------- | ------------------------------------------------------------------------------ | ------------------------------- |
-| `http.url`        | Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]` | Key: `SEMATTRS_HTTP_URL`        |
-| `http.user_agent` | Value of the HTTP User-Agent header sent by the client                         | Key: `SEMATTRS_HTTP_USER_AGENT` |
+| Attribute         | Short Description                                                              |
+| ----------------- | ------------------------------------------------------------------------------ |
+| `http.url`        | Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]` |
+| `http.user_agent` | Value of the HTTP User-Agent header sent by the client                         |
 
 ## Useful links
 


### PR DESCRIPTION
A key column was added to several READMEs, but it was decided to not have them anymore.
So this commit removes the column from the doc that were already added.