### PR TITLE
fix(aws-sdk): add http status code attribute to aws sdk span if aws sdk v3 client exception occurs

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.ts
@@ -538,6 +538,16 @@ export class AwsInstrumentation extends InstrumentationBase {
                   if (requestId) {
                     span.setAttribute(AttributeNames.AWS_REQUEST_ID, requestId);
                   }
+
+                  const httpStatusCode =
+                    err?.$metadata?.httpStatusCode;
+                  if (httpStatusCode) {
+                    span.setAttribute(
+                      SEMATTRS_HTTP_STATUS_CODE,
+                      httpStatusCode
+                    );
+                  }
+
                   const extendedRequestId = err?.extendedRequestId;
                   if (extendedRequestId) {
                     span.setAttribute(

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.ts
@@ -539,8 +539,7 @@ export class AwsInstrumentation extends InstrumentationBase {
                     span.setAttribute(AttributeNames.AWS_REQUEST_ID, requestId);
                   }
 
-                  const httpStatusCode =
-                    err?.$metadata?.httpStatusCode;
+                  const httpStatusCode = err?.$metadata?.httpStatusCode;
                   if (httpStatusCode) {
                     span.setAttribute(
                       SEMATTRS_HTTP_STATUS_CODE,

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/aws-sdk-v3.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/aws-sdk-v3.test.ts
@@ -167,6 +167,7 @@ describe('instrumentation-aws-sdk-v3', () => {
         expect(span.attributes[SEMATTRS_RPC_SYSTEM]).toEqual('aws-api');
         expect(span.attributes[SEMATTRS_RPC_METHOD]).toEqual('PutObject');
         expect(span.attributes[SEMATTRS_RPC_SERVICE]).toEqual('S3');
+        expect(span.attributes[SEMATTRS_HTTP_STATUS_CODE]).toEqual(403);
         expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
         expect(span.attributes[AttributeNames.AWS_REQUEST_ID]).toEqual(
           'MS95GTS7KXQ34X2S'


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Fixes https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2343

- Upon AWS SDK (v3) Client exceptions, AWS SDK V3 Span will not record http.status.code attribute into the span.
  - For comparison, AWS SDK V2 Span already does record and [expects this attribute](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-aws-sdk/test/aws-sdk-v2.test.ts#L301-L303).

## Short description of the changes

- Record `http.status.code` attribute into the span upon client exceptions for AWS SDK V3 Spans.


## Testing

- Updated Unit Tests to check for `http.status.code` attribute
