### PR TITLE
fix(instr-undici): fix issue with config in constructor

### DIFF
--- a/plugins/node/instrumentation-undici/src/undici.ts
+++ b/plugins/node/instrumentation-undici/src/undici.ts
@@ -84,6 +84,12 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
     // This method is called by the `InstrumentationAbstract` constructor before
     // ours is called. So we need to ensure the property is initalized
     this._channelSubs = this._channelSubs || [];
+
+    // Avoid to duplicate subscriptions
+    if (this._channelSubs.length > 0) {
+      return;
+    }
+
     this.subscribeToChannel(
       'undici:request:create',
       this.onRequestCreated.bind(this)

--- a/plugins/node/instrumentation-undici/src/undici.ts
+++ b/plugins/node/instrumentation-undici/src/undici.ts
@@ -76,7 +76,7 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
   }
 
   override disable(): void {
-    super.disable()
+    super.disable();
     this._channelSubs.forEach(sub => sub.channel.unsubscribe(sub.onMessage));
     this._channelSubs.length = 0;
   }
@@ -91,7 +91,7 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
     // instrumentation should be generated. This covers the more likely common
     // case of config being given a construction time, rather than later via
     // `instance.enable()`, `.disable()`, or `.setConfig()` calls.
-    super.enable()
+    super.enable();
 
     // This method is called by the super-class constructor before ours is
     // called. So we need to ensure the property is initalized.

--- a/plugins/node/instrumentation-undici/src/undici.ts
+++ b/plugins/node/instrumentation-undici/src/undici.ts
@@ -139,9 +139,7 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
     // - method is 'CONNECT'
     const config = this.getConfig();
     const shouldIgnoreReq = safeExecuteInTheMiddle(
-      () =>
-        request.method === 'CONNECT' ||
-        config.ignoreRequestHook?.(request),
+      () => request.method === 'CONNECT' || config.ignoreRequestHook?.(request),
       e => e && this._diag.error('caught ignoreRequestHook error: ', e),
       true
     );

--- a/plugins/node/instrumentation-undici/test/fetch.test.ts
+++ b/plugins/node/instrumentation-undici/test/fetch.test.ts
@@ -35,19 +35,16 @@ import { MockPropagation } from './utils/mock-propagation';
 import { MockServer } from './utils/mock-server';
 import { assertSpan } from './utils/assertSpan';
 
-const instrumentation = new UndiciInstrumentation();
-instrumentation.enable();
-instrumentation.disable();
-
-const protocol = 'http';
-const hostname = 'localhost';
-const mockServer = new MockServer();
-const memoryExporter = new InMemorySpanExporter();
-const provider = new NodeTracerProvider();
-provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
-instrumentation.setTracerProvider(provider);
-
 describe('UndiciInstrumentation `fetch` tests', function () {
+  let instrumentation: UndiciInstrumentation;
+
+  const protocol = 'http';
+  const hostname = 'localhost';
+  const mockServer = new MockServer();
+  const memoryExporter = new InMemorySpanExporter();
+  const provider = new NodeTracerProvider();
+  provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+
   before(function (done) {
     // Do not test if the `fetch` global API is not available
     // This applies to nodejs < v18 or nodejs < v16.15 wihtout the flag
@@ -56,6 +53,9 @@ describe('UndiciInstrumentation `fetch` tests', function () {
     if (typeof globalThis.fetch !== 'function') {
       this.skip();
     }
+
+    instrumentation = new UndiciInstrumentation();
+    instrumentation.setTracerProvider(provider);
 
     propagation.setGlobalPropagator(new MockPropagation());
     context.setGlobalContextManager(new AsyncHooksContextManager().enable());
@@ -105,8 +105,8 @@ describe('UndiciInstrumentation `fetch` tests', function () {
       let spans = memoryExporter.getFinishedSpans();
       assert.strictEqual(spans.length, 0);
 
-      // Disable via config
-      instrumentation.setConfig({ enabled: false });
+      // Disable
+      instrumentation.disable();
 
       const fetchUrl = `${protocol}://${hostname}:${mockServer.port}/?query=test`;
       const response = await fetch(fetchUrl);
@@ -126,7 +126,8 @@ describe('UndiciInstrumentation `fetch` tests', function () {
     });
     afterEach(function () {
       // Empty configuration & disable
-      instrumentation.setConfig({ enabled: false });
+      instrumentation.setConfig({});
+      instrumentation.disable();
     });
 
     it('should create valid spans even if the configuration hooks fail', async function () {
@@ -135,7 +136,6 @@ describe('UndiciInstrumentation `fetch` tests', function () {
 
       // Set the bad configuration
       instrumentation.setConfig({
-        enabled: true,
         ignoreRequestHook: () => {
           throw new Error('ignoreRequestHook error');
         },
@@ -204,7 +204,6 @@ describe('UndiciInstrumentation `fetch` tests', function () {
 
       // Set configuration
       instrumentation.setConfig({
-        enabled: true,
         ignoreRequestHook: req => {
           return req.path.indexOf('/ignore/path') !== -1;
         },
@@ -302,7 +301,6 @@ describe('UndiciInstrumentation `fetch` tests', function () {
       assert.strictEqual(spans.length, 0);
 
       instrumentation.setConfig({
-        enabled: true,
         requireParentforSpans: true,
       });
 
@@ -322,7 +320,6 @@ describe('UndiciInstrumentation `fetch` tests', function () {
       assert.strictEqual(spans.length, 0);
 
       instrumentation.setConfig({
-        enabled: true,
         requireParentforSpans: true,
       });
 

--- a/plugins/node/instrumentation-undici/test/metrics.test.ts
+++ b/plugins/node/instrumentation-undici/test/metrics.test.ts
@@ -31,7 +31,6 @@ import { MockServer } from './utils/mock-server';
 import { MockMetricsReader } from './utils/mock-metrics-reader';
 import { SemanticAttributes } from '../src/enums/SemanticAttributes';
 
-
 describe('UndiciInstrumentation metrics tests', function () {
   let instrumentation: UndiciInstrumentation;
   const protocol = 'http';
@@ -44,7 +43,6 @@ describe('UndiciInstrumentation metrics tests', function () {
   );
   const metricReader = new MockMetricsReader(metricsMemoryExporter);
   meterProvider.addMetricReader(metricReader);
-  
 
   before(function (done) {
     // Do not test if the `fetch` global API is not available

--- a/plugins/node/instrumentation-undici/test/metrics.test.ts
+++ b/plugins/node/instrumentation-undici/test/metrics.test.ts
@@ -69,7 +69,7 @@ describe('UndiciInstrumentation metrics tests', function () {
   });
 
   after(function (done) {
-    instrumentation.disable();
+    instrumentation?.disable();
     context.disable();
     propagation.disable();
     mockServer.mockListener(undefined);

--- a/plugins/node/instrumentation-undici/test/metrics.test.ts
+++ b/plugins/node/instrumentation-undici/test/metrics.test.ts
@@ -31,24 +31,21 @@ import { MockServer } from './utils/mock-server';
 import { MockMetricsReader } from './utils/mock-metrics-reader';
 import { SemanticAttributes } from '../src/enums/SemanticAttributes';
 
-const instrumentation = new UndiciInstrumentation();
-instrumentation.enable();
-instrumentation.disable();
-
-const protocol = 'http';
-const hostname = 'localhost';
-const mockServer = new MockServer();
-const provider = new NodeTracerProvider();
-const meterProvider = new MeterProvider();
-const metricsMemoryExporter = new InMemoryMetricExporter(
-  AggregationTemporality.DELTA
-);
-const metricReader = new MockMetricsReader(metricsMemoryExporter);
-meterProvider.addMetricReader(metricReader);
-instrumentation.setTracerProvider(provider);
-instrumentation.setMeterProvider(meterProvider);
 
 describe('UndiciInstrumentation metrics tests', function () {
+  let instrumentation: UndiciInstrumentation;
+  const protocol = 'http';
+  const hostname = 'localhost';
+  const mockServer = new MockServer();
+  const provider = new NodeTracerProvider();
+  const meterProvider = new MeterProvider();
+  const metricsMemoryExporter = new InMemoryMetricExporter(
+    AggregationTemporality.DELTA
+  );
+  const metricReader = new MockMetricsReader(metricsMemoryExporter);
+  meterProvider.addMetricReader(metricReader);
+  
+
   before(function (done) {
     // Do not test if the `fetch` global API is not available
     // This applies to nodejs < v18 or nodejs < v16.15 without the flag
@@ -57,6 +54,10 @@ describe('UndiciInstrumentation metrics tests', function () {
     if (typeof globalThis.fetch !== 'function') {
       this.skip();
     }
+
+    instrumentation = new UndiciInstrumentation();
+    instrumentation.setTracerProvider(provider);
+    instrumentation.setMeterProvider(meterProvider);
 
     context.setGlobalContextManager(new AsyncHooksContextManager().enable());
     mockServer.start(done);
@@ -67,9 +68,6 @@ describe('UndiciInstrumentation metrics tests', function () {
       res.write(JSON.stringify({ success: true }));
       res.end();
     });
-
-    // enable instrumentation for all tests
-    instrumentation.enable();
   });
 
   after(function (done) {

--- a/plugins/node/instrumentation-undici/test/undici.test.ts
+++ b/plugins/node/instrumentation-undici/test/undici.test.ts
@@ -70,7 +70,6 @@ describe('UndiciInstrumentation `undici` tests', function () {
   const memoryExporter = new InMemorySpanExporter();
   const provider = new NodeTracerProvider();
   provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
-  
 
   before(function (done) {
     // Load `undici`. It may fail if nodejs version is <18 because the module uses


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Fixes: #2391 

## Short description of the changes

- removed `enabled` internal config from the logic of the instrumentation. Now it relies only in enable/disable methods
- updated tests
