### PR TITLE
fix(baggage-span-processor): cannot find module

### DIFF
--- a/packages/baggage-span-processor/package.json
+++ b/packages/baggage-span-processor/package.json
@@ -2,7 +2,7 @@
   "name": "@opentelemetry/baggage-span-processor",
   "version": "0.3.0",
   "description": "OpenTelemetry Baggage Span Processor for Node.js",
-  "main": "build/src/index.ts",
+  "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "repository": "open-telemetry/opentelemetry-js-contrib",
   "scripts": {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Fixes the following error:
```
Error: Cannot find module '/Users/long/Repos/wise-rock/node_modules/@opentelemetry/baggage-span-processor/build/src/index.ts'. Please verify that the package.json has a valid "main" entry
    at tryPackage (node:internal/modules/cjs/loader:415:19)
    at Function.Module._findPath (node:internal/modules/cjs/loader:665:18)
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1034:27)
    at Function.Module._resolveFilename.sharedData.moduleResolveFilenameHook.installedValue (/Users/long/Repos/wise-rock/node_modules/@cspotcode/source-map-support/source-map-support.js:811:30)
    at Function.Module._resolveFilename (/Users/long/Repos/wise-rock/node_modules/tsconfig-paths/src/register.ts:115:36)
    at Function.Module._load (node:internal/modules/cjs/loader:901:27)
    at Module.require (node:internal/modules/cjs/loader:1115:19)
    at require (node:internal/modules/helpers:130:18)
    at Object.<anonymous> (/Users/long/Repos/wise-rock/apps/api/src/tracing.ts:3:1)
    at Module._compile (node:internal/modules/cjs/loader:1241:14) {
  code: 'MODULE_NOT_FOUND',
  path: '/Users/long/Repos/wise-rock/node_modules/@opentelemetry/baggage-span-processor/package.json',
  requestPath: '@opentelemetry/baggage-span-processor'
}
```

To reproduce, create a solution with otel and reference `BaggageSpanProcessor`. Compiles successfully but blows up during runtime.

## Short description of the changes

I looked at sibling packages and followed the same convention. I tested it locally by altering `node_modules/@opentelemetry/baggage-span-processor` directly to make sure it works. It worked after that.
