### PR TITLE
fix(instrumentation-generic-pool): update span name typo

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-generic-pool/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-generic-pool/src/instrumentation.ts
@@ -109,7 +109,7 @@ export class GenericPoolInstrumentation extends InstrumentationBase {
     ) {
       const parent = api.context.active();
       const span = instrumentation.tracer.startSpan(
-        'generic-pool.aquire',
+        'generic-pool.acquire',
         {},
         parent
       );
@@ -156,7 +156,7 @@ export class GenericPoolInstrumentation extends InstrumentationBase {
       }
       const parent = api.context.active();
       const span = instrumentation.tracer.startSpan(
-        'generic-pool.aquire',
+        'generic-pool.acquire',
         {},
         parent
       );

--- a/plugins/node/opentelemetry-instrumentation-generic-pool/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-generic-pool/test/index.test.ts
@@ -94,7 +94,7 @@ describe('GenericPool instrumentation', () => {
     assert.strictEqual(await acquire(), CLIENT);
     const [span] = memoryExporter.getFinishedSpans();
     assert.strictEqual(memoryExporter.getFinishedSpans().length, 1);
-    assert.strictEqual(span.name, 'generic-pool.aquire');
+    assert.strictEqual(span.name, 'generic-pool.acquire');
   });
 
   it('should attach it to the parent span', async () => {
@@ -107,7 +107,7 @@ describe('GenericPool instrumentation', () => {
       assert.strictEqual(memoryExporter.getFinishedSpans().length, 2);
 
       const [span] = memoryExporter.getFinishedSpans();
-      assert.strictEqual(span.name, 'generic-pool.aquire');
+      assert.strictEqual(span.name, 'generic-pool.acquire');
       assert.strictEqual(span.parentSpanId, rootSpan.spanContext().spanId);
     });
   });


### PR DESCRIPTION

## Which problem is this PR solving?

- The current span name emitted from `@opentelemetry/instrumentation-generic-pool` is `generic-pool.aquire`, but it should be `generic-pool.acquire` instead. For instance, see this [PR](https://github.com/getsentry/sentry-javascript/pull/13465/files/4d7ddbf7704b35cdc1a52ca25014315a6f6e72f2#r1731640158).

## Short description of the changes
- Span name changed to `generic-pool.acquire`

