### PR TITLE
chore: update otel and unpin node 18 in tests

### DIFF
--- a/.github/workflows/test-all-versions.yml
+++ b/.github/workflows/test-all-versions.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ["14", "16", "18.18.2"]
+        node: ["14", "16", "18"]
     runs-on: ubuntu-latest
     services:
       mongo:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,9 +9,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ["14", "16", "18.18.2"]
+        node: ["14", "16", "18"]
         include:
-            - node: 18.18.2
+            - node: 18
               code-coverage: true
     runs-on: ubuntu-latest
     services:

--- a/package-lock.json
+++ b/package-lock.json
@@ -350,344 +350,6 @@
         "@opentelemetry/api": "^1.4.1"
       }
     },
-    "metapackages/auto-instrumentations-node/node_modules/@opentelemetry/api-logs": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.51.0.tgz",
-      "integrity": "sha512-m/jtfBPEIXS1asltl8fPQtO3Sb1qMpuL61unQajUmM8zIxeMF1AlqzWXM3QedcYgTTFiJCew5uJjyhpmqhc0+g==",
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "metapackages/auto-instrumentations-node/node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.24.0.tgz",
-      "integrity": "sha512-s7xaQ9ifDpJvwbWRLkZD/J5hY35w+MECm4TQUkg6szRcny9lf6oVhWij4w3JJFQgvHQMXU7oXOpX8Z05HxV/8g==",
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "metapackages/auto-instrumentations-node/node_modules/@opentelemetry/core": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.0.tgz",
-      "integrity": "sha512-FP2oN7mVPqcdxJDTTnKExj4mi91EH+DNuArKfHTjPuJWe2K1JfMIVXNfahw1h3onJxQnxS8K0stKkogX05s+Aw==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "metapackages/auto-instrumentations-node/node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.51.0.tgz",
-      "integrity": "sha512-xQpxKzS8ZnxYCa1v+3EKWhwMrSK3+RezpJ+AEKaP2pf2QbLfHt7kKfSn7niR2u3A1Tbe2aC7Ptt9+MafhThOOQ==",
-      "dependencies": {
-        "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.51.0",
-        "@opentelemetry/otlp-transformer": "0.51.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "metapackages/auto-instrumentations-node/node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.51.0.tgz",
-      "integrity": "sha512-zODqnLZmPOxj9CarFv0TrVlx9mgj0TfCMCiUiTdNi9iA2rgdKVo+bjJjpYF6LCTJOQCR5TScAUCKyzwkgDI+iA==",
-      "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/otlp-exporter-base": "0.51.0",
-        "@opentelemetry/otlp-transformer": "0.51.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "metapackages/auto-instrumentations-node/node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.51.0.tgz",
-      "integrity": "sha512-Fi7r0iMqGoFCQQ+WY0pYOWp395vdinZJIkYKnNbnreHxAN/kVDBl2FxbV3DeOKuRxEY08Gyb9ggPf+Zrqp7l/w==",
-      "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/otlp-exporter-base": "0.51.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.51.0",
-        "@opentelemetry/otlp-transformer": "0.51.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "metapackages/auto-instrumentations-node/node_modules/@opentelemetry/exporter-zipkin": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.24.0.tgz",
-      "integrity": "sha512-QeGv0PHONswmu567pf9QliJ6s6DgCu5+ziF+soNS1LTcr1VRRVLViYLmGxmzDFUC48sjNTu7sumcKT0nJXsGBw==",
-      "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "metapackages/auto-instrumentations-node/node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.51.0.tgz",
-      "integrity": "sha512-hR4c9vWVz1QgzCBSyy9zSDkvfTgaK96E6/tfVP6O4dzdZW9HqWimA3lXV/KXadEGqShvM4GToz9EHp2A5RU5bQ==",
-      "dependencies": {
-        "@opentelemetry/core": "1.24.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "metapackages/auto-instrumentations-node/node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.51.0.tgz",
-      "integrity": "sha512-oTRtDvvB0bTRTBVrvKA/oM1gIAqQ6DVQS07pvqiL1cZS8wBrGgpw+2iTd0nV661Y/MhDn/kNWp8lRhMEIKN9bw==",
-      "dependencies": {
-        "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/otlp-exporter-base": "0.51.0",
-        "protobufjs": "^7.2.3"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "metapackages/auto-instrumentations-node/node_modules/@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.51.0.tgz",
-      "integrity": "sha512-WDANDLSUh11Gu5o6iCzmjZraIv5bK8z1L/t6lxQ2NeEKiKUPo5pVOBBQQC/yAQU2yeqkiO1GRCieH+XahZf60A==",
-      "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/otlp-exporter-base": "0.51.0",
-        "protobufjs": "^7.2.3"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "metapackages/auto-instrumentations-node/node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.51.0.tgz",
-      "integrity": "sha512-ylLgx2xumVoSefDHP9GMAU/LG+TU3+8eacVDXV5o1RqWxsdVOaQmCTY0XyDgeRTn6hIOVAq/HHQbRq3iWOrt2A==",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.51.0",
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-logs": "0.51.0",
-        "@opentelemetry/sdk-metrics": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.9.0"
-      }
-    },
-    "metapackages/auto-instrumentations-node/node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.24.0.tgz",
-      "integrity": "sha512-7TMIDE4+NO5vnkor+zned42wqca+hmhW5gWKhmYjUHC5B5uojo1PvtmBrd7kigFu96XvL4ZUWVzibWRWIQ/++Q==",
-      "dependencies": {
-        "@opentelemetry/core": "1.24.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "metapackages/auto-instrumentations-node/node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.24.0.tgz",
-      "integrity": "sha512-r3MX3AmJiUeiWTXSDOdwBeaO+ahvWcFCpuKxmhhsH8Q8LqDnjhNd3krqBh4Qsq9wa0WhWtiQaDs/NOCWoMOlOw==",
-      "dependencies": {
-        "@opentelemetry/core": "1.24.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "metapackages/auto-instrumentations-node/node_modules/@opentelemetry/resources": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.24.0.tgz",
-      "integrity": "sha512-mxC7E7ocUS1tLzepnA7O9/G8G6ZTdjCH2pXme1DDDuCuk6n2/53GADX+GWBuyX0dfIxeMInIbJAdjlfN9GNr6A==",
-      "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "metapackages/auto-instrumentations-node/node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.51.0.tgz",
-      "integrity": "sha512-K4fMBRFD8hQ6khk0rvYFuo6L9ymeGgByir6BcuFIgQuQ00OhYwBi9AruZz5V733Ejq7P8ObR3YyubkOUIbeVAw==",
-      "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.9.0",
-        "@opentelemetry/api-logs": ">=0.39.1"
-      }
-    },
-    "metapackages/auto-instrumentations-node/node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.24.0.tgz",
-      "integrity": "sha512-4tJ+E6N019OZVB/nUW/LoK9xHxfeh88TCoaTqHeLBE9wLYfi6irWW6J9cphMav7J8Qk0D5b7/RM4VEY4dArWOA==",
-      "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0",
-        "lodash.merge": "^4.6.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.9.0"
-      }
-    },
-    "metapackages/auto-instrumentations-node/node_modules/@opentelemetry/sdk-node": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.51.0.tgz",
-      "integrity": "sha512-MrPXDQsTAj3lcY8YUCjb7dvSXVZ5jG6wmjD2LB68V1rsLBdP8j70jsI9GaKijY7QB6psbLq6apO1vYeim5U7aw==",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.51.0",
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.51.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.51.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.51.0",
-        "@opentelemetry/exporter-zipkin": "1.24.0",
-        "@opentelemetry/instrumentation": "0.51.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-logs": "0.51.0",
-        "@opentelemetry/sdk-metrics": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0",
-        "@opentelemetry/sdk-trace-node": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.9.0"
-      }
-    },
-    "metapackages/auto-instrumentations-node/node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.51.0.tgz",
-      "integrity": "sha512-Eg/+Od5bEvzpvZQGhvMyKIkrzB9S7jW+6z9LHEI2VXhl/GrqQ3oBqlzJt4tA6pGtxRmqQWKWGM1wAbwDdW/gUA==",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.51.0",
-        "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.7.1",
-        "require-in-the-middle": "^7.1.1",
-        "semver": "^7.5.2",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "metapackages/auto-instrumentations-node/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.24.0.tgz",
-      "integrity": "sha512-H9sLETZ4jw9UJ3totV8oM5R0m4CW0ZIOLfp4NV3g0CM8HD5zGZcaW88xqzWDgiYRpctFxd+WmHtGX/Upoa2vRg==",
-      "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "metapackages/auto-instrumentations-node/node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.24.0.tgz",
-      "integrity": "sha512-QgByHmM9uloTpcYEEyW9YJEIMKHFSIM677RH9pJPWWwtM2NQFbEp/8HIJw80Ymtaz6cAxg1Kay1ByqIVzq3t5g==",
-      "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.24.0",
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/propagator-b3": "1.24.0",
-        "@opentelemetry/propagator-jaeger": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0",
-        "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.9.0"
-      }
-    },
-    "metapackages/auto-instrumentations-node/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.0.tgz",
-      "integrity": "sha512-yL0jI6Ltuz8R+Opj7jClGrul6pOoYrdfVmzQS4SITXRPH7I5IRZbrwe/6/v8v4WYMa6MYZG480S1+uc/IGfqsA==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "metapackages/auto-instrumentations-web": {
       "name": "@opentelemetry/auto-instrumentations-web",
       "version": "0.39.0",
@@ -8880,9 +8542,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.51.0.tgz",
-      "integrity": "sha512-m/jtfBPEIXS1asltl8fPQtO3Sb1qMpuL61unQajUmM8zIxeMF1AlqzWXM3QedcYgTTFiJCew5uJjyhpmqhc0+g==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.51.1.tgz",
+      "integrity": "sha512-E3skn949Pk1z2XtXu/lxf6QAZpawuTM/IUEXcAzpiUkTd73Hmvw26FiN3cJuTmkpM5hZzHwkomVdtrh/n/zzwA==",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
@@ -8903,9 +8565,9 @@
       "link": true
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.24.0.tgz",
-      "integrity": "sha512-s7xaQ9ifDpJvwbWRLkZD/J5hY35w+MECm4TQUkg6szRcny9lf6oVhWij4w3JJFQgvHQMXU7oXOpX8Z05HxV/8g==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.24.1.tgz",
+      "integrity": "sha512-R5r6DO4kgEOVBxFXhXjwospLQkv+sYxwCfjvoZBe7Zm6KKXAV9kDSJhi/D1BweowdZmO+sdbENLs374gER8hpQ==",
       "engines": {
         "node": ">=14"
       },
@@ -8914,11 +8576,11 @@
       }
     },
     "node_modules/@opentelemetry/context-zone": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-1.24.0.tgz",
-      "integrity": "sha512-Znb6fvmqZy+4ZC63vvf9qktXakTlLOLeBsMizR5E1G/1cM8LKUVR/JJUws+A4QSAY95Rzldi05aqxoc+YUVVKw==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-1.24.1.tgz",
+      "integrity": "sha512-pt5KLJws1m+rHTeEA6uootoyiuZlCt7j90dmdjXnqx4JZH6sFWqWB5IW1gOukDY7Ym3cNKjtoh3/uK0KuSRBfg==",
       "dependencies": {
-        "@opentelemetry/context-zone-peer-dep": "1.24.0",
+        "@opentelemetry/context-zone-peer-dep": "1.24.1",
         "zone.js": "^0.11.0 || ^0.13.0 || ^0.14.0"
       },
       "engines": {
@@ -8926,9 +8588,9 @@
       }
     },
     "node_modules/@opentelemetry/context-zone-peer-dep": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.24.0.tgz",
-      "integrity": "sha512-znNlicjfxRqepQdOZGUN3RYSs+QGoEiGI+cjILBYM4KdEXpoXgxt87l72b0UYhH7YI/uK0TVHse99D0ER9ODAw==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.24.1.tgz",
+      "integrity": "sha512-s67becvBZFFjSLKSiy8ia2m7htsC4gsk8J/X0368FzBYseb/26daYr4ewx6tKcAsmZqJA7402cTQirv175x5BA==",
       "engines": {
         "node": ">=14"
       },
@@ -8942,11 +8604,11 @@
       "link": true
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.0.tgz",
-      "integrity": "sha512-FP2oN7mVPqcdxJDTTnKExj4mi91EH+DNuArKfHTjPuJWe2K1JfMIVXNfahw1h3onJxQnxS8K0stKkogX05s+Aw==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/semantic-conventions": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -8956,13 +8618,13 @@
       }
     },
     "node_modules/@opentelemetry/exporter-jaeger": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.24.0.tgz",
-      "integrity": "sha512-mD28eBrdth937QGU6zgn+6fYBywUaYxLJwANREnE7XS8pHP/Hjxpiy4nb9yIzQ2DqC8Uq7yEnc8ah2pH45B9ZQ==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.24.1.tgz",
+      "integrity": "sha512-zrcY76PVR4itZD2oxQdFgnvS/Lst1CxmMofOhngvTDIXVqSTEf00QfmdIQUljwmycYwxZIvbJ445k3AGRBbZKQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0",
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1",
         "jaeger-client": "^3.15.0"
       },
       "engines": {
@@ -8973,16 +8635,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.51.0.tgz",
-      "integrity": "sha512-xQpxKzS8ZnxYCa1v+3EKWhwMrSK3+RezpJ+AEKaP2pf2QbLfHt7kKfSn7niR2u3A1Tbe2aC7Ptt9+MafhThOOQ==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.51.1.tgz",
+      "integrity": "sha512-P9+Hkszih95ITvldGZ+kXvj9HpD1QfS+PwooyHK72GYA+Bgm+yUSAsDkUkDms8+s9HW6poxURv3LcjaMuBBpVQ==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.51.0",
-        "@opentelemetry/otlp-transformer": "0.51.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.51.1",
+        "@opentelemetry/otlp-transformer": "0.51.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -8992,15 +8654,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.51.0.tgz",
-      "integrity": "sha512-zODqnLZmPOxj9CarFv0TrVlx9mgj0TfCMCiUiTdNi9iA2rgdKVo+bjJjpYF6LCTJOQCR5TScAUCKyzwkgDI+iA==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.51.1.tgz",
+      "integrity": "sha512-n+LhLPsX07URh+HhV2SHVSvz1t4G/l/CE5BjpmhAPqeTceFac1VpyQkavWEJbvnK5bUEXijWt4LxAxFpt2fXyw==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/otlp-exporter-base": "0.51.0",
-        "@opentelemetry/otlp-transformer": "0.51.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/otlp-exporter-base": "0.51.1",
+        "@opentelemetry/otlp-transformer": "0.51.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -9010,16 +8672,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.51.0.tgz",
-      "integrity": "sha512-Fi7r0iMqGoFCQQ+WY0pYOWp395vdinZJIkYKnNbnreHxAN/kVDBl2FxbV3DeOKuRxEY08Gyb9ggPf+Zrqp7l/w==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.51.1.tgz",
+      "integrity": "sha512-SE9f0/6V6EeXC9i+WA4WFjS1EYgaBCpAnI5+lxWvZ7iO7EU1IvHvZhP6Kojr0nLldo83gqg6G7OWFqsID3uF+w==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/otlp-exporter-base": "0.51.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.51.0",
-        "@opentelemetry/otlp-transformer": "0.51.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/otlp-exporter-base": "0.51.1",
+        "@opentelemetry/otlp-proto-exporter-base": "0.51.1",
+        "@opentelemetry/otlp-transformer": "0.51.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -9029,14 +8691,14 @@
       }
     },
     "node_modules/@opentelemetry/exporter-zipkin": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.24.0.tgz",
-      "integrity": "sha512-QeGv0PHONswmu567pf9QliJ6s6DgCu5+ziF+soNS1LTcr1VRRVLViYLmGxmzDFUC48sjNTu7sumcKT0nJXsGBw==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.24.1.tgz",
+      "integrity": "sha512-+Rl/VFmu2n6eaRMnVbyfZx1DqR/1KNyWebYuHyQBZaEAVIn/ZLgmofRpXN1X2nhJ4BNaptQUNxAstCYYz6dKoQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -9054,13 +8716,13 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.51.0.tgz",
-      "integrity": "sha512-Eg/+Od5bEvzpvZQGhvMyKIkrzB9S7jW+6z9LHEI2VXhl/GrqQ3oBqlzJt4tA6pGtxRmqQWKWGM1wAbwDdW/gUA==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.51.1.tgz",
+      "integrity": "sha512-JIrvhpgqY6437QIqToyozrUG1h5UhwHkaGK/WAX+fkrpyPtc+RO5FkRtUd9BH0MibabHHvqsnBGKfKVijbmp8w==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.51.0",
+        "@opentelemetry/api-logs": "0.51.1",
         "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.7.1",
+        "import-in-the-middle": "1.7.4",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2",
         "shimmer": "^1.2.1"
@@ -9121,14 +8783,14 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-fetch": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.51.0.tgz",
-      "integrity": "sha512-dB9wisB2+wyh0wUB1RFNinCS4TqJ7QMVc4jNzy3JCMJudwFWI/stU10DgZ3vwFQNUEBUIz9QmEQSFud7lsvB2w==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.51.1.tgz",
+      "integrity": "sha512-LzciqAnJmmYaXWo2hlrN99NMbYbExo6n6lBKBeMHAi7X/ddhCSOsgSNVbF3kDB7P++PJhjYqLT3hy6SU4AFHcg==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/instrumentation": "0.51.0",
-        "@opentelemetry/sdk-trace-web": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/instrumentation": "0.51.1",
+        "@opentelemetry/sdk-trace-web": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -9150,12 +8812,12 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-grpc": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.51.0.tgz",
-      "integrity": "sha512-Wfhs9e1Hi4nnULLqzt9s2M6+Tz52EkKj6uZnj9ZL3coldlZiP+WmvuUNepds7jcBJg/qDBjnEe96fThPuO7ddA==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.51.1.tgz",
+      "integrity": "sha512-coRTugFL7De/VNH/1NqPlxnfik87jS+jBXsny+Y/lMhXIA3x8t71IyL9ihuewkD+lNtIxIz6Y7Sq6kPuOqz5dQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "0.51.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/instrumentation": "0.51.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -9169,13 +8831,13 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.51.0.tgz",
-      "integrity": "sha512-6VsGPBnU6iVKWhVBnuRpwrmiHfxt8EYrqfnH2glfsMpsn4xy+O6U0yGlggPLhoYeOVafV3h70EEk5MU0tpsbiw==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.51.1.tgz",
+      "integrity": "sha512-6b3nZnFFEz/3xZ6w8bVxctPUWIPWiXuPQ725530JgxnN1cvYFd8CJ75PrHZNjynmzSSnqBkN3ef4R9N+RpMh8Q==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/instrumentation": "0.51.0",
-        "@opentelemetry/semantic-conventions": "1.24.0",
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/instrumentation": "0.51.1",
+        "@opentelemetry/semantic-conventions": "1.24.1",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -9282,14 +8944,14 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-xml-http-request": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.51.0.tgz",
-      "integrity": "sha512-KgLO2qx1z1Wn9NeJgrgNukd10ssK1QqxODwdeBJFO1BaP9sVVargpupYowlDKUL5I3oWOEqi/Oxxdh/fbEsJtw==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.51.1.tgz",
+      "integrity": "sha512-CrQZxADNFr9M3aCgjM3/KXDz12lBrZA5LW+btfgNb78hsLNwqxThtFvXOHr86UsOzJt+h9m4yDeH6YLEvCTBbw==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/instrumentation": "0.51.0",
-        "@opentelemetry/sdk-trace-web": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/instrumentation": "0.51.1",
+        "@opentelemetry/sdk-trace-web": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -9299,11 +8961,11 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.51.0.tgz",
-      "integrity": "sha512-hR4c9vWVz1QgzCBSyy9zSDkvfTgaK96E6/tfVP6O4dzdZW9HqWimA3lXV/KXadEGqShvM4GToz9EHp2A5RU5bQ==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.51.1.tgz",
+      "integrity": "sha512-UYlnOYyDdzo1Gw559EHCzru0RwhvuXCwoH8jGo9J4gO1TE58GjnEmIjomMsKBCym3qWNJfIQXw+9SZCV0DdQNg==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0"
+        "@opentelemetry/core": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -9313,13 +8975,13 @@
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.51.0.tgz",
-      "integrity": "sha512-oTRtDvvB0bTRTBVrvKA/oM1gIAqQ6DVQS07pvqiL1cZS8wBrGgpw+2iTd0nV661Y/MhDn/kNWp8lRhMEIKN9bw==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.51.1.tgz",
+      "integrity": "sha512-ZAS+4pq8o7dsugGTwV9s6JMKSxi+guIHdn0acOv0bqj26e9pWDFx5Ky+bI0aY46uR9Y0JyXqY+KAEYM/SO3DFA==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/otlp-exporter-base": "0.51.0",
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/otlp-exporter-base": "0.51.1",
         "protobufjs": "^7.2.3"
       },
       "engines": {
@@ -9330,12 +8992,12 @@
       }
     },
     "node_modules/@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.51.0.tgz",
-      "integrity": "sha512-WDANDLSUh11Gu5o6iCzmjZraIv5bK8z1L/t6lxQ2NeEKiKUPo5pVOBBQQC/yAQU2yeqkiO1GRCieH+XahZf60A==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.51.1.tgz",
+      "integrity": "sha512-gxxxwfk0inDMb5DLeuxQ3L8TtptxSiTNHE4nnAJH34IQXAVRhXSXW1rK8PmDKDngRPIZ6J7ncUCjjIn8b+AgqQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/otlp-exporter-base": "0.51.0",
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/otlp-exporter-base": "0.51.1",
         "protobufjs": "^7.2.3"
       },
       "engines": {
@@ -9346,16 +9008,16 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.51.0.tgz",
-      "integrity": "sha512-ylLgx2xumVoSefDHP9GMAU/LG+TU3+8eacVDXV5o1RqWxsdVOaQmCTY0XyDgeRTn6hIOVAq/HHQbRq3iWOrt2A==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.51.1.tgz",
+      "integrity": "sha512-OppYOXwV9LQqqtYUCywqoOqX/JT9LQ5/FMuPZ//eTkvuHdUC4ZMwz2c6uSoT2R90GWvvGnF1iEqTGyTT3xAt2Q==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.51.0",
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-logs": "0.51.0",
-        "@opentelemetry/sdk-metrics": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0"
+        "@opentelemetry/api-logs": "0.51.1",
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/sdk-logs": "0.51.1",
+        "@opentelemetry/sdk-metrics": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -9373,11 +9035,11 @@
       "link": true
     },
     "node_modules/@opentelemetry/propagator-aws-xray": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.24.0.tgz",
-      "integrity": "sha512-rcuMtEOTZC7TW84tws1QLUVRElrGSbBJwK0b+qa56zJULDiUIiUpS+dSzO+aUchg7MtTJBZSG5OPsfsKpGgNig==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.24.1.tgz",
+      "integrity": "sha512-RzwoLe6QzsYGcpmxxDbbbgSpe3ncxSM4dtFHXh/rCYGjyq0nZGXKvk26mJtWZ4kQ3nuiIoqSZueIuGmt/mvOTA==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0"
+        "@opentelemetry/core": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -9387,11 +9049,11 @@
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.24.0.tgz",
-      "integrity": "sha512-7TMIDE4+NO5vnkor+zned42wqca+hmhW5gWKhmYjUHC5B5uojo1PvtmBrd7kigFu96XvL4ZUWVzibWRWIQ/++Q==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.24.1.tgz",
+      "integrity": "sha512-nda97ZwhpZKyUJTXqQuKzNhPMUgMLunbbGWn8kroBwegn+nh6OhtyGkrVQsQLNdVKJl0KeB5z0ZgeWszrYhwFw==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0"
+        "@opentelemetry/core": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -9409,11 +9071,11 @@
       "link": true
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.24.0.tgz",
-      "integrity": "sha512-r3MX3AmJiUeiWTXSDOdwBeaO+ahvWcFCpuKxmhhsH8Q8LqDnjhNd3krqBh4Qsq9wa0WhWtiQaDs/NOCWoMOlOw==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.24.1.tgz",
+      "integrity": "sha512-7bRBJn3FG1l195A1m+xXRHvgzAOBsfmRi9uZ5Da18oTh7BLmNDiA8+kpk51FpTsU1PCikPVpRDNPhKVB6lyzZg==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0"
+        "@opentelemetry/core": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -9459,12 +9121,12 @@
       "link": true
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.24.0.tgz",
-      "integrity": "sha512-mxC7E7ocUS1tLzepnA7O9/G8G6ZTdjCH2pXme1DDDuCuk6n2/53GADX+GWBuyX0dfIxeMInIbJAdjlfN9GNr6A==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.24.1.tgz",
+      "integrity": "sha512-cyv0MwAaPF7O86x5hk3NNgenMObeejZFLJJDVuSeSMIsknlsj3oOZzRv3qSzlwYomXsICfBeFFlxwHQte5mGXQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -9474,12 +9136,12 @@
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.51.0.tgz",
-      "integrity": "sha512-K4fMBRFD8hQ6khk0rvYFuo6L9ymeGgByir6BcuFIgQuQ00OhYwBi9AruZz5V733Ejq7P8ObR3YyubkOUIbeVAw==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.51.1.tgz",
+      "integrity": "sha512-ULQQtl82b673PpZc5/0EtH4V+BrwVOgKJZEB7tYZnGTG3I98tQVk89S9/JSixomDr++F4ih+LSJTCqIKBz+MQQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/resources": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -9490,12 +9152,12 @@
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.24.0.tgz",
-      "integrity": "sha512-4tJ+E6N019OZVB/nUW/LoK9xHxfeh88TCoaTqHeLBE9wLYfi6irWW6J9cphMav7J8Qk0D5b7/RM4VEY4dArWOA==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.24.1.tgz",
+      "integrity": "sha512-FrAqCbbGao9iKI+Mgh+OsC9+U2YMoXnlDHe06yH7dvavCKzE3S892dGtX54+WhSFVxHR/TMRVJiK/CV93GR0TQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0",
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/resources": "1.24.1",
         "lodash.merge": "^4.6.2"
       },
       "engines": {
@@ -9506,23 +9168,23 @@
       }
     },
     "node_modules/@opentelemetry/sdk-node": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.51.0.tgz",
-      "integrity": "sha512-MrPXDQsTAj3lcY8YUCjb7dvSXVZ5jG6wmjD2LB68V1rsLBdP8j70jsI9GaKijY7QB6psbLq6apO1vYeim5U7aw==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.51.1.tgz",
+      "integrity": "sha512-GgmNF9C+6esr8PIJxCqHw84rEOkYm6XdFWZ2+Wyc3qaUt92ACoN7uSw5iKNvaUq62W0xii1wsGxwHzyENtPP8w==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.51.0",
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.51.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.51.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.51.0",
-        "@opentelemetry/exporter-zipkin": "1.24.0",
-        "@opentelemetry/instrumentation": "0.51.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-logs": "0.51.0",
-        "@opentelemetry/sdk-metrics": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0",
-        "@opentelemetry/sdk-trace-node": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/api-logs": "0.51.1",
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.51.1",
+        "@opentelemetry/exporter-trace-otlp-http": "0.51.1",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.51.1",
+        "@opentelemetry/exporter-zipkin": "1.24.1",
+        "@opentelemetry/instrumentation": "0.51.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/sdk-logs": "0.51.1",
+        "@opentelemetry/sdk-metrics": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/sdk-trace-node": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -9532,13 +9194,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.24.0.tgz",
-      "integrity": "sha512-H9sLETZ4jw9UJ3totV8oM5R0m4CW0ZIOLfp4NV3g0CM8HD5zGZcaW88xqzWDgiYRpctFxd+WmHtGX/Upoa2vRg==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.24.1.tgz",
+      "integrity": "sha512-zz+N423IcySgjihl2NfjBf0qw1RWe11XIAWVrTNOSSI6dtSPJiVom2zipFB2AEEtJWpv0Iz6DY6+TjnyTV5pWg==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -9548,15 +9210,15 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.24.0.tgz",
-      "integrity": "sha512-QgByHmM9uloTpcYEEyW9YJEIMKHFSIM677RH9pJPWWwtM2NQFbEp/8HIJw80Ymtaz6cAxg1Kay1ByqIVzq3t5g==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.24.1.tgz",
+      "integrity": "sha512-/FZX8uWaGIAwsDhqI8VvQ+qWtfMNlXjaFYGc+vmxgdRFppCSSIRwrPyIhJO1qx61okyYhoyxVEZAfoiNxrfJCg==",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.24.0",
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/propagator-b3": "1.24.0",
-        "@opentelemetry/propagator-jaeger": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0",
+        "@opentelemetry/context-async-hooks": "1.24.1",
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/propagator-b3": "1.24.1",
+        "@opentelemetry/propagator-jaeger": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -9567,13 +9229,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-web": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.24.0.tgz",
-      "integrity": "sha512-G0q8aZPUhRtO/iw2BkjHeNqCMBf0JQX5VqqiPWXn9u5iRkpeQ6LZrGaiymKWOdEqtXCgM44yrCY/4WoJqR0bjQ==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.24.1.tgz",
+      "integrity": "sha512-0w+aKRai9VREeo3VrtW+hcbrE2Fl/uKL7G+oXgRNf6pI9QLaEGuEzUTX+oxXVPBadzjOd+5dqCHYdX7UeVjzwA==",
       "dependencies": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
       },
       "engines": {
         "node": ">=14"
@@ -9583,9 +9245,9 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.0.tgz",
-      "integrity": "sha512-yL0jI6Ltuz8R+Opj7jClGrul6pOoYrdfVmzQS4SITXRPH7I5IRZbrwe/6/v8v4WYMa6MYZG480S1+uc/IGfqsA==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw==",
       "engines": {
         "node": ">=14"
       }
@@ -12566,10 +12228,10 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-import-assertions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
       "peerDependencies": {
         "acorn": "^8"
       }
@@ -14586,9 +14248,9 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
-      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
+      "integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q=="
     },
     "node_modules/class-transformer": {
       "version": "0.5.1",
@@ -20280,12 +19942,12 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.1.tgz",
-      "integrity": "sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.4.tgz",
+      "integrity": "sha512-Lk+qzWmiQuRPPulGQeK5qq0v32k2bHnWrRPFgqyvhw7Kkov5L6MOLOIU3pcWeujc9W4q54Cp3Q2WV16eQkc7Bg==",
       "dependencies": {
         "acorn": "^8.8.2",
-        "acorn-import-assertions": "^1.9.0",
+        "acorn-import-attributes": "^1.9.5",
         "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
       }
@@ -37276,11 +36938,10 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0"
       },
       "devDependencies": {
-        "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/api": "^1.0.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.6.5",
         "expect": "29.2.0",
@@ -46521,9 +46182,9 @@
       "integrity": "sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w=="
     },
     "@opentelemetry/api-logs": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.51.0.tgz",
-      "integrity": "sha512-m/jtfBPEIXS1asltl8fPQtO3Sb1qMpuL61unQajUmM8zIxeMF1AlqzWXM3QedcYgTTFiJCew5uJjyhpmqhc0+g==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.51.1.tgz",
+      "integrity": "sha512-E3skn949Pk1z2XtXu/lxf6QAZpawuTM/IUEXcAzpiUkTd73Hmvw26FiN3cJuTmkpM5hZzHwkomVdtrh/n/zzwA==",
       "requires": {
         "@opentelemetry/api": "^1.0.0"
       }
@@ -46587,228 +46248,6 @@
         "sinon": "15.2.0",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
-      },
-      "dependencies": {
-        "@opentelemetry/api-logs": {
-          "version": "0.51.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.51.0.tgz",
-          "integrity": "sha512-m/jtfBPEIXS1asltl8fPQtO3Sb1qMpuL61unQajUmM8zIxeMF1AlqzWXM3QedcYgTTFiJCew5uJjyhpmqhc0+g==",
-          "requires": {
-            "@opentelemetry/api": "^1.0.0"
-          }
-        },
-        "@opentelemetry/context-async-hooks": {
-          "version": "1.24.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.24.0.tgz",
-          "integrity": "sha512-s7xaQ9ifDpJvwbWRLkZD/J5hY35w+MECm4TQUkg6szRcny9lf6oVhWij4w3JJFQgvHQMXU7oXOpX8Z05HxV/8g==",
-          "requires": {}
-        },
-        "@opentelemetry/core": {
-          "version": "1.24.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.0.tgz",
-          "integrity": "sha512-FP2oN7mVPqcdxJDTTnKExj4mi91EH+DNuArKfHTjPuJWe2K1JfMIVXNfahw1h3onJxQnxS8K0stKkogX05s+Aw==",
-          "requires": {
-            "@opentelemetry/semantic-conventions": "1.24.0"
-          }
-        },
-        "@opentelemetry/exporter-trace-otlp-grpc": {
-          "version": "0.51.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.51.0.tgz",
-          "integrity": "sha512-xQpxKzS8ZnxYCa1v+3EKWhwMrSK3+RezpJ+AEKaP2pf2QbLfHt7kKfSn7niR2u3A1Tbe2aC7Ptt9+MafhThOOQ==",
-          "requires": {
-            "@grpc/grpc-js": "^1.7.1",
-            "@opentelemetry/core": "1.24.0",
-            "@opentelemetry/otlp-grpc-exporter-base": "0.51.0",
-            "@opentelemetry/otlp-transformer": "0.51.0",
-            "@opentelemetry/resources": "1.24.0",
-            "@opentelemetry/sdk-trace-base": "1.24.0"
-          }
-        },
-        "@opentelemetry/exporter-trace-otlp-http": {
-          "version": "0.51.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.51.0.tgz",
-          "integrity": "sha512-zODqnLZmPOxj9CarFv0TrVlx9mgj0TfCMCiUiTdNi9iA2rgdKVo+bjJjpYF6LCTJOQCR5TScAUCKyzwkgDI+iA==",
-          "requires": {
-            "@opentelemetry/core": "1.24.0",
-            "@opentelemetry/otlp-exporter-base": "0.51.0",
-            "@opentelemetry/otlp-transformer": "0.51.0",
-            "@opentelemetry/resources": "1.24.0",
-            "@opentelemetry/sdk-trace-base": "1.24.0"
-          }
-        },
-        "@opentelemetry/exporter-trace-otlp-proto": {
-          "version": "0.51.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.51.0.tgz",
-          "integrity": "sha512-Fi7r0iMqGoFCQQ+WY0pYOWp395vdinZJIkYKnNbnreHxAN/kVDBl2FxbV3DeOKuRxEY08Gyb9ggPf+Zrqp7l/w==",
-          "requires": {
-            "@opentelemetry/core": "1.24.0",
-            "@opentelemetry/otlp-exporter-base": "0.51.0",
-            "@opentelemetry/otlp-proto-exporter-base": "0.51.0",
-            "@opentelemetry/otlp-transformer": "0.51.0",
-            "@opentelemetry/resources": "1.24.0",
-            "@opentelemetry/sdk-trace-base": "1.24.0"
-          }
-        },
-        "@opentelemetry/exporter-zipkin": {
-          "version": "1.24.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.24.0.tgz",
-          "integrity": "sha512-QeGv0PHONswmu567pf9QliJ6s6DgCu5+ziF+soNS1LTcr1VRRVLViYLmGxmzDFUC48sjNTu7sumcKT0nJXsGBw==",
-          "requires": {
-            "@opentelemetry/core": "1.24.0",
-            "@opentelemetry/resources": "1.24.0",
-            "@opentelemetry/sdk-trace-base": "1.24.0",
-            "@opentelemetry/semantic-conventions": "1.24.0"
-          }
-        },
-        "@opentelemetry/otlp-exporter-base": {
-          "version": "0.51.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.51.0.tgz",
-          "integrity": "sha512-hR4c9vWVz1QgzCBSyy9zSDkvfTgaK96E6/tfVP6O4dzdZW9HqWimA3lXV/KXadEGqShvM4GToz9EHp2A5RU5bQ==",
-          "requires": {
-            "@opentelemetry/core": "1.24.0"
-          }
-        },
-        "@opentelemetry/otlp-grpc-exporter-base": {
-          "version": "0.51.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.51.0.tgz",
-          "integrity": "sha512-oTRtDvvB0bTRTBVrvKA/oM1gIAqQ6DVQS07pvqiL1cZS8wBrGgpw+2iTd0nV661Y/MhDn/kNWp8lRhMEIKN9bw==",
-          "requires": {
-            "@grpc/grpc-js": "^1.7.1",
-            "@opentelemetry/core": "1.24.0",
-            "@opentelemetry/otlp-exporter-base": "0.51.0",
-            "protobufjs": "^7.2.3"
-          }
-        },
-        "@opentelemetry/otlp-proto-exporter-base": {
-          "version": "0.51.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.51.0.tgz",
-          "integrity": "sha512-WDANDLSUh11Gu5o6iCzmjZraIv5bK8z1L/t6lxQ2NeEKiKUPo5pVOBBQQC/yAQU2yeqkiO1GRCieH+XahZf60A==",
-          "requires": {
-            "@opentelemetry/core": "1.24.0",
-            "@opentelemetry/otlp-exporter-base": "0.51.0",
-            "protobufjs": "^7.2.3"
-          }
-        },
-        "@opentelemetry/otlp-transformer": {
-          "version": "0.51.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.51.0.tgz",
-          "integrity": "sha512-ylLgx2xumVoSefDHP9GMAU/LG+TU3+8eacVDXV5o1RqWxsdVOaQmCTY0XyDgeRTn6hIOVAq/HHQbRq3iWOrt2A==",
-          "requires": {
-            "@opentelemetry/api-logs": "0.51.0",
-            "@opentelemetry/core": "1.24.0",
-            "@opentelemetry/resources": "1.24.0",
-            "@opentelemetry/sdk-logs": "0.51.0",
-            "@opentelemetry/sdk-metrics": "1.24.0",
-            "@opentelemetry/sdk-trace-base": "1.24.0"
-          }
-        },
-        "@opentelemetry/propagator-b3": {
-          "version": "1.24.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.24.0.tgz",
-          "integrity": "sha512-7TMIDE4+NO5vnkor+zned42wqca+hmhW5gWKhmYjUHC5B5uojo1PvtmBrd7kigFu96XvL4ZUWVzibWRWIQ/++Q==",
-          "requires": {
-            "@opentelemetry/core": "1.24.0"
-          }
-        },
-        "@opentelemetry/propagator-jaeger": {
-          "version": "1.24.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.24.0.tgz",
-          "integrity": "sha512-r3MX3AmJiUeiWTXSDOdwBeaO+ahvWcFCpuKxmhhsH8Q8LqDnjhNd3krqBh4Qsq9wa0WhWtiQaDs/NOCWoMOlOw==",
-          "requires": {
-            "@opentelemetry/core": "1.24.0"
-          }
-        },
-        "@opentelemetry/resources": {
-          "version": "1.24.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.24.0.tgz",
-          "integrity": "sha512-mxC7E7ocUS1tLzepnA7O9/G8G6ZTdjCH2pXme1DDDuCuk6n2/53GADX+GWBuyX0dfIxeMInIbJAdjlfN9GNr6A==",
-          "requires": {
-            "@opentelemetry/core": "1.24.0",
-            "@opentelemetry/semantic-conventions": "1.24.0"
-          }
-        },
-        "@opentelemetry/sdk-logs": {
-          "version": "0.51.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.51.0.tgz",
-          "integrity": "sha512-K4fMBRFD8hQ6khk0rvYFuo6L9ymeGgByir6BcuFIgQuQ00OhYwBi9AruZz5V733Ejq7P8ObR3YyubkOUIbeVAw==",
-          "requires": {
-            "@opentelemetry/core": "1.24.0",
-            "@opentelemetry/resources": "1.24.0"
-          }
-        },
-        "@opentelemetry/sdk-metrics": {
-          "version": "1.24.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.24.0.tgz",
-          "integrity": "sha512-4tJ+E6N019OZVB/nUW/LoK9xHxfeh88TCoaTqHeLBE9wLYfi6irWW6J9cphMav7J8Qk0D5b7/RM4VEY4dArWOA==",
-          "requires": {
-            "@opentelemetry/core": "1.24.0",
-            "@opentelemetry/resources": "1.24.0",
-            "lodash.merge": "^4.6.2"
-          }
-        },
-        "@opentelemetry/sdk-node": {
-          "version": "0.51.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.51.0.tgz",
-          "integrity": "sha512-MrPXDQsTAj3lcY8YUCjb7dvSXVZ5jG6wmjD2LB68V1rsLBdP8j70jsI9GaKijY7QB6psbLq6apO1vYeim5U7aw==",
-          "requires": {
-            "@opentelemetry/api-logs": "0.51.0",
-            "@opentelemetry/core": "1.24.0",
-            "@opentelemetry/exporter-trace-otlp-grpc": "0.51.0",
-            "@opentelemetry/exporter-trace-otlp-http": "0.51.0",
-            "@opentelemetry/exporter-trace-otlp-proto": "0.51.0",
-            "@opentelemetry/exporter-zipkin": "1.24.0",
-            "@opentelemetry/instrumentation": "0.51.0",
-            "@opentelemetry/resources": "1.24.0",
-            "@opentelemetry/sdk-logs": "0.51.0",
-            "@opentelemetry/sdk-metrics": "1.24.0",
-            "@opentelemetry/sdk-trace-base": "1.24.0",
-            "@opentelemetry/sdk-trace-node": "1.24.0",
-            "@opentelemetry/semantic-conventions": "1.24.0"
-          },
-          "dependencies": {
-            "@opentelemetry/instrumentation": {
-              "version": "0.51.0",
-              "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.51.0.tgz",
-              "integrity": "sha512-Eg/+Od5bEvzpvZQGhvMyKIkrzB9S7jW+6z9LHEI2VXhl/GrqQ3oBqlzJt4tA6pGtxRmqQWKWGM1wAbwDdW/gUA==",
-              "requires": {
-                "@opentelemetry/api-logs": "0.51.0",
-                "@types/shimmer": "^1.0.2",
-                "import-in-the-middle": "1.7.1",
-                "require-in-the-middle": "^7.1.1",
-                "semver": "^7.5.2",
-                "shimmer": "^1.2.1"
-              }
-            }
-          }
-        },
-        "@opentelemetry/sdk-trace-base": {
-          "version": "1.24.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.24.0.tgz",
-          "integrity": "sha512-H9sLETZ4jw9UJ3totV8oM5R0m4CW0ZIOLfp4NV3g0CM8HD5zGZcaW88xqzWDgiYRpctFxd+WmHtGX/Upoa2vRg==",
-          "requires": {
-            "@opentelemetry/core": "1.24.0",
-            "@opentelemetry/resources": "1.24.0",
-            "@opentelemetry/semantic-conventions": "1.24.0"
-          }
-        },
-        "@opentelemetry/sdk-trace-node": {
-          "version": "1.24.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.24.0.tgz",
-          "integrity": "sha512-QgByHmM9uloTpcYEEyW9YJEIMKHFSIM677RH9pJPWWwtM2NQFbEp/8HIJw80Ymtaz6cAxg1Kay1ByqIVzq3t5g==",
-          "requires": {
-            "@opentelemetry/context-async-hooks": "1.24.0",
-            "@opentelemetry/core": "1.24.0",
-            "@opentelemetry/propagator-b3": "1.24.0",
-            "@opentelemetry/propagator-jaeger": "1.24.0",
-            "@opentelemetry/sdk-trace-base": "1.24.0",
-            "semver": "^7.5.2"
-          }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.24.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.0.tgz",
-          "integrity": "sha512-yL0jI6Ltuz8R+Opj7jClGrul6pOoYrdfVmzQS4SITXRPH7I5IRZbrwe/6/v8v4WYMa6MYZG480S1+uc/IGfqsA=="
-        }
       }
     },
     "@opentelemetry/auto-instrumentations-web": {
@@ -46856,7 +46295,7 @@
     "@opentelemetry/baggage-span-processor": {
       "version": "file:packages/baggage-span-processor",
       "requires": {
-        "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.6.5",
@@ -46877,24 +46316,24 @@
       }
     },
     "@opentelemetry/context-async-hooks": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.24.0.tgz",
-      "integrity": "sha512-s7xaQ9ifDpJvwbWRLkZD/J5hY35w+MECm4TQUkg6szRcny9lf6oVhWij4w3JJFQgvHQMXU7oXOpX8Z05HxV/8g==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.24.1.tgz",
+      "integrity": "sha512-R5r6DO4kgEOVBxFXhXjwospLQkv+sYxwCfjvoZBe7Zm6KKXAV9kDSJhi/D1BweowdZmO+sdbENLs374gER8hpQ==",
       "requires": {}
     },
     "@opentelemetry/context-zone": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-1.24.0.tgz",
-      "integrity": "sha512-Znb6fvmqZy+4ZC63vvf9qktXakTlLOLeBsMizR5E1G/1cM8LKUVR/JJUws+A4QSAY95Rzldi05aqxoc+YUVVKw==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-1.24.1.tgz",
+      "integrity": "sha512-pt5KLJws1m+rHTeEA6uootoyiuZlCt7j90dmdjXnqx4JZH6sFWqWB5IW1gOukDY7Ym3cNKjtoh3/uK0KuSRBfg==",
       "requires": {
-        "@opentelemetry/context-zone-peer-dep": "1.24.0",
+        "@opentelemetry/context-zone-peer-dep": "1.24.1",
         "zone.js": "^0.11.0 || ^0.13.0 || ^0.14.0"
       }
     },
     "@opentelemetry/context-zone-peer-dep": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.24.0.tgz",
-      "integrity": "sha512-znNlicjfxRqepQdOZGUN3RYSs+QGoEiGI+cjILBYM4KdEXpoXgxt87l72b0UYhH7YI/uK0TVHse99D0ER9ODAw==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.24.1.tgz",
+      "integrity": "sha512-s67becvBZFFjSLKSiy8ia2m7htsC4gsk8J/X0368FzBYseb/26daYr4ewx6tKcAsmZqJA7402cTQirv175x5BA==",
       "requires": {}
     },
     "@opentelemetry/contrib-test-utils": {
@@ -46914,71 +46353,71 @@
       }
     },
     "@opentelemetry/core": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.0.tgz",
-      "integrity": "sha512-FP2oN7mVPqcdxJDTTnKExj4mi91EH+DNuArKfHTjPuJWe2K1JfMIVXNfahw1h3onJxQnxS8K0stKkogX05s+Aw==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.24.1.tgz",
+      "integrity": "sha512-wMSGfsdmibI88K9wB498zXY04yThPexo8jvwNNlm542HZB7XrrMRBbAyKJqG8qDRJwIBdBrPMi4V9ZPW/sqrcg==",
       "requires": {
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/semantic-conventions": "1.24.1"
       }
     },
     "@opentelemetry/exporter-jaeger": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.24.0.tgz",
-      "integrity": "sha512-mD28eBrdth937QGU6zgn+6fYBywUaYxLJwANREnE7XS8pHP/Hjxpiy4nb9yIzQ2DqC8Uq7yEnc8ah2pH45B9ZQ==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.24.1.tgz",
+      "integrity": "sha512-zrcY76PVR4itZD2oxQdFgnvS/Lst1CxmMofOhngvTDIXVqSTEf00QfmdIQUljwmycYwxZIvbJ445k3AGRBbZKQ==",
       "requires": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0",
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1",
         "jaeger-client": "^3.15.0"
       }
     },
     "@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.51.0.tgz",
-      "integrity": "sha512-xQpxKzS8ZnxYCa1v+3EKWhwMrSK3+RezpJ+AEKaP2pf2QbLfHt7kKfSn7niR2u3A1Tbe2aC7Ptt9+MafhThOOQ==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.51.1.tgz",
+      "integrity": "sha512-P9+Hkszih95ITvldGZ+kXvj9HpD1QfS+PwooyHK72GYA+Bgm+yUSAsDkUkDms8+s9HW6poxURv3LcjaMuBBpVQ==",
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.51.0",
-        "@opentelemetry/otlp-transformer": "0.51.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.51.1",
+        "@opentelemetry/otlp-transformer": "0.51.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1"
       }
     },
     "@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.51.0.tgz",
-      "integrity": "sha512-zODqnLZmPOxj9CarFv0TrVlx9mgj0TfCMCiUiTdNi9iA2rgdKVo+bjJjpYF6LCTJOQCR5TScAUCKyzwkgDI+iA==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.51.1.tgz",
+      "integrity": "sha512-n+LhLPsX07URh+HhV2SHVSvz1t4G/l/CE5BjpmhAPqeTceFac1VpyQkavWEJbvnK5bUEXijWt4LxAxFpt2fXyw==",
       "requires": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/otlp-exporter-base": "0.51.0",
-        "@opentelemetry/otlp-transformer": "0.51.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/otlp-exporter-base": "0.51.1",
+        "@opentelemetry/otlp-transformer": "0.51.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1"
       }
     },
     "@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.51.0.tgz",
-      "integrity": "sha512-Fi7r0iMqGoFCQQ+WY0pYOWp395vdinZJIkYKnNbnreHxAN/kVDBl2FxbV3DeOKuRxEY08Gyb9ggPf+Zrqp7l/w==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.51.1.tgz",
+      "integrity": "sha512-SE9f0/6V6EeXC9i+WA4WFjS1EYgaBCpAnI5+lxWvZ7iO7EU1IvHvZhP6Kojr0nLldo83gqg6G7OWFqsID3uF+w==",
       "requires": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/otlp-exporter-base": "0.51.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.51.0",
-        "@opentelemetry/otlp-transformer": "0.51.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/otlp-exporter-base": "0.51.1",
+        "@opentelemetry/otlp-proto-exporter-base": "0.51.1",
+        "@opentelemetry/otlp-transformer": "0.51.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1"
       }
     },
     "@opentelemetry/exporter-zipkin": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.24.0.tgz",
-      "integrity": "sha512-QeGv0PHONswmu567pf9QliJ6s6DgCu5+ziF+soNS1LTcr1VRRVLViYLmGxmzDFUC48sjNTu7sumcKT0nJXsGBw==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.24.1.tgz",
+      "integrity": "sha512-+Rl/VFmu2n6eaRMnVbyfZx1DqR/1KNyWebYuHyQBZaEAVIn/ZLgmofRpXN1X2nhJ4BNaptQUNxAstCYYz6dKoQ==",
       "requires": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
       }
     },
     "@opentelemetry/host-metrics": {
@@ -47041,13 +46480,13 @@
       }
     },
     "@opentelemetry/instrumentation": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.51.0.tgz",
-      "integrity": "sha512-Eg/+Od5bEvzpvZQGhvMyKIkrzB9S7jW+6z9LHEI2VXhl/GrqQ3oBqlzJt4tA6pGtxRmqQWKWGM1wAbwDdW/gUA==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.51.1.tgz",
+      "integrity": "sha512-JIrvhpgqY6437QIqToyozrUG1h5UhwHkaGK/WAX+fkrpyPtc+RO5FkRtUd9BH0MibabHHvqsnBGKfKVijbmp8w==",
       "requires": {
-        "@opentelemetry/api-logs": "0.51.0",
+        "@opentelemetry/api-logs": "0.51.1",
         "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.7.1",
+        "import-in-the-middle": "1.7.4",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2",
         "shimmer": "^1.2.1"
@@ -47428,14 +46867,14 @@
       }
     },
     "@opentelemetry/instrumentation-fetch": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.51.0.tgz",
-      "integrity": "sha512-dB9wisB2+wyh0wUB1RFNinCS4TqJ7QMVc4jNzy3JCMJudwFWI/stU10DgZ3vwFQNUEBUIz9QmEQSFud7lsvB2w==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.51.1.tgz",
+      "integrity": "sha512-LzciqAnJmmYaXWo2hlrN99NMbYbExo6n6lBKBeMHAi7X/ddhCSOsgSNVbF3kDB7P++PJhjYqLT3hy6SU4AFHcg==",
       "requires": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/instrumentation": "0.51.0",
-        "@opentelemetry/sdk-trace-web": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/instrumentation": "0.51.1",
+        "@opentelemetry/sdk-trace-web": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
       }
     },
     "@opentelemetry/instrumentation-fs": {
@@ -47534,12 +46973,12 @@
       }
     },
     "@opentelemetry/instrumentation-grpc": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.51.0.tgz",
-      "integrity": "sha512-Wfhs9e1Hi4nnULLqzt9s2M6+Tz52EkKj6uZnj9ZL3coldlZiP+WmvuUNepds7jcBJg/qDBjnEe96fThPuO7ddA==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.51.1.tgz",
+      "integrity": "sha512-coRTugFL7De/VNH/1NqPlxnfik87jS+jBXsny+Y/lMhXIA3x8t71IyL9ihuewkD+lNtIxIz6Y7Sq6kPuOqz5dQ==",
       "requires": {
-        "@opentelemetry/instrumentation": "0.51.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/instrumentation": "0.51.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
       }
     },
     "@opentelemetry/instrumentation-hapi": {
@@ -47565,13 +47004,13 @@
       }
     },
     "@opentelemetry/instrumentation-http": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.51.0.tgz",
-      "integrity": "sha512-6VsGPBnU6iVKWhVBnuRpwrmiHfxt8EYrqfnH2glfsMpsn4xy+O6U0yGlggPLhoYeOVafV3h70EEk5MU0tpsbiw==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.51.1.tgz",
+      "integrity": "sha512-6b3nZnFFEz/3xZ6w8bVxctPUWIPWiXuPQ725530JgxnN1cvYFd8CJ75PrHZNjynmzSSnqBkN3ef4R9N+RpMh8Q==",
       "requires": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/instrumentation": "0.51.0",
-        "@opentelemetry/semantic-conventions": "1.24.0",
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/instrumentation": "0.51.1",
+        "@opentelemetry/semantic-conventions": "1.24.1",
         "semver": "^7.5.2"
       }
     },
@@ -48584,56 +48023,56 @@
       }
     },
     "@opentelemetry/instrumentation-xml-http-request": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.51.0.tgz",
-      "integrity": "sha512-KgLO2qx1z1Wn9NeJgrgNukd10ssK1QqxODwdeBJFO1BaP9sVVargpupYowlDKUL5I3oWOEqi/Oxxdh/fbEsJtw==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.51.1.tgz",
+      "integrity": "sha512-CrQZxADNFr9M3aCgjM3/KXDz12lBrZA5LW+btfgNb78hsLNwqxThtFvXOHr86UsOzJt+h9m4yDeH6YLEvCTBbw==",
       "requires": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/instrumentation": "0.51.0",
-        "@opentelemetry/sdk-trace-web": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/instrumentation": "0.51.1",
+        "@opentelemetry/sdk-trace-web": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
       }
     },
     "@opentelemetry/otlp-exporter-base": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.51.0.tgz",
-      "integrity": "sha512-hR4c9vWVz1QgzCBSyy9zSDkvfTgaK96E6/tfVP6O4dzdZW9HqWimA3lXV/KXadEGqShvM4GToz9EHp2A5RU5bQ==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.51.1.tgz",
+      "integrity": "sha512-UYlnOYyDdzo1Gw559EHCzru0RwhvuXCwoH8jGo9J4gO1TE58GjnEmIjomMsKBCym3qWNJfIQXw+9SZCV0DdQNg==",
       "requires": {
-        "@opentelemetry/core": "1.24.0"
+        "@opentelemetry/core": "1.24.1"
       }
     },
     "@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.51.0.tgz",
-      "integrity": "sha512-oTRtDvvB0bTRTBVrvKA/oM1gIAqQ6DVQS07pvqiL1cZS8wBrGgpw+2iTd0nV661Y/MhDn/kNWp8lRhMEIKN9bw==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.51.1.tgz",
+      "integrity": "sha512-ZAS+4pq8o7dsugGTwV9s6JMKSxi+guIHdn0acOv0bqj26e9pWDFx5Ky+bI0aY46uR9Y0JyXqY+KAEYM/SO3DFA==",
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/otlp-exporter-base": "0.51.0",
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/otlp-exporter-base": "0.51.1",
         "protobufjs": "^7.2.3"
       }
     },
     "@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.51.0.tgz",
-      "integrity": "sha512-WDANDLSUh11Gu5o6iCzmjZraIv5bK8z1L/t6lxQ2NeEKiKUPo5pVOBBQQC/yAQU2yeqkiO1GRCieH+XahZf60A==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.51.1.tgz",
+      "integrity": "sha512-gxxxwfk0inDMb5DLeuxQ3L8TtptxSiTNHE4nnAJH34IQXAVRhXSXW1rK8PmDKDngRPIZ6J7ncUCjjIn8b+AgqQ==",
       "requires": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/otlp-exporter-base": "0.51.0",
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/otlp-exporter-base": "0.51.1",
         "protobufjs": "^7.2.3"
       }
     },
     "@opentelemetry/otlp-transformer": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.51.0.tgz",
-      "integrity": "sha512-ylLgx2xumVoSefDHP9GMAU/LG+TU3+8eacVDXV5o1RqWxsdVOaQmCTY0XyDgeRTn6hIOVAq/HHQbRq3iWOrt2A==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.51.1.tgz",
+      "integrity": "sha512-OppYOXwV9LQqqtYUCywqoOqX/JT9LQ5/FMuPZ//eTkvuHdUC4ZMwz2c6uSoT2R90GWvvGnF1iEqTGyTT3xAt2Q==",
       "requires": {
-        "@opentelemetry/api-logs": "0.51.0",
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-logs": "0.51.0",
-        "@opentelemetry/sdk-metrics": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0"
+        "@opentelemetry/api-logs": "0.51.1",
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/sdk-logs": "0.51.1",
+        "@opentelemetry/sdk-metrics": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1"
       }
     },
     "@opentelemetry/plugin-react-load": {
@@ -48703,19 +48142,19 @@
       }
     },
     "@opentelemetry/propagator-aws-xray": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.24.0.tgz",
-      "integrity": "sha512-rcuMtEOTZC7TW84tws1QLUVRElrGSbBJwK0b+qa56zJULDiUIiUpS+dSzO+aUchg7MtTJBZSG5OPsfsKpGgNig==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.24.1.tgz",
+      "integrity": "sha512-RzwoLe6QzsYGcpmxxDbbbgSpe3ncxSM4dtFHXh/rCYGjyq0nZGXKvk26mJtWZ4kQ3nuiIoqSZueIuGmt/mvOTA==",
       "requires": {
-        "@opentelemetry/core": "1.24.0"
+        "@opentelemetry/core": "1.24.1"
       }
     },
     "@opentelemetry/propagator-b3": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.24.0.tgz",
-      "integrity": "sha512-7TMIDE4+NO5vnkor+zned42wqca+hmhW5gWKhmYjUHC5B5uojo1PvtmBrd7kigFu96XvL4ZUWVzibWRWIQ/++Q==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.24.1.tgz",
+      "integrity": "sha512-nda97ZwhpZKyUJTXqQuKzNhPMUgMLunbbGWn8kroBwegn+nh6OhtyGkrVQsQLNdVKJl0KeB5z0ZgeWszrYhwFw==",
       "requires": {
-        "@opentelemetry/core": "1.24.0"
+        "@opentelemetry/core": "1.24.1"
       }
     },
     "@opentelemetry/propagator-grpc-census-binary": {
@@ -48905,11 +48344,11 @@
       }
     },
     "@opentelemetry/propagator-jaeger": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.24.0.tgz",
-      "integrity": "sha512-r3MX3AmJiUeiWTXSDOdwBeaO+ahvWcFCpuKxmhhsH8Q8LqDnjhNd3krqBh4Qsq9wa0WhWtiQaDs/NOCWoMOlOw==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.24.1.tgz",
+      "integrity": "sha512-7bRBJn3FG1l195A1m+xXRHvgzAOBsfmRi9uZ5Da18oTh7BLmNDiA8+kpk51FpTsU1PCikPVpRDNPhKVB6lyzZg==",
       "requires": {
-        "@opentelemetry/core": "1.24.0"
+        "@opentelemetry/core": "1.24.1"
       }
     },
     "@opentelemetry/propagator-ot-trace": {
@@ -49150,90 +48589,90 @@
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.24.0.tgz",
-      "integrity": "sha512-mxC7E7ocUS1tLzepnA7O9/G8G6ZTdjCH2pXme1DDDuCuk6n2/53GADX+GWBuyX0dfIxeMInIbJAdjlfN9GNr6A==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.24.1.tgz",
+      "integrity": "sha512-cyv0MwAaPF7O86x5hk3NNgenMObeejZFLJJDVuSeSMIsknlsj3oOZzRv3qSzlwYomXsICfBeFFlxwHQte5mGXQ==",
       "requires": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
       }
     },
     "@opentelemetry/sdk-logs": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.51.0.tgz",
-      "integrity": "sha512-K4fMBRFD8hQ6khk0rvYFuo6L9ymeGgByir6BcuFIgQuQ00OhYwBi9AruZz5V733Ejq7P8ObR3YyubkOUIbeVAw==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.51.1.tgz",
+      "integrity": "sha512-ULQQtl82b673PpZc5/0EtH4V+BrwVOgKJZEB7tYZnGTG3I98tQVk89S9/JSixomDr++F4ih+LSJTCqIKBz+MQQ==",
       "requires": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/resources": "1.24.1"
       }
     },
     "@opentelemetry/sdk-metrics": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.24.0.tgz",
-      "integrity": "sha512-4tJ+E6N019OZVB/nUW/LoK9xHxfeh88TCoaTqHeLBE9wLYfi6irWW6J9cphMav7J8Qk0D5b7/RM4VEY4dArWOA==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.24.1.tgz",
+      "integrity": "sha512-FrAqCbbGao9iKI+Mgh+OsC9+U2YMoXnlDHe06yH7dvavCKzE3S892dGtX54+WhSFVxHR/TMRVJiK/CV93GR0TQ==",
       "requires": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0",
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/resources": "1.24.1",
         "lodash.merge": "^4.6.2"
       }
     },
     "@opentelemetry/sdk-node": {
-      "version": "0.51.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.51.0.tgz",
-      "integrity": "sha512-MrPXDQsTAj3lcY8YUCjb7dvSXVZ5jG6wmjD2LB68V1rsLBdP8j70jsI9GaKijY7QB6psbLq6apO1vYeim5U7aw==",
+      "version": "0.51.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.51.1.tgz",
+      "integrity": "sha512-GgmNF9C+6esr8PIJxCqHw84rEOkYm6XdFWZ2+Wyc3qaUt92ACoN7uSw5iKNvaUq62W0xii1wsGxwHzyENtPP8w==",
       "requires": {
-        "@opentelemetry/api-logs": "0.51.0",
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.51.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.51.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.51.0",
-        "@opentelemetry/exporter-zipkin": "1.24.0",
-        "@opentelemetry/instrumentation": "0.51.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/sdk-logs": "0.51.0",
-        "@opentelemetry/sdk-metrics": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0",
-        "@opentelemetry/sdk-trace-node": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/api-logs": "0.51.1",
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.51.1",
+        "@opentelemetry/exporter-trace-otlp-http": "0.51.1",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.51.1",
+        "@opentelemetry/exporter-zipkin": "1.24.1",
+        "@opentelemetry/instrumentation": "0.51.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/sdk-logs": "0.51.1",
+        "@opentelemetry/sdk-metrics": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/sdk-trace-node": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
       }
     },
     "@opentelemetry/sdk-trace-base": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.24.0.tgz",
-      "integrity": "sha512-H9sLETZ4jw9UJ3totV8oM5R0m4CW0ZIOLfp4NV3g0CM8HD5zGZcaW88xqzWDgiYRpctFxd+WmHtGX/Upoa2vRg==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.24.1.tgz",
+      "integrity": "sha512-zz+N423IcySgjihl2NfjBf0qw1RWe11XIAWVrTNOSSI6dtSPJiVom2zipFB2AEEtJWpv0Iz6DY6+TjnyTV5pWg==",
       "requires": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/resources": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/resources": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
       }
     },
     "@opentelemetry/sdk-trace-node": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.24.0.tgz",
-      "integrity": "sha512-QgByHmM9uloTpcYEEyW9YJEIMKHFSIM677RH9pJPWWwtM2NQFbEp/8HIJw80Ymtaz6cAxg1Kay1ByqIVzq3t5g==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.24.1.tgz",
+      "integrity": "sha512-/FZX8uWaGIAwsDhqI8VvQ+qWtfMNlXjaFYGc+vmxgdRFppCSSIRwrPyIhJO1qx61okyYhoyxVEZAfoiNxrfJCg==",
       "requires": {
-        "@opentelemetry/context-async-hooks": "1.24.0",
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/propagator-b3": "1.24.0",
-        "@opentelemetry/propagator-jaeger": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0",
+        "@opentelemetry/context-async-hooks": "1.24.1",
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/propagator-b3": "1.24.1",
+        "@opentelemetry/propagator-jaeger": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1",
         "semver": "^7.5.2"
       }
     },
     "@opentelemetry/sdk-trace-web": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.24.0.tgz",
-      "integrity": "sha512-G0q8aZPUhRtO/iw2BkjHeNqCMBf0JQX5VqqiPWXn9u5iRkpeQ6LZrGaiymKWOdEqtXCgM44yrCY/4WoJqR0bjQ==",
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.24.1.tgz",
+      "integrity": "sha512-0w+aKRai9VREeo3VrtW+hcbrE2Fl/uKL7G+oXgRNf6pI9QLaEGuEzUTX+oxXVPBadzjOd+5dqCHYdX7UeVjzwA==",
       "requires": {
-        "@opentelemetry/core": "1.24.0",
-        "@opentelemetry/sdk-trace-base": "1.24.0",
-        "@opentelemetry/semantic-conventions": "1.24.0"
+        "@opentelemetry/core": "1.24.1",
+        "@opentelemetry/sdk-trace-base": "1.24.1",
+        "@opentelemetry/semantic-conventions": "1.24.1"
       }
     },
     "@opentelemetry/semantic-conventions": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.0.tgz",
-      "integrity": "sha512-yL0jI6Ltuz8R+Opj7jClGrul6pOoYrdfVmzQS4SITXRPH7I5IRZbrwe/6/v8v4WYMa6MYZG480S1+uc/IGfqsA=="
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.24.1.tgz",
+      "integrity": "sha512-VkliWlS4/+GHLLW7J/rVBA00uXus1SWvwFvcUDxDwmFxYfg/2VI6ekwdXS28cjI8Qz2ky2BzG8OUHo+WeYIWqw=="
     },
     "@opentelemetry/sql-common": {
       "version": "file:packages/opentelemetry-sql-common",
@@ -51725,10 +51164,10 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg=="
     },
-    "acorn-import-assertions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
-      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+    "acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
       "requires": {}
     },
     "acorn-jsx": {
@@ -53299,9 +52738,9 @@
       }
     },
     "cjs-module-lexer": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
-      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
+      "integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q=="
     },
     "class-transformer": {
       "version": "0.5.1",
@@ -57817,12 +57256,12 @@
       }
     },
     "import-in-the-middle": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.1.tgz",
-      "integrity": "sha512-1LrZPDtW+atAxH42S6288qyDFNQ2YCty+2mxEPRtfazH6Z5QwkaBSTS2ods7hnVJioF6rkRfNoA6A/MstpFXLg==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.7.4.tgz",
+      "integrity": "sha512-Lk+qzWmiQuRPPulGQeK5qq0v32k2bHnWrRPFgqyvhw7Kkov5L6MOLOIU3pcWeujc9W4q54Cp3Q2WV16eQkc7Bg==",
       "requires": {
         "acorn": "^8.8.2",
-        "acorn-import-assertions": "^1.9.0",
+        "acorn-import-attributes": "^1.9.5",
         "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
       }


### PR DESCRIPTION
- Updates to 1.24.1/0.51.1. Due to the used dependency ranges, this updates `package-lock.json` only.
- Also removes the workaround that pinned tests to use 18.18.2

Closes #2021 
Partially enables #2169 