### PR TITLE
fix(auto-instrumentations-node): check if detector key in map rather than value false-iness

### DIFF
--- a/metapackages/auto-instrumentations-node/src/utils.ts
+++ b/metapackages/auto-instrumentations-node/src/utils.ts
@@ -273,12 +273,11 @@ export function getResourceDetectorsFromEnv(): Array<Detector | DetectorSync> {
   }
 
   return resourceDetectorsFromEnv.flatMap(detector => {
-    const resourceDetector = resourceDetectors.get(detector);
-    if (!resourceDetector) {
+    if (!resourceDetectors.has(detector)) {
       diag.error(
         `Invalid resource detector "${detector}" specified in the environment variable OTEL_NODE_RESOURCE_DETECTORS`
       );
     }
-    return resourceDetector || [];
+    return resourceDetectors.get(detector) || [];
   });
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2311

## Short description of the changes

In auto-instrumentations-node, checking the false-iness of `Detector | Detector[]` values in the detector map was incorrectly causing:

> Invalid resource detector "aws" specified in the environment variable OTEL_NODE_RESOURCE_DETECTORS

This PR fixes the issue by checking for the provided detector key in the detector map instead.
