### PR TITLE
ci: only publish after releases are created

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -61,7 +61,7 @@ jobs:
           fetch-depth: 0
 
       - name: Rebuild Packages
-        # only checkout if a release has been created
+        # only rebuild if a release has been created
         if: ${{ steps.release.outputs.releases_created }}
         run: |
           npm ci

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -71,7 +71,7 @@ jobs:
       # need to publish all unpublished versions to npm here
       # See: https://github.com/lerna/lerna/tree/main/commands/publish#bump-from-package
       - name: Publish to npm
-        # only checkout if a release has been created
+        # only publish if a release has been created
         if: ${{ steps.release.outputs.releases_created }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,14 +54,14 @@ jobs:
 
       # get main again
       - name: Checkout Repository
-        # only checkout if releases have been created
+        # only checkout if a release has been created
         if: ${{ steps.release.outputs.releases_created }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Rebuild Packages
-        # only checkout if releases have been created
+        # only checkout if a release has been created
         if: ${{ steps.release.outputs.releases_created }}
         run: |
           npm ci
@@ -71,7 +71,7 @@ jobs:
       # need to publish all unpublished versions to npm here
       # See: https://github.com/lerna/lerna/tree/main/commands/publish#bump-from-package
       - name: Publish to npm
-        # only checkout if releases have been created
+        # only checkout if a release has been created
         if: ${{ steps.release.outputs.releases_created }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -54,11 +54,15 @@ jobs:
 
       # get main again
       - name: Checkout Repository
+        # only checkout if releases have been created
+        if: ${{ steps.release.outputs.releases_created }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Rebuild Packages
+        # only checkout if releases have been created
+        if: ${{ steps.release.outputs.releases_created }}
         run: |
           npm ci
           npm run compile
@@ -67,6 +71,8 @@ jobs:
       # need to publish all unpublished versions to npm here
       # See: https://github.com/lerna/lerna/tree/main/commands/publish#bump-from-package
       - name: Publish to npm
+        # only checkout if releases have been created
+        if: ${{ steps.release.outputs.releases_created }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         run: npx lerna publish from-package --no-push --no-private --no-git-tag-version --no-verify-access --yes


### PR DESCRIPTION
## Which problem is this PR solving?

- closes #2020

## Short description of the changes

- Add conditional checks to steps that require a release to be created first.

According to [`release-please-action` Outputs section](https://github.com/google-github-actions/release-please-action?tab=readme-ov-file#outputs) `releases_created` is `true` if any release was created, `false` otherwise. This should be the right option compared to the previous attempt that used `release_created` which is only `true` if a root component release was created, `false` otherwise. Thanks for the [tip](https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2020#issuecomment-2078830357) @pichlermarc ! Hopefully this one works better. 🤞 