### PR TITLE
feat(opentelemetry-test-utils): export class TestMetricReader

### DIFF
--- a/packages/opentelemetry-test-utils/src/test-utils.ts
+++ b/packages/opentelemetry-test-utils/src/test-utils.ts
@@ -182,7 +182,7 @@ export const getPackageVersion = (packageName: string) => {
   return JSON.parse(fs.readFileSync(pjPath, 'utf8')).version;
 };
 
-class TestMetricReader extends MetricReader {
+export class TestMetricReader extends MetricReader {
   constructor() {
     super();
   }


### PR DESCRIPTION
Follow up from https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2388. I forgot to add the `export` to the new class `TestMetricReader` on that PR. 