### PR TITLE
ci: only publish after release is created

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,11 +54,15 @@ jobs:
 
       # get main again
       - name: Checkout Repository
+        # only checkout if a release has been created
+        if: ${{ steps.release.outputs.release_created }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Rebuild Packages
+        # only rebuild if a release has been created
+        if: ${{ steps.release.outputs.release_created }}
         run: |
           npm ci
           npm run compile
@@ -67,6 +71,8 @@ jobs:
       # need to publish all unpublished versions to npm here
       # See: https://github.com/lerna/lerna/tree/main/commands/publish#bump-from-package
       - name: Publish to npm
+        # only publish if a release has been created
+        if: ${{ steps.release.outputs.release_created }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         run: npx lerna publish from-package --no-push --no-private --no-git-tag-version --no-verify-access --yes


### PR DESCRIPTION
## Which problem is this PR solving?

- closes #2020

## Short description of the changes

- Add conditional checks to steps that require a release to be created first. Based on docs provided in the [action README for Automating publication to npm](https://github.com/google-github-actions/release-please-action?tab=readme-ov-file#automating-publication-to-npm)