### PR TITLE
fix(instr-undici): wrong user agent reported if no user agent were set

### DIFF
--- a/plugins/node/instrumentation-undici/src/undici.ts
+++ b/plugins/node/instrumentation-undici/src/undici.ts
@@ -205,7 +205,9 @@ export class UndiciInstrumentation extends InstrumentationBase {
       const idx = request.headers.findIndex(
         h => h.toLowerCase() === 'user-agent'
       );
-      userAgent = request.headers[idx + 1];
+      if (idx >= 0) {
+        userAgent = request.headers[idx + 1];
+      }
     } else if (typeof request.headers === 'string') {
       const headers = request.headers.split('\r\n');
       const uaHeader = headers.find(h =>

--- a/plugins/node/instrumentation-undici/test/undici.test.ts
+++ b/plugins/node/instrumentation-undici/test/undici.test.ts
@@ -743,5 +743,43 @@ describe('UndiciInstrumentation `undici` tests', function () {
         },
       });
     });
+
+    it('should not report an user-agent if it was not defined', async function () {
+      let spans = memoryExporter.getFinishedSpans();
+      assert.strictEqual(spans.length, 0);
+
+      // Do some requests
+      const headers = {
+        'foo-client': 'bar',
+      };
+
+      const queryRequestUrl = `${protocol}://${hostname}:${mockServer.port}/?query=test`;
+      const queryResponse = await undici.request(queryRequestUrl, { headers });
+      await consumeResponseBody(queryResponse.body);
+
+      assert.ok(
+        queryResponse.headers['propagation-error'] == null,
+        'propagation is set for instrumented requests'
+      );
+
+      spans = memoryExporter.getFinishedSpans();
+      const span = spans[0];
+      assert.ok(span, 'a span is present');
+      assert.strictEqual(spans.length, 1);
+      assertSpan(span, {
+        hostname: 'localhost',
+        httpStatusCode: queryResponse.statusCode,
+        httpMethod: 'GET',
+        path: '/',
+        query: '?query=test',
+        reqHeaders: headers,
+        resHeaders: queryResponse.headers,
+      });
+      assert.strictEqual(
+        span.attributes['user_agent.original'],
+        undefined,
+        'user-agent is undefined'
+      );
+    });
   });
 });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- undici instrumentation wrongly reports the first header's name as the `user-agent` if no `user-agent` header was set (default behavior of `undici` from what I can tell)

## Short description of the changes

`request.headers.findIndex(h => h.toLowerCase() === 'user-agent')` returns `-1` if no `user-agent` header was present.

I added a check to avoid reporting `headers[0]` as `user-agent`


Added a test, not sure if it's useful? Especially as it might break in the future if `undici` decide to add a default `user-agent`