### PR TITLE
fix(ci): rollback #2133

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,15 +54,11 @@ jobs:
 
       # get main again
       - name: Checkout Repository
-        # only checkout if a release has been created
-        if: ${{ steps.release.outputs.release_created }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Rebuild Packages
-        # only rebuild if a release has been created
-        if: ${{ steps.release.outputs.release_created }}
         run: |
           npm ci
           npm run compile
@@ -71,8 +67,6 @@ jobs:
       # need to publish all unpublished versions to npm here
       # See: https://github.com/lerna/lerna/tree/main/commands/publish#bump-from-package
       - name: Publish to npm
-        # only publish if a release has been created
-        if: ${{ steps.release.outputs.release_created }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         run: npx lerna publish from-package --no-push --no-private --no-git-tag-version --no-verify-access --yes


### PR DESCRIPTION
rolls back #2133 as the release workflow is now not working anymore (step output does not work correctly)?

Reopens #2020 