### PR TITLE
ci: generate npm provenance statements when publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,8 @@ name: Run Release Please
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       # The logic below handles the npm publication:
       - name: Checkout Repository
@@ -75,4 +77,5 @@ jobs:
         if: ${{ steps.release.outputs.releases_created }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NPM_CONFIG_PROVENANCE: true
         run: npx lerna publish from-package --no-push --no-private --no-git-tag-version --no-verify-access --yes


### PR DESCRIPTION
## Which problem is this PR solving?

npm has a feature to display provenance statements for published packages. This allows users to see and verify how the package in npm has been built and published. Documentation for the npm feature is [here](https://docs.npmjs.com/generating-provenance-statements).

## Short description of the changes

Since this repository is already using a Github Actions workflow to publish to npm, the only change is to add the `id-token` permission and configure npm to publish with provenance. There are three options documented [here](https://docs.npmjs.com/generating-provenance-statements#using-third-party-package-publishing-tools):

- `NPM_CONFIG_PROVENANCE` env variable
- `publishConfig.provenance` configuration in package.json
- flag in .npmrc file

I have chosen the environment variable. The package.json option would require updating all package.json files for packages that are published. The npmrc option seems less visible to me than having it directly in the workflow.

I have not tested this with this repository (due to the `release-please` process). However, I setup a separate [repository for testing](https://github.com/martinkuba/provenance-test) from which I was able to simulate publishing similar to how it works here. An example of a published package with the provenance statement can be seen [here](https://www.npmjs.com/package/@martinkuba/provenance-test-pkg1).
