### PR TITLE
test: minor cleanup to pino ESM test

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-pino/test/pino-enabled.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pino/test/pino-enabled.test.ts
@@ -239,10 +239,8 @@ describe('PinoInstrumentation', () => {
       });
     });
   });
+
   describe('ESM usage', () => {
-    beforeEach(() => {
-      testContext = setupInstrumentationAndInitTestContext();
-    });
     it('should work with ESM default import', async function () {
       testContext = setupInstrumentationAndInitTestContext();
       let logRecords: any[];


### PR DESCRIPTION
The ESM tests are out of process so the setup done in
setupInstrumentationAndInitTestContext() isn't relevant.
