### PR TITLE
chore: add instrumentation metadata to package.json

### DIFF
--- a/plugins/node/instrumentation-amqplib/package.json
+++ b/plugins/node/instrumentation-amqplib/package.json
@@ -44,7 +44,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "AmqplibInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/instrumentation-amqplib/package.json
+++ b/plugins/node/instrumentation-amqplib/package.json
@@ -41,6 +41,10 @@
     "watch": "tsc -w",
     "test:docker:run": "docker run -d --hostname demo-amqplib-rabbit --name amqplib-unittests -p 22221:5672 --env RABBITMQ_DEFAULT_USER=username --env RABBITMQ_DEFAULT_PASS=password rabbitmq:3"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"
   },

--- a/plugins/node/instrumentation-amqplib/package.json
+++ b/plugins/node/instrumentation-amqplib/package.json
@@ -42,8 +42,14 @@
     "test:docker:run": "docker run -d --hostname demo-amqplib-rabbit --name amqplib-unittests -p 22221:5672 --env RABBITMQ_DEFAULT_USER=username --env RABBITMQ_DEFAULT_PASS=password rabbitmq:3"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/plugins/node/instrumentation-cucumber/package.json
+++ b/plugins/node/instrumentation-cucumber/package.json
@@ -20,8 +20,14 @@
     "compile": "tsc -p ."
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "cucumber",

--- a/plugins/node/instrumentation-cucumber/package.json
+++ b/plugins/node/instrumentation-cucumber/package.json
@@ -19,6 +19,10 @@
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p ."
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "cucumber",
     "instrumentation",

--- a/plugins/node/instrumentation-cucumber/package.json
+++ b/plugins/node/instrumentation-cucumber/package.json
@@ -22,7 +22,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "CucumberInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/instrumentation-dataloader/package.json
+++ b/plugins/node/instrumentation-dataloader/package.json
@@ -18,6 +18,10 @@
     "test-all-versions": "tav",
     "version:update": "node ../../../scripts/version-update.js"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "dataloader",
     "instrumentation",

--- a/plugins/node/instrumentation-dataloader/package.json
+++ b/plugins/node/instrumentation-dataloader/package.json
@@ -19,8 +19,14 @@
     "version:update": "node ../../../scripts/version-update.js"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "dataloader",

--- a/plugins/node/instrumentation-dataloader/package.json
+++ b/plugins/node/instrumentation-dataloader/package.json
@@ -21,7 +21,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "DataloaderInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/instrumentation-fs/package.json
+++ b/plugins/node/instrumentation-fs/package.json
@@ -18,6 +18,10 @@
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p ."
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "fs",
     "instrumentation",

--- a/plugins/node/instrumentation-fs/package.json
+++ b/plugins/node/instrumentation-fs/package.json
@@ -21,7 +21,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "FsInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/instrumentation-fs/package.json
+++ b/plugins/node/instrumentation-fs/package.json
@@ -19,8 +19,14 @@
     "compile": "tsc -p ."
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "fs",

--- a/plugins/node/instrumentation-kafkajs/package.json
+++ b/plugins/node/instrumentation-kafkajs/package.json
@@ -19,8 +19,14 @@
     "compile": "tsc -p ."
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "kafkajs",

--- a/plugins/node/instrumentation-kafkajs/package.json
+++ b/plugins/node/instrumentation-kafkajs/package.json
@@ -18,6 +18,10 @@
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p ."
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "kafkajs",
     "instrumentation",

--- a/plugins/node/instrumentation-kafkajs/package.json
+++ b/plugins/node/instrumentation-kafkajs/package.json
@@ -21,7 +21,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "KafkajsInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/instrumentation-lru-memoizer/package.json
+++ b/plugins/node/instrumentation-lru-memoizer/package.json
@@ -19,6 +19,10 @@
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p ."
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "lru-memoizer",
     "instrumentation",

--- a/plugins/node/instrumentation-lru-memoizer/package.json
+++ b/plugins/node/instrumentation-lru-memoizer/package.json
@@ -22,7 +22,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "LruMemoizerInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/instrumentation-lru-memoizer/package.json
+++ b/plugins/node/instrumentation-lru-memoizer/package.json
@@ -20,8 +20,14 @@
     "compile": "tsc -p ."
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "lru-memoizer",

--- a/plugins/node/instrumentation-mongoose/package.json
+++ b/plugins/node/instrumentation-mongoose/package.json
@@ -23,7 +23,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "MongooseInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/instrumentation-mongoose/package.json
+++ b/plugins/node/instrumentation-mongoose/package.json
@@ -20,6 +20,10 @@
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p ."
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "mongodb",
     "mongoose",

--- a/plugins/node/instrumentation-mongoose/package.json
+++ b/plugins/node/instrumentation-mongoose/package.json
@@ -21,8 +21,14 @@
     "compile": "tsc -p ."
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "mongodb",

--- a/plugins/node/instrumentation-runtime-node/package.json
+++ b/plugins/node/instrumentation-runtime-node/package.json
@@ -20,7 +20,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "RuntimeNodeInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/instrumentation-runtime-node/package.json
+++ b/plugins/node/instrumentation-runtime-node/package.json
@@ -17,6 +17,10 @@
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "version:update": "node ../../../scripts/version-update.js"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",
   "engines": {

--- a/plugins/node/instrumentation-runtime-node/package.json
+++ b/plugins/node/instrumentation-runtime-node/package.json
@@ -18,8 +18,14 @@
     "version:update": "node ../../../scripts/version-update.js"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",

--- a/plugins/node/instrumentation-socket.io/package.json
+++ b/plugins/node/instrumentation-socket.io/package.json
@@ -19,6 +19,10 @@
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p ."
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "socket.io",
     "instrumentation",

--- a/plugins/node/instrumentation-socket.io/package.json
+++ b/plugins/node/instrumentation-socket.io/package.json
@@ -22,7 +22,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "SocketIoInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/instrumentation-socket.io/package.json
+++ b/plugins/node/instrumentation-socket.io/package.json
@@ -20,8 +20,14 @@
     "compile": "tsc -p ."
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "socket.io",

--- a/plugins/node/instrumentation-tedious/package.json
+++ b/plugins/node/instrumentation-tedious/package.json
@@ -19,8 +19,14 @@
     "version:update": "node ../../../scripts/version-update.js"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "instrumentation",

--- a/plugins/node/instrumentation-tedious/package.json
+++ b/plugins/node/instrumentation-tedious/package.json
@@ -18,6 +18,10 @@
     "test-all-versions": "tav",
     "version:update": "node ../../../scripts/version-update.js"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "instrumentation",
     "microsoft",

--- a/plugins/node/instrumentation-tedious/package.json
+++ b/plugins/node/instrumentation-tedious/package.json
@@ -21,7 +21,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "TediousInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/instrumentation-undici/package.json
+++ b/plugins/node/instrumentation-undici/package.json
@@ -22,7 +22,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "UndiciInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/instrumentation-undici/package.json
+++ b/plugins/node/instrumentation-undici/package.json
@@ -19,6 +19,10 @@
     "prewatch": "npm run precompile",
     "version:update": "node ../../../scripts/version-update.js"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "opentelemetry",
     "fetch",

--- a/plugins/node/instrumentation-undici/package.json
+++ b/plugins/node/instrumentation-undici/package.json
@@ -20,8 +20,14 @@
     "version:update": "node ../../../scripts/version-update.js"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "opentelemetry",

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
@@ -19,8 +19,14 @@
     "compile": "tsc -p ."
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "aws-lambda",

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
@@ -18,6 +18,10 @@
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p ."
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "aws-lambda",
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
@@ -21,7 +21,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "AwsLambdaInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
@@ -42,8 +42,14 @@
     "watch": "tsc -w"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
@@ -44,7 +44,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "AwsInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
@@ -41,6 +41,10 @@
     "version:update": "node ../../../scripts/version-update.js",
     "watch": "tsc -w"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"
   },

--- a/plugins/node/opentelemetry-instrumentation-bunyan/package.json
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/package.json
@@ -19,8 +19,14 @@
     "version:update": "node ../../../scripts/version-update.js"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "bunyan",

--- a/plugins/node/opentelemetry-instrumentation-bunyan/package.json
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/package.json
@@ -21,7 +21,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "BunyanInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-bunyan/package.json
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/package.json
@@ -18,6 +18,10 @@
     "test-all-versions": "tav",
     "version:update": "node ../../../scripts/version-update.js"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "bunyan",
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-cassandra/package.json
+++ b/plugins/node/opentelemetry-instrumentation-cassandra/package.json
@@ -18,6 +18,10 @@
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p ."
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "cassandra-driver",
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-cassandra/package.json
+++ b/plugins/node/opentelemetry-instrumentation-cassandra/package.json
@@ -19,8 +19,14 @@
     "compile": "tsc -p ."
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "cassandra-driver",

--- a/plugins/node/opentelemetry-instrumentation-cassandra/package.json
+++ b/plugins/node/opentelemetry-instrumentation-cassandra/package.json
@@ -21,7 +21,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "CassandraDriverInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-connect/package.json
+++ b/plugins/node/opentelemetry-instrumentation-connect/package.json
@@ -19,8 +19,14 @@
     "watch": "tsc -w"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "connect",

--- a/plugins/node/opentelemetry-instrumentation-connect/package.json
+++ b/plugins/node/opentelemetry-instrumentation-connect/package.json
@@ -21,7 +21,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "ConnectInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-connect/package.json
+++ b/plugins/node/opentelemetry-instrumentation-connect/package.json
@@ -18,6 +18,10 @@
     "version:update": "node ../../../scripts/version-update.js",
     "watch": "tsc -w"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "connect",
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-dns/package.json
+++ b/plugins/node/opentelemetry-instrumentation-dns/package.json
@@ -21,7 +21,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "DnsInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-dns/package.json
+++ b/plugins/node/opentelemetry-instrumentation-dns/package.json
@@ -19,8 +19,14 @@
     "compile": "tsc -p ."
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "dns",

--- a/plugins/node/opentelemetry-instrumentation-dns/package.json
+++ b/plugins/node/opentelemetry-instrumentation-dns/package.json
@@ -18,6 +18,10 @@
     "lint:readme": "node ../../../scripts/lint-readme",
     "compile": "tsc -p ."
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "dns",
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-express/package.json
+++ b/plugins/node/opentelemetry-instrumentation-express/package.json
@@ -23,7 +23,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "ExpressInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-express/package.json
+++ b/plugins/node/opentelemetry-instrumentation-express/package.json
@@ -20,6 +20,10 @@
     "prepublishOnly": "npm run compile",
     "watch": "tsc -w"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "express",
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-express/package.json
+++ b/plugins/node/opentelemetry-instrumentation-express/package.json
@@ -21,8 +21,14 @@
     "watch": "tsc -w"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "express",

--- a/plugins/node/opentelemetry-instrumentation-fastify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-fastify/package.json
@@ -20,8 +20,14 @@
     "watch": "tsc -w"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "fastify",

--- a/plugins/node/opentelemetry-instrumentation-fastify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-fastify/package.json
@@ -19,6 +19,10 @@
     "prewatch": "npm run precompile",
     "watch": "tsc -w"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "fastify",
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-fastify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-fastify/package.json
@@ -22,7 +22,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "FastifyInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
+++ b/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
@@ -20,8 +20,14 @@
     "watch": "tsc -w"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "generic-pool",

--- a/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
+++ b/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
@@ -22,7 +22,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "GenericPoolInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
+++ b/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
@@ -19,6 +19,10 @@
     "prepublishOnly": "npm run compile",
     "watch": "tsc -w"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "generic-pool",
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-graphql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-graphql/package.json
@@ -20,6 +20,10 @@
     "version:update": "node ../../../scripts/version-update.js",
     "watch": "tsc -w"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "graphql",
     "metrics",

--- a/plugins/node/opentelemetry-instrumentation-graphql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-graphql/package.json
@@ -23,7 +23,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "GraphQLInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-graphql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-graphql/package.json
@@ -21,8 +21,14 @@
     "watch": "tsc -w"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "graphql",

--- a/plugins/node/opentelemetry-instrumentation-hapi/package.json
+++ b/plugins/node/opentelemetry-instrumentation-hapi/package.json
@@ -22,7 +22,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "HapiInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-hapi/package.json
+++ b/plugins/node/opentelemetry-instrumentation-hapi/package.json
@@ -20,8 +20,14 @@
     "prepublishOnly": "npm run compile"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "hapi",

--- a/plugins/node/opentelemetry-instrumentation-hapi/package.json
+++ b/plugins/node/opentelemetry-instrumentation-hapi/package.json
@@ -19,6 +19,10 @@
     "compile": "tsc -p .",
     "prepublishOnly": "npm run compile"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "hapi",
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-ioredis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/package.json
@@ -25,7 +25,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "IORedisInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-ioredis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/package.json
@@ -23,8 +23,14 @@
     "prepublishOnly": "npm run compile"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-ioredis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/package.json
@@ -22,6 +22,10 @@
     "compile": "tsc -p .",
     "prepublishOnly": "npm run compile"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "instrumentation",
     "ioredis",

--- a/plugins/node/opentelemetry-instrumentation-knex/package.json
+++ b/plugins/node/opentelemetry-instrumentation-knex/package.json
@@ -20,8 +20,14 @@
     "watch": "tsc -w"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-knex/package.json
+++ b/plugins/node/opentelemetry-instrumentation-knex/package.json
@@ -22,7 +22,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "KnexInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-knex/package.json
+++ b/plugins/node/opentelemetry-instrumentation-knex/package.json
@@ -19,6 +19,10 @@
     "prepublishOnly": "npm run compile",
     "watch": "tsc -w"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "instrumentation",
     "knex",

--- a/plugins/node/opentelemetry-instrumentation-koa/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/package.json
@@ -23,7 +23,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "KoaInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-koa/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/package.json
@@ -20,6 +20,10 @@
     "prepublishOnly": "npm run compile",
     "watch": "tsc -w"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "instrumentation",
     "koa",

--- a/plugins/node/opentelemetry-instrumentation-koa/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/package.json
@@ -21,8 +21,14 @@
     "watch": "tsc -w"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-memcached/package.json
+++ b/plugins/node/opentelemetry-instrumentation-memcached/package.json
@@ -19,6 +19,10 @@
     "test:local": "cross-env RUN_MEMCACHED_TESTS_LOCAL=true npm run test",
     "version:update": "node ../../../scripts/version-update.js"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "instrumentation",
     "memcached",

--- a/plugins/node/opentelemetry-instrumentation-memcached/package.json
+++ b/plugins/node/opentelemetry-instrumentation-memcached/package.json
@@ -20,8 +20,14 @@
     "version:update": "node ../../../scripts/version-update.js"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-memcached/package.json
+++ b/plugins/node/opentelemetry-instrumentation-memcached/package.json
@@ -22,7 +22,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "MemcachedInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-mongodb/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/package.json
@@ -27,7 +27,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "MongoDBInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-mongodb/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/package.json
@@ -25,8 +25,14 @@
     "watch": "tsc -w"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "mongodb",

--- a/plugins/node/opentelemetry-instrumentation-mongodb/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/package.json
@@ -24,6 +24,10 @@
     "prepublishOnly": "npm run compile",
     "watch": "tsc -w"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "mongodb",
     "nodejs",

--- a/plugins/node/opentelemetry-instrumentation-mysql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql/package.json
@@ -20,7 +20,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "MySQLInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-mysql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql/package.json
@@ -17,6 +17,10 @@
     "test": "nyc ts-mocha -p tsconfig.json 'test/**/*.test.ts'",
     "version:update": "node ../../../scripts/version-update.js"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "instrumentation",
     "mysql",

--- a/plugins/node/opentelemetry-instrumentation-mysql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql/package.json
@@ -18,8 +18,14 @@
     "version:update": "node ../../../scripts/version-update.js"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-mysql2/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/package.json
@@ -21,7 +21,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "MySQL2Instrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-mysql2/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/package.json
@@ -19,8 +19,14 @@
     "version:update": "node ../../../scripts/version-update.js"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-mysql2/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/package.json
@@ -18,6 +18,10 @@
     "test-all-versions": "tav",
     "version:update": "node ../../../scripts/version-update.js"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "instrumentation",
     "mysql",

--- a/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
+++ b/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
@@ -19,6 +19,10 @@
     "test-all-versions": "tav",
     "version:update": "node ../../../scripts/version-update.js"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "instrumentation",
     "nestjs",

--- a/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
+++ b/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
@@ -22,7 +22,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "NestInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
+++ b/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
@@ -20,8 +20,14 @@
     "version:update": "node ../../../scripts/version-update.js"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-net/package.json
+++ b/plugins/node/opentelemetry-instrumentation-net/package.json
@@ -19,8 +19,14 @@
     "compile": "tsc -p ."
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "connect",

--- a/plugins/node/opentelemetry-instrumentation-net/package.json
+++ b/plugins/node/opentelemetry-instrumentation-net/package.json
@@ -18,6 +18,10 @@
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p ."
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "connect",
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-net/package.json
+++ b/plugins/node/opentelemetry-instrumentation-net/package.json
@@ -21,7 +21,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "NetInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-pg/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pg/package.json
@@ -24,8 +24,14 @@
     "watch": "tsc -w"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-pg/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pg/package.json
@@ -26,7 +26,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "PgInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-pg/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pg/package.json
@@ -23,6 +23,10 @@
     "version:update": "node ../../../scripts/version-update.js",
     "watch": "tsc -w"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "instrumentation",
     "nodejs",

--- a/plugins/node/opentelemetry-instrumentation-pino/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pino/package.json
@@ -20,8 +20,14 @@
     "compile": "tsc -p ."
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-pino/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pino/package.json
@@ -19,6 +19,10 @@
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p ."
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "instrumentation",
     "logging",

--- a/plugins/node/opentelemetry-instrumentation-pino/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pino/package.json
@@ -22,7 +22,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "PinoInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-redis-4/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis-4/package.json
@@ -25,8 +25,14 @@
     "prepublishOnly": "npm run compile"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-redis-4/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis-4/package.json
@@ -27,7 +27,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "RedisInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-redis-4/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis-4/package.json
@@ -24,6 +24,10 @@
     "compile": "tsc -p .",
     "prepublishOnly": "npm run compile"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "instrumentation",
     "nodejs",

--- a/plugins/node/opentelemetry-instrumentation-redis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis/package.json
@@ -25,8 +25,14 @@
     "prepublishOnly": "npm run compile"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-redis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis/package.json
@@ -27,7 +27,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "RedisInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-redis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis/package.json
@@ -24,6 +24,10 @@
     "compile": "tsc -p .",
     "prepublishOnly": "npm run compile"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "instrumentation",
     "nodejs",

--- a/plugins/node/opentelemetry-instrumentation-restify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-restify/package.json
@@ -20,6 +20,10 @@
     "version:update": "node ../../../scripts/version-update.js",
     "watch": "tsc -w"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "instrumentation",
     "nodejs",

--- a/plugins/node/opentelemetry-instrumentation-restify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-restify/package.json
@@ -23,7 +23,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "RestifyInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-restify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-restify/package.json
@@ -21,8 +21,14 @@
     "watch": "tsc -w"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-router/package.json
+++ b/plugins/node/opentelemetry-instrumentation-router/package.json
@@ -20,8 +20,14 @@
     "watch": "tsc -w"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-router/package.json
+++ b/plugins/node/opentelemetry-instrumentation-router/package.json
@@ -19,6 +19,10 @@
     "prepublishOnly": "npm run compile",
     "watch": "tsc -w"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "instrumentation",
     "nodejs",

--- a/plugins/node/opentelemetry-instrumentation-router/package.json
+++ b/plugins/node/opentelemetry-instrumentation-router/package.json
@@ -22,7 +22,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "RouterInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-winston/package.json
+++ b/plugins/node/opentelemetry-instrumentation-winston/package.json
@@ -22,7 +22,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "WinstonInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "node"
         ]

--- a/plugins/node/opentelemetry-instrumentation-winston/package.json
+++ b/plugins/node/opentelemetry-instrumentation-winston/package.json
@@ -20,8 +20,14 @@
     "compile": "tsc -p ."
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["node"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "node"
+        ]
+      }
+    ]
   },
   "keywords": [
     "instrumentation",

--- a/plugins/node/opentelemetry-instrumentation-winston/package.json
+++ b/plugins/node/opentelemetry-instrumentation-winston/package.json
@@ -19,6 +19,10 @@
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "tsc -p ."
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["node"]
+  },
   "keywords": [
     "instrumentation",
     "logging",

--- a/plugins/web/opentelemetry-instrumentation-document-load/package.json
+++ b/plugins/web/opentelemetry-instrumentation-document-load/package.json
@@ -22,8 +22,14 @@
     "watch": "tsc --build -watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["web"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "web"
+        ]
+      }
+    ]
   },
   "keywords": [
     "opentelemetry",

--- a/plugins/web/opentelemetry-instrumentation-document-load/package.json
+++ b/plugins/web/opentelemetry-instrumentation-document-load/package.json
@@ -21,6 +21,10 @@
     "test:browser": "wtr --coverage",
     "watch": "tsc --build -watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["web"]
+  },
   "keywords": [
     "opentelemetry",
     "document-load",

--- a/plugins/web/opentelemetry-instrumentation-document-load/package.json
+++ b/plugins/web/opentelemetry-instrumentation-document-load/package.json
@@ -24,7 +24,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "DocumentLoadInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "web"
         ]

--- a/plugins/web/opentelemetry-instrumentation-long-task/package.json
+++ b/plugins/web/opentelemetry-instrumentation-long-task/package.json
@@ -22,8 +22,14 @@
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["web"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "web"
+        ]
+      }
+    ]
   },
   "keywords": [
     "opentelemetry",

--- a/plugins/web/opentelemetry-instrumentation-long-task/package.json
+++ b/plugins/web/opentelemetry-instrumentation-long-task/package.json
@@ -21,6 +21,10 @@
     "test:browser": "nyc karma start --single-run",
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["web"]
+  },
   "keywords": [
     "opentelemetry",
     "web",

--- a/plugins/web/opentelemetry-instrumentation-long-task/package.json
+++ b/plugins/web/opentelemetry-instrumentation-long-task/package.json
@@ -24,7 +24,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "LongTaskInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "web"
         ]

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
@@ -24,7 +24,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "UserInteractionInstrumentation",
+        "type": "instrumentation",
         "platforms": [
           "web"
         ]

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
@@ -22,8 +22,14 @@
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["web"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "web"
+        ]
+      }
+    ]
   },
   "keywords": [
     "opentelemetry",

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
@@ -21,6 +21,10 @@
     "test:browser": "karma start --single-run",
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["web"]
+  },
   "keywords": [
     "opentelemetry",
     "web",

--- a/plugins/web/opentelemetry-plugin-react-load/package.json
+++ b/plugins/web/opentelemetry-plugin-react-load/package.json
@@ -21,6 +21,10 @@
     "test:browser": "nyc karma start --single-run",
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json"
   },
+  "opentelemetry": {
+    "componentType": "instrumentation",
+    "platforms": ["web"]
+  },
   "keywords": [
     "opentelemetry",
     "react",

--- a/plugins/web/opentelemetry-plugin-react-load/package.json
+++ b/plugins/web/opentelemetry-plugin-react-load/package.json
@@ -22,8 +22,14 @@
     "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json"
   },
   "opentelemetry": {
-    "componentType": "instrumentation",
-    "platforms": ["web"]
+    "components": [
+      {
+        "componentType": "instrumentation",
+        "platforms": [
+          "web"
+        ]
+      }
+    ]
   },
   "keywords": [
     "opentelemetry",

--- a/plugins/web/opentelemetry-plugin-react-load/package.json
+++ b/plugins/web/opentelemetry-plugin-react-load/package.json
@@ -24,7 +24,8 @@
   "opentelemetry": {
     "components": [
       {
-        "componentType": "instrumentation",
+        "name": "BaseOpenTelemetryComponent",
+        "type": "instrumentation",
         "platforms": [
           "web"
         ]

--- a/scripts/lint-readme.js
+++ b/scripts/lint-readme.js
@@ -2,10 +2,6 @@ const fs = require('fs');
 const path = require('path');
 
 const packageRoot = process.cwd();
-const monorepoRoot = path.resolve(__dirname, '..');
-
-const autoInstrumentationNodeDeps = require(`${monorepoRoot}/metapackages/auto-instrumentations-node/package.json`).dependencies;
-const autoInstrumentationWebDeps = require(`${monorepoRoot}/metapackages/auto-instrumentations-web/package.json`).dependencies;
 
 // extract info from package.json
 const packageJsonUrl = path.resolve(`${packageRoot}/package.json`);

--- a/scripts/lint-readme.js
+++ b/scripts/lint-readme.js
@@ -23,7 +23,7 @@ if (!pjson.opentelemetry.components || pjson.opentelemetry.components.length !==
 
 // only instrumentations are supported at the moment
 const componentMetadata = pjson.opentelemetry.components[0];
-if (componentMetadata.componentType !== 'instrumentation') {
+if (componentMetadata.type !== 'instrumentation') {
   throw new Error(
     `package.json should contain a component of type "instrumentation" in "opentelemetry" property.`
   );

--- a/scripts/lint-readme.js
+++ b/scripts/lint-readme.js
@@ -12,9 +12,15 @@ const packageJsonUrl = path.resolve(`${packageRoot}/package.json`);
 const pjson = require(packageJsonUrl);
 const instrumentationPackageName = pjson.name;
 
+if (!pjson.opentelemetry) {
+  throw new Error(
+    `package.json is missing the "opentelemetry" field. Please add it.`
+  );
+}
+
 // identify if it's node or web
-const isNode = instrumentationPackageName in autoInstrumentationNodeDeps;
-const isWeb = instrumentationPackageName in autoInstrumentationWebDeps;
+const isNode = 'node' in pjson.opentelemetry.platforms;
+const isWeb = 'web' in pjson.opentelemetry.platforms;
 
 // extract info from README.md
 const currentReadmeContent = fs.readFileSync(

--- a/scripts/lint-readme.js
+++ b/scripts/lint-readme.js
@@ -14,9 +14,37 @@ if (!pjson.opentelemetry) {
   );
 }
 
+// only packages that contains one component of type "instrumentation" are supported at the moment
+if (!pjson.opentelemetry.components || pjson.opentelemetry.components.length !== 1) {
+  throw new Error(
+    `package.json should contain only one component in "opentelemetry" property.`
+  );
+}
+
+// only instrumentations are supported at the moment
+const componentMetadata = pjson.opentelemetry.components[0];
+if (componentMetadata.componentType !== 'instrumentation') {
+  throw new Error(
+    `package.json should contain a component of type "instrumentation" in "opentelemetry" property.`
+  );
+}
+
+// each instrumentation should target either node or web
+if (!componentMetadata.platforms || componentMetadata.platforms.length !== 1) {
+  throw new Error(
+    `package.json should contain exactly one of "node" or "web" in "platforms" property of the instrumentation component.`
+  );
+}
+
 // identify if it's node or web
-const isNode = 'node' in pjson.opentelemetry.platforms;
-const isWeb = 'web' in pjson.opentelemetry.platforms;
+const isNode = componentMetadata.platforms.includes('node');
+const isWeb = componentMetadata.platforms.includes('web');
+
+if (isNode === isWeb) {
+  throw new Error(
+    `package.json should populate exactly one of "node" or "web" in "platforms" property of the instrumentation component.`
+  );
+}
 
 // extract info from README.md
 const currentReadmeContent = fs.readFileSync(


### PR DESCRIPTION
This is the first implementation of https://github.com/open-telemetry/opentelemetry-js/issues/4725 into the contrib repo.

It adds metadata on the OpenTelemetry components that are exported from this npm package (which at the moment is one per package, but not always the case, for example [`opentelemetry-resource-detector-aws`](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-aws) which exports multiple detectors.

For each component, one can currently publish its:
- `name` the name of the component as exported from the package. currently not used in this PR but intended to be added to auto-create the code example for each instrumentation.
- `componentType` - "instrumentation". In the future we can add metadata to more components and this field can identify if the component is "instrumentation" / "sampler" / "propagator" / resource-detector" etc.
- `platforms` - an array with either "node" or "web".  instrumentations are always either web or node, but I want to keep it generic so we can mark future non-instrumentation components as both web and node, or add additional platforms if the need arise (like deno).

I have updated the lint-markdown script to use this info directly from the package itself, instead of reading it indirectly from the auto-instrumentation packages dependencies.

After this one merges, I will work on adding and utilizing more metadata as followup PRs as described in the issue.