### PR TITLE
feat(instr-tedious): support tedious@19

### DIFF
--- a/plugins/node/instrumentation-tedious/.tav.yml
+++ b/plugins/node/instrumentation-tedious/.tav.yml
@@ -24,3 +24,10 @@ tedious:
     # TypeScript v5 to use. This peerDependencies can be removed when this
     # package updates to TypeScript v5.
     peerDependencies: typescript@5
+  - versions:
+      include: ">=19 <20"
+      mode: latest-majors
+    node: '>=18.17'
+    commands: npm run test
+    # See typescript@5 note above.
+    peerDependencies: typescript@5

--- a/plugins/node/instrumentation-tedious/README.md
+++ b/plugins/node/instrumentation-tedious/README.md
@@ -17,7 +17,7 @@ npm install --save @opentelemetry/instrumentation-tedious
 
 ## Supported Versions
 
-- [tedious](https://www.npmjs.com/package/tedious) `>=1.11.0 <19`
+- [tedious](https://www.npmjs.com/package/tedious) `>=1.11.0 <20`
 
 ## Usage
 

--- a/plugins/node/instrumentation-tedious/src/instrumentation.ts
+++ b/plugins/node/instrumentation-tedious/src/instrumentation.ts
@@ -78,7 +78,7 @@ export class TediousInstrumentation extends InstrumentationBase<TediousInstrumen
     return [
       new InstrumentationNodeModuleDefinition(
         TediousInstrumentation.COMPONENT,
-        ['>=1.11.0 <19'],
+        ['>=1.11.0 <20'],
         (moduleExports: typeof tedious) => {
           const ConnectionPrototype: any = moduleExports.Connection.prototype;
           for (const method of PATCHED_METHODS) {

--- a/plugins/node/instrumentation-tedious/test/instrumentation.test.ts
+++ b/plugins/node/instrumentation-tedious/test/instrumentation.test.ts
@@ -79,7 +79,11 @@ const incompatVersions =
   (semver.lt(processVersion, '15.0.0') &&
     semver.gte(tediousVersion, '16.0.0')) ||
   // tedious@17 removed support for node v16 and v19 https://github.com/tediousjs/tedious/releases/tag/v17.0.0
-  (semver.lt(processVersion, '17.0.0') && semver.gte(tediousVersion, '17.0.0'));
+  (semver.lt(processVersion, '17.0.0') &&
+    semver.gte(tediousVersion, '17.0.0')) ||
+  // tedious@19 removed support for node <18.17.0 https://github.com/tediousjs/tedious/releases/tag/v19.0.0
+  (semver.lt(processVersion, '18.17.0') &&
+    semver.gte(tediousVersion, '19.0.0'));
 
 describe('tedious', () => {
   let tedious: any;


### PR DESCRIPTION
https://github.com/tediousjs/tedious/releases/tag/v19.0.0
tedious@19 bumps the min supported Node.js to 18.17.0.

Refs: #2400
