### PR TITLE
fix(winston-transport): Add attribute serialization

### DIFF
--- a/packages/winston-transport/src/utils.ts
+++ b/packages/winston-transport/src/utils.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  AnyValue,
   LogAttributes,
   LogRecord,
   Logger,
@@ -67,7 +68,7 @@ export function emitLogRecord(
   const attributes: LogAttributes = {};
   for (const key in splat) {
     if (Object.prototype.hasOwnProperty.call(splat, key)) {
-      attributes[key] = splat[key];
+      attributes[key] = serializeAttribute(splat[key]);
     }
   }
   const logRecord: LogRecord = {
@@ -77,4 +78,25 @@ export function emitLogRecord(
     attributes: attributes,
   };
   logger.emit(logRecord);
+}
+
+// Serialize objects and errors
+function serializeAttribute(value: any): AnyValue {
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return value;
+  }
+  if (value instanceof Error) {
+    return `[object Error] { message: "${value.message}", name: "${value.name}", stack: "${value.stack}"}`;
+  } else {
+    try {
+      return JSON.stringify(value);
+    } catch (err: unknown) {
+      // Failed to serialize, return string cast
+      return String(value);
+    }
+  }
 }

--- a/packages/winston-transport/test/openTelemetryTransport.test.ts
+++ b/packages/winston-transport/test/openTelemetryTransport.test.ts
@@ -143,4 +143,34 @@ describe('OpenTelemetryTransportV3', () => {
       assert.strictEqual(logRecords[7].severityNumber, SeverityNumber.DEBUG);
     });
   });
+
+  it('serialized attibutes', () => {
+    const transport = new OpenTelemetryTransportV3();
+    transport.log(
+      {
+        message: 'test',
+        level: 'error',
+        someObject: { test: 'value' },
+        someArray: [{ test: 'value' }],
+        someError: new Error('testError'),
+      },
+      () => {}
+    );
+    const logRecords = memoryLogExporter.getFinishedLogRecords();
+    assert.strictEqual(logRecords.length, 1);
+    assert.strictEqual(
+      logRecords[0].attributes['someObject'],
+      '{"test":"value"}'
+    );
+    assert.strictEqual(
+      logRecords[0].attributes['someArray'],
+      '[{"test":"value"}]'
+    );
+    assert.ok(
+      (logRecords[0].attributes['someError'] as string).startsWith(
+        '[object Error] { message: "testError", name: "Error", stack: "Error: testError'
+      ),
+      'Wrong error serialization'
+    );
+  });
 });


### PR DESCRIPTION
## Which problem is this PR solving?
#2351

## Short description of the changes
Added serialization of Winston parameters to ensure supported types are passed through.
