### PR TITLE
fix(koa)!: use generic config hook types and move dep to dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12632,6 +12632,7 @@
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.7.tgz",
       "integrity": "sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -12667,6 +12668,7 @@
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
       "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "dev": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -12716,6 +12718,7 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -12723,7 +12726,8 @@
     "node_modules/@types/content-disposition": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.8.tgz",
-      "integrity": "sha512-QVSSvno3dE0MgO76pJhmv4Qyi/j0Yk9pBp0Y7TJ2Tlj+KCgJWY6qX7nnxCOLkZ3VYRSIk1WTxCvwUSdx6CCLdg=="
+      "integrity": "sha512-QVSSvno3dE0MgO76pJhmv4Qyi/j0Yk9pBp0Y7TJ2Tlj+KCgJWY6qX7nnxCOLkZ3VYRSIk1WTxCvwUSdx6CCLdg==",
+      "dev": true
     },
     "node_modules/@types/convert-source-map": {
       "version": "2.0.3",
@@ -12741,6 +12745,7 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.9.0.tgz",
       "integrity": "sha512-40Zk8qR147RABiQ7NQnBzWzDcjKzNrntB5BAmeGCb2p/MIyOE+4BVvc17wumsUqUw00bJYqoXFHYygQnEFh4/Q==",
+      "dev": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/express": "*",
@@ -12793,6 +12798,7 @@
       "version": "4.17.18",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.18.tgz",
       "integrity": "sha512-Sxv8BSLLgsBYmcnGdGjjEjqET2U+AKAdCRODmMiq02FgjwuV75Ut85DRpvFjyw/Mk0vgUOliGRU0UUmuuZHByQ==",
+      "dev": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -12804,6 +12810,7 @@
       "version": "4.17.43",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.43.tgz",
       "integrity": "sha512-oaYtiBirUOPQGSWNGPWnzyAFJ0BP3cwvN4oWZQY+zUBwpVIGsKUkpBpSztp74drYcjavs7SKFZ4DX1V2QeN8rg==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -12824,12 +12831,14 @@
     "node_modules/@types/http-assert": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.5.tgz",
-      "integrity": "sha512-4+tE/lwdAahgZT1g30Jkdm9PzFRde0xwxBNUyRsCitRvCQB90iuA2uJYdUnhnANRcqGXaWOGY4FEoxeElNAK2g=="
+      "integrity": "sha512-4+tE/lwdAahgZT1g30Jkdm9PzFRde0xwxBNUyRsCitRvCQB90iuA2uJYdUnhnANRcqGXaWOGY4FEoxeElNAK2g==",
+      "dev": true
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+      "dev": true
     },
     "node_modules/@types/ioredis4": {
       "name": "@types/ioredis",
@@ -12889,12 +12898,14 @@
     "node_modules/@types/keygrip": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.6.tgz",
-      "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ=="
+      "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ==",
+      "dev": true
     },
     "node_modules/@types/koa": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.14.0.tgz",
-      "integrity": "sha512-DTDUyznHGNHAl+wd1n0z1jxNajduyTh8R53xoewuerdBzGo6Ogj6F2299BFtrexJw4NtgjsI5SMPCmV9gZwGXA==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.15.0.tgz",
+      "integrity": "sha512-7QFsywoE5URbuVnG3loe03QXuGajrnotr3gQkXcEBShORai23MePfFYdhz90FEtBBpkyIYQbVD+evKtloCgX3g==",
+      "dev": true,
       "dependencies": {
         "@types/accepts": "*",
         "@types/content-disposition": "*",
@@ -12907,9 +12918,10 @@
       }
     },
     "node_modules/@types/koa__router": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/@types/koa__router/-/koa__router-12.0.3.tgz",
-      "integrity": "sha512-5YUJVv6NwM1z7m6FuYpKfNLTZ932Z6EF6xy2BbtpJSyn13DKNQEkXVffFVSnJHxvwwWh2SAeumpjAYUELqgjyw==",
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/@types/koa__router/-/koa__router-12.0.4.tgz",
+      "integrity": "sha512-Y7YBbSmfXZpa/m5UGGzb7XadJIRBRnwNY9cdAojZGp65Cpe5MAP3mOZE7e3bImt8dfKS4UFcR16SLH8L/z7PBw==",
+      "dev": true,
       "dependencies": {
         "@types/koa": "*"
       }
@@ -12918,6 +12930,7 @@
       "version": "3.2.8",
       "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.8.tgz",
       "integrity": "sha512-4Olc63RY+MKvxMwVknCUDhRQX1pFQoBZ/lXcRLP69PQkEpze/0cr8LNqJQe5NFb/b19DWi2a5bTi2VAlQzhJuA==",
+      "dev": true,
       "dependencies": {
         "@types/koa": "*"
       }
@@ -12954,7 +12967,8 @@
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
@@ -13042,12 +13056,14 @@
     "node_modules/@types/qs": {
       "version": "6.9.11",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.11.tgz",
-      "integrity": "sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ=="
+      "integrity": "sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ==",
+      "dev": true
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "17.0.67",
@@ -13135,6 +13151,7 @@
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
       "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "dev": true,
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -13144,6 +13161,7 @@
       "version": "1.15.5",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.5.tgz",
       "integrity": "sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==",
+      "dev": true,
       "dependencies": {
         "@types/http-errors": "*",
         "@types/mime": "*",
@@ -38872,9 +38890,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.52.0",
-        "@opentelemetry/semantic-conventions": "^1.22.0",
-        "@types/koa": "2.14.0",
-        "@types/koa__router": "12.0.3"
+        "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
         "@koa/router": "12.0.0",
@@ -38884,6 +38900,8 @@
         "@opentelemetry/instrumentation-http": "^0.52.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
+        "@types/koa": "2.15.0",
+        "@types/koa__router": "12.0.4",
         "@types/mocha": "7.0.2",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.18",
@@ -52077,8 +52095,8 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
-        "@types/koa": "2.14.0",
-        "@types/koa__router": "12.0.3",
+        "@types/koa": "2.15.0",
+        "@types/koa__router": "12.0.4",
         "@types/mocha": "7.0.2",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.18",
@@ -56785,6 +56803,7 @@
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.7.tgz",
       "integrity": "sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -56820,6 +56839,7 @@
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
       "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "dev": true,
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -56869,6 +56889,7 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -56876,7 +56897,8 @@
     "@types/content-disposition": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.8.tgz",
-      "integrity": "sha512-QVSSvno3dE0MgO76pJhmv4Qyi/j0Yk9pBp0Y7TJ2Tlj+KCgJWY6qX7nnxCOLkZ3VYRSIk1WTxCvwUSdx6CCLdg=="
+      "integrity": "sha512-QVSSvno3dE0MgO76pJhmv4Qyi/j0Yk9pBp0Y7TJ2Tlj+KCgJWY6qX7nnxCOLkZ3VYRSIk1WTxCvwUSdx6CCLdg==",
+      "dev": true
     },
     "@types/convert-source-map": {
       "version": "2.0.3",
@@ -56894,6 +56916,7 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.9.0.tgz",
       "integrity": "sha512-40Zk8qR147RABiQ7NQnBzWzDcjKzNrntB5BAmeGCb2p/MIyOE+4BVvc17wumsUqUw00bJYqoXFHYygQnEFh4/Q==",
+      "dev": true,
       "requires": {
         "@types/connect": "*",
         "@types/express": "*",
@@ -56946,6 +56969,7 @@
       "version": "4.17.18",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.18.tgz",
       "integrity": "sha512-Sxv8BSLLgsBYmcnGdGjjEjqET2U+AKAdCRODmMiq02FgjwuV75Ut85DRpvFjyw/Mk0vgUOliGRU0UUmuuZHByQ==",
+      "dev": true,
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -56957,6 +56981,7 @@
       "version": "4.17.43",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.43.tgz",
       "integrity": "sha512-oaYtiBirUOPQGSWNGPWnzyAFJ0BP3cwvN4oWZQY+zUBwpVIGsKUkpBpSztp74drYcjavs7SKFZ4DX1V2QeN8rg==",
+      "dev": true,
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -56976,12 +57001,14 @@
     "@types/http-assert": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.5.tgz",
-      "integrity": "sha512-4+tE/lwdAahgZT1g30Jkdm9PzFRde0xwxBNUyRsCitRvCQB90iuA2uJYdUnhnANRcqGXaWOGY4FEoxeElNAK2g=="
+      "integrity": "sha512-4+tE/lwdAahgZT1g30Jkdm9PzFRde0xwxBNUyRsCitRvCQB90iuA2uJYdUnhnANRcqGXaWOGY4FEoxeElNAK2g==",
+      "dev": true
     },
     "@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA=="
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+      "dev": true
     },
     "@types/ioredis4": {
       "version": "npm:@types/ioredis@4.28.10",
@@ -57040,12 +57067,14 @@
     "@types/keygrip": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.6.tgz",
-      "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ=="
+      "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ==",
+      "dev": true
     },
     "@types/koa": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.14.0.tgz",
-      "integrity": "sha512-DTDUyznHGNHAl+wd1n0z1jxNajduyTh8R53xoewuerdBzGo6Ogj6F2299BFtrexJw4NtgjsI5SMPCmV9gZwGXA==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.15.0.tgz",
+      "integrity": "sha512-7QFsywoE5URbuVnG3loe03QXuGajrnotr3gQkXcEBShORai23MePfFYdhz90FEtBBpkyIYQbVD+evKtloCgX3g==",
+      "dev": true,
       "requires": {
         "@types/accepts": "*",
         "@types/content-disposition": "*",
@@ -57058,9 +57087,10 @@
       }
     },
     "@types/koa__router": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/@types/koa__router/-/koa__router-12.0.3.tgz",
-      "integrity": "sha512-5YUJVv6NwM1z7m6FuYpKfNLTZ932Z6EF6xy2BbtpJSyn13DKNQEkXVffFVSnJHxvwwWh2SAeumpjAYUELqgjyw==",
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/@types/koa__router/-/koa__router-12.0.4.tgz",
+      "integrity": "sha512-Y7YBbSmfXZpa/m5UGGzb7XadJIRBRnwNY9cdAojZGp65Cpe5MAP3mOZE7e3bImt8dfKS4UFcR16SLH8L/z7PBw==",
+      "dev": true,
       "requires": {
         "@types/koa": "*"
       }
@@ -57069,6 +57099,7 @@
       "version": "3.2.8",
       "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.8.tgz",
       "integrity": "sha512-4Olc63RY+MKvxMwVknCUDhRQX1pFQoBZ/lXcRLP69PQkEpze/0cr8LNqJQe5NFb/b19DWi2a5bTi2VAlQzhJuA==",
+      "dev": true,
       "requires": {
         "@types/koa": "*"
       }
@@ -57105,7 +57136,8 @@
     "@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.5",
@@ -57193,12 +57225,14 @@
     "@types/qs": {
       "version": "6.9.11",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.11.tgz",
-      "integrity": "sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ=="
+      "integrity": "sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ==",
+      "dev": true
     },
     "@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true
     },
     "@types/react": {
       "version": "17.0.67",
@@ -57288,6 +57322,7 @@
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
       "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "dev": true,
       "requires": {
         "@types/mime": "^1",
         "@types/node": "*"
@@ -57297,6 +57332,7 @@
       "version": "1.15.5",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.5.tgz",
       "integrity": "sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==",
+      "dev": true,
       "requires": {
         "@types/http-errors": "*",
         "@types/mime": "*",

--- a/plugins/node/opentelemetry-instrumentation-koa/README.md
+++ b/plugins/node/opentelemetry-instrumentation-koa/README.md
@@ -65,11 +65,18 @@ Note that generator-based middleware are deprecated and won't be instrumented.
 
 Instrumentation configuration accepts a custom "hook" function which will be called for every instrumented Koa middleware layer involved in a request. Custom attributes can be set on the span or run any custom logic per layer.
 
-```javascript
+NOTE: `KoaRequestInfo.context` and `KoaRequestInfo.middlewareLayer` are typed as `any`. If you want type support make sure you have `@types/koa` and `@types/koa__router` installed then you can use the following type definitions:
+
+```typescript
 import { KoaInstrumentation } from "@opentelemetry/instrumentation-koa"
+import type { Middleware, ParameterizedContext, DefaultState } from 'koa';
+import type { RouterParamContext } from '@koa/router';
+
+type KoaContext = ParameterizedContext<DefaultState, RouterParamContext>;
+type KoaMiddleware = Middleware<DefaultState, KoaContext>;
 
 const koaInstrumentation = new KoaInstrumentation({
-  requestHook: function (span: Span, info: KoaRequestInfo) {
+  requestHook: function (span: Span, info: KoaRequestInfo<KoaContext, KoaMiddleware>) {
     span.setAttribute(
       'http.method',
       info.context.request.method

--- a/plugins/node/opentelemetry-instrumentation-koa/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/package.json
@@ -53,6 +53,8 @@
     "@opentelemetry/instrumentation-http": "^0.52.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
+    "@types/koa": "2.15.0",
+    "@types/koa__router": "12.0.4",
     "@types/mocha": "7.0.2",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.18",
@@ -68,9 +70,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.52.0",
-    "@opentelemetry/semantic-conventions": "^1.22.0",
-    "@types/koa": "2.14.0",
-    "@types/koa__router": "12.0.3"
+    "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-koa#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-koa/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/src/instrumentation.ts
@@ -23,12 +23,13 @@ import {
 } from '@opentelemetry/instrumentation';
 
 import type * as koa from 'koa';
-import { KoaContext, KoaLayerType, KoaInstrumentationConfig } from './types';
+import { KoaLayerType, KoaInstrumentationConfig } from './types';
 import { PACKAGE_NAME, PACKAGE_VERSION } from './version';
 import { getMiddlewareMetadata, isLayerIgnored } from './utils';
 import { getRPCMetadata, RPCType } from '@opentelemetry/core';
 import {
   kLayerPatched,
+  KoaContext,
   KoaMiddleware,
   KoaPatchedMiddleware,
 } from './internal-types';

--- a/plugins/node/opentelemetry-instrumentation-koa/src/internal-types.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/src/internal-types.ts
@@ -16,7 +16,10 @@
 import type { Middleware, ParameterizedContext, DefaultState } from 'koa';
 import type * as Router from '@koa/router';
 
-export type KoaContext = ParameterizedContext<DefaultState, Router.RouterParamContext>;
+export type KoaContext = ParameterizedContext<
+  DefaultState,
+  Router.RouterParamContext
+>;
 export type KoaMiddleware = Middleware<DefaultState, KoaContext> & {
   router?: Router;
 };

--- a/plugins/node/opentelemetry-instrumentation-koa/src/internal-types.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/src/internal-types.ts
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { Middleware, DefaultState } from 'koa';
-import { KoaContext } from './types';
+import type { Middleware, ParameterizedContext, DefaultState } from 'koa';
 import type * as Router from '@koa/router';
 
+export type KoaContext = ParameterizedContext<DefaultState, Router.RouterParamContext>;
 export type KoaMiddleware = Middleware<DefaultState, KoaContext> & {
   router?: Router;
 };

--- a/plugins/node/opentelemetry-instrumentation-koa/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/src/types.ts
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { Middleware, ParameterizedContext, DefaultState } from 'koa';
-import type { RouterParamContext } from '@koa/router';
 import { Span } from '@opentelemetry/api';
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 
@@ -23,11 +21,30 @@ export enum KoaLayerType {
   MIDDLEWARE = 'middleware',
 }
 
-export type KoaContext = ParameterizedContext<DefaultState, RouterParamContext>;
-
-export type KoaRequestInfo = {
-  context: KoaContext;
-  middlewareLayer: Middleware<DefaultState, KoaContext>;
+/**
+ * Information about the current Koa middleware layer
+ * The middleware layer type is any by default.
+ * One can install koa types packages `@types/koa` and `@types/koa__router` 
+ * with compatible versions to the koa version used in the project
+ * to get more specific types for the middleware layer property.
+ * 
+ * Example use in a custom attribute function:
+ * ```ts
+ * import type { Middleware, ParameterizedContext, DefaultState } from 'koa';
+ * import type { RouterParamContext } from '@koa/router';
+ * 
+ * type KoaContext = ParameterizedContext<DefaultState, RouterParamContext>;
+ * type KoaMiddleware = Middleware<DefaultState, KoaContext>;
+ * 
+ * const koaConfig: KoaInstrumentationConfig<KoaContext, KoaMiddleware> = {
+ *  requestHook: (span: Span, info: KoaRequestInfo<KoaContext, KoaMiddleware>) => {
+ *   // custom typescript code that can access the typed into.middlewareLayer and info.context
+ * }
+ * 
+ */
+export type KoaRequestInfo<KoaContextType = any, KoaMiddlewareType = any> = {
+  context: KoaContextType;
+  middlewareLayer: KoaMiddlewareType;
   layerType: KoaLayerType;
 };
 
@@ -36,16 +53,16 @@ export type KoaRequestInfo = {
  * @param span - The Express middleware layer span.
  * @param context - The current KoaContext.
  */
-export interface KoaRequestCustomAttributeFunction {
-  (span: Span, info: KoaRequestInfo): void;
+export interface KoaRequestCustomAttributeFunction<KoaContextType = any, KoaMiddlewareType = any> {
+  (span: Span, info: KoaRequestInfo<KoaContextType, KoaMiddlewareType>): void;
 }
 
 /**
  * Options available for the Koa Instrumentation (see [documentation](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-Instrumentation-koa#koa-Instrumentation-options))
  */
-export interface KoaInstrumentationConfig extends InstrumentationConfig {
+export interface KoaInstrumentationConfig<KoaContextType = any, KoaMiddlewareType = any> extends InstrumentationConfig {
   /** Ignore specific layers based on their type */
   ignoreLayersType?: KoaLayerType[];
   /** Function for adding custom attributes to each middleware layer span */
-  requestHook?: KoaRequestCustomAttributeFunction;
+  requestHook?: KoaRequestCustomAttributeFunction<KoaContextType, KoaMiddlewareType>;
 }

--- a/plugins/node/opentelemetry-instrumentation-koa/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/src/types.ts
@@ -24,23 +24,23 @@ export enum KoaLayerType {
 /**
  * Information about the current Koa middleware layer
  * The middleware layer type is any by default.
- * One can install koa types packages `@types/koa` and `@types/koa__router` 
+ * One can install koa types packages `@types/koa` and `@types/koa__router`
  * with compatible versions to the koa version used in the project
  * to get more specific types for the middleware layer property.
- * 
+ *
  * Example use in a custom attribute function:
  * ```ts
  * import type { Middleware, ParameterizedContext, DefaultState } from 'koa';
  * import type { RouterParamContext } from '@koa/router';
- * 
+ *
  * type KoaContext = ParameterizedContext<DefaultState, RouterParamContext>;
  * type KoaMiddleware = Middleware<DefaultState, KoaContext>;
- * 
+ *
  * const koaConfig: KoaInstrumentationConfig<KoaContext, KoaMiddleware> = {
  *  requestHook: (span: Span, info: KoaRequestInfo<KoaContext, KoaMiddleware>) => {
  *   // custom typescript code that can access the typed into.middlewareLayer and info.context
  * }
- * 
+ *
  */
 export type KoaRequestInfo<KoaContextType = any, KoaMiddlewareType = any> = {
   context: KoaContextType;
@@ -53,16 +53,25 @@ export type KoaRequestInfo<KoaContextType = any, KoaMiddlewareType = any> = {
  * @param span - The Express middleware layer span.
  * @param context - The current KoaContext.
  */
-export interface KoaRequestCustomAttributeFunction<KoaContextType = any, KoaMiddlewareType = any> {
+export interface KoaRequestCustomAttributeFunction<
+  KoaContextType = any,
+  KoaMiddlewareType = any
+> {
   (span: Span, info: KoaRequestInfo<KoaContextType, KoaMiddlewareType>): void;
 }
 
 /**
  * Options available for the Koa Instrumentation (see [documentation](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-Instrumentation-koa#koa-Instrumentation-options))
  */
-export interface KoaInstrumentationConfig<KoaContextType = any, KoaMiddlewareType = any> extends InstrumentationConfig {
+export interface KoaInstrumentationConfig<
+  KoaContextType = any,
+  KoaMiddlewareType = any
+> extends InstrumentationConfig {
   /** Ignore specific layers based on their type */
   ignoreLayersType?: KoaLayerType[];
   /** Function for adding custom attributes to each middleware layer span */
-  requestHook?: KoaRequestCustomAttributeFunction<KoaContextType, KoaMiddlewareType>;
+  requestHook?: KoaRequestCustomAttributeFunction<
+    KoaContextType,
+    KoaMiddlewareType
+  >;
 }

--- a/plugins/node/opentelemetry-instrumentation-koa/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/src/utils.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { KoaContext, KoaLayerType, KoaInstrumentationConfig } from './types';
-import { KoaMiddleware } from './internal-types';
+import { KoaLayerType, KoaInstrumentationConfig } from './types';
+import { KoaContext, KoaMiddleware } from './internal-types';
 import { AttributeNames } from './enums/AttributeNames';
 import { Attributes } from '@opentelemetry/api';
 import { SEMATTRS_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';

--- a/plugins/node/opentelemetry-instrumentation-koa/test/koa.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/test/koa.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import type { Middleware, ParameterizedContext, DefaultState } from 'koa';
+import type { RouterParamContext } from '@koa/router';
 import * as KoaRouter from '@koa/router';
 import { context, trace, Span, SpanKind } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
@@ -28,6 +30,9 @@ import {
   SEMATTRS_HTTP_METHOD,
   SEMATTRS_HTTP_ROUTE,
 } from '@opentelemetry/semantic-conventions';
+
+type KoaContext = ParameterizedContext<DefaultState, RouterParamContext>;
+type KoaMiddleware = Middleware<DefaultState, KoaContext>;
 
 import { KoaInstrumentation } from '../src';
 const plugin = new KoaInstrumentation();
@@ -594,7 +599,7 @@ describe('Koa Instrumentation', () => {
         )
       );
 
-      const requestHook = sinon.spy((span: Span, info: KoaRequestInfo) => {
+      const requestHook = sinon.spy((span: Span, info: KoaRequestInfo<KoaContext, KoaMiddleware>) => {
         span.setAttribute(SEMATTRS_HTTP_METHOD, info.context.request.method);
 
         throw Error('error thrown in requestHook');
@@ -645,7 +650,7 @@ describe('Koa Instrumentation', () => {
         )
       );
 
-      const requestHook = sinon.spy((span: Span, info: KoaRequestInfo) => {
+      const requestHook = sinon.spy((span: Span, info: KoaRequestInfo<KoaContext, KoaMiddleware>) => {
         span.setAttribute('http.method', info.context.request.method);
         span.setAttribute('app.env', info.context.app.env);
         span.setAttribute('koa.layer', info.layerType);

--- a/plugins/node/opentelemetry-instrumentation-koa/test/koa.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/test/koa.test.ts
@@ -599,11 +599,13 @@ describe('Koa Instrumentation', () => {
         )
       );
 
-      const requestHook = sinon.spy((span: Span, info: KoaRequestInfo<KoaContext, KoaMiddleware>) => {
-        span.setAttribute(SEMATTRS_HTTP_METHOD, info.context.request.method);
+      const requestHook = sinon.spy(
+        (span: Span, info: KoaRequestInfo<KoaContext, KoaMiddleware>) => {
+          span.setAttribute(SEMATTRS_HTTP_METHOD, info.context.request.method);
 
-        throw Error('error thrown in requestHook');
-      });
+          throw Error('error thrown in requestHook');
+        }
+      );
 
       plugin.setConfig({
         requestHook,
@@ -650,11 +652,13 @@ describe('Koa Instrumentation', () => {
         )
       );
 
-      const requestHook = sinon.spy((span: Span, info: KoaRequestInfo<KoaContext, KoaMiddleware>) => {
-        span.setAttribute('http.method', info.context.request.method);
-        span.setAttribute('app.env', info.context.app.env);
-        span.setAttribute('koa.layer', info.layerType);
-      });
+      const requestHook = sinon.spy(
+        (span: Span, info: KoaRequestInfo<KoaContext, KoaMiddleware>) => {
+          span.setAttribute('http.method', info.context.request.method);
+          span.setAttribute('app.env', info.context.app.env);
+          span.setAttribute('koa.layer', info.layerType);
+        }
+      );
 
       plugin.setConfig({
         requestHook,


### PR DESCRIPTION
 fixes #2228 

This PR aims to remove the instrumentation package dependency on the koa types packages, by making the relevant types generic and defaulting to `any`. That allows users who choose to implement the hook, to either use type `any`, or install the relevant types packages and populate the generic parameters.

- [x] moved koa types packages to dev dependency instead of regular dependency
- [x] documented how to use in README
- [x] updated tests to verify it compiles correctly when used in recommended way
- [x] compiled the new code and verified that `d.ts` files transitively imported from `index.d.ts` do not import types from `@types/koa`, `@types/koa__router` or any other dev dependency

**Breaking Change** 

- this PR makes it so that `KoaContext` is no longer exported as public type from the package 
- some hook info properties type will change to `any` by default, which should not break anyone I believe, but will no not verified  this variable typing as before.

**Prior Art**

defaults to any and allow to use generics to type correctly:

- [express instrumentation](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-express#using-requesthook) see concensus [here](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1804#issuecomment-1843639947)

vendors part of the type as default, but allows to specify the full type when desired:
- [kafkajs](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/0ed40384287a8d06549c2a9c98a26ea9b068c472/plugins/node/instrumentation-kafkajs/src/types.ts#L32)
- [undici](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/0ed40384287a8d06549c2a9c98a26ea9b068c472/plugins/node/instrumentation-undici/src/types.ts#L46)
 
