### PR TITLE
fix(instr-knex): set correct SpanKind for traces

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-knex/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-knex/src/instrumentation.ts
@@ -160,6 +160,7 @@ export class KnexInstrumentation extends InstrumentationBase {
         const span = instrumentation.tracer.startSpan(
           utils.getName(name, operation, table),
           {
+            kind: api.SpanKind.CLIENT,
             attributes,
           },
           parent

--- a/plugins/node/opentelemetry-instrumentation-knex/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-knex/test/index.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { context, trace } from '@opentelemetry/api';
+import { SpanKind, context, trace } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import {
@@ -471,6 +471,7 @@ const assertSpans = (actualSpans: any[], expectedSpans: any[]) => {
     try {
       assert.notStrictEqual(span, undefined);
       assert.notStrictEqual(expected, undefined);
+      assert.strictEqual(span.kind, SpanKind.CLIENT);
       assertMatch(span.name, new RegExp(expected.op));
       assertMatch(span.name, new RegExp(':memory:'));
       assert.strictEqual(span.attributes['db.system'], 'sqlite');


### PR DESCRIPTION
## Which problem is this PR solving?

- The span kind is set to default where it should be set to `SpanKind.CLIENT`

Fixes: #1839 

## Short description of the changes

- set span kind to `SpanKind.CLIENT` when starting it
