### PR TITLE
fix(instrumentation-express): set correct http.route to root span

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-express/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-express/src/instrumentation.ts
@@ -187,7 +187,10 @@ export class ExpressInstrumentation extends InstrumentationBase<ExpressInstrumen
         ] as ExpressLayerType;
 
         const rpcMetadata = getRPCMetadata(context.active());
-        if (rpcMetadata?.type === RPCType.HTTP) {
+        if (
+          rpcMetadata?.type === RPCType.HTTP &&
+          (!rpcMetadata.route || rpcMetadata?.route?.length < route?.length)
+        ) {
           rpcMetadata.route = route || '/';
         }
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?
- Fixes #2678
- When nested express routers used, wrong route set to `http.route` attribute in root span. But real route can be found deep inside of child spans which was created for middlewares or request handlers.

## Short description of the changes

- When capturing endpoint route - ignore it if it's shorter than saved one.


<img width="1512" alt="image" src="https://github.com/user-attachments/assets/52d32e0d-9532-4d45-b9d7-1f2b02189daa">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/8aab4364-2102-419e-9344-7aab29167858">

