### PR TITLE
refactor(instr-aws-sdk): use exported strings for attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37459,7 +37459,7 @@
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/propagation-utils": "^0.30.8",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
         "@aws-sdk/client-dynamodb": "3.85.0",
@@ -45818,7 +45818,7 @@
         "@opentelemetry/instrumentation": "^0.50.0",
         "@opentelemetry/propagation-utils": "^0.30.8",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.18",

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -44,8 +44,9 @@ import {
   AWSXRayPropagator,
 } from '@opentelemetry/propagator-aws-xray';
 import {
-  SemanticAttributes,
-  SemanticResourceAttributes,
+  SEMATTRS_FAAS_EXECUTION,
+  SEMRESATTRS_CLOUD_ACCOUNT_ID,
+  SEMRESATTRS_FAAS_ID,
 } from '@opentelemetry/semantic-conventions';
 
 import {
@@ -201,9 +202,9 @@ export class AwsLambdaInstrumentation extends InstrumentationBase {
         {
           kind: SpanKind.SERVER,
           attributes: {
-            [SemanticAttributes.FAAS_EXECUTION]: context.awsRequestId,
-            [SemanticResourceAttributes.FAAS_ID]: context.invokedFunctionArn,
-            [SemanticResourceAttributes.CLOUD_ACCOUNT_ID]:
+            [SEMATTRS_FAAS_EXECUTION]: context.awsRequestId,
+            [SEMRESATTRS_FAAS_ID]: context.invokedFunctionArn,
+            [SEMRESATTRS_CLOUD_ACCOUNT_ID]:
               AwsLambdaInstrumentation._extractAccountId(
                 context.invokedFunctionArn
               ),

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler.test.ts
@@ -33,8 +33,9 @@ import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { Context } from 'aws-lambda';
 import * as assert from 'assert';
 import {
-  SemanticAttributes,
-  SemanticResourceAttributes,
+  SEMATTRS_EXCEPTION_MESSAGE,
+  SEMATTRS_FAAS_EXECUTION,
+  SEMRESATTRS_FAAS_NAME,
 } from '@opentelemetry/semantic-conventions';
 import {
   Context as OtelContext,
@@ -56,7 +57,7 @@ const assertSpanSuccess = (span: ReadableSpan) => {
   assert.strictEqual(span.kind, SpanKind.SERVER);
   assert.strictEqual(span.name, 'my_function');
   assert.strictEqual(
-    span.attributes[SemanticAttributes.FAAS_EXECUTION],
+    span.attributes[SEMATTRS_FAAS_EXECUTION],
     'aws_request_id'
   );
   assert.strictEqual(span.attributes['faas.id'], 'my_arn');
@@ -68,7 +69,7 @@ const assertSpanFailure = (span: ReadableSpan) => {
   assert.strictEqual(span.kind, SpanKind.SERVER);
   assert.strictEqual(span.name, 'my_function');
   assert.strictEqual(
-    span.attributes[SemanticAttributes.FAAS_EXECUTION],
+    span.attributes[SEMATTRS_FAAS_EXECUTION],
     'aws_request_id'
   );
   assert.strictEqual(span.attributes['faas.id'], 'my_arn');
@@ -76,7 +77,7 @@ const assertSpanFailure = (span: ReadableSpan) => {
   assert.strictEqual(span.status.message, 'handler error');
   assert.strictEqual(span.events.length, 1);
   assert.strictEqual(
-    span.events[0].attributes![SemanticAttributes.EXCEPTION_MESSAGE],
+    span.events[0].attributes![SEMATTRS_EXCEPTION_MESSAGE],
     'handler error'
   );
 };
@@ -841,10 +842,7 @@ describe('lambda handler', () => {
       it('sync - success', async () => {
         initializeHandler('lambda-test/async.handler', {
           requestHook: (span, { context }) => {
-            span.setAttribute(
-              SemanticResourceAttributes.FAAS_NAME,
-              context.functionName
-            );
+            span.setAttribute(SEMRESATTRS_FAAS_NAME, context.functionName);
           },
         });
 
@@ -853,7 +851,7 @@ describe('lambda handler', () => {
         const [span] = spans;
         assert.strictEqual(spans.length, 1);
         assert.strictEqual(
-          span.attributes[SemanticResourceAttributes.FAAS_NAME],
+          span.attributes[SEMRESATTRS_FAAS_NAME],
           ctx.functionName
         );
         assertSpanSuccess(span);

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/README.md
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/README.md
@@ -117,6 +117,54 @@ The instrumentation's config `preRequestHook`, `responseHook` and `sqsProcessHoo
 
 The `moduleVersionAttributeName` config option is removed. To add the aws-sdk package version to spans, use the `moduleVersion` attribute in hook info for `preRequestHook` and `responseHook` functions.
 
+## Semantic Conventions
+
+This package uses `@opentelemetry/semantic-conventions` version `1.22+`, which implements Semantic Convention [Version 1.7.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/semantic_conventions/README.md)
+
+Attributes collected:
+
+| Attribute                                     | Short Description                                                                              | Service  |
+| --------------------------------------------- | ---------------------------------------------------------------------------------------------- | -------- |
+| `http.status_code`                            | (aws-sdk) HTTP response status code.                                                           |          |
+| `rpc.method`                                  | The name of the (logical) method being called.                                                 |          |
+| `rpc.service`                                 | The full (logical) name of the service being called.                                           |          |
+| `rpc.system`                                  | A string identifying the remoting system.                                                      |          |
+| `aws.dynamodb.attribute_definitions`          | The JSON-serialized value of each item in the `AttributeDefinitions` request field.            | dynamodb |
+| `aws.dynamodb.consistent_read`                | The value of the `ConsistentRead` request parameter.                                           | dynamodb |
+| `aws.dynamodb.consumed_capacity`              | The JSON-serialized value of each item in the `ConsumedCapacity` response field.               | dynamodb |
+| `aws.dynamodb.count`                          | The value of the `Count` response parameter.                                                   | dynamodb |
+| `aws.dynamodb.exclusive_start_table`          | The value of the `ExclusiveStartTableName` request parameter.                                  | dynamodb |
+| `aws.dynamodb.global_secondary_index_updates` | The JSON-serialized value of each item in the the `GlobalSecondaryIndexUpdates` request field. | dynamodb |
+| `aws.dynamodb.global_secondary_indexes`       | The JSON-serialized value of each item of the `GlobalSecondaryIndexes` request field.          | dynamodb |
+| `aws.dynamodb.index_name`                     | The value of the `IndexName` request parameter.                                                | dynamodb |
+| `aws.dynamodb.item_collection_metrics`        | The JSON-serialized value of the `ItemCollectionMetrics` response field.                       | dynamodb |
+| `aws.dynamodb.limit`                          | The value of the `Limit` request parameter.                                                    | dynamodb |
+| `aws.dynamodb.local_secondary_indexes`        | The JSON-serialized value of each item of the `LocalSecondaryIndexes` request field.           | dynamodb |
+| `aws.dynamodb.projection`                     | The value of the `ProjectionExpression` request parameter.                                     | dynamodb |
+| `aws.dynamodb.provisioned_read_capacity`      | The value of the `ProvisionedThroughput.ReadCapacityUnits` request parameter.                  | dynamodb |
+| `aws.dynamodb.provisioned_write_capacity`     | The value of the `ProvisionedThroughput.WriteCapacityUnits` request parameter.                 | dynamodb |
+| `aws.dynamodb.scan_forward`                   | The value of the `ScanIndexForward` request parameter.                                         | dynamodb |
+| `aws.dynamodb.scanned_count`                  | The value of the `ScannedCount` response parameter.                                            | dynamodb |
+| `aws.dynamodb.segment`                        | The value of the `Segment` request parameter.                                                  | dynamodb |
+| `aws.dynamodb.select`                         | The value of the `Select` request parameter.                                                   | dynamodb |
+| `aws.dynamodb.table_count`                    | The number of items in the `TableNames` response parameter.                                    | dynamodb |
+| `aws.dynamodb.table_names`                    | The keys in the `RequestItems` object field.                                                   | dynamodb |
+| `aws.dynamodb.total_segments`                 | The value of the `TotalSegments` request parameter.                                            | dynamodb |
+| `db.name`                                     | The name of the database being accessed.                                                       | dynamodb |
+| `db.operation`                                | The name of the operation being executed.                                                      | dynamodb |
+| `db.statement`                                | The database statement being executed.                                                         | dynamodb |
+| `db.system`                                   | An identifier for the database management system (DBMS) product being used.                    | dynamodb |
+| `faas.execution`                              | The execution ID of the current function execution.                                            | lambda   |
+| `faas.invoked_name`                           | The name of the invoked function.                                                              | lambda   |
+| `faas.invoked_provider`                       | The cloud provider of the invoked function.                                                    | lambda   |
+| `faas.invoked_region`                         | The cloud region of the invoked function.                                                      | lambda   |
+| `messaging.destination`                       | The message destination name.                                                                  | sns, sqs |
+| `messaging.destination_kind`                  | The kind of message destination.                                                               | sns, sqs |
+| `messaging.system`                            | A string identifying the messaging system.                                                     | sns, sqs |
+| `messaging.operation`                         | A string identifying the kind of message consumption.                                          | sqs      |
+| `messaging.message_id`                        | A value used by the messaging system as an identifier for the message.                         | sqs      |
+| `messaging.url`                               | The connection string.                                                                         | sqs      |
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
@@ -47,7 +47,7 @@
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.50.0",
     "@opentelemetry/propagation-utils": "^0.30.8",
-    "@opentelemetry/semantic-conventions": "^1.0.0"
+    "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "3.85.0",

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.ts
@@ -58,7 +58,7 @@ import {
 } from './utils';
 import { propwrap } from './propwrap';
 import { RequestMetadata } from './services/ServiceExtension';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_HTTP_STATUS_CODE } from '@opentelemetry/semantic-conventions';
 
 const V3_CLIENT_CONFIG_KEY = Symbol(
   'opentelemetry.instrumentation.aws-sdk.client.config'
@@ -369,10 +369,7 @@ export class AwsInstrumentation extends InstrumentationBase<any> {
 
         const httpStatusCode = response.httpResponse?.statusCode;
         if (httpStatusCode) {
-          span.setAttribute(
-            SemanticAttributes.HTTP_STATUS_CODE,
-            httpStatusCode
-          );
+          span.setAttribute(SEMATTRS_HTTP_STATUS_CODE, httpStatusCode);
         }
         span.end();
       });
@@ -526,7 +523,7 @@ export class AwsInstrumentation extends InstrumentationBase<any> {
                     response.output?.$metadata?.httpStatusCode;
                   if (httpStatusCode) {
                     span.setAttribute(
-                      SemanticAttributes.HTTP_STATUS_CODE,
+                      SEMATTRS_HTTP_STATUS_CODE,
                       httpStatusCode
                     );
                   }

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/dynamodb.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/dynamodb.ts
@@ -14,16 +14,40 @@
  * limitations under the License.
  */
 import {
+  Attributes,
   DiagLogger,
   Span,
-  SpanAttributes,
   SpanKind,
   Tracer,
 } from '@opentelemetry/api';
 import { RequestMetadata, ServiceExtension } from './ServiceExtension';
 import {
-  DbSystemValues,
-  SemanticAttributes,
+  DBSYSTEMVALUES_DYNAMODB,
+  SEMATTRS_AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS,
+  SEMATTRS_AWS_DYNAMODB_CONSISTENT_READ,
+  SEMATTRS_AWS_DYNAMODB_CONSUMED_CAPACITY,
+  SEMATTRS_AWS_DYNAMODB_COUNT,
+  SEMATTRS_AWS_DYNAMODB_EXCLUSIVE_START_TABLE,
+  SEMATTRS_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES,
+  SEMATTRS_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES,
+  SEMATTRS_AWS_DYNAMODB_INDEX_NAME,
+  SEMATTRS_AWS_DYNAMODB_ITEM_COLLECTION_METRICS,
+  SEMATTRS_AWS_DYNAMODB_LIMIT,
+  SEMATTRS_AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES,
+  SEMATTRS_AWS_DYNAMODB_PROJECTION,
+  SEMATTRS_AWS_DYNAMODB_PROVISIONED_READ_CAPACITY,
+  SEMATTRS_AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY,
+  SEMATTRS_AWS_DYNAMODB_SCAN_FORWARD,
+  SEMATTRS_AWS_DYNAMODB_SCANNED_COUNT,
+  SEMATTRS_AWS_DYNAMODB_SEGMENT,
+  SEMATTRS_AWS_DYNAMODB_SELECT,
+  SEMATTRS_AWS_DYNAMODB_TABLE_COUNT,
+  SEMATTRS_AWS_DYNAMODB_TABLE_NAMES,
+  SEMATTRS_AWS_DYNAMODB_TOTAL_SEGMENTS,
+  SEMATTRS_DB_NAME,
+  SEMATTRS_DB_OPERATION,
+  SEMATTRS_DB_STATEMENT,
+  SEMATTRS_DB_SYSTEM,
 } from '@opentelemetry/semantic-conventions';
 import {
   AwsSdkInstrumentationConfig,
@@ -46,10 +70,10 @@ export class DynamodbServiceExtension implements ServiceExtension {
     const isIncoming = false;
     const operation = normalizedRequest.commandName;
 
-    const spanAttributes: SpanAttributes = {
-      [SemanticAttributes.DB_SYSTEM]: DbSystemValues.DYNAMODB,
-      [SemanticAttributes.DB_NAME]: normalizedRequest.commandInput?.TableName,
-      [SemanticAttributes.DB_OPERATION]: operation,
+    const spanAttributes: Attributes = {
+      [SEMATTRS_DB_SYSTEM]: DBSYSTEMVALUES_DYNAMODB,
+      [SEMATTRS_DB_NAME]: normalizedRequest.commandInput?.TableName,
+      [SEMATTRS_DB_OPERATION]: operation,
     };
 
     if (config.dynamoDBStatementSerializer) {
@@ -60,7 +84,7 @@ export class DynamodbServiceExtension implements ServiceExtension {
         );
 
         if (typeof sanitizedStatement === 'string') {
-          spanAttributes[SemanticAttributes.DB_STATEMENT] = sanitizedStatement;
+          spanAttributes[SEMATTRS_DB_STATEMENT] = sanitizedStatement;
         }
       } catch (err) {
         diag.error('failed to sanitize DynamoDB statement', err);
@@ -72,11 +96,11 @@ export class DynamodbServiceExtension implements ServiceExtension {
     if (normalizedRequest.commandInput?.TableName) {
       // Necessary for commands with only 1 table name (example: CreateTable). Attribute is TableName not keys of RequestItems
       // single table name returned for operations like CreateTable
-      spanAttributes[SemanticAttributes.AWS_DYNAMODB_TABLE_NAMES] = [
+      spanAttributes[SEMATTRS_AWS_DYNAMODB_TABLE_NAMES] = [
         normalizedRequest.commandInput.TableName,
       ];
     } else if (normalizedRequest.commandInput?.RequestItems) {
-      spanAttributes[SemanticAttributes.AWS_DYNAMODB_TABLE_NAMES] = Object.keys(
+      spanAttributes[SEMATTRS_AWS_DYNAMODB_TABLE_NAMES] = Object.keys(
         normalizedRequest.commandInput.RequestItems
       );
     }
@@ -84,13 +108,9 @@ export class DynamodbServiceExtension implements ServiceExtension {
     if (operation === 'CreateTable' || operation === 'UpdateTable') {
       // only check for ProvisionedThroughput since ReadCapacityUnits and WriteCapacity units are required attributes
       if (normalizedRequest.commandInput?.ProvisionedThroughput) {
-        spanAttributes[
-          SemanticAttributes.AWS_DYNAMODB_PROVISIONED_READ_CAPACITY
-        ] =
+        spanAttributes[SEMATTRS_AWS_DYNAMODB_PROVISIONED_READ_CAPACITY] =
           normalizedRequest.commandInput.ProvisionedThroughput.ReadCapacityUnits;
-        spanAttributes[
-          SemanticAttributes.AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY
-        ] =
+        spanAttributes[SEMATTRS_AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY] =
           normalizedRequest.commandInput.ProvisionedThroughput.WriteCapacityUnits;
       }
     }
@@ -101,33 +121,31 @@ export class DynamodbServiceExtension implements ServiceExtension {
       operation === 'Query'
     ) {
       if (normalizedRequest.commandInput?.ConsistentRead) {
-        spanAttributes[SemanticAttributes.AWS_DYNAMODB_CONSISTENT_READ] =
+        spanAttributes[SEMATTRS_AWS_DYNAMODB_CONSISTENT_READ] =
           normalizedRequest.commandInput.ConsistentRead;
       }
     }
 
     if (operation === 'Query' || operation === 'Scan') {
       if (normalizedRequest.commandInput?.ProjectionExpression) {
-        spanAttributes[SemanticAttributes.AWS_DYNAMODB_PROJECTION] =
+        spanAttributes[SEMATTRS_AWS_DYNAMODB_PROJECTION] =
           normalizedRequest.commandInput.ProjectionExpression;
       }
     }
 
     if (operation === 'CreateTable') {
       if (normalizedRequest.commandInput?.GlobalSecondaryIndexes) {
-        spanAttributes[
-          SemanticAttributes.AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES
-        ] = this.toArray(
-          normalizedRequest.commandInput.GlobalSecondaryIndexes
-        ).map((x: { [DictionaryKey: string]: any }) => JSON.stringify(x));
+        spanAttributes[SEMATTRS_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES] =
+          this.toArray(
+            normalizedRequest.commandInput.GlobalSecondaryIndexes
+          ).map((x: { [DictionaryKey: string]: any }) => JSON.stringify(x));
       }
 
       if (normalizedRequest.commandInput?.LocalSecondaryIndexes) {
-        spanAttributes[
-          SemanticAttributes.AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES
-        ] = this.toArray(
-          normalizedRequest.commandInput.LocalSecondaryIndexes
-        ).map((x: { [DictionaryKey: string]: any }) => JSON.stringify(x));
+        spanAttributes[SEMATTRS_AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES] =
+          this.toArray(
+            normalizedRequest.commandInput.LocalSecondaryIndexes
+          ).map((x: { [DictionaryKey: string]: any }) => JSON.stringify(x));
       }
     }
 
@@ -137,71 +155,70 @@ export class DynamodbServiceExtension implements ServiceExtension {
       operation === 'Scan'
     ) {
       if (normalizedRequest.commandInput?.Limit) {
-        spanAttributes[SemanticAttributes.AWS_DYNAMODB_LIMIT] =
+        spanAttributes[SEMATTRS_AWS_DYNAMODB_LIMIT] =
           normalizedRequest.commandInput.Limit;
       }
     }
 
     if (operation === 'ListTables') {
       if (normalizedRequest.commandInput?.ExclusiveStartTableName) {
-        spanAttributes[SemanticAttributes.AWS_DYNAMODB_EXCLUSIVE_START_TABLE] =
+        spanAttributes[SEMATTRS_AWS_DYNAMODB_EXCLUSIVE_START_TABLE] =
           normalizedRequest.commandInput.ExclusiveStartTableName;
       }
     }
 
     if (operation === 'Query') {
       if (normalizedRequest.commandInput?.ScanIndexForward) {
-        spanAttributes[SemanticAttributes.AWS_DYNAMODB_SCAN_FORWARD] =
+        spanAttributes[SEMATTRS_AWS_DYNAMODB_SCAN_FORWARD] =
           normalizedRequest.commandInput.ScanIndexForward;
       }
 
       if (normalizedRequest.commandInput?.IndexName) {
-        spanAttributes[SemanticAttributes.AWS_DYNAMODB_INDEX_NAME] =
+        spanAttributes[SEMATTRS_AWS_DYNAMODB_INDEX_NAME] =
           normalizedRequest.commandInput.IndexName;
       }
 
       if (normalizedRequest.commandInput?.Select) {
-        spanAttributes[SemanticAttributes.AWS_DYNAMODB_SELECT] =
+        spanAttributes[SEMATTRS_AWS_DYNAMODB_SELECT] =
           normalizedRequest.commandInput.Select;
       }
     }
 
     if (operation === 'Scan') {
       if (normalizedRequest.commandInput?.Segment) {
-        spanAttributes[SemanticAttributes.AWS_DYNAMODB_SEGMENT] =
+        spanAttributes[SEMATTRS_AWS_DYNAMODB_SEGMENT] =
           normalizedRequest.commandInput?.Segment;
       }
 
       if (normalizedRequest.commandInput?.TotalSegments) {
-        spanAttributes[SemanticAttributes.AWS_DYNAMODB_TOTAL_SEGMENTS] =
+        spanAttributes[SEMATTRS_AWS_DYNAMODB_TOTAL_SEGMENTS] =
           normalizedRequest.commandInput?.TotalSegments;
       }
 
       if (normalizedRequest.commandInput?.IndexName) {
-        spanAttributes[SemanticAttributes.AWS_DYNAMODB_INDEX_NAME] =
+        spanAttributes[SEMATTRS_AWS_DYNAMODB_INDEX_NAME] =
           normalizedRequest.commandInput.IndexName;
       }
 
       if (normalizedRequest.commandInput?.Select) {
-        spanAttributes[SemanticAttributes.AWS_DYNAMODB_SELECT] =
+        spanAttributes[SEMATTRS_AWS_DYNAMODB_SELECT] =
           normalizedRequest.commandInput.Select;
       }
     }
 
     if (operation === 'UpdateTable') {
       if (normalizedRequest.commandInput?.AttributeDefinitions) {
-        spanAttributes[SemanticAttributes.AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS] =
+        spanAttributes[SEMATTRS_AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS] =
           this.toArray(normalizedRequest.commandInput.AttributeDefinitions).map(
             (x: { [DictionaryKey: string]: any }) => JSON.stringify(x)
           );
       }
 
       if (normalizedRequest.commandInput?.GlobalSecondaryIndexUpdates) {
-        spanAttributes[
-          SemanticAttributes.AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES
-        ] = this.toArray(
-          normalizedRequest.commandInput.GlobalSecondaryIndexUpdates
-        ).map((x: { [DictionaryKey: string]: any }) => JSON.stringify(x));
+        spanAttributes[SEMATTRS_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES] =
+          this.toArray(
+            normalizedRequest.commandInput.GlobalSecondaryIndexUpdates
+          ).map((x: { [DictionaryKey: string]: any }) => JSON.stringify(x));
       }
     }
 
@@ -221,7 +238,7 @@ export class DynamodbServiceExtension implements ServiceExtension {
   ) {
     if (response.data?.ConsumedCapacity) {
       span.setAttribute(
-        SemanticAttributes.AWS_DYNAMODB_CONSUMED_CAPACITY,
+        SEMATTRS_AWS_DYNAMODB_CONSUMED_CAPACITY,
         toArray(response.data.ConsumedCapacity).map(
           (x: { [DictionaryKey: string]: any }) => JSON.stringify(x)
         )
@@ -230,7 +247,7 @@ export class DynamodbServiceExtension implements ServiceExtension {
 
     if (response.data?.ItemCollectionMetrics) {
       span.setAttribute(
-        SemanticAttributes.AWS_DYNAMODB_ITEM_COLLECTION_METRICS,
+        SEMATTRS_AWS_DYNAMODB_ITEM_COLLECTION_METRICS,
         this.toArray(response.data.ItemCollectionMetrics).map(
           (x: { [DictionaryKey: string]: any }) => JSON.stringify(x)
         )
@@ -239,21 +256,18 @@ export class DynamodbServiceExtension implements ServiceExtension {
 
     if (response.data?.TableNames) {
       span.setAttribute(
-        SemanticAttributes.AWS_DYNAMODB_TABLE_COUNT,
+        SEMATTRS_AWS_DYNAMODB_TABLE_COUNT,
         response.data?.TableNames.length
       );
     }
 
     if (response.data?.Count) {
-      span.setAttribute(
-        SemanticAttributes.AWS_DYNAMODB_COUNT,
-        response.data?.Count
-      );
+      span.setAttribute(SEMATTRS_AWS_DYNAMODB_COUNT, response.data?.Count);
     }
 
     if (response.data?.ScannedCount) {
       span.setAttribute(
-        SemanticAttributes.AWS_DYNAMODB_SCANNED_COUNT,
+        SEMATTRS_AWS_DYNAMODB_SCANNED_COUNT,
         response.data?.ScannedCount
       );
     }

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/lambda.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/lambda.ts
@@ -20,7 +20,12 @@ import {
   diag,
   SpanAttributes,
 } from '@opentelemetry/api';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMATTRS_FAAS_EXECUTION,
+  SEMATTRS_FAAS_INVOKED_NAME,
+  SEMATTRS_FAAS_INVOKED_PROVIDER,
+  SEMATTRS_FAAS_INVOKED_REGION,
+} from '@opentelemetry/semantic-conventions';
 import {
   AwsSdkInstrumentationConfig,
   NormalizedRequest,
@@ -46,12 +51,11 @@ export class LambdaServiceExtension implements ServiceExtension {
     switch (request.commandName) {
       case 'Invoke':
         spanAttributes = {
-          [SemanticAttributes.FAAS_INVOKED_NAME]: functionName,
-          [SemanticAttributes.FAAS_INVOKED_PROVIDER]: 'aws',
+          [SEMATTRS_FAAS_INVOKED_NAME]: functionName,
+          [SEMATTRS_FAAS_INVOKED_PROVIDER]: 'aws',
         };
         if (request.region) {
-          spanAttributes[SemanticAttributes.FAAS_INVOKED_REGION] =
-            request.region;
+          spanAttributes[SEMATTRS_FAAS_INVOKED_REGION] = request.region;
         }
         spanName = `${functionName} ${LambdaCommands.Invoke}`;
         break;
@@ -87,10 +91,7 @@ export class LambdaServiceExtension implements ServiceExtension {
     switch (response.request.commandName) {
       case LambdaCommands.Invoke:
         {
-          span.setAttribute(
-            SemanticAttributes.FAAS_EXECUTION,
-            response.requestId
-          );
+          span.setAttribute(SEMATTRS_FAAS_EXECUTION, response.requestId);
         }
         break;
     }

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/lambda.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/lambda.ts
@@ -13,13 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  Span,
-  SpanKind,
-  Tracer,
-  diag,
-  SpanAttributes,
-} from '@opentelemetry/api';
+import { Span, SpanKind, Tracer, diag, Attributes } from '@opentelemetry/api';
 import {
   SEMATTRS_FAAS_EXECUTION,
   SEMATTRS_FAAS_INVOKED_NAME,
@@ -45,7 +39,7 @@ export class LambdaServiceExtension implements ServiceExtension {
   ): RequestMetadata {
     const functionName = this.extractFunctionName(request.commandInput);
 
-    let spanAttributes: SpanAttributes = {};
+    let spanAttributes: Attributes = {};
     let spanName: string | undefined;
 
     switch (request.commandName) {

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sns.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sns.ts
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Span, Tracer, SpanKind, SpanAttributes } from '@opentelemetry/api';
+import { Span, Tracer, SpanKind, Attributes } from '@opentelemetry/api';
 import {
-  MessagingDestinationKindValues,
-  SemanticAttributes,
+  MESSAGINGDESTINATIONKINDVALUES_TOPIC,
+  SEMATTRS_MESSAGING_DESTINATION,
+  SEMATTRS_MESSAGING_DESTINATION_KIND,
+  SEMATTRS_MESSAGING_SYSTEM,
 } from '@opentelemetry/semantic-conventions';
 import {
   NormalizedRequest,
@@ -33,26 +35,26 @@ export class SnsServiceExtension implements ServiceExtension {
   ): RequestMetadata {
     let spanKind: SpanKind = SpanKind.CLIENT;
     let spanName = `SNS ${request.commandName}`;
-    const spanAttributes: SpanAttributes = {
-      [SemanticAttributes.MESSAGING_SYSTEM]: 'aws.sns',
+    const spanAttributes: Attributes = {
+      [SEMATTRS_MESSAGING_SYSTEM]: 'aws.sns',
     };
 
     if (request.commandName === 'Publish') {
       spanKind = SpanKind.PRODUCER;
 
-      spanAttributes[SemanticAttributes.MESSAGING_DESTINATION_KIND] =
-        MessagingDestinationKindValues.TOPIC;
+      spanAttributes[SEMATTRS_MESSAGING_DESTINATION_KIND] =
+        MESSAGINGDESTINATIONKINDVALUES_TOPIC;
       const { TopicArn, TargetArn, PhoneNumber } = request.commandInput;
-      spanAttributes[SemanticAttributes.MESSAGING_DESTINATION] =
+      spanAttributes[SEMATTRS_MESSAGING_DESTINATION] =
         this.extractDestinationName(TopicArn, TargetArn, PhoneNumber);
-      // ToDO: Use SpanAttributes.MESSAGING_DESTINATION_NAME when implemented
+      // ToDO: Use SEMATTRS_MESSAGING_DESTINATION_NAME when implemented
       spanAttributes['messaging.destination.name'] =
         TopicArn || TargetArn || PhoneNumber || 'unknown';
 
       spanName = `${
         PhoneNumber
           ? 'phone_number'
-          : spanAttributes[SemanticAttributes.MESSAGING_DESTINATION]
+          : spanAttributes[SEMATTRS_MESSAGING_DESTINATION]
       } send`;
     }
 

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sqs.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sqs.ts
@@ -21,7 +21,7 @@ import {
   trace,
   context,
   ROOT_CONTEXT,
-  SpanAttributes,
+  Attributes,
 } from '@opentelemetry/api';
 import { pubsubPropagation } from '@opentelemetry/propagation-utils';
 import { RequestMetadata, ServiceExtension } from './ServiceExtension';
@@ -32,9 +32,15 @@ import {
   NormalizedResponse,
 } from '../types';
 import {
-  MessagingDestinationKindValues,
-  MessagingOperationValues,
-  SemanticAttributes,
+  MESSAGINGDESTINATIONKINDVALUES_QUEUE,
+  MESSAGINGOPERATIONVALUES_PROCESS,
+  MESSAGINGOPERATIONVALUES_RECEIVE,
+  SEMATTRS_MESSAGING_DESTINATION,
+  SEMATTRS_MESSAGING_DESTINATION_KIND,
+  SEMATTRS_MESSAGING_MESSAGE_ID,
+  SEMATTRS_MESSAGING_OPERATION,
+  SEMATTRS_MESSAGING_SYSTEM,
+  SEMATTRS_MESSAGING_URL,
 } from '@opentelemetry/semantic-conventions';
 import {
   contextGetter,
@@ -53,12 +59,12 @@ export class SqsServiceExtension implements ServiceExtension {
     let spanKind: SpanKind = SpanKind.CLIENT;
     let spanName: string | undefined;
 
-    const spanAttributes: SpanAttributes = {
-      [SemanticAttributes.MESSAGING_SYSTEM]: 'aws.sqs',
-      [SemanticAttributes.MESSAGING_DESTINATION_KIND]:
-        MessagingDestinationKindValues.QUEUE,
-      [SemanticAttributes.MESSAGING_DESTINATION]: queueName,
-      [SemanticAttributes.MESSAGING_URL]: queueUrl,
+    const spanAttributes: Attributes = {
+      [SEMATTRS_MESSAGING_SYSTEM]: 'aws.sqs',
+      [SEMATTRS_MESSAGING_DESTINATION_KIND]:
+        MESSAGINGDESTINATIONKINDVALUES_QUEUE,
+      [SEMATTRS_MESSAGING_DESTINATION]: queueName,
+      [SEMATTRS_MESSAGING_URL]: queueUrl,
     };
 
     let isIncoming = false;
@@ -69,8 +75,8 @@ export class SqsServiceExtension implements ServiceExtension {
           isIncoming = true;
           spanKind = SpanKind.CONSUMER;
           spanName = `${queueName} receive`;
-          spanAttributes[SemanticAttributes.MESSAGING_OPERATION] =
-            MessagingOperationValues.RECEIVE;
+          spanAttributes[SEMATTRS_MESSAGING_OPERATION] =
+            MESSAGINGOPERATIONVALUES_RECEIVE;
 
           request.commandInput.MessageAttributeNames =
             addPropagationFieldsToAttributeNames(
@@ -134,7 +140,7 @@ export class SqsServiceExtension implements ServiceExtension {
     switch (response.request.commandName) {
       case 'SendMessage':
         span.setAttribute(
-          SemanticAttributes.MESSAGING_MESSAGE_ID,
+          SEMATTRS_MESSAGING_MESSAGE_ID,
           response?.data?.MessageId
         );
         break;
@@ -164,14 +170,14 @@ export class SqsServiceExtension implements ServiceExtension {
                 contextGetter
               ),
               attributes: {
-                [SemanticAttributes.MESSAGING_SYSTEM]: 'aws.sqs',
-                [SemanticAttributes.MESSAGING_DESTINATION]: queueName,
-                [SemanticAttributes.MESSAGING_DESTINATION_KIND]:
-                  MessagingDestinationKindValues.QUEUE,
-                [SemanticAttributes.MESSAGING_MESSAGE_ID]: message.MessageId,
-                [SemanticAttributes.MESSAGING_URL]: queueUrl,
-                [SemanticAttributes.MESSAGING_OPERATION]:
-                  MessagingOperationValues.PROCESS,
+                [SEMATTRS_MESSAGING_SYSTEM]: 'aws.sqs',
+                [SEMATTRS_MESSAGING_DESTINATION]: queueName,
+                [SEMATTRS_MESSAGING_DESTINATION_KIND]:
+                  MESSAGINGDESTINATIONKINDVALUES_QUEUE,
+                [SEMATTRS_MESSAGING_MESSAGE_ID]: message.MessageId,
+                [SEMATTRS_MESSAGING_URL]: queueUrl,
+                [SEMATTRS_MESSAGING_OPERATION]:
+                  MESSAGINGOPERATIONVALUES_PROCESS,
               },
             }),
             processHook: (span: Span, message: SQS.Message) =>

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/utils.ts
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 import { NormalizedRequest } from './types';
-import { Context, SpanAttributes, context } from '@opentelemetry/api';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { Attributes, Context, context } from '@opentelemetry/api';
+import {
+  SEMATTRS_RPC_METHOD,
+  SEMATTRS_RPC_SERVICE,
+  SEMATTRS_RPC_SYSTEM,
+} from '@opentelemetry/semantic-conventions';
 import { AttributeNames } from './enums';
 
 const toPascalCase = (str: string): string =>
@@ -60,11 +64,11 @@ export const normalizeV3Request = (
 
 export const extractAttributesFromNormalizedRequest = (
   normalizedRequest: NormalizedRequest
-): SpanAttributes => {
+): Attributes => {
   return {
-    [SemanticAttributes.RPC_SYSTEM]: 'aws-api',
-    [SemanticAttributes.RPC_METHOD]: normalizedRequest.commandName,
-    [SemanticAttributes.RPC_SERVICE]: normalizedRequest.serviceName,
+    [SEMATTRS_RPC_SYSTEM]: 'aws-api',
+    [SEMATTRS_RPC_METHOD]: normalizedRequest.commandName,
+    [SEMATTRS_RPC_SERVICE]: normalizedRequest.serviceName,
     [AttributeNames.AWS_REGION]: normalizedRequest.region,
   };
 };

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/aws-sdk-v2.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/aws-sdk-v2.test.ts
@@ -32,7 +32,7 @@ import { SpanStatusCode, Span, SpanKind } from '@opentelemetry/api';
 import { AttributeNames } from '../src/enums';
 import { mockV2AwsSend } from './testing-utils';
 import { expect } from 'expect';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SEMATTRS_HTTP_STATUS_CODE } from '@opentelemetry/semantic-conventions';
 import { AWSError } from 'aws-sdk';
 import { HttpResponse } from 'aws-sdk/lib/http_response';
 
@@ -131,9 +131,9 @@ describe('instrumentation-aws-sdk-v2', () => {
         expect(spanCreateBucket.attributes[AttributeNames.AWS_REGION]).toBe(
           'us-east-1'
         );
-        expect(
-          spanCreateBucket.attributes[SemanticAttributes.HTTP_STATUS_CODE]
-        ).toBe(200);
+        expect(spanCreateBucket.attributes[SEMATTRS_HTTP_STATUS_CODE]).toBe(
+          200
+        );
 
         expect(spanCreateBucket.name).toBe('S3.CreateBucket');
         expect(spanCreateBucket.kind).toEqual(SpanKind.CLIENT);
@@ -159,9 +159,7 @@ describe('instrumentation-aws-sdk-v2', () => {
           'us-east-1'
         );
         expect(spanPutObject.name).toBe('S3.PutObject');
-        expect(
-          spanPutObject.attributes[SemanticAttributes.HTTP_STATUS_CODE]
-        ).toBe(200);
+        expect(spanPutObject.attributes[SEMATTRS_HTTP_STATUS_CODE]).toBe(200);
       });
 
       it('adds proper number of spans with correct attributes if both, promise and callback were used', async () => {
@@ -210,9 +208,7 @@ describe('instrumentation-aws-sdk-v2', () => {
         expect(spanPutObjectCb.attributes[AttributeNames.AWS_REGION]).toBe(
           'us-east-1'
         );
-        expect(
-          spanPutObjectCb.attributes[SemanticAttributes.HTTP_STATUS_CODE]
-        ).toBe(200);
+        expect(spanPutObjectCb.attributes[SEMATTRS_HTTP_STATUS_CODE]).toBe(200);
       });
 
       it('adds proper number of spans with correct attributes if only promise was used', async () => {
@@ -248,9 +244,7 @@ describe('instrumentation-aws-sdk-v2', () => {
         expect(spanPutObjectCb.attributes[AttributeNames.AWS_REGION]).toBe(
           'us-east-1'
         );
-        expect(
-          spanPutObjectCb.attributes[SemanticAttributes.HTTP_STATUS_CODE]
-        ).toBe(200);
+        expect(spanPutObjectCb.attributes[SEMATTRS_HTTP_STATUS_CODE]).toBe(200);
       });
 
       it('should create span if no callback is supplied', done => {
@@ -304,9 +298,9 @@ describe('instrumentation-aws-sdk-v2', () => {
           })
         );
 
-        expect(
-          spanCreateBucket.attributes[SemanticAttributes.HTTP_STATUS_CODE]
-        ).toBe(400);
+        expect(spanCreateBucket.attributes[SEMATTRS_HTTP_STATUS_CODE]).toBe(
+          400
+        );
       });
     });
   });

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/aws-sdk-v3.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/aws-sdk-v3.test.ts
@@ -42,9 +42,18 @@ import 'mocha';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { context, SpanStatusCode, trace, Span } from '@opentelemetry/api';
 import {
-  MessagingDestinationKindValues,
-  MessagingOperationValues,
-  SemanticAttributes,
+  MESSAGINGDESTINATIONKINDVALUES_QUEUE,
+  MESSAGINGOPERATIONVALUES_RECEIVE,
+  SEMATTRS_HTTP_STATUS_CODE,
+  SEMATTRS_MESSAGING_DESTINATION,
+  SEMATTRS_MESSAGING_DESTINATION_KIND,
+  SEMATTRS_MESSAGING_MESSAGE_ID,
+  SEMATTRS_MESSAGING_OPERATION,
+  SEMATTRS_MESSAGING_SYSTEM,
+  SEMATTRS_MESSAGING_URL,
+  SEMATTRS_RPC_METHOD,
+  SEMATTRS_RPC_SERVICE,
+  SEMATTRS_RPC_SYSTEM,
 } from '@opentelemetry/semantic-conventions';
 import { AttributeNames } from '../src/enums';
 import { expect } from 'expect';
@@ -72,15 +81,13 @@ describe('instrumentation-aws-sdk-v3', () => {
       await s3Client.putObject(params);
       expect(getTestSpans().length).toBe(1);
       const [span] = getTestSpans();
-      expect(span.attributes[SemanticAttributes.RPC_SYSTEM]).toEqual('aws-api');
-      expect(span.attributes[SemanticAttributes.RPC_METHOD]).toEqual(
-        'PutObject'
-      );
-      expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual('S3');
+      expect(span.attributes[SEMATTRS_RPC_SYSTEM]).toEqual('aws-api');
+      expect(span.attributes[SEMATTRS_RPC_METHOD]).toEqual('PutObject');
+      expect(span.attributes[SEMATTRS_RPC_SERVICE]).toEqual('S3');
       expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
       expect(span.name).toEqual('S3.PutObject');
       expect(span.kind).toEqual(SpanKind.CLIENT);
-      expect(span.attributes[SemanticAttributes.HTTP_STATUS_CODE]).toEqual(200);
+      expect(span.attributes[SEMATTRS_HTTP_STATUS_CODE]).toEqual(200);
     });
 
     it('callback interface', done => {
@@ -98,18 +105,12 @@ describe('instrumentation-aws-sdk-v3', () => {
       s3Client.putObject(params, (err: any, data?: PutObjectCommandOutput) => {
         expect(getTestSpans().length).toBe(1);
         const [span] = getTestSpans();
-        expect(span.attributes[SemanticAttributes.RPC_SYSTEM]).toEqual(
-          'aws-api'
-        );
-        expect(span.attributes[SemanticAttributes.RPC_METHOD]).toEqual(
-          'PutObject'
-        );
-        expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual('S3');
+        expect(span.attributes[SEMATTRS_RPC_SYSTEM]).toEqual('aws-api');
+        expect(span.attributes[SEMATTRS_RPC_METHOD]).toEqual('PutObject');
+        expect(span.attributes[SEMATTRS_RPC_SERVICE]).toEqual('S3');
         expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
         expect(span.name).toEqual('S3.PutObject');
-        expect(span.attributes[SemanticAttributes.HTTP_STATUS_CODE]).toEqual(
-          200
-        );
+        expect(span.attributes[SEMATTRS_HTTP_STATUS_CODE]).toEqual(200);
         done();
       });
     });
@@ -130,14 +131,12 @@ describe('instrumentation-aws-sdk-v3', () => {
       await client.send(new PutObjectCommand(params));
       expect(getTestSpans().length).toBe(1);
       const [span] = getTestSpans();
-      expect(span.attributes[SemanticAttributes.RPC_SYSTEM]).toEqual('aws-api');
-      expect(span.attributes[SemanticAttributes.RPC_METHOD]).toEqual(
-        'PutObject'
-      );
-      expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual('S3');
+      expect(span.attributes[SEMATTRS_RPC_SYSTEM]).toEqual('aws-api');
+      expect(span.attributes[SEMATTRS_RPC_METHOD]).toEqual('PutObject');
+      expect(span.attributes[SEMATTRS_RPC_SERVICE]).toEqual('S3');
       expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
       expect(span.name).toEqual('S3.PutObject');
-      expect(span.attributes[SemanticAttributes.HTTP_STATUS_CODE]).toEqual(200);
+      expect(span.attributes[SEMATTRS_HTTP_STATUS_CODE]).toEqual(200);
     });
 
     it('aws error', async () => {
@@ -165,13 +164,9 @@ describe('instrumentation-aws-sdk-v3', () => {
         expect(span.events.length).toBe(1);
         expect(span.events[0].name).toEqual('exception');
 
-        expect(span.attributes[SemanticAttributes.RPC_SYSTEM]).toEqual(
-          'aws-api'
-        );
-        expect(span.attributes[SemanticAttributes.RPC_METHOD]).toEqual(
-          'PutObject'
-        );
-        expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual('S3');
+        expect(span.attributes[SEMATTRS_RPC_SYSTEM]).toEqual('aws-api');
+        expect(span.attributes[SEMATTRS_RPC_METHOD]).toEqual('PutObject');
+        expect(span.attributes[SEMATTRS_RPC_SERVICE]).toEqual('S3');
         expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
         expect(span.attributes[AttributeNames.AWS_REQUEST_ID]).toEqual(
           'MS95GTS7KXQ34X2S'
@@ -309,34 +304,26 @@ describe('instrumentation-aws-sdk-v3', () => {
         const [span] = getTestSpans();
 
         // make sure we have the general aws attributes:
-        expect(span.attributes[SemanticAttributes.RPC_SYSTEM]).toEqual(
-          'aws-api'
-        );
-        expect(span.attributes[SemanticAttributes.RPC_METHOD]).toEqual(
-          'SendMessage'
-        );
-        expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual('SQS');
+        expect(span.attributes[SEMATTRS_RPC_SYSTEM]).toEqual('aws-api');
+        expect(span.attributes[SEMATTRS_RPC_METHOD]).toEqual('SendMessage');
+        expect(span.attributes[SEMATTRS_RPC_SERVICE]).toEqual('SQS');
         expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
 
         // custom messaging attributes
-        expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual(
-          'aws.sqs'
+        expect(span.attributes[SEMATTRS_MESSAGING_SYSTEM]).toEqual('aws.sqs');
+        expect(span.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]).toEqual(
+          MESSAGINGDESTINATIONKINDVALUES_QUEUE
         );
-        expect(
-          span.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]
-        ).toEqual(MessagingDestinationKindValues.QUEUE);
-        expect(
-          span.attributes[SemanticAttributes.MESSAGING_DESTINATION]
-        ).toEqual('otel-demo-aws-sdk');
-        expect(span.attributes[SemanticAttributes.MESSAGING_URL]).toEqual(
+        expect(span.attributes[SEMATTRS_MESSAGING_DESTINATION]).toEqual(
+          'otel-demo-aws-sdk'
+        );
+        expect(span.attributes[SEMATTRS_MESSAGING_URL]).toEqual(
           params.QueueUrl
         );
-        expect(
-          span.attributes[SemanticAttributes.MESSAGING_MESSAGE_ID]
-        ).toEqual(response.MessageId);
-        expect(span.attributes[SemanticAttributes.HTTP_STATUS_CODE]).toEqual(
-          200
+        expect(span.attributes[SEMATTRS_MESSAGING_MESSAGE_ID]).toEqual(
+          response.MessageId
         );
+        expect(span.attributes[SEMATTRS_HTTP_STATUS_CODE]).toEqual(200);
       });
 
       it('sqs send message batch attributes', async () => {
@@ -375,31 +362,25 @@ describe('instrumentation-aws-sdk-v3', () => {
         const [span] = getTestSpans();
 
         // make sure we have the general aws attributes:
-        expect(span.attributes[SemanticAttributes.RPC_SYSTEM]).toEqual(
-          'aws-api'
-        );
-        expect(span.attributes[SemanticAttributes.RPC_METHOD]).toEqual(
+        expect(span.attributes[SEMATTRS_RPC_SYSTEM]).toEqual('aws-api');
+        expect(span.attributes[SEMATTRS_RPC_METHOD]).toEqual(
           'SendMessageBatch'
         );
-        expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual('SQS');
+        expect(span.attributes[SEMATTRS_RPC_SERVICE]).toEqual('SQS');
         expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
 
         // messaging semantic attributes
-        expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual(
-          'aws.sqs'
+        expect(span.attributes[SEMATTRS_MESSAGING_SYSTEM]).toEqual('aws.sqs');
+        expect(span.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]).toEqual(
+          MESSAGINGDESTINATIONKINDVALUES_QUEUE
         );
-        expect(
-          span.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]
-        ).toEqual(MessagingDestinationKindValues.QUEUE);
-        expect(
-          span.attributes[SemanticAttributes.MESSAGING_DESTINATION]
-        ).toEqual('otel-demo-aws-sdk');
-        expect(span.attributes[SemanticAttributes.MESSAGING_URL]).toEqual(
+        expect(span.attributes[SEMATTRS_MESSAGING_DESTINATION]).toEqual(
+          'otel-demo-aws-sdk'
+        );
+        expect(span.attributes[SEMATTRS_MESSAGING_URL]).toEqual(
           params.QueueUrl
         );
-        expect(span.attributes[SemanticAttributes.HTTP_STATUS_CODE]).toEqual(
-          200
-        );
+        expect(span.attributes[SEMATTRS_HTTP_STATUS_CODE]).toEqual(200);
       });
 
       it('sqs receive add messaging attributes', done => {
@@ -428,19 +409,13 @@ describe('instrumentation-aws-sdk-v3', () => {
           const [span] = getTestSpans();
 
           // make sure we have the general aws attributes:
-          expect(span.attributes[SemanticAttributes.RPC_SYSTEM]).toEqual(
-            'aws-api'
-          );
-          expect(span.attributes[SemanticAttributes.RPC_METHOD]).toEqual(
+          expect(span.attributes[SEMATTRS_RPC_SYSTEM]).toEqual('aws-api');
+          expect(span.attributes[SEMATTRS_RPC_METHOD]).toEqual(
             'ReceiveMessage'
           );
-          expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual(
-            'SQS'
-          );
+          expect(span.attributes[SEMATTRS_RPC_SERVICE]).toEqual('SQS');
           expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
-          expect(span.attributes[SemanticAttributes.HTTP_STATUS_CODE]).toEqual(
-            200
-          );
+          expect(span.attributes[SEMATTRS_HTTP_STATUS_CODE]).toEqual(200);
           done();
         });
       });
@@ -474,8 +449,8 @@ describe('instrumentation-aws-sdk-v3', () => {
           expect(receiveCallbackSpan).toBeDefined();
           const attributes = (receiveCallbackSpan as unknown as ReadableSpan)
             .attributes;
-          expect(attributes[SemanticAttributes.MESSAGING_OPERATION]).toMatch(
-            MessagingOperationValues.RECEIVE
+          expect(attributes[SEMATTRS_MESSAGING_OPERATION]).toMatch(
+            MESSAGINGOPERATIONVALUES_RECEIVE
           );
           done();
         });

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/dynamodb.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/dynamodb.test.ts
@@ -30,8 +30,32 @@ import { AWSError } from 'aws-sdk';
 
 import { mockV2AwsSend } from './testing-utils';
 import {
-  DbSystemValues,
-  SemanticAttributes,
+  DBSYSTEMVALUES_DYNAMODB,
+  SEMATTRS_AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS,
+  SEMATTRS_AWS_DYNAMODB_CONSISTENT_READ,
+  SEMATTRS_AWS_DYNAMODB_CONSUMED_CAPACITY,
+  SEMATTRS_AWS_DYNAMODB_COUNT,
+  SEMATTRS_AWS_DYNAMODB_EXCLUSIVE_START_TABLE,
+  SEMATTRS_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES,
+  SEMATTRS_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES,
+  SEMATTRS_AWS_DYNAMODB_INDEX_NAME,
+  SEMATTRS_AWS_DYNAMODB_ITEM_COLLECTION_METRICS,
+  SEMATTRS_AWS_DYNAMODB_LIMIT,
+  SEMATTRS_AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES,
+  SEMATTRS_AWS_DYNAMODB_PROJECTION,
+  SEMATTRS_AWS_DYNAMODB_PROVISIONED_READ_CAPACITY,
+  SEMATTRS_AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY,
+  SEMATTRS_AWS_DYNAMODB_SCAN_FORWARD,
+  SEMATTRS_AWS_DYNAMODB_SCANNED_COUNT,
+  SEMATTRS_AWS_DYNAMODB_SEGMENT,
+  SEMATTRS_AWS_DYNAMODB_SELECT,
+  SEMATTRS_AWS_DYNAMODB_TABLE_COUNT,
+  SEMATTRS_AWS_DYNAMODB_TABLE_NAMES,
+  SEMATTRS_AWS_DYNAMODB_TOTAL_SEGMENTS,
+  SEMATTRS_DB_NAME,
+  SEMATTRS_DB_OPERATION,
+  SEMATTRS_DB_STATEMENT,
+  SEMATTRS_DB_SYSTEM,
 } from '@opentelemetry/semantic-conventions';
 import { expect } from 'expect';
 import type { ConsumedCapacity as ConsumedCapacityV2 } from 'aws-sdk/clients/dynamodb';
@@ -90,33 +114,27 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SemanticAttributes.DB_SYSTEM]).toStrictEqual(
-            DbSystemValues.DYNAMODB
+          expect(attrs[SEMATTRS_DB_SYSTEM]).toStrictEqual(
+            DBSYSTEMVALUES_DYNAMODB
           );
-          expect(attrs[SemanticAttributes.DB_NAME]).toStrictEqual('test-table');
-          expect(attrs[SemanticAttributes.DB_OPERATION]).toStrictEqual('Query');
-          expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_SCAN_FORWARD]
-          ).toStrictEqual(true);
-          expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_CONSISTENT_READ]
-          ).toStrictEqual(true);
-          expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_INDEX_NAME]
-          ).toStrictEqual('name_to_group');
-          expect(attrs[SemanticAttributes.AWS_DYNAMODB_SELECT]).toStrictEqual(
+          expect(attrs[SEMATTRS_DB_NAME]).toStrictEqual('test-table');
+          expect(attrs[SEMATTRS_DB_OPERATION]).toStrictEqual('Query');
+          expect(attrs[SEMATTRS_AWS_DYNAMODB_SCAN_FORWARD]).toStrictEqual(true);
+          expect(attrs[SEMATTRS_AWS_DYNAMODB_CONSISTENT_READ]).toStrictEqual(
+            true
+          );
+          expect(attrs[SEMATTRS_AWS_DYNAMODB_INDEX_NAME]).toStrictEqual(
+            'name_to_group'
+          );
+          expect(attrs[SEMATTRS_AWS_DYNAMODB_SELECT]).toStrictEqual(
             'ALL_ATTRIBUTES'
           );
-          expect(attrs[SemanticAttributes.AWS_DYNAMODB_LIMIT]).toStrictEqual(
-            10
-          );
-          expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_TABLE_NAMES]
-          ).toStrictEqual(['test-table']);
-          expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_PROJECTION]
-          ).toStrictEqual('id');
-          expect(attrs).not.toHaveProperty(SemanticAttributes.DB_STATEMENT);
+          expect(attrs[SEMATTRS_AWS_DYNAMODB_LIMIT]).toStrictEqual(10);
+          expect(attrs[SEMATTRS_AWS_DYNAMODB_TABLE_NAMES]).toStrictEqual([
+            'test-table',
+          ]);
+          expect(attrs[SEMATTRS_AWS_DYNAMODB_PROJECTION]).toStrictEqual('id');
+          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -157,39 +175,29 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SemanticAttributes.DB_SYSTEM]).toStrictEqual(
-            DbSystemValues.DYNAMODB
+          expect(attrs[SEMATTRS_DB_SYSTEM]).toStrictEqual(
+            DBSYSTEMVALUES_DYNAMODB
           );
-          expect(attrs[SemanticAttributes.DB_NAME]).toStrictEqual('test-table');
-          expect(attrs[SemanticAttributes.DB_OPERATION]).toStrictEqual('Scan');
-          expect(attrs[SemanticAttributes.AWS_DYNAMODB_SEGMENT]).toStrictEqual(
-            10
+          expect(attrs[SEMATTRS_DB_NAME]).toStrictEqual('test-table');
+          expect(attrs[SEMATTRS_DB_OPERATION]).toStrictEqual('Scan');
+          expect(attrs[SEMATTRS_AWS_DYNAMODB_SEGMENT]).toStrictEqual(10);
+          expect(attrs[SEMATTRS_AWS_DYNAMODB_TOTAL_SEGMENTS]).toStrictEqual(
+            100
           );
-          expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_TOTAL_SEGMENTS]
-          ).toStrictEqual(100);
-          expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_INDEX_NAME]
-          ).toStrictEqual('index_name');
-          expect(attrs[SemanticAttributes.AWS_DYNAMODB_SELECT]).toStrictEqual(
+          expect(attrs[SEMATTRS_AWS_DYNAMODB_INDEX_NAME]).toStrictEqual(
+            'index_name'
+          );
+          expect(attrs[SEMATTRS_AWS_DYNAMODB_SELECT]).toStrictEqual(
             'ALL_ATTRIBUTES'
           );
-          expect(attrs[SemanticAttributes.AWS_DYNAMODB_COUNT]).toStrictEqual(
-            10
-          );
-          expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_SCANNED_COUNT]
-          ).toStrictEqual(50);
-          expect(attrs[SemanticAttributes.AWS_DYNAMODB_LIMIT]).toStrictEqual(
-            10
-          );
-          expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_TABLE_NAMES]
-          ).toStrictEqual(['test-table']);
-          expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_PROJECTION]
-          ).toStrictEqual('id');
-          expect(attrs).not.toHaveProperty(SemanticAttributes.DB_STATEMENT);
+          expect(attrs[SEMATTRS_AWS_DYNAMODB_COUNT]).toStrictEqual(10);
+          expect(attrs[SEMATTRS_AWS_DYNAMODB_SCANNED_COUNT]).toStrictEqual(50);
+          expect(attrs[SEMATTRS_AWS_DYNAMODB_LIMIT]).toStrictEqual(10);
+          expect(attrs[SEMATTRS_AWS_DYNAMODB_TABLE_NAMES]).toStrictEqual([
+            'test-table',
+          ]);
+          expect(attrs[SEMATTRS_AWS_DYNAMODB_PROJECTION]).toStrictEqual('id');
+          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -226,16 +234,16 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SemanticAttributes.DB_SYSTEM]).toStrictEqual(
-            DbSystemValues.DYNAMODB
+          expect(attrs[SEMATTRS_DB_SYSTEM]).toStrictEqual(
+            DBSYSTEMVALUES_DYNAMODB
           );
           expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_ITEM_COLLECTION_METRICS]
+            attrs[SEMATTRS_AWS_DYNAMODB_ITEM_COLLECTION_METRICS]
           ).toStrictEqual([
             JSON.stringify({ ItemCollectionKey: [], SizeEstimateRangeGB: [0] }),
           ]);
 
-          expect(attrs).not.toHaveProperty(SemanticAttributes.DB_STATEMENT);
+          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -321,29 +329,29 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SemanticAttributes.DB_SYSTEM]).toStrictEqual(
-            DbSystemValues.DYNAMODB
+          expect(attrs[SEMATTRS_DB_SYSTEM]).toStrictEqual(
+            DBSYSTEMVALUES_DYNAMODB
           );
           expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_ITEM_COLLECTION_METRICS]
+            attrs[SEMATTRS_AWS_DYNAMODB_ITEM_COLLECTION_METRICS]
           ).toStrictEqual([
             JSON.stringify({ ItemCollectionKey: [], SizeEstimateRangeGB: [0] }),
           ]);
 
           expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES]
+            attrs[SEMATTRS_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES]
           ).toStrictEqual([JSON.stringify(globalSecondaryIndexMockData)]);
 
           expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES]
+            attrs[SEMATTRS_AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES]
           ).toStrictEqual([JSON.stringify(localSecondaryIndexMockData)]);
           expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_PROVISIONED_READ_CAPACITY]
+            attrs[SEMATTRS_AWS_DYNAMODB_PROVISIONED_READ_CAPACITY]
           ).toStrictEqual(20);
           expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY]
+            attrs[SEMATTRS_AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY]
           ).toStrictEqual(30);
-          expect(attrs).not.toHaveProperty(SemanticAttributes.DB_STATEMENT);
+          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -394,14 +402,12 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SemanticAttributes.DB_SYSTEM]).toStrictEqual(
-            DbSystemValues.DYNAMODB
+          expect(attrs[SEMATTRS_DB_SYSTEM]).toStrictEqual(
+            DBSYSTEMVALUES_DYNAMODB
           );
 
           expect(
-            attrs[
-              SemanticAttributes.AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES
-            ]
+            attrs[SEMATTRS_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES]
           ).toStrictEqual([
             JSON.stringify({
               Update: {
@@ -414,7 +420,7 @@ describe('DynamoDB', () => {
             }),
           ]);
           expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS]
+            attrs[SEMATTRS_AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS]
           ).toStrictEqual([
             JSON.stringify({
               AttributeName: 'test_attr',
@@ -422,12 +428,12 @@ describe('DynamoDB', () => {
             }),
           ]);
           expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_PROVISIONED_READ_CAPACITY]
+            attrs[SEMATTRS_AWS_DYNAMODB_PROVISIONED_READ_CAPACITY]
           ).toStrictEqual(10);
           expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY]
+            attrs[SEMATTRS_AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY]
           ).toStrictEqual(15);
-          expect(attrs).not.toHaveProperty(SemanticAttributes.DB_STATEMENT);
+          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -455,21 +461,17 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SemanticAttributes.DB_SYSTEM]).toStrictEqual(
-            DbSystemValues.DYNAMODB
+          expect(attrs[SEMATTRS_DB_SYSTEM]).toStrictEqual(
+            DBSYSTEMVALUES_DYNAMODB
           );
 
           expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_EXCLUSIVE_START_TABLE]
+            attrs[SEMATTRS_AWS_DYNAMODB_EXCLUSIVE_START_TABLE]
           ).toStrictEqual('start_table');
-          expect(attrs[SemanticAttributes.AWS_DYNAMODB_LIMIT]).toStrictEqual(
-            10
-          );
-          expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_TABLE_COUNT]
-          ).toStrictEqual(3);
+          expect(attrs[SEMATTRS_AWS_DYNAMODB_LIMIT]).toStrictEqual(10);
+          expect(attrs[SEMATTRS_AWS_DYNAMODB_TABLE_COUNT]).toStrictEqual(3);
 
-          expect(attrs).not.toHaveProperty(SemanticAttributes.DB_STATEMENT);
+          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -511,19 +513,17 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SemanticAttributes.DB_SYSTEM]).toStrictEqual(
-            DbSystemValues.DYNAMODB
+          expect(attrs[SEMATTRS_DB_SYSTEM]).toStrictEqual(
+            DBSYSTEMVALUES_DYNAMODB
           );
-          expect(attrs[SemanticAttributes.DB_OPERATION]).toStrictEqual(
-            'BatchGetItem'
-          );
+          expect(attrs[SEMATTRS_DB_OPERATION]).toStrictEqual('BatchGetItem');
+          expect(attrs[SEMATTRS_AWS_DYNAMODB_TABLE_NAMES]).toStrictEqual([
+            'test-table',
+          ]);
           expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_TABLE_NAMES]
-          ).toStrictEqual(['test-table']);
-          expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_CONSUMED_CAPACITY]
+            attrs[SEMATTRS_AWS_DYNAMODB_CONSUMED_CAPACITY]
           ).toBeUndefined();
-          expect(attrs).not.toHaveProperty(SemanticAttributes.DB_STATEMENT);
+          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -556,23 +556,19 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SemanticAttributes.DB_SYSTEM]).toStrictEqual(
-            DbSystemValues.DYNAMODB
+          expect(attrs[SEMATTRS_DB_SYSTEM]).toStrictEqual(
+            DBSYSTEMVALUES_DYNAMODB
           );
-          expect(attrs[SemanticAttributes.DB_OPERATION]).toStrictEqual(
-            'BatchGetItem'
-          );
-          expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_TABLE_NAMES]
-          ).toStrictEqual(['test-table']);
-          expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_CONSUMED_CAPACITY]
-          ).toStrictEqual(
+          expect(attrs[SEMATTRS_DB_OPERATION]).toStrictEqual('BatchGetItem');
+          expect(attrs[SEMATTRS_AWS_DYNAMODB_TABLE_NAMES]).toStrictEqual([
+            'test-table',
+          ]);
+          expect(attrs[SEMATTRS_AWS_DYNAMODB_CONSUMED_CAPACITY]).toStrictEqual(
             consumedCapacityResponseMockData.map((x: ConsumedCapacity) =>
               JSON.stringify(x)
             )
           );
-          expect(attrs).not.toHaveProperty(SemanticAttributes.DB_STATEMENT);
+          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -605,17 +601,15 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SemanticAttributes.DB_SYSTEM]).toStrictEqual('dynamodb');
-          expect(attrs[SemanticAttributes.DB_OPERATION]).toStrictEqual(
-            'BatchGetItem'
-          );
+          expect(attrs[SEMATTRS_DB_SYSTEM]).toStrictEqual('dynamodb');
+          expect(attrs[SEMATTRS_DB_OPERATION]).toStrictEqual('BatchGetItem');
+          expect(attrs[SEMATTRS_AWS_DYNAMODB_TABLE_NAMES]).toStrictEqual([
+            'test-table',
+          ]);
           expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_TABLE_NAMES]
-          ).toStrictEqual(['test-table']);
-          expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_CONSUMED_CAPACITY]
+            attrs[SEMATTRS_AWS_DYNAMODB_CONSUMED_CAPACITY]
           ).toBeUndefined();
-          expect(attrs).not.toHaveProperty(SemanticAttributes.DB_STATEMENT);
+          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -644,15 +638,11 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SemanticAttributes.DB_SYSTEM]).toStrictEqual(
-            DbSystemValues.DYNAMODB
+          expect(attrs[SEMATTRS_DB_SYSTEM]).toStrictEqual(
+            DBSYSTEMVALUES_DYNAMODB
           );
-          expect(attrs[SemanticAttributes.DB_OPERATION]).toStrictEqual(
-            'PutItem'
-          );
-          expect(
-            attrs[SemanticAttributes.AWS_DYNAMODB_CONSUMED_CAPACITY]
-          ).toStrictEqual([
+          expect(attrs[SEMATTRS_DB_OPERATION]).toStrictEqual('PutItem');
+          expect(attrs[SEMATTRS_AWS_DYNAMODB_CONSUMED_CAPACITY]).toStrictEqual([
             JSON.stringify({
               TableName: 'test-table',
               CapacityUnits: 0.5,
@@ -681,14 +671,12 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SemanticAttributes.DB_SYSTEM]).toStrictEqual(
-            DbSystemValues.DYNAMODB
+          expect(attrs[SEMATTRS_DB_SYSTEM]).toStrictEqual(
+            DBSYSTEMVALUES_DYNAMODB
           );
-          expect(attrs[SemanticAttributes.DB_OPERATION]).toStrictEqual(
-            'PutItem'
-          );
+          expect(attrs[SEMATTRS_DB_OPERATION]).toStrictEqual('PutItem');
           expect(attrs).not.toHaveProperty(
-            SemanticAttributes.AWS_DYNAMODB_CONSUMED_CAPACITY
+            SEMATTRS_AWS_DYNAMODB_CONSUMED_CAPACITY
           );
           expect(err).toBeFalsy();
           done();
@@ -753,7 +741,7 @@ describe('DynamoDB', () => {
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
 
-          expect(attrs).not.toHaveProperty(SemanticAttributes.DB_STATEMENT);
+          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -796,7 +784,7 @@ describe('DynamoDB', () => {
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
 
-          expect(attrs).not.toHaveProperty(SemanticAttributes.DB_STATEMENT);
+          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -839,7 +827,7 @@ describe('DynamoDB', () => {
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
 
-          expect(attrs).not.toHaveProperty(SemanticAttributes.DB_STATEMENT);
+          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -939,7 +927,7 @@ describe('DynamoDB', () => {
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
 
-          expect(attrs[SemanticAttributes.DB_STATEMENT]).toStrictEqual(
+          expect(attrs[SEMATTRS_DB_STATEMENT]).toStrictEqual(
             SERIALIZED_DB_STATEMENT
           );
           expect(err).toBeFalsy();
@@ -1023,7 +1011,7 @@ describe('DynamoDB', () => {
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
 
-          expect(attrs[SemanticAttributes.DB_STATEMENT]).toStrictEqual(
+          expect(attrs[SEMATTRS_DB_STATEMENT]).toStrictEqual(
             SERIALIZED_DB_STATEMENT
           );
           expect(err).toBeFalsy();
@@ -1072,7 +1060,7 @@ describe('DynamoDB', () => {
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
 
-          expect(attrs[SemanticAttributes.DB_STATEMENT]).toStrictEqual(
+          expect(attrs[SEMATTRS_DB_STATEMENT]).toStrictEqual(
             SERIALIZED_DB_STATEMENT
           );
           expect(err).toBeFalsy();
@@ -1101,7 +1089,7 @@ describe('DynamoDB', () => {
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
 
-          expect(attrs[SemanticAttributes.DB_STATEMENT]).toStrictEqual(
+          expect(attrs[SEMATTRS_DB_STATEMENT]).toStrictEqual(
             SERIALIZED_DB_STATEMENT
           );
           expect(err).toBeFalsy();
@@ -1136,7 +1124,7 @@ describe('DynamoDB', () => {
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
 
-          expect(attrs[SemanticAttributes.DB_STATEMENT]).toStrictEqual(
+          expect(attrs[SEMATTRS_DB_STATEMENT]).toStrictEqual(
             SERIALIZED_DB_STATEMENT
           );
           expect(err).toBeFalsy();

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/lambda.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/lambda.test.ts
@@ -21,7 +21,11 @@ import {
 } from '@opentelemetry/contrib-test-utils';
 registerInstrumentationTesting(new AwsInstrumentation());
 
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  SEMATTRS_FAAS_EXECUTION,
+  SEMATTRS_FAAS_INVOKED_NAME,
+  SEMATTRS_FAAS_INVOKED_PROVIDER,
+} from '@opentelemetry/semantic-conventions';
 import { SpanKind } from '@opentelemetry/api';
 
 import { Lambda, InvocationType } from '@aws-sdk/client-lambda';
@@ -90,9 +94,7 @@ describe('Lambda', () => {
         };
         const span = await getInvokedSpan(params);
 
-        expect(
-          span.attributes[SemanticAttributes.FAAS_INVOKED_PROVIDER]
-        ).toEqual('aws');
+        expect(span.attributes[SEMATTRS_FAAS_INVOKED_PROVIDER]).toEqual('aws');
       });
 
       it('should add the function name as a semantic attribute', async () => {
@@ -107,7 +109,7 @@ describe('Lambda', () => {
         };
         const span = await getInvokedSpan(params);
 
-        expect(span.attributes[SemanticAttributes.FAAS_INVOKED_NAME]).toEqual(
+        expect(span.attributes[SEMATTRS_FAAS_INVOKED_NAME]).toEqual(
           'ot-test-function-name'
         );
       });
@@ -347,12 +349,10 @@ describe('Lambda', () => {
         const [span] = getTestSpans();
 
         expect(span.kind).toEqual(SpanKind.CLIENT);
-        expect(span.attributes[SemanticAttributes.FAAS_INVOKED_NAME]).toEqual(
+        expect(span.attributes[SEMATTRS_FAAS_INVOKED_NAME]).toEqual(
           'ot-test-function-name'
         );
-        expect(
-          span.attributes[SemanticAttributes.FAAS_INVOKED_PROVIDER]
-        ).toEqual('aws');
+        expect(span.attributes[SEMATTRS_FAAS_INVOKED_PROVIDER]).toEqual('aws');
       });
     });
 
@@ -385,7 +385,7 @@ describe('Lambda', () => {
       expect(getTestSpans().length).toBe(1);
       const [span] = getTestSpans();
 
-      expect(span.attributes[SemanticAttributes.FAAS_EXECUTION]).toEqual(
+      expect(span.attributes[SEMATTRS_FAAS_EXECUTION]).toEqual(
         '95882c2b-3fd2-485d-ada3-9fcb1ca65459'
       );
     });

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/sns.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/sns.test.ts
@@ -31,8 +31,11 @@ import { expect } from 'expect';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import * as sinon from 'sinon';
 import {
-  MessagingDestinationKindValues,
-  SemanticAttributes,
+  MESSAGINGDESTINATIONKINDVALUES_TOPIC,
+  SEMATTRS_MESSAGING_DESTINATION,
+  SEMATTRS_MESSAGING_DESTINATION_KIND,
+  SEMATTRS_MESSAGING_SYSTEM,
+  SEMATTRS_RPC_METHOD,
 } from '@opentelemetry/semantic-conventions';
 import { SpanKind } from '@opentelemetry/api';
 
@@ -78,21 +81,17 @@ describe('SNS - v2', () => {
       expect(publishSpans.length).toBe(1);
 
       const publishSpan = publishSpans[0];
-      expect(
-        publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]
-      ).toBe(MessagingDestinationKindValues.TOPIC);
-      expect(
-        publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]
-      ).toBe(topicName);
+      expect(publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]).toBe(
+        MESSAGINGDESTINATIONKINDVALUES_TOPIC
+      );
+      expect(publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]).toBe(
+        topicName
+      );
       expect(publishSpan.attributes['messaging.destination.name']).toBe(
         fakeARN
       );
-      expect(publishSpan.attributes[SemanticAttributes.RPC_METHOD]).toBe(
-        'Publish'
-      );
-      expect(publishSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toBe(
-        'aws.sns'
-      );
+      expect(publishSpan.attributes[SEMATTRS_RPC_METHOD]).toBe('Publish');
+      expect(publishSpan.attributes[SEMATTRS_MESSAGING_SYSTEM]).toBe('aws.sns');
       expect(publishSpan.kind).toBe(SpanKind.PRODUCER);
     });
 
@@ -111,9 +110,9 @@ describe('SNS - v2', () => {
       );
       expect(publishSpans.length).toBe(1);
       const publishSpan = publishSpans[0];
-      expect(
-        publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]
-      ).toBe(PhoneNumber);
+      expect(publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]).toBe(
+        PhoneNumber
+      );
       expect(publishSpan.attributes['messaging.destination.name']).toBe(
         PhoneNumber
       );
@@ -158,12 +157,10 @@ describe('SNS - v2', () => {
 
       const createTopicSpan = createTopicSpans[0];
       expect(
-        createTopicSpan.attributes[
-          SemanticAttributes.MESSAGING_DESTINATION_KIND
-        ]
+        createTopicSpan.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]
       ).toBeUndefined();
       expect(
-        createTopicSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]
+        createTopicSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]
       ).toBeUndefined();
       expect(
         createTopicSpan.attributes['messaging.destination.name']
@@ -208,21 +205,17 @@ describe('SNS - v3', () => {
       expect(publishSpans.length).toBe(1);
 
       const publishSpan = publishSpans[0];
-      expect(
-        publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]
-      ).toBe(MessagingDestinationKindValues.TOPIC);
-      expect(
-        publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]
-      ).toBe(topicV3Name);
+      expect(publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]).toBe(
+        MESSAGINGDESTINATIONKINDVALUES_TOPIC
+      );
+      expect(publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]).toBe(
+        topicV3Name
+      );
       expect(publishSpan.attributes['messaging.destination.name']).toBe(
         topicV3ARN
       );
-      expect(publishSpan.attributes[SemanticAttributes.RPC_METHOD]).toBe(
-        'Publish'
-      );
-      expect(publishSpan.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toBe(
-        'aws.sns'
-      );
+      expect(publishSpan.attributes[SEMATTRS_RPC_METHOD]).toBe('Publish');
+      expect(publishSpan.attributes[SEMATTRS_MESSAGING_SYSTEM]).toBe('aws.sns');
       expect(publishSpan.kind).toBe(SpanKind.PRODUCER);
     });
 
@@ -238,9 +231,9 @@ describe('SNS - v3', () => {
       );
       expect(publishSpans.length).toBe(1);
       const publishSpan = publishSpans[0];
-      expect(
-        publishSpan.attributes[SemanticAttributes.MESSAGING_DESTINATION]
-      ).toBe(PhoneNumber);
+      expect(publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]).toBe(
+        PhoneNumber
+      );
     });
   });
 });

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/sqs.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/sqs.test.ts
@@ -26,9 +26,19 @@ import { AWSError } from 'aws-sdk';
 import type { SQS } from 'aws-sdk';
 
 import {
-  MessagingDestinationKindValues,
-  MessagingOperationValues,
-  SemanticAttributes,
+  MESSAGINGDESTINATIONKINDVALUES_QUEUE,
+  MESSAGINGOPERATIONVALUES_PROCESS,
+  MESSAGINGOPERATIONVALUES_RECEIVE,
+  SEMATTRS_HTTP_STATUS_CODE,
+  SEMATTRS_MESSAGING_DESTINATION,
+  SEMATTRS_MESSAGING_DESTINATION_KIND,
+  SEMATTRS_MESSAGING_MESSAGE_ID,
+  SEMATTRS_MESSAGING_OPERATION,
+  SEMATTRS_MESSAGING_SYSTEM,
+  SEMATTRS_MESSAGING_URL,
+  SEMATTRS_RPC_METHOD,
+  SEMATTRS_RPC_SERVICE,
+  SEMATTRS_RPC_SYSTEM,
 } from '@opentelemetry/semantic-conventions';
 import {
   context,
@@ -179,15 +189,15 @@ describe('SQS', () => {
     ) => {
       const awsReceiveSpan = spans.filter(
         s =>
-          s.attributes[SemanticAttributes.MESSAGING_OPERATION] ===
-          MessagingOperationValues.RECEIVE
+          s.attributes[SEMATTRS_MESSAGING_OPERATION] ===
+          MESSAGINGOPERATIONVALUES_RECEIVE
       );
       expect(awsReceiveSpan.length).toBe(1);
 
       const processSpans = spans.filter(
         s =>
-          s.attributes[SemanticAttributes.MESSAGING_OPERATION] ===
-          MessagingOperationValues.PROCESS
+          s.attributes[SEMATTRS_MESSAGING_OPERATION] ===
+          MESSAGINGOPERATIONVALUES_PROCESS
       );
       expect(processSpans.length).toBe(2);
       expect(processSpans[0].parentSpanId).toStrictEqual(
@@ -382,30 +392,24 @@ describe('SQS', () => {
       const [span] = getTestSpans();
 
       // make sure we have the general aws attributes:
-      expect(span.attributes[SemanticAttributes.RPC_SYSTEM]).toEqual('aws-api');
-      expect(span.attributes[SemanticAttributes.RPC_METHOD]).toEqual(
-        'SendMessage'
-      );
-      expect(span.attributes[SemanticAttributes.RPC_SERVICE]).toEqual('SQS');
+      expect(span.attributes[SEMATTRS_RPC_SYSTEM]).toEqual('aws-api');
+      expect(span.attributes[SEMATTRS_RPC_METHOD]).toEqual('SendMessage');
+      expect(span.attributes[SEMATTRS_RPC_SERVICE]).toEqual('SQS');
       expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
 
       // custom messaging attributes
-      expect(span.attributes[SemanticAttributes.MESSAGING_SYSTEM]).toEqual(
-        'aws.sqs'
+      expect(span.attributes[SEMATTRS_MESSAGING_SYSTEM]).toEqual('aws.sqs');
+      expect(span.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]).toEqual(
+        MESSAGINGDESTINATIONKINDVALUES_QUEUE
       );
-      expect(
-        span.attributes[SemanticAttributes.MESSAGING_DESTINATION_KIND]
-      ).toEqual(MessagingDestinationKindValues.QUEUE);
-      expect(span.attributes[SemanticAttributes.MESSAGING_DESTINATION]).toEqual(
+      expect(span.attributes[SEMATTRS_MESSAGING_DESTINATION]).toEqual(
         QueueName
       );
-      expect(span.attributes[SemanticAttributes.MESSAGING_URL]).toEqual(
-        params.QueueUrl
-      );
-      expect(span.attributes[SemanticAttributes.MESSAGING_MESSAGE_ID]).toEqual(
+      expect(span.attributes[SEMATTRS_MESSAGING_URL]).toEqual(params.QueueUrl);
+      expect(span.attributes[SEMATTRS_MESSAGING_MESSAGE_ID]).toEqual(
         response.MessageId
       );
-      expect(span.attributes[SemanticAttributes.HTTP_STATUS_CODE]).toEqual(200);
+      expect(span.attributes[SEMATTRS_HTTP_STATUS_CODE]).toEqual(200);
     });
 
     it('sqsProcessHook called and add message attribute to span', async () => {
@@ -435,8 +439,8 @@ describe('SQS', () => {
 
       const processSpans = getTestSpans().filter(
         s =>
-          s.attributes[SemanticAttributes.MESSAGING_OPERATION] ===
-          MessagingOperationValues.PROCESS
+          s.attributes[SEMATTRS_MESSAGING_OPERATION] ===
+          MESSAGINGOPERATIONVALUES_PROCESS
       );
       expect(processSpans.length).toBe(2);
       expect(
@@ -459,8 +463,8 @@ describe('SQS', () => {
       );
       const processSpans = getTestSpans().filter(
         s =>
-          s.attributes[SemanticAttributes.MESSAGING_OPERATION] ===
-          MessagingOperationValues.PROCESS
+          s.attributes[SEMATTRS_MESSAGING_OPERATION] ===
+          MESSAGINGOPERATIONVALUES_PROCESS
       );
       expect(processSpans.length).toBe(2);
     });
@@ -488,8 +492,8 @@ describe('SQS', () => {
 
       const processSpans = getTestSpans().filter(
         s =>
-          s.attributes[SemanticAttributes.MESSAGING_OPERATION] ===
-          MessagingOperationValues.PROCESS
+          s.attributes[SEMATTRS_MESSAGING_OPERATION] ===
+          MESSAGINGOPERATIONVALUES_PROCESS
       );
       expect(processSpans.length).toBe(2);
       expect(processSpans[0].status.code).toStrictEqual(SpanStatusCode.UNSET);
@@ -514,7 +518,7 @@ describe('SQS', () => {
       expect(spans.length).toBe(1);
 
       // Spot check a single attribute as a sanity check.
-      expect(spans[0].attributes[SemanticAttributes.RPC_METHOD]).toEqual(
+      expect(spans[0].attributes[SEMATTRS_RPC_METHOD]).toEqual(
         'SendMessageBatch'
       );
     });


### PR DESCRIPTION
## Which problem is this PR solving?

- updates #2025 

## Short description of the changes

- Update `@opentelemetry/semantic-conventions` to `^1.22` for aws-sdk instrumentation
- Replace `SemanticAttributes.*` with exported strings `SEMATTRS_*`
- Replace `SemanticResourceAttributes.*` with exported strings `SEMRESATTRS_*`
- Replace `DbSystemValues.*` with exported strings `DBSYSTEMVALUES_*`
- Replace `MessagingDestinationKindValues.*` with exported strings `MESSAGINGDESTINATIONKINDVALUES_*`
- Replace `MessagingOperationValues.*` with exported strings `MESSAGINGOPERATIONVALUES_*`
- Update README with new semantic convention package version and key
- Replace deprecated `SpanAttributes` with `Attributes`
