### PR TITLE
fix(instr-knex): handle config provider functions

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-knex/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-knex/test/index.test.ts
@@ -452,6 +452,27 @@ describe('Knex instrumentation', () => {
       );
     });
   });
+
+  it('works when knex is configured with connection function', async () => {
+    client = knex({
+      client: 'sqlite3',
+      // Use a function to configure the connection
+      connection: async () => ({
+        filename: ':memory:',
+      }),
+      useNullAsDefault: true,
+    });
+
+    await client.raw('SELECT 1');
+
+    const instrumentationSpans = memoryExporter.getFinishedSpans();
+    assert.strictEqual(instrumentationSpans.length, 1);
+    assert.strictEqual(instrumentationSpans[0].name, 'raw :memory:');
+    assert.strictEqual(
+      instrumentationSpans[0].attributes['net.transport'],
+      'inproc'
+    );
+  });
 });
 
 const assertSpans = (actualSpans: any[], expectedSpans: any[]) => {


### PR DESCRIPTION
## Which problem is this PR solving?

The knex connection configuration can be set with a static object, or with a function. From the [knex docs](https://knexjs.org/guide/#configuration-options):

> A function can be used to determine the connection configuration dynamically. This function receives no parameters, and returns either a configuration object or a promise for a configuration object.
>
> ```
> const knex = require('knex')({
>   client: 'sqlite3',
>   connection: () => ({
>     filename: process.env.SQLITE_FILENAME,
>   }),
> });
> ```

This instrumentation didn't handle the function case previously, resulting in `undefined` in the span name and a bunch of missing attributes.

## Short description of the changes

Instead of accessing properties in `client.config.connection`, the instrumentation should be accessing `client.connectionSettings`. This gets set for static configs [here](https://github.com/knex/knex/blob/f6ea8122b61af25cb20f445ee0d731d0a8eed567/lib/client.js#L76) and for config provider functions [here](https://github.com/knex/knex/blob/f6ea8122b61af25cb20f445ee0d731d0a8eed567/lib/client.js#L256)
