### PR TITLE
test(instrumentation-restify): add ESM test for restify

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-restify/test/fixtures/use-restify.cjs
+++ b/plugins/node/opentelemetry-instrumentation-restify/test/fixtures/use-restify.cjs
@@ -1,0 +1,55 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Use fastify from an ES module:
+//    node --experimental-loader=@opentelemetry/instrumentation/hook.mjs use-restify.mjs
+
+const { createTestNodeSdk } = require('@opentelemetry/contrib-test-utils');
+
+const { RestifyInstrumentation } = require('../../build/src/index.js');
+
+const sdk = createTestNodeSdk({
+  serviceName: 'use-restify',
+  instrumentations: [
+    new RestifyInstrumentation()
+  ]
+})
+sdk.start();
+
+const restify = require('restify');
+const http = require('http');
+
+const app = restify.createServer();
+const PORT = 3000;
+
+app.get('/post/:id', (req, res, next) => {
+  res.send(`Post id: ${req.params.id}`);
+});
+app.listen(PORT)
+
+new Promise(resolve => {
+  http.get(`http://localhost:${PORT}/post/0`, (res) => {
+    res.resume();
+    res.on('end', () => {
+      resolve();
+    });
+  })
+}).then(() => {
+  app.close();
+}).then(() => {
+  sdk.shutdown();
+});
+

--- a/plugins/node/opentelemetry-instrumentation-restify/test/fixtures/use-restify.mjs
+++ b/plugins/node/opentelemetry-instrumentation-restify/test/fixtures/use-restify.mjs
@@ -1,0 +1,53 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Use fastify from an ES module:
+//    node --experimental-loader=@opentelemetry/instrumentation/hook.mjs use-restify.mjs
+
+import { createTestNodeSdk } from '@opentelemetry/contrib-test-utils';
+
+import { RestifyInstrumentation } from '../../build/src/index.js';
+
+const sdk = createTestNodeSdk({
+  serviceName: 'use-restify',
+  instrumentations: [
+    new RestifyInstrumentation()
+  ]
+})
+sdk.start();
+
+import restify from 'restify';
+import http from 'http';
+
+const app = restify.createServer();
+const PORT = 3000;
+
+app.get('/post/:id', (req, res, next) => {
+  res.send(`Post id: ${req.params.id}`);
+});
+app.listen(PORT)
+
+await new Promise(resolve => {
+  http.get(`http://localhost:${PORT}/post/0`, (res) => {
+    res.resume();
+    res.on('end', () => {
+      resolve();
+    });
+  })
+});
+
+await app.close();
+await sdk.shutdown();


### PR DESCRIPTION
## Which problem is this PR solving?

- updates #1942 

## Short description of the changes

- add `use-restify.mjs` fixture for testing ESM usage of restify instrumentation
- add ESM test for restify instrumentation

Also added `use-restify.cjs` for now to show that instrumentation looks to currently work for CJS but not ESM.

```sh
# works, shows span in output
➜  fixtures git:(jamie.restify-esm-test) ✗ node use-restify.cjs
# doesnt work
➜  fixtures git:(jamie.restify-esm-test) ✗ node --experimental-loader=@opentelemetry/instrumentation/hook.mjs use-restify.mjs
```