### PR TITLE
chore: remove skipLibCheck: true from tsconfigs where it is not necessary

### DIFF
--- a/metapackages/auto-instrumentations-web/tsconfig.esm.json
+++ b/metapackages/auto-instrumentations-web/tsconfig.esm.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "build/esm",
-    "skipLibCheck": true,
     "tsBuildInfoFile": "build/esm/tsconfig.esm.tsbuildinfo"
   },
   "include": [

--- a/metapackages/auto-instrumentations-web/tsconfig.esnext.json
+++ b/metapackages/auto-instrumentations-web/tsconfig.esnext.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "build/esnext",
-    "skipLibCheck": true,
     "tsBuildInfoFile": "build/esnext/tsconfig.esnext.tsbuildinfo"
   },
   "include": ["src/**/*.ts"]

--- a/metapackages/auto-instrumentations-web/tsconfig.json
+++ b/metapackages/auto-instrumentations-web/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "build",
-    "skipLibCheck": true
   },
   "include": [
     "src/**/*.ts",

--- a/plugins/node/instrumentation-cucumber/tsconfig.json
+++ b/plugins/node/instrumentation-cucumber/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../../tsconfig.base",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "build",
-    "skipLibCheck": true
+    "outDir": "build"
   },
   "include": ["src/**/*.ts", "test/**/*.ts"]
 }

--- a/plugins/node/instrumentation-mongoose/tsconfig.json
+++ b/plugins/node/instrumentation-mongoose/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../../tsconfig.base",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "build",
-    "skipLibCheck": true
+    "outDir": "build"
   },
   "include": [
     "src/**/*.ts",

--- a/plugins/node/opentelemetry-instrumentation-mongodb/tsconfig.json
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../../tsconfig.base",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "build",
-    "skipLibCheck": true
+    "outDir": "build"
   },
   "include": [
     "src/**/*.ts",

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/tsconfig.esm.json
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/tsconfig.esm.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "build/esm",
-    "skipLibCheck": true,
     "tsBuildInfoFile": "build/esm/tsconfig.esm.tsbuildinfo"
   },
   "include": [

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/tsconfig.esnext.json
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/tsconfig.esnext.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "build/esnext",
-    "skipLibCheck": true,
     "tsBuildInfoFile": "build/esnext/tsconfig.esnext.tsbuildinfo"
   },
   "include": [

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/tsconfig.json
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../../tsconfig.base",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "build",
-    "skipLibCheck": true
+    "outDir": "build"
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
`skipLibCheck: true` is set a few instrumentation libraries, even though they're not necessary anymore. The only remaining instrumentation that needs it is `@opentelemetry/instrumentation-lru-memoizer`.