### PR TITLE
fix(@opentelemetry/instrumentation-winston): Removing error details when @opentelemetry/winston-transport is not available

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-winston/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-winston/src/instrumentation.ts
@@ -221,9 +221,7 @@ export class WinstonInstrumentation extends InstrumentationBase {
               args[0].transports = newTransports;
             } catch (err) {
               instrumentation._diag.warn(
-                'OpenTelemetry Winston transport is not available, log records will not be automatically sent.',
-                err
-              );
+                '@opentelemetry/winston-transport is not available, log records will not be automatically sent.');
             }
           }
         }

--- a/plugins/node/opentelemetry-instrumentation-winston/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-winston/src/instrumentation.ts
@@ -221,7 +221,8 @@ export class WinstonInstrumentation extends InstrumentationBase {
               args[0].transports = newTransports;
             } catch (err) {
               instrumentation._diag.warn(
-                '@opentelemetry/winston-transport is not available, log records will not be automatically sent.');
+                '@opentelemetry/winston-transport is not available, log records will not be automatically sent.'
+              );
             }
           }
         }


### PR DESCRIPTION
## Which problem is this PR solving?
Fixes #2244

## Short description of the changes
Removed error details in diag.warn call
