### PR TITLE
chore(instrumentation-fs): remove unused semconv package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36969,8 +36969,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.50.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/instrumentation": "^0.50.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -46144,7 +46143,6 @@
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.6.5",
         "@types/sinon": "^10.0.11",

--- a/plugins/node/instrumentation-fs/package.json
+++ b/plugins/node/instrumentation-fs/package.json
@@ -59,8 +59,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.50.0",
-    "@opentelemetry/semantic-conventions": "^1.0.0"
+    "@opentelemetry/instrumentation": "^0.50.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-fs#readme"
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- updates #2025 
  - sort of

## Short description of the changes

- remove unused package `@opentelemetry/semantic-conventions`
