### PR TITLE
feat!: use modern diagnostics_channel API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38476,7 +38476,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.19.47",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
         "rimraf": "5.0.10",
@@ -38487,10 +38487,19 @@
         "undici": "6.11.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">= 18.19.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.7.0"
+      }
+    },
+    "plugins/node/instrumentation-undici/node_modules/@types/node": {
+      "version": "18.19.47",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.47.tgz",
+      "integrity": "sha512-1f7dB3BL/bpd9tnDJrrHb66Y+cVrhxSOTGorRNdHwYTUlTay3HuTDPKo9a/4vX9pMQkhYBcAbL4jQdNlhCFP9A==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "plugins/node/opentelemetry-instrumentation-aws-lambda": {
@@ -53025,7 +53034,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.19.47",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
         "rimraf": "5.0.10",
@@ -53034,6 +53043,17 @@
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4",
         "undici": "6.11.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.19.47",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.47.tgz",
+          "integrity": "sha512-1f7dB3BL/bpd9tnDJrrHb66Y+cVrhxSOTGorRNdHwYTUlTay3HuTDPKo9a/4vX9pMQkhYBcAbL4jQdNlhCFP9A==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-user-interaction": {

--- a/plugins/node/instrumentation-undici/package.json
+++ b/plugins/node/instrumentation-undici/package.json
@@ -30,7 +30,7 @@
   "author": "OpenTelemetry Authors",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=14"
+    "node": ">= 18.19.0"
   },
   "files": [
     "build/src/**/*.js",
@@ -46,7 +46,7 @@
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.19.47",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "rimraf": "5.0.10",

--- a/plugins/node/instrumentation-undici/src/internal-types.ts
+++ b/plugins/node/instrumentation-undici/src/internal-types.ts
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { Channel } from 'diagnostics_channel';
-
 import { UndiciRequest, UndiciResponse } from './types';
 
 export interface ListenerRecord {
   name: string;
-  channel: Channel;
-  onMessage: (message: any, name: string) => void;
+  onMessage: (message: any, name: string | symbol) => void;
+  unsubscribe: () => void;
 }
 
 export interface RequestMessage {

--- a/plugins/node/instrumentation-undici/src/undici.ts
+++ b/plugins/node/instrumentation-undici/src/undici.ts
@@ -77,7 +77,7 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
 
   override disable(): void {
     super.disable();
-    this._channelSubs.forEach(sub => sub.channel.unsubscribe(sub.onMessage));
+    this._channelSubs.forEach(sub => sub.unsubscribe());
     this._channelSubs.length = 0;
   }
 
@@ -139,12 +139,11 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
     diagnosticChannel: string,
     onMessage: ListenerRecord['onMessage']
   ) {
-    const channel = diagch.channel(diagnosticChannel);
-    channel.subscribe(onMessage);
+    diagch.subscribe(diagnosticChannel, onMessage);
     this._channelSubs.push({
       name: diagnosticChannel,
-      channel,
       onMessage,
+      unsubscribe: () => diagch.unsubscribe(diagnosticChannel, onMessage),
     });
   }
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

I'm observing that `instrumentation-undici` does not work in Node.js 18.16.0 if code was started with no Internet access. I nailed it down to usage of `channel.subscribe(onMessage)` which was deprecated in Node.js 18.7.0.

Interestingly enough new API does not pass tests on all Node.js versions between 18.7.0 and 18.18.2. I think this is related to https://github.com/nodejs/node/pull/47520. Thus I'm setting minimal engine version to 18.19.0.

## Short description of the changes

Use [diagnostics_channel.subscribe(name, onMessage)](https://nodejs.org/api/diagnostics_channel.html#diagnostics_channelsubscribename-onmessage) instead of [channel.subscribe(onMessage)](https://nodejs.org/api/diagnostics_channel.html#channelsubscribeonmessage).