### PR TITLE
feat(opentelemetry-test-utils): create TestMetricReader

### DIFF
--- a/packages/opentelemetry-test-utils/src/test-utils.ts
+++ b/packages/opentelemetry-test-utils/src/test-utils.ts
@@ -24,12 +24,14 @@ import {
 } from '@opentelemetry/api';
 import * as assert from 'assert';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { MetricReader, MeterProvider } from '@opentelemetry/sdk-metrics';
 import {
   hrTimeToMilliseconds,
   hrTimeToMicroseconds,
 } from '@opentelemetry/core';
 import * as path from 'path';
 import * as fs from 'fs';
+import { InstrumentationBase } from '@opentelemetry/instrumentation';
 
 const dockerRunCmds = {
   cassandra:
@@ -178,4 +180,25 @@ export const getPackageVersion = (packageName: string) => {
     'package.json'
   );
   return JSON.parse(fs.readFileSync(pjPath, 'utf8')).version;
+};
+
+class TestMetricReader extends MetricReader {
+  constructor() {
+    super();
+  }
+
+  protected async onForceFlush(): Promise<void> {}
+  protected async onShutdown(): Promise<void> {}
+}
+
+export const initMeterProvider = (
+  instrumentation: InstrumentationBase
+): TestMetricReader => {
+  const metricReader = new TestMetricReader();
+  const meterProvider = new MeterProvider({
+    readers: [metricReader],
+  });
+  instrumentation.setMeterProvider(meterProvider);
+
+  return metricReader;
 };


### PR DESCRIPTION
Creation of a TestMetricReader that can be used during tests involving metric collection.

Created based on comment: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2349#discussion_r1708887639

For usage, the function `initMeterProvider` can be called on the `beforeEach` of tests, and the return of `metricReader` can be used such as `const { resourceMetrics, errors } = await metricReader.collect();`

Once a new version of the package `opentelemetry-test-utils` is created, I will update the PR mentioned above with its usage.
