### PR TITLE
Add page view instrumentation plugin

### DIFF
--- a/examples/web/examples/document-load/index.js
+++ b/examples/web/examples/document-load/index.js
@@ -1,15 +1,20 @@
 import { context, trace } from '@opentelemetry/api';
 import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+import { events } from '@opentelemetry/api-events';
+import { EventLoggerProvider } from '@opentelemetry/sdk-events';
+import { LoggerProvider,SimpleLogRecordProcessor,ConsoleLogRecordExporter } from '@opentelemetry/sdk-logs';
 import { DocumentLoadInstrumentation } from '@opentelemetry/instrumentation-document-load';
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http'
 import { B3Propagator } from '@opentelemetry/propagator-b3';
 import { CompositePropagator, W3CTraceContextPropagator } from '@opentelemetry/core';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { Resource } from '@opentelemetry/resources';
 import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { PageViewEventInstrumentation } from "@opentelemetry/instrumentation-page-view";
 
 const provider = new WebTracerProvider({
   resource: new Resource({
@@ -17,8 +22,15 @@ const provider = new WebTracerProvider({
   }),
 });
 
+const loggerProvider = new LoggerProvider({resource: new Resource({[SEMRESATTRS_SERVICE_NAME]: 'web-service-dl'})});
+
 provider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
 provider.addSpanProcessor(new SimpleSpanProcessor(new OTLPTraceExporter()));
+
+loggerProvider.addLogRecordProcessor(new SimpleLogRecordProcessor(new ConsoleLogRecordExporter()));
+loggerProvider.addLogRecordProcessor(new SimpleLogRecordProcessor(new OTLPLogExporter()));
+const eventLoggerProvider = new EventLoggerProvider(loggerProvider);
+events.setGlobalEventLoggerProvider(eventLoggerProvider);
 
 provider.register({
   contextManager: new ZoneContextManager(),
@@ -38,6 +50,7 @@ registerInstrumentations({
         'http://localhost:8090',
       ],
     }),
+    new PageViewEventInstrumentation({enabled:false})
   ],
   tracerProvider: provider,
 });

--- a/examples/web/examples/document-load/index.js
+++ b/examples/web/examples/document-load/index.js
@@ -1,20 +1,15 @@
 import { context, trace } from '@opentelemetry/api';
 import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
-import { events } from '@opentelemetry/api-events';
-import { EventLoggerProvider } from '@opentelemetry/sdk-events';
-import { LoggerProvider,SimpleLogRecordProcessor,ConsoleLogRecordExporter } from '@opentelemetry/sdk-logs';
 import { DocumentLoadInstrumentation } from '@opentelemetry/instrumentation-document-load';
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
-import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http'
 import { B3Propagator } from '@opentelemetry/propagator-b3';
 import { CompositePropagator, W3CTraceContextPropagator } from '@opentelemetry/core';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { Resource } from '@opentelemetry/resources';
 import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
-import { PageViewEventInstrumentation } from "@opentelemetry/instrumentation-page-view";
 
 const provider = new WebTracerProvider({
   resource: new Resource({
@@ -22,15 +17,8 @@ const provider = new WebTracerProvider({
   }),
 });
 
-const loggerProvider = new LoggerProvider({resource: new Resource({[SEMRESATTRS_SERVICE_NAME]: 'web-service-dl'})});
-
 provider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
 provider.addSpanProcessor(new SimpleSpanProcessor(new OTLPTraceExporter()));
-
-loggerProvider.addLogRecordProcessor(new SimpleLogRecordProcessor(new ConsoleLogRecordExporter()));
-loggerProvider.addLogRecordProcessor(new SimpleLogRecordProcessor(new OTLPLogExporter()));
-const eventLoggerProvider = new EventLoggerProvider(loggerProvider);
-events.setGlobalEventLoggerProvider(eventLoggerProvider);
 
 provider.register({
   contextManager: new ZoneContextManager(),
@@ -50,7 +38,6 @@ registerInstrumentations({
         'http://localhost:8090',
       ],
     }),
-    new PageViewEventInstrumentation({enabled:false})
   ],
   tracerProvider: provider,
 });
@@ -125,3 +112,4 @@ const prepareClickEvent = () => {
 };
 
 window.addEventListener('load', prepareClickEvent);
+

--- a/examples/web/examples/page-view/index.html
+++ b/examples/web/examples/page-view/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>Document Load Plugin Example</title>
+  <title>Page View Plugin Example</title>
   <base href="/">
 
   <!--
@@ -22,12 +22,11 @@
 
 <body>
   Example of using Web Tracer with document load plugin with console exporter and collector exporter
-  <script type="text/javascript" src="document-load.js"></script>
+  <script type="text/javascript" src="page-view.js"></script>
   <br/>
-  <button id="button1">Test WebTracer with ZoneContextManager - async</button>
   <nav>
-    <a href="document-load/route1" data-link>Route 1</a>
-    <a href="document-load/route2" data-link>Route 2</a>
+    <a href="page-view/route1" data-link>Route 1</a>
+    <a href="page-view/route2" data-link>Route 2</a>
   </nav>
 
   <div id="content">

--- a/examples/web/examples/page-view/index.js
+++ b/examples/web/examples/page-view/index.js
@@ -1,0 +1,62 @@
+import { context, trace } from '@opentelemetry/api';
+import { events } from '@opentelemetry/api-events';
+import { EventLoggerProvider } from '@opentelemetry/sdk-events';
+import { LoggerProvider,SimpleLogRecordProcessor,ConsoleLogRecordExporter } from '@opentelemetry/sdk-logs';
+import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http'
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { Resource } from '@opentelemetry/resources';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { PageViewInstrumentation } from "@opentelemetry/instrumentation-page-view";
+
+const loggerProvider = new LoggerProvider({resource: new Resource({[SEMRESATTRS_SERVICE_NAME]: 'web-service-dl'})});
+
+loggerProvider.addLogRecordProcessor(new SimpleLogRecordProcessor(new ConsoleLogRecordExporter()));
+loggerProvider.addLogRecordProcessor(new SimpleLogRecordProcessor(new OTLPLogExporter()));
+const eventLoggerProvider = new EventLoggerProvider(loggerProvider);
+events.setGlobalEventLoggerProvider(eventLoggerProvider);
+
+registerInstrumentations({
+  instrumentations: [
+    new PageViewInstrumentation({enabled:false})
+  ],
+});
+
+// Define routes and their content
+const routes = {
+  '/page-view/route1': '<h2>Welcome to Route 1</h2><p>This is the content for Route 1.</p>',
+  '/page-view/route2': '<h2>Welcome to Route 2</h2><p>This is the content for Route 2.</p>'
+};
+
+// Function to navigate to a route
+function navigateTo(url) {
+  console.log('Navigating to', url);
+  history.pushState(null, null, url);
+  handleRouteChange();
+}
+
+// Function to handle the route change
+function handleRouteChange() {
+  const path = window.location.pathname; // Get current path
+  const routeContent = routes[path] || `<h2>Not on Route </h2>`;
+  document.getElementById('content').innerHTML = routeContent;
+}
+
+// Attach event listeners to navigation links
+
+const attachEventListenersToLinks = () => {
+  document.querySelectorAll('a[data-link]').forEach(link => {
+    console.log('attach event listener to link', link.href)
+    link.addEventListener('click', (event) => {
+      console.log('Link clicked', event.target.href)
+      event.preventDefault();
+      navigateTo(event.target.href);
+    });
+  });
+}
+
+window.addEventListener('popstate', handleRouteChange);
+const loadTimeSetup = () => {
+  handleRouteChange();
+  attachEventListenersToLinks();
+}
+window.addEventListener('load', loadTimeSetup);

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "docker:start": "cd ./docker && docker-compose down && docker-compose up",
     "docker:startd": "cd ./docker && docker-compose down && docker-compose up -d",
-    "start": "webpack-dev-server -d --progress --colors --port 8090 --config webpack.config.js --hot --inline --host 0.0.0.0 --content-base examples"
+    "start": "webpack serve --mode development --progress --port 8090 --config webpack.config.js --hot --host 0.0.0.0 --static examples"
   },
   "repository": {
     "type": "git",
@@ -30,21 +30,24 @@
     "@babel/core": "^7.21.8",
     "babel-loader": "^8.3.0",
     "ts-loader": "^6.2.2",
-    "webpack": "5.89.0",
-    "webpack-cli": "^3.3.12",
-    "webpack-dev-server": "^3.11.3",
-    "webpack-merge": "^4.2.2"
+    "webpack": "^5.93.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.0.4",
+    "webpack-merge": "^6.0.1"
   },
   "dependencies": {
     "@opentelemetry/api": "^1.4.1",
+    "@opentelemetry/api-events": "^0.52.1",
     "@opentelemetry/auto-instrumentations-web": "^0.32.2",
     "@opentelemetry/context-zone": "^1.13.0",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.52.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.39.1",
     "@opentelemetry/instrumentation": "^0.39.1",
-    "@opentelemetry/instrumentation-document-load": "^0.32.2",
     "@opentelemetry/instrumentation-user-interaction": "^0.32.3",
     "@opentelemetry/instrumentation-xml-http-request": "^0.39.1",
     "@opentelemetry/propagator-b3": "^1.13.0",
+    "@opentelemetry/sdk-events": "^0.52.1",
+    "@opentelemetry/sdk-logs": "^0.52.1",
     "@opentelemetry/sdk-trace-web": "^1.13.0",
     "@opentelemetry/semantic-conventions": "^1.23.0"
   },

--- a/examples/web/webpack.config.js
+++ b/examples/web/webpack.config.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const webpack = require('webpack');
-const webpackMerge = require('webpack-merge');
+const { merge } = require('webpack-merge');
 const path = require('path');
 
 const directory = path.resolve(__dirname);
@@ -9,9 +9,10 @@ const directory = path.resolve(__dirname);
 const common = {
   mode: 'development',
   entry: {
-    'document-load': 'examples/document-load/index.js',
-    meta: 'examples/meta/index.js',
-    'user-interaction': 'examples/user-interaction/index.js',
+    'document-load': path.resolve(__dirname, 'examples/document-load/index.js'),
+    meta: path.resolve(__dirname, 'examples/meta/index.js'),
+    'user-interaction': path.resolve(__dirname, 'examples/user-interaction/index.js'),
+    'page-view': path.resolve(__dirname, 'examples/page-view/index.js'),
   },
   output: {
     path: path.resolve(__dirname, 'dist'),
@@ -22,15 +23,15 @@ const common = {
   module: {
     rules: [
       {
-        test: /\.js[x]?$/,
-        exclude: /(node_modules)/,
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
         use: {
           loader: 'babel-loader',
         },
       },
       {
         test: /\.ts$/,
-        exclude: /(node_modules)/,
+        exclude: /node_modules/,
         use: {
           loader: 'ts-loader',
         },
@@ -46,14 +47,22 @@ const common = {
   },
 };
 
-module.exports = webpackMerge(common, {
+const devConfig = {
   devtool: 'eval-source-map',
   devServer: {
-    contentBase: path.resolve(__dirname),
+    static: {
+      directory: path.resolve(__dirname, 'examples'),
+    },
+    compress: true,
+    port: 8090,
+    hot: true,
+    host: '0.0.0.0',
   },
   plugins: [
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('development'),
     }),
   ],
-});
+};
+
+module.exports = merge(common, devConfig);

--- a/plugins/web/opentelemetry-instrumentation-page-view/LICENSE
+++ b/plugins/web/opentelemetry-instrumentation-page-view/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/plugins/web/opentelemetry-instrumentation-page-view/README.md
+++ b/plugins/web/opentelemetry-instrumentation-page-view/README.md
@@ -1,0 +1,152 @@
+# OpenTelemetry Instrumentation Document Load
+
+[![NPM Published Version][npm-img]][npm-url]
+[![Apache License][license-image]][license-image]
+
+This module provides automatic instrumentation for *document load* for Web applications, which may be loaded using the [`@opentelemetry/sdk-trace-web`](https://www.npmjs.com/package/@opentelemetry/sdk-trace-web) package.
+
+If total installation size is not constrained, it is recommended to use the [`@opentelemetry/auto-instrumentations-web`](https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-web) bundle with [`@opentelemetry/sdk-trace-web`](https://www.npmjs.com/package/@opentelemetry/sdk-trace-web) for the most seamless instrumentation experience.
+
+Compatible with OpenTelemetry JS API and SDK `1.0+`.
+
+## Installation
+
+```bash
+npm install --save @opentelemetry/instrumentation-document-load
+```
+
+## Usage
+
+```js
+import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+import { DocumentLoadInstrumentation } from '@opentelemetry/instrumentation-document-load';
+import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { B3Propagator } from '@opentelemetry/propagator-b3';
+import { CompositePropagator, W3CTraceContextPropagator } from '@opentelemetry/core';
+
+const provider = new WebTracerProvider();
+
+provider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+
+provider.register({
+  propagator: new CompositePropagator({
+    propagators: [
+      new B3Propagator(),
+      new W3CTraceContextPropagator(),
+    ],
+  }),
+});
+
+registerInstrumentations({
+  instrumentations: [
+    new DocumentLoadInstrumentation(),
+    new XMLHttpRequestInstrumentation({
+      ignoreUrls: [/localhost/],
+      propagateTraceHeaderCorsUrls: [
+        'http://localhost:8090',
+      ],
+    }),
+  ],
+});
+
+```
+
+## Optional: Send a trace parent from your server
+
+This instrumentation supports connecting the server side spans for the initial HTML load with the client side span for the load from the browser's timing API. This works by having the server send its parent trace context (trace ID, span ID and trace sampling decision) to the client.
+
+Because the browser does not send a trace context header for the initial page navigation, the server needs to fake a trace context header in a middleware and then send that trace context header back to the client as a meta tag *traceparent* . The *traceparent* meta tag should be in the [trace context W3C draft format][trace-context-url] . For example:
+
+```html
+  ...
+<head>
+  <!--
+    https://www.w3.org/TR/trace-context/
+    Set the `traceparent` in the server's HTML template code. It should be
+    dynamically generated server side to have the server's request trace Id,
+    a parent span Id that was set on the server's request span, and the trace
+    flags to indicate the server's sampling decision
+    (01 = sampled, 00 = notsampled).
+    '{version}-{traceId}-{spanId}-{sampleDecision}'
+  -->
+  <meta name="traceparent" content="00-ab42124a3c573678d4d8b21ba52df3bf-d21f7bc17caa5aba-01">
+</head>
+<body>
+  ...
+  <script>
+    // and then initialise the WebTracer
+    // var webTracer = new WebTracer({ .......
+  </script>
+</body>
+```
+
+## Optional : Add custom attributes to spans if needed
+
+If it is needed to add custom attributes to the document load span,and/or document fetch span and/or resource fetch spans, respective functions to do so needs to be provided
+as a config to the DocumentLoad Instrumentation as shown below. The attributes will be added to the respective spans
+before the individual are spans are ended. If the function throws an error , no attributes will be added to the span and
+the rest of the process continues.
+
+```js
+const addCustomAttributesToSpan = (span: Span) => {
+  span.setAttribute('<custom.attribute.key>','<custom-attribute-value>');
+}
+const addCustomAttributesToResourceFetchSpan = (span: Span, resource: PerformanceResourceTiming) => {
+  span.setAttribute('<custom.attribute.key>','<custom-attribute-value>');
+  span.setAttribute('resource.tcp.duration_ms', resource.connectEnd - resource.connectStart);
+}
+registerInstrumentations({
+  instrumentations: [
+    new DocumentLoadInstrumentation({
+        applyCustomAttributesOnSpan: {
+            documentLoad: addCustomAttributesToSpan,
+            resourceFetch: addCustomAttributesToResourceFetchSpan
+        }
+    })
+    ]
+})
+```
+
+See [examples/tracer-web](https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/tracer-web) for a short example.
+
+## Document Load Instrumentation Options
+
+The document load instrumentation plugin has few options available to choose from. You can set the following:
+
+| Options                                                                                                                                                                  | Type                          | Description                                                                             |
+|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|-----------------------------------------------------------------------------------------|
+| `applyCustomAttributesOnSpan.documentLoad`| `DocumentLoadCustomAttributeFunction` | Function for adding custom attributes to `documentLoad` spans.                                                  |
+| `applyCustomAttributesOnSpan.documentFetch`                      | `DocumentLoadCustomAttributeFunction`                     | Function for adding custom attributes to `documentFetch` spans.  |
+| `applyCustomAttributesOnSpan.resourceFetch`                      | `ResourceFetchCustomAttributeFunction`                     | Function for adding custom attributes to `resourceFetch` spans  |
+| `ignoreNetworkEvents`                      | `boolean`                     | Ignore adding [network events as span events](https://github.com/open-telemetry/opentelemetry-js/blob/e49c4c7f42c6c444da3f802687cfa4f2d6983f46/packages/opentelemetry-sdk-trace-web/src/enums/PerformanceTimingNames.ts#L17) for document fetch and resource fetch spans.  |
+| `ignorePerformancePaintEvents`                      | `boolean`                     | Ignore adding performance resource paint span events to document load spans.  |
+
+## Semantic Conventions
+
+This package uses `@opentelemetry/semantic-conventions` version `1.22+`, which implements Semantic Convention [Version 1.7.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/semantic_conventions/README.md)
+
+Attributes collected:
+
+| Attribute         | Short Description                                                              |
+| ----------------- | ------------------------------------------------------------------------------ |
+| `http.url`        | Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]` |
+| `http.user_agent` | Value of the HTTP User-Agent header sent by the client                         |
+
+## Useful links
+
+- For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
+- For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>
+- For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
+
+## License
+
+Apache 2.0 - See [LICENSE][license-url] for more information.
+
+[discussions-url]: https://github.com/open-telemetry/opentelemetry-js/discussions
+[license-url]: https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/LICENSE
+[license-image]: https://img.shields.io/badge/license-Apache_2.0-green.svg?style=flat
+[npm-url]: https://www.npmjs.com/package/@opentelemetry/instrumentation-document-load
+[npm-img]: https://badge.fury.io/js/%40opentelemetry%2Finstrumentation-document-load.svg
+[trace-context-url]: https://www.w3.org/TR/trace-context

--- a/plugins/web/opentelemetry-instrumentation-page-view/README.md
+++ b/plugins/web/opentelemetry-instrumentation-page-view/README.md
@@ -1,138 +1,69 @@
-# OpenTelemetry Instrumentation Document Load
+# OpenTelemetry Instrumentation Page View
 
 [![NPM Published Version][npm-img]][npm-url]
 [![Apache License][license-image]][license-image]
 
-This module provides automatic instrumentation for *document load* for Web applications, which may be loaded using the [`@opentelemetry/sdk-trace-web`](https://www.npmjs.com/package/@opentelemetry/sdk-trace-web) package.
-
-If total installation size is not constrained, it is recommended to use the [`@opentelemetry/auto-instrumentations-web`](https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-web) bundle with [`@opentelemetry/sdk-trace-web`](https://www.npmjs.com/package/@opentelemetry/sdk-trace-web) for the most seamless instrumentation experience.
-
+This module provides automatic instrumentation for *page view* for Web applications. It uses the events sdk to create a page view event and sends it to the configured log processor. The page view event is created when the page is loaded or a route change occurs.
+The event contains the following attributes:
+- `name`: The name of the page view event.
+- `timestamp`: The timestamp of the event.
+- `data`: The data of the event. The data contains the following attributes:
+  - `location`: The location of the page.
+  - `referrer`: The referrer of the page.
+  - `title`: The title of the page.
+  - `url`: The url of the page.
+  - `type`: The type of the page, either `page-load(base_page)` or `route-change(virtual_page)`.
+  - `customAttributes`: The custom attributes added to the event. The custom attributes are added by the user.
 Compatible with OpenTelemetry JS API and SDK `1.0+`.
 
 ## Installation
 
 ```bash
-npm install --save @opentelemetry/instrumentation-document-load
+npm install --save @opentelemetry/instrumentation-page-view
 ```
 
 ## Usage
 
 ```js
-import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
-import { DocumentLoadInstrumentation } from '@opentelemetry/instrumentation-document-load';
-import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
+import { events } from '@opentelemetry/api-events';
+import { EventLoggerProvider } from '@opentelemetry/sdk-events';
+import { ConsoleLogRecordExporter, SimpleLogRecordProcessor, LoggerProvider } from '@opentelemetry/sdk-logs';
+import { PageViewInstrumentation } from '@opentelemetry/instrumentation-page-view';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
-import { B3Propagator } from '@opentelemetry/propagator-b3';
-import { CompositePropagator, W3CTraceContextPropagator } from '@opentelemetry/core';
 
-const provider = new WebTracerProvider();
-
-provider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
-
-provider.register({
-  propagator: new CompositePropagator({
-    propagators: [
-      new B3Propagator(),
-      new W3CTraceContextPropagator(),
-    ],
-  }),
-});
+const loggerProvider = new LoggerProvider({resource: new Resource({[SEMRESATTRS_SERVICE_NAME]: '<service-name>'})});
+loggerProvider.addLogRecordProcessor(new SimpleLogRecordProcessor(new ConsoleLogRecordExporter()));
+const eventLoggerProvider = new EventLoggerProvider(loggerProvider);
+events.setGlobalEventLoggerProvider(eventLoggerProvider);
 
 registerInstrumentations({
-  instrumentations: [
-    new DocumentLoadInstrumentation(),
-    new XMLHttpRequestInstrumentation({
-      ignoreUrls: [/localhost/],
-      propagateTraceHeaderCorsUrls: [
-        'http://localhost:8090',
-      ],
-    }),
+  instrumentations : [
+    new PageViewInstrumentation()
   ],
 });
 
 ```
 
-## Optional: Send a trace parent from your server
 
-This instrumentation supports connecting the server side spans for the initial HTML load with the client side span for the load from the browser's timing API. This works by having the server send its parent trace context (trace ID, span ID and trace sampling decision) to the client.
+## Optional : Add custom attributes to events if needed
 
-Because the browser does not send a trace context header for the initial page navigation, the server needs to fake a trace context header in a middleware and then send that trace context header back to the client as a meta tag *traceparent* . The *traceparent* meta tag should be in the [trace context W3C draft format][trace-context-url] . For example:
-
-```html
-  ...
-<head>
-  <!--
-    https://www.w3.org/TR/trace-context/
-    Set the `traceparent` in the server's HTML template code. It should be
-    dynamically generated server side to have the server's request trace Id,
-    a parent span Id that was set on the server's request span, and the trace
-    flags to indicate the server's sampling decision
-    (01 = sampled, 00 = notsampled).
-    '{version}-{traceId}-{spanId}-{sampleDecision}'
-  -->
-  <meta name="traceparent" content="00-ab42124a3c573678d4d8b21ba52df3bf-d21f7bc17caa5aba-01">
-</head>
-<body>
-  ...
-  <script>
-    // and then initialise the WebTracer
-    // var webTracer = new WebTracer({ .......
-  </script>
-</body>
-```
-
-## Optional : Add custom attributes to spans if needed
-
-If it is needed to add custom attributes to the document load span,and/or document fetch span and/or resource fetch spans, respective functions to do so needs to be provided
-as a config to the DocumentLoad Instrumentation as shown below. The attributes will be added to the respective spans
-before the individual are spans are ended. If the function throws an error , no attributes will be added to the span and
+If it is needed to add custom data to the page view event, the following function needs to be provided
+as a config to the Page View Event Instrumentation as shown below. The attributes will be added to the event data. If the function throws an error , no attributes will be added to the event.
 the rest of the process continues.
 
 ```js
-const addCustomAttributesToSpan = (span: Span) => {
-  span.setAttribute('<custom.attribute.key>','<custom-attribute-value>');
+const addCustomDataToEvent = (event: Event) => {
+  event.data['<custom.attribute.key>'] = '<custom-attribute-value>';
 }
-const addCustomAttributesToResourceFetchSpan = (span: Span, resource: PerformanceResourceTiming) => {
-  span.setAttribute('<custom.attribute.key>','<custom-attribute-value>');
-  span.setAttribute('resource.tcp.duration_ms', resource.connectEnd - resource.connectStart);
-}
+
 registerInstrumentations({
   instrumentations: [
-    new DocumentLoadInstrumentation({
-        applyCustomAttributesOnSpan: {
-            documentLoad: addCustomAttributesToSpan,
-            resourceFetch: addCustomAttributesToResourceFetchSpan
-        }
+    new PageViewEventInstrumentation({
+        applyCustomEventData:addCustomDataToEvent
     })
     ]
 })
 ```
-
-See [examples/tracer-web](https://github.com/open-telemetry/opentelemetry-js/tree/main/examples/tracer-web) for a short example.
-
-## Document Load Instrumentation Options
-
-The document load instrumentation plugin has few options available to choose from. You can set the following:
-
-| Options                                                                                                                                                                  | Type                          | Description                                                                             |
-|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|-----------------------------------------------------------------------------------------|
-| `applyCustomAttributesOnSpan.documentLoad`| `DocumentLoadCustomAttributeFunction` | Function for adding custom attributes to `documentLoad` spans.                                                  |
-| `applyCustomAttributesOnSpan.documentFetch`                      | `DocumentLoadCustomAttributeFunction`                     | Function for adding custom attributes to `documentFetch` spans.  |
-| `applyCustomAttributesOnSpan.resourceFetch`                      | `ResourceFetchCustomAttributeFunction`                     | Function for adding custom attributes to `resourceFetch` spans  |
-| `ignoreNetworkEvents`                      | `boolean`                     | Ignore adding [network events as span events](https://github.com/open-telemetry/opentelemetry-js/blob/e49c4c7f42c6c444da3f802687cfa4f2d6983f46/packages/opentelemetry-sdk-trace-web/src/enums/PerformanceTimingNames.ts#L17) for document fetch and resource fetch spans.  |
-| `ignorePerformancePaintEvents`                      | `boolean`                     | Ignore adding performance resource paint span events to document load spans.  |
-
-## Semantic Conventions
-
-This package uses `@opentelemetry/semantic-conventions` version `1.22+`, which implements Semantic Convention [Version 1.7.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/semantic_conventions/README.md)
-
-Attributes collected:
-
-| Attribute         | Short Description                                                              |
-| ----------------- | ------------------------------------------------------------------------------ |
-| `http.url`        | Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]` |
-| `http.user_agent` | Value of the HTTP User-Agent header sent by the client                         |
 
 ## Useful links
 

--- a/plugins/web/opentelemetry-instrumentation-page-view/package.json
+++ b/plugins/web/opentelemetry-instrumentation-page-view/package.json
@@ -1,0 +1,81 @@
+{
+  "name": "@opentelemetry/instrumentation-page-view",
+  "version": "0.39.0",
+  "description": "OpenTelemetry instrumentation for page view operations in browser applications",
+  "main": "build/src/index.js",
+  "module": "build/esm/index.js",
+  "esnext": "build/esnext/index.js",
+  "types": "build/src/index.d.ts",
+  "repository": "open-telemetry/opentelemetry-js-contrib",
+  "scripts": {
+    "clean": "tsc --build --clean tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
+    "lint": "eslint . --ext .ts",
+    "lint:fix": "eslint . --ext .ts --fix",
+    "lint:readme": "node ../../../scripts/lint-readme.js",
+    "precompile": "tsc --version && lerna run version:update --scope @opentelemetry/instrumentation-page-view --include-dependencies",
+    "prewatch": "npm run precompile",
+    "version:update": "node ../../../scripts/version-update.js",
+    "compile": "tsc --build tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
+    "prepublishOnly": "npm run compile",
+    "tdd": "wtr --watch",
+    "test:browser": "wtr --coverage",
+    "watch": "tsc --build -watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json"
+  },
+  "keywords": [
+    "opentelemetry",
+    "page-view",
+    "web",
+    "tracing",
+    "profiling",
+    "plugin"
+  ],
+  "author": "OpenTelemetry Authors",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=14"
+  },
+  "files": [
+    "build/esm/**/*.js",
+    "build/esm/**/*.map",
+    "build/esm/**/*.d.ts",
+    "build/esnext/**/*.js",
+    "build/esnext/**/*.map",
+    "build/esnext/**/*.d.ts",
+    "build/src/**/*.js",
+    "build/src/**/*.map",
+    "build/src/**/*.d.ts"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.3.0"
+  },
+  "devDependencies": {
+    "@babel/core": "7.22.17",
+    "@jsdevtools/coverage-istanbul-loader": "3.0.5",
+    "@opentelemetry/api": "^1.3.0",
+    "@opentelemetry/sdk-events": "^0.52.0",
+    "@rollup/plugin-commonjs": "^26.0.0",
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@types/chai": "^4.3.10",
+    "@types/mocha": "8.2.3",
+    "@types/node": "18.6.5",
+    "@types/sinon": "10.0.18",
+    "@web/dev-server-esbuild": "^1.0.1",
+    "@web/dev-server-rollup": "^0.6.1",
+    "@web/test-runner": "^0.18.0",
+    "chai": "^4.3.10",
+    "sinon": "15.2.0",
+    "typescript": "4.4.4"
+  },
+  "dependencies": {
+    "@opentelemetry/api-events": "^0.52.0",
+    "@opentelemetry/core": "^1.8.0",
+    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/sdk-trace-base": "^1.0.0",
+    "@opentelemetry/sdk-trace-web": "^1.15.0",
+    "@opentelemetry/semantic-conventions": "^1.22.0"
+  },
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/web/opentelemetry-instrumentation-page-view#readme"
+}

--- a/plugins/web/opentelemetry-instrumentation-page-view/src/enums/PageTypes.ts
+++ b/plugins/web/opentelemetry-instrumentation-page-view/src/enums/PageTypes.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export enum PageTypes {
+  BASE_PAGE,
+  VIRTUAL_PAGE,
+}

--- a/plugins/web/opentelemetry-instrumentation-page-view/src/index.ts
+++ b/plugins/web/opentelemetry-instrumentation-page-view/src/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './instrumentation';
+export * from './enums/PageTypes';
+export * from './types';

--- a/plugins/web/opentelemetry-instrumentation-page-view/src/instrumentation.ts
+++ b/plugins/web/opentelemetry-instrumentation-page-view/src/instrumentation.ts
@@ -29,10 +29,10 @@ import { PageTypes } from './enums/PageTypes';
  * This class represents a page view instrumentation plugin
  */
 
-export class PageViewEventInstrumentation extends InstrumentationBase<PageViewInstrumentationConfig> {
+export class PageViewInstrumentation extends InstrumentationBase<PageViewInstrumentationConfig> {
   static readonly instrumentationName =
     '@opentelemetry/instrumentation-page-view';
-  readonly component: string = 'page-view-event';
+  readonly component: string = 'page-view';
   readonly version: string = '1';
   moduleName = this.component;
   emitter: EventLogger | null = null;

--- a/plugins/web/opentelemetry-instrumentation-page-view/src/instrumentation.ts
+++ b/plugins/web/opentelemetry-instrumentation-page-view/src/instrumentation.ts
@@ -1,0 +1,186 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  InstrumentationBase,
+  isWrapped,
+} from '@opentelemetry/instrumentation';
+import { Event, events, EventLogger } from '@opentelemetry/api-events';
+import { PACKAGE_NAME, PACKAGE_VERSION } from './version';
+import {
+  ApplyCustomEventDataFunction,
+  PageViewInstrumentationConfig,
+} from './types';
+import { PageTypes } from './enums/PageTypes';
+/**
+ * This class represents a page view instrumentation plugin
+ */
+
+export class PageViewEventInstrumentation extends InstrumentationBase<PageViewInstrumentationConfig> {
+  static readonly instrumentationName =
+    '@opentelemetry/instrumentation-page-view';
+  readonly component: string = 'page-view-event';
+  readonly version: string = '1';
+  moduleName = this.component;
+  emitter: EventLogger | null = null;
+  oldUrl = location.href;
+  applyCustomEventData: ApplyCustomEventDataFunction | undefined = undefined;
+
+  /**
+   *
+   * @param config
+   */
+  constructor(config: PageViewInstrumentationConfig) {
+    super(PACKAGE_NAME, PACKAGE_VERSION, config);
+    this.emitter = events.getEventLogger(
+      PACKAGE_NAME,
+      PACKAGE_VERSION
+    );
+    this.applyCustomEventData = config?.applyCustomEventData;
+  }
+
+  init() {}
+
+  /**
+   * callback to be executed when page is viewed
+   */
+  private _onPageView() {
+    const pageViewEvent: Event = {
+      name: 'page_view',
+      data: {
+        url: document.documentURI as string,
+        referrer: document.referrer,
+        title: document.title,
+        type: PageTypes.BASE_PAGE,
+      },
+    };
+    this._applyCustomEventData(pageViewEvent, this.applyCustomEventData);
+    this.emitter?.emit(pageViewEvent);
+  }
+
+  /**
+   * callback to be executed when page is viewed
+   */
+  private _onVirtualPageView(changeState: string | null | undefined) {
+    const title = document.title;
+    const referrer = this.oldUrl;
+    // Dont emit an event if the route didn't change
+    if (referrer === location.href) {
+      return;
+    }
+    const vPageViewEvent: Event = {
+      name: 'page_view',
+      data: {
+        'http.url': window.location.href,
+        title,
+        changeState: changeState || '',
+        referrer,
+        type: PageTypes.VIRTUAL_PAGE,
+      },
+    };
+    this._applyCustomEventData(vPageViewEvent, this.applyCustomEventData);
+    this.emitter?.emit(vPageViewEvent);
+  }
+
+  public _setEmitter(emitter: EventLogger) {
+    this.emitter = emitter;
+  }
+
+  /**
+   * executes callback {_onDocumenContentLoaded } when the page is viewed
+   */
+  private _waitForPageLoad() {
+    document.addEventListener('DOMContentLoaded', this._onPageView.bind(this));
+  }
+
+  /**
+   * implements enable function
+   */
+  override enable() {
+    this._patchHistoryApi();
+    // remove previously attached load to avoid adding the same event twice
+    // in case of multiple enable calling.
+    document.removeEventListener(
+      'DOMContentLoaded',
+      this._onPageView.bind(this)
+    );
+    this._waitForPageLoad();
+  }
+
+  /**
+   * implements disable function
+   */
+  override disable() {
+    this._unpatchHistoryApi();
+    document.removeEventListener(
+      'DOMContentLoaded',
+      this._onPageView.bind(this)
+    );
+  }
+
+  /**
+   * Patches the certain history api method
+   */
+  _patchHistoryMethod(changeState: string) {
+    const plugin = this;
+    return (original: any) => {
+      return function patchHistoryMethod(this: History, ...args: unknown[]) {
+        const result = original.apply(this, args);
+        const url = location.href;
+        const oldUrl = plugin.oldUrl;
+        if (url !== oldUrl) {
+          plugin._onVirtualPageView(changeState);
+          plugin.oldUrl = location.href;
+        }
+        return result;
+      };
+    };
+  }
+
+  private _patchHistoryApi(): void {
+    // unpatching here disables other instrumentation that use the same api to wrap history, commenting it out
+    // this._unpatchHistoryApi();
+
+    this._wrap(
+      history,
+      'replaceState',
+      this._patchHistoryMethod('replaceState')
+    );
+    this._wrap(history, 'pushState', this._patchHistoryMethod('pushState'));
+  }
+  /**
+   * unpatch the history api methods
+   */
+  _unpatchHistoryApi() {
+    if (isWrapped(history.replaceState)) this._unwrap(history, 'replaceState');
+    if (isWrapped(history.pushState)) this._unwrap(history, 'pushState');
+  }
+
+  /**
+   *
+   * @param logRecord
+   * @param applyCustomLogAttributes
+   * Add custom attributes to the log record
+   */
+  _applyCustomEventData(
+    event: Event,
+    applyCustomEventData: ApplyCustomEventDataFunction | undefined
+  ) {
+    if (applyCustomEventData) {
+      applyCustomEventData(event);
+    }
+  }
+}

--- a/plugins/web/opentelemetry-instrumentation-page-view/src/types.ts
+++ b/plugins/web/opentelemetry-instrumentation-page-view/src/types.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import { Event } from '@opentelemetry/api-events';
+
+/**
+ * PageViewInstrumentationConfig
+ */
+export interface PageViewInstrumentationConfig extends InstrumentationConfig {
+  applyCustomEventData?: ApplyCustomEventDataFunction;
+}
+
+export interface ApplyCustomEventDataFunction {
+  (event: Event): void;
+}

--- a/plugins/web/opentelemetry-instrumentation-page-view/test/pageView.test.ts
+++ b/plugins/web/opentelemetry-instrumentation-page-view/test/pageView.test.ts
@@ -1,0 +1,239 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  LoggerProvider,
+  InMemoryLogRecordExporter,
+  SimpleLogRecordProcessor,
+  ReadableLogRecord,
+} from '@opentelemetry/sdk-logs';
+import { EventLoggerProvider } from '@opentelemetry/sdk-events';
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { PageViewEventInstrumentation } from '../src';
+import { Attributes } from '@opentelemetry/api';
+import { logs } from '@opentelemetry/api-logs';
+import { events } from '@opentelemetry/api-events';
+import { PageTypes } from '../src/enums/PageTypes';
+
+describe('PageView Instrumentation', () => {
+  let plugin: PageViewEventInstrumentation;
+  const sandbox = sinon.createSandbox();
+
+  const exporter = new InMemoryLogRecordExporter();
+  const provider = new LoggerProvider();
+  const logRecordProcessor = new SimpleLogRecordProcessor(exporter);
+  provider.addLogRecordProcessor(logRecordProcessor);
+  logs.setGlobalLoggerProvider(provider);
+  const eventEmitterProvider = new EventLoggerProvider(provider);
+  events.setGlobalEventLoggerProvider(eventEmitterProvider);
+
+  afterEach(() => {
+    exporter.reset();
+    plugin.disable();
+  });
+
+  describe('constructor', () => {
+    it('should construct an instance', () => {
+      plugin = new PageViewEventInstrumentation({
+        enabled: false,
+      });
+
+      assert.strictEqual(exporter.getFinishedLogRecords().length, 0);
+      assert.ok(plugin instanceof PageViewEventInstrumentation);
+    });
+  });
+
+  describe('export page_view LogRecord', () => {
+    it("should export LogRecord for page_view event type 0 when 'DOMContentLoaded' event is fired", done => {
+      plugin = new PageViewEventInstrumentation({
+        enabled: false,
+      });
+
+      const spy = sandbox.spy(document, 'addEventListener');
+      plugin.enable();
+
+      assert.ok(spy.calledOnce);
+
+      document.dispatchEvent(new Event('DOMContentLoaded'));
+
+      assert.strictEqual(exporter.getFinishedLogRecords().length, 1);
+
+      const pageViewLogRecord =
+        exporter.getFinishedLogRecords()[0] as ReadableLogRecord;
+      assert.strictEqual(
+        pageViewLogRecord.attributes['event.domain'],
+        'browser'
+      );
+      assert.strictEqual(
+        pageViewLogRecord.attributes['event.name'],
+        'page_view'
+      );
+      assert.deepEqual(pageViewLogRecord.attributes['event.data'], {
+        type: PageTypes.BASE_PAGE,
+        url: document.documentURI as string,
+        referrer: document.referrer,
+        title: document.title,
+      });
+      done();
+    });
+
+    it('should export LogRecord for page_view event type 1 when history.pushState() is called', done => {
+      const vpStartTime = 16842729000 * 1000000;
+      const referrer = location.href;
+
+      plugin = new PageViewEventInstrumentation({
+        enabled: true,
+        applyCustomEventData: event => {
+          if (event.data) {
+            (event.data as any)['vp.startTime'] = vpStartTime;
+          }
+        },
+      });
+
+      history.pushState({}, '', '/dummy1.html');
+      assert.strictEqual(exporter.getFinishedLogRecords().length, 1);
+
+      const pageViewLogRecord =
+        exporter.getFinishedLogRecords()[0] as ReadableLogRecord;
+      assert.strictEqual(
+        pageViewLogRecord.attributes['event.domain'],
+        'browser'
+      );
+      assert.strictEqual(
+        pageViewLogRecord.attributes['event.name'],
+        'page_view'
+      );
+
+      assert.deepEqual(pageViewLogRecord.attributes['event.data'], {
+        'http.url': document.documentURI as string,
+        referrer: referrer,
+        title: document.title,
+        changeState: 'pushState',
+        'vp.startTime': vpStartTime,
+        type: PageTypes.VIRTUAL_PAGE,
+      });
+      done();
+    });
+
+    it('should export LogRecord for page_view event type 1 when history.replaceState() is called', done => {
+      const vpStartTime = 16842729000 * 1000000;
+      const referrer = location.href;
+
+      plugin = new PageViewEventInstrumentation({
+        enabled: true,
+        applyCustomEventData: event => {
+          if (event.data) {
+            (event.data as any)['vp.startTime'] = vpStartTime;
+          }
+        },
+      });
+
+      history.replaceState({}, '', '/dummy2.html');
+
+      assert.strictEqual(exporter.getFinishedLogRecords().length, 1);
+
+      const pageViewLogRecord =
+        exporter.getFinishedLogRecords()[0] as ReadableLogRecord;
+      assert.strictEqual(
+        pageViewLogRecord.attributes['event.domain'],
+        'browser'
+      );
+      assert.strictEqual(
+        pageViewLogRecord.attributes['event.name'],
+        'page_view'
+      );
+
+      assert.deepEqual(pageViewLogRecord.attributes['event.data'], {
+        'http.url': document.documentURI as string,
+        referrer: referrer,
+        title: document.title,
+        changeState: 'replaceState',
+        'vp.startTime': vpStartTime,
+        type: PageTypes.VIRTUAL_PAGE,
+      });
+      done();
+    });
+
+    it('should not export LogRecord for page_view event type 1 if the referrer is not changed.', done => {
+      const vpStartTime = 16842729000 * 1000000;
+
+      plugin = new PageViewEventInstrumentation({
+        enabled: true,
+        applyCustomEventData: event => {
+          if (event.data) {
+            (event.data as any)['vp.startTime'] = vpStartTime;
+          }
+        },
+      });
+
+      const firstReferrer = location.href;
+      history.pushState({}, '', '/dummy3.html');
+      assert.strictEqual(exporter.getFinishedLogRecords().length, 1);
+
+      const pageViewLogRecord =
+        exporter.getFinishedLogRecords()[0] as ReadableLogRecord;
+      assert.strictEqual(
+        pageViewLogRecord.attributes['event.domain'],
+        'browser'
+      );
+      assert.strictEqual(
+        pageViewLogRecord.attributes['event.name'],
+        'page_view'
+      );
+
+      assert.deepEqual(pageViewLogRecord.attributes['event.data'], {
+        'http.url': document.documentURI as string,
+        referrer: firstReferrer,
+        title: document.title,
+        changeState: 'pushState',
+        'vp.startTime': vpStartTime,
+        type: PageTypes.VIRTUAL_PAGE,
+      });
+
+      const secondReferrer = location.href;
+      history.pushState({}, '', '/dummy3.html');
+      assert.strictEqual(exporter.getFinishedLogRecords().length, 1);
+
+      const pageViewLogRecord2 =
+        exporter.getFinishedLogRecords()[0] as ReadableLogRecord;
+
+      assert.strictEqual(
+        pageViewLogRecord2.attributes['event.domain'],
+        'browser'
+      );
+      assert.strictEqual(
+        pageViewLogRecord2.attributes['event.name'],
+        'page_view'
+      );
+
+      assert.deepEqual(pageViewLogRecord2.attributes['event.data'], {
+        'http.url': document.documentURI as string,
+        referrer: firstReferrer,
+        title: document.title,
+        changeState: 'pushState',
+        'vp.startTime': vpStartTime,
+        type: PageTypes.VIRTUAL_PAGE,
+      });
+
+      assert.notStrictEqual(
+        (<Attributes>pageViewLogRecord2.attributes['event.data'])['referrer'],
+        secondReferrer
+      );
+      done();
+    });
+  });
+});

--- a/plugins/web/opentelemetry-instrumentation-page-view/test/pageView.test.ts
+++ b/plugins/web/opentelemetry-instrumentation-page-view/test/pageView.test.ts
@@ -23,14 +23,14 @@ import {
 import { EventLoggerProvider } from '@opentelemetry/sdk-events';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import { PageViewEventInstrumentation } from '../src';
+import { PageViewInstrumentation } from '../src';
 import { Attributes } from '@opentelemetry/api';
 import { logs } from '@opentelemetry/api-logs';
 import { events } from '@opentelemetry/api-events';
 import { PageTypes } from '../src/enums/PageTypes';
 
 describe('PageView Instrumentation', () => {
-  let plugin: PageViewEventInstrumentation;
+  let plugin: PageViewInstrumentation;
   const sandbox = sinon.createSandbox();
 
   const exporter = new InMemoryLogRecordExporter();
@@ -48,18 +48,18 @@ describe('PageView Instrumentation', () => {
 
   describe('constructor', () => {
     it('should construct an instance', () => {
-      plugin = new PageViewEventInstrumentation({
+      plugin = new PageViewInstrumentation({
         enabled: false,
       });
 
       assert.strictEqual(exporter.getFinishedLogRecords().length, 0);
-      assert.ok(plugin instanceof PageViewEventInstrumentation);
+      assert.ok(plugin instanceof PageViewInstrumentation);
     });
   });
 
   describe('export page_view LogRecord', () => {
     it("should export LogRecord for page_view event type 0 when 'DOMContentLoaded' event is fired", done => {
-      plugin = new PageViewEventInstrumentation({
+      plugin = new PageViewInstrumentation({
         enabled: false,
       });
 
@@ -95,7 +95,7 @@ describe('PageView Instrumentation', () => {
       const vpStartTime = 16842729000 * 1000000;
       const referrer = location.href;
 
-      plugin = new PageViewEventInstrumentation({
+      plugin = new PageViewInstrumentation({
         enabled: true,
         applyCustomEventData: event => {
           if (event.data) {
@@ -133,7 +133,7 @@ describe('PageView Instrumentation', () => {
       const vpStartTime = 16842729000 * 1000000;
       const referrer = location.href;
 
-      plugin = new PageViewEventInstrumentation({
+      plugin = new PageViewInstrumentation({
         enabled: true,
         applyCustomEventData: event => {
           if (event.data) {
@@ -171,7 +171,7 @@ describe('PageView Instrumentation', () => {
     it('should not export LogRecord for page_view event type 1 if the referrer is not changed.', done => {
       const vpStartTime = 16842729000 * 1000000;
 
-      plugin = new PageViewEventInstrumentation({
+      plugin = new PageViewInstrumentation({
         enabled: true,
         applyCustomEventData: event => {
           if (event.data) {

--- a/plugins/web/opentelemetry-instrumentation-page-view/tsconfig.esm.json
+++ b/plugins/web/opentelemetry-instrumentation-page-view/tsconfig.esm.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.esm.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build/esm",
+    "tsBuildInfoFile": "build/esm/tsconfig.esm.tsbuildinfo"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/plugins/web/opentelemetry-instrumentation-page-view/tsconfig.esnext.json
+++ b/plugins/web/opentelemetry-instrumentation-page-view/tsconfig.esnext.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.esnext.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build/esnext",
+    "tsBuildInfoFile": "build/esnext/tsconfig.esnext.tsbuildinfo"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/plugins/web/opentelemetry-instrumentation-page-view/tsconfig.json
+++ b/plugins/web/opentelemetry-instrumentation-page-view/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ]
+}


### PR DESCRIPTION
Part of the client sdk project, Implement PageView event instrumentation
[#2372](https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2372)

This PR adds the page view instrumentation which sends an event when a page is loaded (as soon as the html is loaded) or when a route change happens (tracking the history push and replace states)

Tested on an example app with generic routes that use the history api
