### PR TITLE
fix(auto-instrumentations-node): check if detector key in map rather than value false-iness

### DIFF
--- a/metapackages/auto-instrumentations-node/src/utils.ts
+++ b/metapackages/auto-instrumentations-node/src/utils.ts
@@ -273,12 +273,11 @@ export function getResourceDetectorsFromEnv(): Array<Detector | DetectorSync> {
   }
 
   return resourceDetectorsFromEnv.flatMap(detector => {
-    const resourceDetector = resourceDetectors.get(detector);
-    if (!resourceDetector) {
+    if (!resourceDetectors.has(detector)) {
       diag.error(
         `Invalid resource detector "${detector}" specified in the environment variable OTEL_NODE_RESOURCE_DETECTORS`
       );
     }
-    return resourceDetector || [];
+    return resourceDetectors.get(detector) || [];
   });
 }


### PR DESCRIPTION
## Which problem is this PR solving?

https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2311

## Short description of the changes

In auto-instrumentations-node, the check for detector configuration values is evaluating the `false`-iness of the map value, causing it to incorrectly treat `Detector | Detector[]` values as `false`-y. This PR changes that check to instead check for the the presence of the key value in the map.