### PR TITLE
docs(test-utils): fix package name in readme

### DIFF
--- a/packages/opentelemetry-test-utils/README.md
+++ b/packages/opentelemetry-test-utils/README.md
@@ -28,7 +28,7 @@ Since [root hook plugin](https://mochajs.org/#root-hook-plugins) are used, this 
 1. Add dev dependency on this package:
 
 ```sh
-npm install @opentelemetry/test-utils --save-dev
+npm install @opentelemetry/contrib-test-utils --save-dev
 ```
 
 1. [`require`](https://mochajs.org/#-require-module-r-module) this package in mocha invocation:
@@ -37,22 +37,22 @@ As command line argument option to mocha:
 
 ```js
     "scripts": {
-        "test": "mocha --require @opentelemetry/test-utils",
-        "test:jaeger": "OTEL_EXPORTER_JAEGER_AGENT_HOST=localhost mocha --require @opentelemetry/test-utils",
+        "test": "mocha --require @opentelemetry/contrib-test-utils",
+        "test:jaeger": "OTEL_EXPORTER_JAEGER_AGENT_HOST=localhost mocha --require @opentelemetry/contrib-test-utils",
     },
 ``
 
 Or by using config file / package.json config:
 ```js
     "mocha": {
-        "require": [ "@opentelemetry/test-utils" ]
+        "require": [ "@opentelemetry/contrib-test-utils" ]
     }
 ```
 
 1. In your `.spec` file, import `registerInstrumentationTesting` and `getTestSpans` functions and use them to create instrumentation class instance and make assertions in the test:
 
 ```js
-import { getTestSpans, registerInstrumentationTesting } from '@opentelemetry/test-utils';
+import { getTestSpans, registerInstrumentationTesting } from '@opentelemetry/contrib-test-utils';
 
 const instrumentation = registerInstrumentationTesting(new MyAwesomeInstrumentation());
 


### PR DESCRIPTION
## Which problem is this PR solving?

- confusion about what package to install from npm

## Short description of the changes

- Looks like this was renamed from test-utils to contrib-test-utils a few years back but the readme still uses the old name. I happened across it when I was looking for the test code and was confused about the package name. This is super tiny, merge at will.
