### PR TITLE
fix(instrumentation-connect): add source maps to package

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-connect/package.json
+++ b/plugins/node/opentelemetry-instrumentation-connect/package.json
@@ -32,6 +32,7 @@
   },
   "files": [
     "build/src/**/*.js",
+    "build/src/**/*.js.map",
     "build/src/**/*.d.ts"
   ],
   "publishConfig": {


### PR DESCRIPTION
## Which problem is this PR solving?

Missing source-maps in instrumentation-connect.
Fixes #2199

## Short description of the changes

- adds source-map files to `files` 
