### PR TITLE
chore: remove link to non existing file

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-pg/README.md
+++ b/plugins/node/opentelemetry-instrumentation-pg/README.md
@@ -38,8 +38,6 @@ registerInstrumentations({
 
 PgInstrumentation contains both pg and [`pg.Pool`](https://node-postgres.com/api/pool) so it will be instrumented automatically.
 
-See [examples/postgres](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/examples/postgres) for a short example.
-
 ### PostgreSQL Instrumentation Options
 
 PostgreSQL instrumentation has few options available to choose from. You can set the following:


### PR DESCRIPTION
The PR https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2171 removed the postgres example, but there was still a link to the file on the README file, which was now returning 404.

This PR remove the mention to the no longer existing file
