### PR TITLE
chore: update to new release-please-action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           npm ci
 
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@f3969c04a4ec81d7a9aa4010d84ae6a7602f86a7 # v4.1.1
         id: release
         with:
           token: ${{secrets.RELEASE_PR_TOKEN}}


### PR DESCRIPTION
https://github.com/google-github-actions/release-please-action/ was recently
archived and deprecated in favour of
https://github.com/googleapis/release-please-action

This also pins to a specific git SHA which is somewhat recommended
for security hardening:
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
