### PR TITLE
fix!: export instrumentations only as named export

### DIFF
--- a/plugins/node/instrumentation-dataloader/src/index.ts
+++ b/plugins/node/instrumentation-dataloader/src/index.ts
@@ -15,4 +15,4 @@
  */
 
 export * from './types';
-export { DataloaderInstrumentation } from './instrumentation';
+export * from './instrumentation';

--- a/plugins/node/instrumentation-fs/src/index.ts
+++ b/plugins/node/instrumentation-fs/src/index.ts
@@ -14,11 +14,5 @@
  * limitations under the License.
  */
 
-import FsInstrumentation from './instrumentation';
-
-export { FsInstrumentation };
-
 export * from './instrumentation';
 export * from './types';
-
-export default FsInstrumentation;

--- a/plugins/node/instrumentation-fs/src/instrumentation.ts
+++ b/plugins/node/instrumentation-fs/src/instrumentation.ts
@@ -51,7 +51,7 @@ function patchedFunctionWithOriginalProperties<
   return Object.assign(patchedFunction, original);
 }
 
-export default class FsInstrumentation extends InstrumentationBase {
+export class FsInstrumentation extends InstrumentationBase {
   constructor(config: FsInstrumentationConfig = {}) {
     super(PACKAGE_NAME, PACKAGE_VERSION, config);
   }

--- a/plugins/node/instrumentation-fs/test/fs.test.ts
+++ b/plugins/node/instrumentation-fs/test/fs.test.ts
@@ -22,7 +22,7 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 import * as assert from 'assert';
 import { promisify } from 'util';
-import Instrumentation from '../src';
+import { FsInstrumentation } from '../src';
 import * as sinon from 'sinon';
 import type * as FSType from 'fs';
 import tests, { TestCase, TestCreator } from './definitions';
@@ -66,12 +66,12 @@ provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
 describe('fs instrumentation', () => {
   let contextManager: AsyncHooksContextManager;
   let fs: typeof FSType;
-  let plugin: Instrumentation;
+  let plugin: FsInstrumentation;
 
   beforeEach(async () => {
     contextManager = new AsyncHooksContextManager();
     context.setGlobalContextManager(contextManager.enable());
-    plugin = new Instrumentation(pluginConfig);
+    plugin = new FsInstrumentation(pluginConfig);
     plugin.setTracerProvider(provider);
     plugin.enable();
     fs = require('fs');

--- a/plugins/node/instrumentation-fs/test/fsHooks.test.ts
+++ b/plugins/node/instrumentation-fs/test/fsHooks.test.ts
@@ -19,7 +19,7 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 import * as assert from 'assert';
-import Instrumentation from '../src';
+import { FsInstrumentation } from '../src';
 import * as sinon from 'sinon';
 import type * as FSType from 'fs';
 import type { FsInstrumentationConfig } from '../src/types';
@@ -76,11 +76,11 @@ const assertFailingCallHooks = (expectedFunctionName: string) => {
 };
 
 describe('fs instrumentation: hooks', () => {
-  let plugin: Instrumentation;
+  let plugin: FsInstrumentation;
   let fs: typeof FSType;
 
   beforeEach(async () => {
-    plugin = new Instrumentation(pluginConfig);
+    plugin = new FsInstrumentation(pluginConfig);
     plugin.setTracerProvider(provider);
     plugin.setConfig(pluginConfig as FsInstrumentationConfig);
     plugin.enable();

--- a/plugins/node/instrumentation-fs/test/fsPromises.test.ts
+++ b/plugins/node/instrumentation-fs/test/fsPromises.test.ts
@@ -21,7 +21,7 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 import * as assert from 'assert';
-import Instrumentation from '../src';
+import { FsInstrumentation } from '../src';
 import * as sinon from 'sinon';
 import type * as FSPromisesType from 'fs/promises';
 import tests, { FsFunction, TestCase, TestCreator } from './definitions';
@@ -45,12 +45,12 @@ provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
 describe('fs/promises instrumentation', () => {
   let contextManager: AsyncHooksContextManager;
   let fsPromises: typeof FSPromisesType;
-  let plugin: Instrumentation;
+  let plugin: FsInstrumentation;
 
   beforeEach(async () => {
     contextManager = new AsyncHooksContextManager();
     context.setGlobalContextManager(contextManager.enable());
-    plugin = new Instrumentation(pluginConfig);
+    plugin = new FsInstrumentation(pluginConfig);
     plugin.setTracerProvider(provider);
     plugin.enable();
     fsPromises = require('fs/promises');

--- a/plugins/node/instrumentation-fs/test/fsPromisesHooks.test.ts
+++ b/plugins/node/instrumentation-fs/test/fsPromisesHooks.test.ts
@@ -19,7 +19,7 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 import * as assert from 'assert';
-import Instrumentation from '../src';
+import { FsInstrumentation } from '../src';
 import * as sinon from 'sinon';
 import type * as FSPromisesType from 'fs/promises';
 import type { FsInstrumentationConfig } from '../src/types';
@@ -80,11 +80,11 @@ const assertFailingCallHooks = (expectedFunctionName: string) => {
 const fsConstantsR_OK = 4;
 
 describe('fs/promises instrumentation: hooks', () => {
-  let plugin: Instrumentation;
+  let plugin: FsInstrumentation;
   let fsPromises: typeof FSPromisesType;
 
   beforeEach(async () => {
-    plugin = new Instrumentation(pluginConfig);
+    plugin = new FsInstrumentation(pluginConfig);
     plugin.setTracerProvider(provider);
     plugin.setConfig(pluginConfig as FsInstrumentationConfig);
     plugin.enable();

--- a/plugins/node/instrumentation-fs/test/parent.test.ts
+++ b/plugins/node/instrumentation-fs/test/parent.test.ts
@@ -18,7 +18,7 @@ import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
-import Instrumentation from '../src';
+import { FsInstrumentation } from '../src';
 import * as assert from 'assert';
 import type * as FSType from 'fs';
 import type { FsInstrumentationConfig } from '../src/types';
@@ -32,14 +32,14 @@ provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
 const tracer = provider.getTracer('default');
 
 describe('fs instrumentation: requireParentSpan', () => {
-  let plugin: Instrumentation;
+  let plugin: FsInstrumentation;
   let fs: typeof FSType;
   let ambientContext: api.Context;
   let endRootSpan: () => void;
   let expectedAmbientSpanCount: number;
 
   const initializePlugin = (pluginConfig: FsInstrumentationConfig) => {
-    plugin = new Instrumentation();
+    plugin = new FsInstrumentation();
     plugin.setTracerProvider(provider);
     plugin.setConfig(pluginConfig);
     plugin.enable();

--- a/plugins/node/instrumentation-lru-memoizer/src/index.ts
+++ b/plugins/node/instrumentation-lru-memoizer/src/index.ts
@@ -14,8 +14,4 @@
  * limitations under the License.
  */
 
-import LruMemoizerInstrumentation from './instrumentation';
-
-export { LruMemoizerInstrumentation };
-
-export default LruMemoizerInstrumentation;
+export * from './instrumentation';

--- a/plugins/node/instrumentation-lru-memoizer/src/instrumentation.ts
+++ b/plugins/node/instrumentation-lru-memoizer/src/instrumentation.ts
@@ -22,7 +22,7 @@ import {
 } from '@opentelemetry/instrumentation';
 import { PACKAGE_NAME, PACKAGE_VERSION } from './version';
 
-export default class LruMemoizerInstrumentation extends InstrumentationBase {
+export class LruMemoizerInstrumentation extends InstrumentationBase {
   constructor(config: InstrumentationConfig = {}) {
     super(PACKAGE_NAME, PACKAGE_VERSION, config);
   }

--- a/plugins/node/instrumentation-lru-memoizer/test/index.test.ts
+++ b/plugins/node/instrumentation-lru-memoizer/test/index.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import LruMemoizerInstrumentation from '../src';
+import { LruMemoizerInstrumentation } from '../src';
 import { trace, context } from '@opentelemetry/api';
 import { expect } from 'expect';
 

--- a/plugins/node/instrumentation-runtime-node/src/index.ts
+++ b/plugins/node/instrumentation-runtime-node/src/index.ts
@@ -13,5 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { RuntimeNodeInstrumentation } from './instrumentation';
-export { RuntimeNodeInstrumentationConfig } from './types';
+
+export * from './instrumentation';
+export * from './types';

--- a/plugins/node/instrumentation-tedious/src/index.ts
+++ b/plugins/node/instrumentation-tedious/src/index.ts
@@ -14,9 +14,5 @@
  * limitations under the License.
  */
 
-import { TediousInstrumentation } from './instrumentation';
-
 export * from './instrumentation';
-export default TediousInstrumentation;
-
 export * from './types';

--- a/plugins/node/instrumentation-undici/src/index.ts
+++ b/plugins/node/instrumentation-undici/src/index.ts
@@ -16,13 +16,3 @@
 
 export * from './undici';
 export * from './types';
-
-export { UndiciInstrumentation } from './undici';
-export {
-  UndiciRequest,
-  UndiciResponse,
-  IgnoreRequestFunction,
-  RequestHookFunction,
-  StartSpanHookFunction,
-  UndiciInstrumentationConfig,
-} from './types';

--- a/plugins/node/instrumentation-undici/src/index.ts
+++ b/plugins/node/instrumentation-undici/src/index.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+export * from './undici';
+export * from './types';
+
 export { UndiciInstrumentation } from './undici';
 export {
   UndiciRequest,

--- a/plugins/node/opentelemetry-instrumentation-generic-pool/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-generic-pool/src/index.ts
@@ -14,7 +14,4 @@
  * limitations under the License.
  */
 
-import GenericPoolInstrumentation from './instrumentation';
-
-export { GenericPoolInstrumentation };
-export default GenericPoolInstrumentation;
+export * from './instrumentation';

--- a/plugins/node/opentelemetry-instrumentation-generic-pool/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-generic-pool/src/instrumentation.ts
@@ -28,7 +28,7 @@ import { PACKAGE_NAME, PACKAGE_VERSION } from './version';
 
 const MODULE_NAME = 'generic-pool';
 
-export default class Instrumentation extends InstrumentationBase {
+export class GenericPoolInstrumentation extends InstrumentationBase {
   // only used for v2 - v2.3)
   private _isDisabled = false;
 

--- a/plugins/node/opentelemetry-instrumentation-generic-pool/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-generic-pool/test/index.test.ts
@@ -22,8 +22,8 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 
-import Instrumentation from '../src';
-const plugin = new Instrumentation();
+import { GenericPoolInstrumentation } from '../src';
+const plugin = new GenericPoolInstrumentation();
 
 import * as util from 'util';
 import * as genericPool from 'generic-pool';

--- a/plugins/node/opentelemetry-instrumentation-knex/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-knex/src/index.ts
@@ -14,9 +14,5 @@
  * limitations under the License.
  */
 
-import { KnexInstrumentation } from './instrumentation';
-
 export * from './instrumentation';
-export default KnexInstrumentation;
-
 export * from './types';

--- a/plugins/node/opentelemetry-instrumentation-knex/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-knex/test/index.test.ts
@@ -23,8 +23,8 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 import * as assert from 'assert';
 
-import Instrumentation from '../src';
-const plugin = new Instrumentation({
+import { KnexInstrumentation } from '../src';
+const plugin = new KnexInstrumentation({
   maxQueryLength: 50,
 });
 

--- a/plugins/node/opentelemetry-instrumentation-memcached/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-memcached/src/index.ts
@@ -14,9 +14,5 @@
  * limitations under the License.
  */
 
-import { Instrumentation } from './instrumentation';
-export * from './types';
-
 export * from './instrumentation';
-export default Instrumentation;
-export { Instrumentation as MemcachedInstrumentation };
+export * from './types';

--- a/plugins/node/opentelemetry-instrumentation-memcached/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-memcached/src/instrumentation.ts
@@ -31,7 +31,7 @@ import * as utils from './utils';
 import { InstrumentationConfig } from './types';
 import { PACKAGE_NAME, PACKAGE_VERSION } from './version';
 
-export class Instrumentation extends InstrumentationBase {
+export class MemcachedInstrumentation extends InstrumentationBase {
   static readonly COMPONENT = 'memcached';
   static readonly COMMON_ATTRIBUTES = {
     [SEMATTRS_DB_SYSTEM]: DBSYSTEMVALUES_MEMCACHED,
@@ -44,12 +44,16 @@ export class Instrumentation extends InstrumentationBase {
     super(
       PACKAGE_NAME,
       PACKAGE_VERSION,
-      Object.assign({}, Instrumentation.DEFAULT_CONFIG, config)
+      Object.assign({}, MemcachedInstrumentation.DEFAULT_CONFIG, config)
     );
   }
 
   override setConfig(config: InstrumentationConfig = {}) {
-    this._config = Object.assign({}, Instrumentation.DEFAULT_CONFIG, config);
+    this._config = Object.assign(
+      {},
+      MemcachedInstrumentation.DEFAULT_CONFIG,
+      config
+    );
   }
 
   init() {
@@ -97,7 +101,7 @@ export class Instrumentation extends InstrumentationBase {
           kind: api.SpanKind.CLIENT,
           attributes: {
             'memcached.version': moduleVersion,
-            ...Instrumentation.COMMON_ATTRIBUTES,
+            ...MemcachedInstrumentation.COMMON_ATTRIBUTES,
           },
         }
       );

--- a/plugins/node/opentelemetry-instrumentation-memcached/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-memcached/test/index.test.ts
@@ -30,7 +30,7 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 import type * as Memcached from 'memcached';
 import * as assert from 'assert';
-import Instrumentation from '../src';
+import { MemcachedInstrumentation } from '../src';
 import {
   DBSYSTEMVALUES_MEMCACHED,
   SEMATTRS_DB_SYSTEM,
@@ -40,7 +40,7 @@ import {
 } from '@opentelemetry/semantic-conventions';
 import * as util from 'util';
 
-const instrumentation = new Instrumentation();
+const instrumentation = new MemcachedInstrumentation();
 const memoryExporter = new InMemorySpanExporter();
 
 const CONFIG = {

--- a/plugins/node/opentelemetry-instrumentation-mysql2/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/src/index.ts
@@ -14,9 +14,5 @@
  * limitations under the License.
  */
 
-import { MySQL2Instrumentation } from './instrumentation';
-
 export * from './instrumentation';
-export default MySQL2Instrumentation;
-
 export * from './types';

--- a/plugins/node/opentelemetry-instrumentation-nestjs-core/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-nestjs-core/src/index.ts
@@ -14,9 +14,5 @@
  * limitations under the License.
  */
 
-import { Instrumentation } from './instrumentation';
-
 export * from './instrumentation';
-export { Instrumentation as NestInstrumentation };
-
 export * from './enums/AttributeNames';

--- a/plugins/node/opentelemetry-instrumentation-nestjs-core/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-nestjs-core/src/instrumentation.ts
@@ -35,10 +35,10 @@ import { AttributeNames, NestType } from './enums';
 
 const supportedVersions = ['>=4.0.0 <11'];
 
-export class Instrumentation extends InstrumentationBase {
+export class NestInstrumentation extends InstrumentationBase {
   static readonly COMPONENT = '@nestjs/core';
   static readonly COMMON_ATTRIBUTES = {
-    component: Instrumentation.COMPONENT,
+    component: NestInstrumentation.COMPONENT,
   };
 
   constructor(config: InstrumentationConfig = {}) {
@@ -47,7 +47,7 @@ export class Instrumentation extends InstrumentationBase {
 
   init() {
     const module = new InstrumentationNodeModuleDefinition(
-      Instrumentation.COMPONENT,
+      NestInstrumentation.COMPONENT,
       supportedVersions
     );
 
@@ -122,7 +122,7 @@ function createWrapNestFactoryCreate(
     ) {
       const span = tracer.startSpan('Create Nest App', {
         attributes: {
-          ...Instrumentation.COMMON_ATTRIBUTES,
+          ...NestInstrumentation.COMMON_ATTRIBUTES,
           [AttributeNames.TYPE]: NestType.APP_CREATION,
           [AttributeNames.VERSION]: moduleVersion,
           [AttributeNames.MODULE]: nestModule.name,
@@ -171,7 +171,7 @@ function createWrapCreateHandler(tracer: api.Tracer, moduleVersion?: string) {
       ) {
         const span = tracer.startSpan(spanName, {
           attributes: {
-            ...Instrumentation.COMMON_ATTRIBUTES,
+            ...NestInstrumentation.COMMON_ATTRIBUTES,
             [AttributeNames.VERSION]: moduleVersion,
             [AttributeNames.TYPE]: NestType.REQUEST_CONTEXT,
             [SEMATTRS_HTTP_METHOD]: req.method,
@@ -206,7 +206,7 @@ function createWrapHandler(
   const spanName = handler.name || 'anonymous nest handler';
   const options = {
     attributes: {
-      ...Instrumentation.COMMON_ATTRIBUTES,
+      ...NestInstrumentation.COMMON_ATTRIBUTES,
       [AttributeNames.VERSION]: moduleVersion,
       [AttributeNames.TYPE]: NestType.REQUEST_HANDLER,
       [AttributeNames.CALLBACK]: handler.name,

--- a/plugins/node/opentelemetry-instrumentation-restify/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/src/index.ts
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-import { RestifyInstrumentation } from './instrumentation';
-
 export * from './instrumentation';
-export default RestifyInstrumentation;
-
 export * from './enums/AttributeNames';
 export * from './types';

--- a/plugins/node/opentelemetry-instrumentation-restify/test/restify.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/test/restify.test.ts
@@ -24,7 +24,7 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 
-import RestifyInstrumentation from '../src';
+import { RestifyInstrumentation } from '../src';
 import * as types from '../src/internal-types';
 import { RestifyRequestInfo } from '../src/types';
 const plugin = new RestifyInstrumentation();

--- a/plugins/node/opentelemetry-instrumentation-router/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-router/src/index.ts
@@ -14,9 +14,5 @@
  * limitations under the License.
  */
 
-import RouterInstrumentation from './instrumentation';
-
-export { RouterInstrumentation };
-export default RouterInstrumentation;
-
+export * from './instrumentation';
 export * from './enums/AttributeNames';

--- a/plugins/node/opentelemetry-instrumentation-router/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-router/src/instrumentation.ts
@@ -36,7 +36,7 @@ import LayerType from './enums/LayerType';
 
 const supportedVersions = ['>=1.0.0 <2'];
 
-export default class RouterInstrumentation extends InstrumentationBase {
+export class RouterInstrumentation extends InstrumentationBase {
   constructor(config: InstrumentationConfig = {}) {
     super(PACKAGE_NAME, PACKAGE_VERSION, config);
   }

--- a/plugins/node/opentelemetry-instrumentation-router/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-router/test/index.test.ts
@@ -22,9 +22,9 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 
-import Instrumentation from '../src';
+import { RouterInstrumentation } from '../src';
 import { InstrumentationSpan } from '../src/internal-types';
-const plugin = new Instrumentation();
+const plugin = new RouterInstrumentation();
 
 import * as http from 'http';
 import * as Router from 'router';


### PR DESCRIPTION
This PR is targets how we name and export instrumentation classes from our packages across the repo, and introduces consistency and best practices to align the code base.

It makes it so that:
- each instrumentation class has the same name as the name it is exported with (few were called `Instrumentation` instead of `FooInstrumentation`)
- align the `index.ts` file to export consistently - everything from `instrumentation.ts` and `type.ts`. This is to remove complexity and promote safe practices. This aligns the few places which were too complex, to an equivalent import and export statements to align with most packages in the repo.
- Remove the default export of the instrumentation class from the few places where it was present. since all instrumentations supports named exports of the class, I assume very few people if any are actually importing an instrumentation this way, but it is possible however, and those users will have their transplation broken when upgrading to the new version and will need to update the import. 

### Benefits

- Consistency across the various packages in the repo - better maintenance and developing experince.
- Shorter code - remove some of the un-needed complexities in the `index.ts` files and replace with shorter equivalents. 
- better practices - the `types.ts` and `instrumentation.ts` files are intended to be user facing, and only export what the user is expected to consume. More on that in [the GUIDELINES](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/GUIDELINES.md#types). Exporting everything from those files will prevent accidentally forgetting to add new types to the `index.ts` as happen in the past

### Breaking Change

This PR is a breaking change by removing the default export for the following instrumentations:
- `fs`
- `lru-memoizer`
- `tedious`
- `generic-pool`
- `knex`
- `memcahed`
- `mysql2`
- `restify`
- `router`

As state above, it is possible breaking change, but very unlikely for real users as this style is supported for only few instrumentations. It will be published as minor patch which should not be pulled automatically by users that has caret dependency, so they need to actively pull new version and will observe the transpilation failing.