### PR TITLE
fix(detector-gpc): suppress tracing when requesting for GCP metadata

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-gcp/test/detectors/GcpDetector.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-gcp/test/detectors/GcpDetector.test.ts
@@ -31,7 +31,6 @@ import {
   assertContainerResource,
   assertEmptyResource,
 } from '@opentelemetry/contrib-test-utils';
-import { Resource } from '@opentelemetry/resources';
 
 const HEADERS = {
   [HEADER_NAME.toLowerCase()]: HEADER_VALUE,
@@ -85,7 +84,10 @@ describe('gcpDetector', () => {
       const secondaryScope = nock(SECONDARY_HOST_ADDRESS)
         .get(INSTANCE_PATH)
         .reply(200, {}, HEADERS);
-      const resource: Resource = await gcpDetector.detect();
+
+      const resource = gcpDetector.detect();
+      await resource.waitForAsyncAttributes?.();
+
       secondaryScope.done();
       scope.done();
 
@@ -121,7 +123,10 @@ describe('gcpDetector', () => {
       const secondaryScope = nock(SECONDARY_HOST_ADDRESS)
         .get(INSTANCE_PATH)
         .reply(200, {}, HEADERS);
-      const resource = await gcpDetector.detect();
+
+      const resource = gcpDetector.detect();
+      await resource.waitForAsyncAttributes?.();
+
       secondaryScope.done();
       scope.done();
 
@@ -155,7 +160,10 @@ describe('gcpDetector', () => {
       const secondaryScope = nock(SECONDARY_HOST_ADDRESS)
         .get(INSTANCE_PATH)
         .reply(200, {}, HEADERS);
-      const resource = await gcpDetector.detect();
+
+      const resource = gcpDetector.detect();
+      await resource.waitForAsyncAttributes?.();
+
       secondaryScope.done();
       scope.done();
 
@@ -167,7 +175,9 @@ describe('gcpDetector', () => {
     });
 
     it('returns empty resource if not detected', async () => {
-      const resource = await gcpDetector.detect();
+      const resource = gcpDetector.detect();
+      await resource.waitForAsyncAttributes?.();
+
       assertEmptyResource(resource);
     });
   });


### PR DESCRIPTION
## Which problem is this PR solving?

This is a 1st PR for fixing #2320. Some of the detectors are using `http` or other instrumented modules to get resource related data. In this case GCP resource detector is using `http` module to get info and this results on some spans being exported. These spans are not related to the instrumented service so it shouldn't be there

## Short description of the changes

- Update `GcpDetector` class to implement `DetectorSync` interface
- use `suppresTracing` and `unsuppresTracing` APIs to make sure spans are not exported
