### PR TITLE
chore: fix some package dirs in component_owners metadata

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -17,6 +17,8 @@ components:
   detectors/node/opentelemetry-resource-detector-instana:
     - basti1302
     - kirrg001
+  incubator/opentelemetry-sampler-aws-xray:
+    - carolabadeer
   metapackages/auto-instrumentations-node:
     - dyladan
     - pichlermarc
@@ -33,8 +35,6 @@ components:
   packages/opentelemetry-host-metrics:
     - legendecas
   packages/opentelemetry-id-generator-aws-xray:
-    - carolabadeer
-  packages/opentelemetry-sampler-aws-xray:
     - carolabadeer
   packages/opentelemetry-propagation-utils:
     - dyladan
@@ -143,8 +143,6 @@ components:
     - obecny
   plugins/web/opentelemetry-plugin-react-load:
     - martinkuba
-  propagators/opentelemetry-propagator-grpc-census-binary: []
-    # Unmaintained?
   propagators/opentelemetry-propagator-instana:
     - basti1302
     - kirrg001

--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -113,7 +113,7 @@ components:
     - rauno56
   plugins/node/opentelemetry-instrumentation-net:
     - seemk
-  plugins/node/opentelemetry-instrumentation-runtime-node:
+  plugins/node/instrumentation-runtime-node:
     - d4nyll
   plugins/node/opentelemetry-instrumentation-pg:
     - maryliag
@@ -128,7 +128,7 @@ components:
     - rauno56
   plugins/node/opentelemetry-instrumentation-router:
     - rauno56
-  plugins/node/opentelemetry-instrumentation-undici:
+  plugins/node/instrumentation-undici:
     - david-luna
     - trentm
   plugins/node/opentelemetry-instrumentation-winston:


### PR DESCRIPTION
I noticed that a number of the dirs in `component_owners.yml` were incorrect.

```sh
% cat .github/component_owners.yml | rg '^  \w' | cut -d: -f1 | while read d; do if [[ ! -d $d ]]; then echo bad dir $d; fi; done
bad dir packages/opentelemetry-sampler-aws-xray
bad dir plugins/node/opentelemetry-instrumentation-runtime-node
bad dir plugins/node/opentelemetry-instrumentation-undici
bad dir propagators/opentelemetry-propagator-grpc-census-binary
```