### PR TITLE
chore: exempt dependencies, autorelease PRs from unmaintained-package autoclose

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -28,6 +28,7 @@ jobs:
 
           Are you familiar with this package? Consider [becoming a component owner](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/CONTRIBUTING.md#becoming-a-component-owner).'
           close-issue-message: 'This issue was closed because no owner or sponsor has been found after 14 days'
+          stale-issue-label: pkg-status:unmaintained:autoclose-scheduled
           only-labels: pkg-status:unmaintained,feature-request
           exempt-issue-labels: bug,has:sponsor,type:semconv-update
       - uses: actions/stale@v9
@@ -38,5 +39,6 @@ jobs:
 
           Are you familiar with this package? Consider [becoming a component owner](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/CONTRIBUTING.md#becoming-a-component-owner).'
           close-pr-message: 'This issue was closed because no owner or sponsor has been found after 14 days'
+          stale-pr-label: pkg-status:unmaintained:autoclose-scheduled
           only-labels: pkg-status:unmaintained
-          exempt-pr-labels: bug,has:sponsor,type:semconv-update
+          exempt-pr-labels: bug,has:sponsor,type:semconv-update,dependencies,autorelease:pending


### PR DESCRIPTION
See #2275, the `stale` label was applied and the bot commented even though it's a release PR (changes to unmaintained packages were part of that). 

This PR addresses two issues:

- To prevent `release-please` and `renovate-bot` from running into the 14-day autoclose for unmaintained packages this PR adds the labels `dependencies` and `autorelease:pending` to the exempt labels.
- To avoid misunderstandings, use `pkg-status:unmaintained:autoclose-scheduled` label instead of `stale`