### PR TITLE
fix(host-metrics): make host metrics constructor options optional

### DIFF
--- a/packages/opentelemetry-host-metrics/README.md
+++ b/packages/opentelemetry-host-metrics/README.md
@@ -36,7 +36,7 @@ const meterProvider = new MeterProvider({
   readers: [reader],
 });
 
-const hostMetrics = new HostMetrics({ meterProvider, name: 'example-host-metrics' });
+const hostMetrics = new HostMetrics({ meterProvider });
 hostMetrics.start();
 ```
 

--- a/packages/opentelemetry-host-metrics/src/BaseMetrics.ts
+++ b/packages/opentelemetry-host-metrics/src/BaseMetrics.ts
@@ -25,12 +25,8 @@ import { PACKAGE_NAME, PACKAGE_VERSION } from './version';
 export interface MetricsCollectorConfig {
   // Meter Provider
   meterProvider?: MeterProvider;
-  // Character to be used to join metrics - default is "."
-  metricNameSeparator?: string;
   // Name of component
-  name: string;
-  // metric export endpoint
-  url?: string;
+  name?: string;
 }
 
 const DEFAULT_NAME = PACKAGE_NAME;
@@ -43,12 +39,14 @@ export abstract class BaseMetrics {
   protected _meter: Meter;
   private _name: string;
 
-  constructor(config: MetricsCollectorConfig) {
-    this._name = config.name || DEFAULT_NAME;
-    const meterProvider = config.meterProvider || metrics.getMeterProvider();
-    if (!config.meterProvider) {
+  constructor(config?: MetricsCollectorConfig) {
+    // Do not use `??` operator to allow falling back to default when the
+    // specified name is an empty string.
+    this._name = config?.name || DEFAULT_NAME;
+    if (config?.meterProvider == null) {
       this._logger.warn('No meter provider, using default');
     }
+    const meterProvider = config?.meterProvider ?? metrics.getMeterProvider();
     this._meter = meterProvider.getMeter(this._name, PACKAGE_VERSION);
   }
 

--- a/packages/opentelemetry-host-metrics/test/metric.test.ts
+++ b/packages/opentelemetry-host-metrics/test/metric.test.ts
@@ -103,9 +103,7 @@ describe('Host Metrics', () => {
 
   describe('constructor', () => {
     it('should create a new instance', () => {
-      const hostMetrics = new HostMetrics({
-        name: 'opentelemetry-host-metrics',
-      });
+      const hostMetrics = new HostMetrics();
       assert.ok(hostMetrics instanceof HostMetrics);
     });
 
@@ -114,7 +112,6 @@ describe('Host Metrics', () => {
 
       const hostMetrics = new HostMetrics({
         meterProvider,
-        name: 'opentelemetry-host-metrics',
       });
       hostMetrics.start();
       assert.ok(hostMetrics instanceof HostMetrics);


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Fixes https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2274

## Short description of the changes

- Fields of `MetricsCollectorConfig` should all be optional.
- Remove unused option fields.
