### PR TITLE
chore(deps): update deps matching "@opentelemetry/"

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-instana/package.json
+++ b/detectors/node/opentelemetry-resource-detector-instana/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/contrib-test-utils": "^0.40.0",
-    "@opentelemetry/sdk-node": "^0.52.0",
+    "@opentelemetry/sdk-node": "^0.53.0",
     "@types/mocha": "8.2.3",
     "@types/node": "18.6.5",
     "@types/semver": "7.5.8",

--- a/metapackages/auto-configuration-propagators/package.json
+++ b/metapackages/auto-configuration-propagators/package.json
@@ -46,10 +46,10 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.25.1",
+    "@opentelemetry/propagator-aws-xray": "^1.25.1",
+    "@opentelemetry/propagator-aws-xray-lambda": "^0.53.0",
     "@opentelemetry/propagator-b3": "^1.25.1",
     "@opentelemetry/propagator-jaeger": "^1.25.1",
-    "@opentelemetry/propagator-aws-xray": "^1.25.1",
-    "@opentelemetry/propagator-aws-xray-lambda": "^0.52.1",
     "@opentelemetry/propagator-ot-trace": "^0.27.2"
   },
   "files": [

--- a/metapackages/auto-instrumentations-node/package.json
+++ b/metapackages/auto-instrumentations-node/package.json
@@ -49,7 +49,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/instrumentation-amqplib": "^0.41.0",
     "@opentelemetry/instrumentation-aws-lambda": "^0.43.0",
     "@opentelemetry/instrumentation-aws-sdk": "^0.43.1",
@@ -64,9 +64,9 @@
     "@opentelemetry/instrumentation-fs": "^0.14.0",
     "@opentelemetry/instrumentation-generic-pool": "^0.38.1",
     "@opentelemetry/instrumentation-graphql": "^0.42.0",
-    "@opentelemetry/instrumentation-grpc": "^0.52.0",
+    "@opentelemetry/instrumentation-grpc": "^0.53.0",
     "@opentelemetry/instrumentation-hapi": "^0.40.0",
-    "@opentelemetry/instrumentation-http": "^0.52.0",
+    "@opentelemetry/instrumentation-http": "^0.53.0",
     "@opentelemetry/instrumentation-ioredis": "^0.42.0",
     "@opentelemetry/instrumentation-kafkajs": "^0.2.0",
     "@opentelemetry/instrumentation-knex": "^0.39.0",
@@ -95,7 +95,7 @@
     "@opentelemetry/resource-detector-container": "^0.4.0",
     "@opentelemetry/resource-detector-gcp": "^0.29.10",
     "@opentelemetry/resources": "^1.24.0",
-    "@opentelemetry/sdk-node": "^0.52.0"
+    "@opentelemetry/sdk-node": "^0.53.0"
   },
   "files": [
     "build/src/**/*.js",

--- a/metapackages/auto-instrumentations-web/package.json
+++ b/metapackages/auto-instrumentations-web/package.json
@@ -64,11 +64,11 @@
     "webpack-merge": "5.10.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/instrumentation-document-load": "^0.39.0",
-    "@opentelemetry/instrumentation-fetch": "^0.52.0",
+    "@opentelemetry/instrumentation-fetch": "^0.53.0",
     "@opentelemetry/instrumentation-user-interaction": "^0.39.0",
-    "@opentelemetry/instrumentation-xml-http-request": "^0.52.0"
+    "@opentelemetry/instrumentation-xml-http-request": "^0.53.0"
   },
   "files": [
     "build/src/**/*.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -258,7 +258,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
-        "@opentelemetry/sdk-node": "^0.52.0",
+        "@opentelemetry/sdk-node": "^0.53.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.6.5",
         "@types/semver": "7.5.8",
@@ -289,7 +289,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.25.1",
         "@opentelemetry/propagator-aws-xray": "^1.25.1",
-        "@opentelemetry/propagator-aws-xray-lambda": "^0.52.1",
+        "@opentelemetry/propagator-aws-xray-lambda": "^0.53.0",
         "@opentelemetry/propagator-b3": "^1.25.1",
         "@opentelemetry/propagator-jaeger": "^1.25.1",
         "@opentelemetry/propagator-ot-trace": "^0.27.2"
@@ -318,7 +318,7 @@
       "version": "0.49.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/instrumentation-amqplib": "^0.41.0",
         "@opentelemetry/instrumentation-aws-lambda": "^0.43.0",
         "@opentelemetry/instrumentation-aws-sdk": "^0.43.1",
@@ -333,9 +333,9 @@
         "@opentelemetry/instrumentation-fs": "^0.14.0",
         "@opentelemetry/instrumentation-generic-pool": "^0.38.1",
         "@opentelemetry/instrumentation-graphql": "^0.42.0",
-        "@opentelemetry/instrumentation-grpc": "^0.52.0",
+        "@opentelemetry/instrumentation-grpc": "^0.53.0",
         "@opentelemetry/instrumentation-hapi": "^0.40.0",
-        "@opentelemetry/instrumentation-http": "^0.52.0",
+        "@opentelemetry/instrumentation-http": "^0.53.0",
         "@opentelemetry/instrumentation-ioredis": "^0.42.0",
         "@opentelemetry/instrumentation-kafkajs": "^0.2.0",
         "@opentelemetry/instrumentation-knex": "^0.39.0",
@@ -364,7 +364,7 @@
         "@opentelemetry/resource-detector-container": "^0.4.0",
         "@opentelemetry/resource-detector-gcp": "^0.29.10",
         "@opentelemetry/resources": "^1.24.0",
-        "@opentelemetry/sdk-node": "^0.52.0"
+        "@opentelemetry/sdk-node": "^0.53.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.4.1",
@@ -390,11 +390,11 @@
       "version": "0.40.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/instrumentation-document-load": "^0.39.0",
-        "@opentelemetry/instrumentation-fetch": "^0.52.0",
+        "@opentelemetry/instrumentation-fetch": "^0.53.0",
         "@opentelemetry/instrumentation-user-interaction": "^0.39.0",
-        "@opentelemetry/instrumentation-xml-http-request": "^0.52.0"
+        "@opentelemetry/instrumentation-xml-http-request": "^0.53.0"
       },
       "devDependencies": {
         "@babel/core": "7.24.6",
@@ -10241,9 +10241,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.1.tgz",
-      "integrity": "sha512-qnSqB2DQ9TPP96dl8cDubDvrUyWc0/sK81xHTK8eSUspzDM3bsewX903qclQFvVhgStjRWdC5bLb3kQqMkfV5A==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
+      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
@@ -10268,9 +10268,9 @@
       "link": true
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.25.1.tgz",
-      "integrity": "sha512-UW/ge9zjvAEmRWVapOP0qyCvPulWU6cQxGxDbWEFfGOj1VBBZAuOqTo3X6yWmDTD3Xe15ysCZChHncr2xFMIfQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.26.0.tgz",
+      "integrity": "sha512-HedpXXYzzbaoutw6DFLWLDket2FwLkLpil4hGCZ1xYEIMTcivdfwEOISgdbLEWyG3HW52gTq2V9mOVJrONgiwg==",
       "engines": {
         "node": ">=14"
       },
@@ -10279,11 +10279,11 @@
       }
     },
     "node_modules/@opentelemetry/context-zone": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-1.25.1.tgz",
-      "integrity": "sha512-kHbMs95mKNJPpfd1LE1/IRxUw5D1fyTOM+0R1yDOOzffs9ZZsQqgQ1Q7q0bWZ/kVLWjL43fiALe+rPtQvRShdg==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-1.26.0.tgz",
+      "integrity": "sha512-ckBEUKo7jZnZ2jARcntv365413cTe9Ra7uMQWvdk10K3tWOUsLnBG8dSMRbkaA+XL9hWGrZ1MMI8UXrwnbp0FA==",
       "dependencies": {
-        "@opentelemetry/context-zone-peer-dep": "1.25.1",
+        "@opentelemetry/context-zone-peer-dep": "1.26.0",
         "zone.js": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
       },
       "engines": {
@@ -10291,9 +10291,9 @@
       }
     },
     "node_modules/@opentelemetry/context-zone-peer-dep": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.25.1.tgz",
-      "integrity": "sha512-UxSY9K90xOg2eI7qZStx0HV6DZT6tcRX+IiAWTvROi6h9Td2c2vlQhBZ9F1JH7kINmNCZN1f1//O9rSioPEMlg==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.26.0.tgz",
+      "integrity": "sha512-Mgdy0WsHR52h5AnN2nhZJrelDK6unOFr8aSn3ToETk6DLSOijayOi0M0SZM72qhWr7iFrJ1oxGEIK8uzVaSC8Q==",
       "engines": {
         "node": ">=14"
       },
@@ -10307,11 +10307,12 @@
       "link": true
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
-      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.26.0.tgz",
+      "integrity": "sha512-1iKxXXE8415Cdv0yjG3G6hQnB5eVEsJce3QaawX8SjDn0mAS0ZM8fAbZZJD4ajvhC15cePvosSCut404KrIIvQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/semantic-conventions": "1.27.0"
       },
       "engines": {
         "node": ">=14"
@@ -10321,13 +10322,13 @@
       }
     },
     "node_modules/@opentelemetry/exporter-jaeger": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.25.1.tgz",
-      "integrity": "sha512-6/HwzrwUx0fpkFXrouF0IJp+hpN8xkx8RqEk+BZfeoMAHydpyigyYsKyAtAZRwfJe45WWJbJUqoK8aBjiC9iLQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.26.0.tgz",
+      "integrity": "sha512-l5NMFwFr5NWWRNcURUS8/RdkBmR3+dPGE33f51XfamKXsEfZUkRC8V1L2D7hzKhXxcFmYLcprg4/sYpeKtYoAQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0",
         "jaeger-client": "^3.15.0"
       },
       "engines": {
@@ -10337,17 +10338,73 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.52.1.tgz",
-      "integrity": "sha512-pVkSH20crBwMTqB3nIN4jpQKUEoB0Z94drIHpYyEqs7UBr+I0cpYyOR3bqjA/UasQUMROb3GX8ZX4/9cVRqGBQ==",
+    "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.53.0.tgz",
+      "integrity": "sha512-x5ygAQgWAQOI+UOhyV3z9eW7QU2dCfnfOuIBiyYmC2AWr74f6x/3JBnP27IAcEx6aihpqBYWKnpoUTztkVPAZw==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.52.1",
-        "@opentelemetry/otlp-transformer": "0.52.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.53.0",
+        "@opentelemetry/otlp-transformer": "0.53.0",
+        "@opentelemetry/sdk-logs": "0.53.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.53.0.tgz",
+      "integrity": "sha512-cSRKgD/n8rb+Yd+Cif6EnHEL/VZg1o8lEcEwFji1lwene6BdH51Zh3feAD9p2TyVoBKrl6Q9Zm2WltSp2k9gWQ==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.53.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/otlp-exporter-base": "0.53.0",
+        "@opentelemetry/otlp-transformer": "0.53.0",
+        "@opentelemetry/sdk-logs": "0.53.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.53.0.tgz",
+      "integrity": "sha512-jhEcVL1deeWNmTUP05UZMriZPSWUBcfg94ng7JuBb1q2NExgnADQFl1VQQ+xo62/JepK+MxQe4xAwlsDQFbISA==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.53.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/otlp-exporter-base": "0.53.0",
+        "@opentelemetry/otlp-transformer": "0.53.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-logs": "0.53.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.53.0.tgz",
+      "integrity": "sha512-m6KSh6OBDwfDjpzPVbuJbMgMbkoZfpxYH2r262KckgX9cMYvooWXEKzlJYsNDC6ADr28A1rtRoUVRwNfIN4tUg==",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.53.0",
+        "@opentelemetry/otlp-transformer": "0.53.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0"
       },
       "engines": {
         "node": ">=14"
@@ -10357,15 +10414,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.52.1.tgz",
-      "integrity": "sha512-05HcNizx0BxcFKKnS5rwOV+2GevLTVIRA0tRgWYyw4yCgR53Ic/xk83toYKts7kbzcI+dswInUg/4s8oyA+tqg==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.53.0.tgz",
+      "integrity": "sha512-m7F5ZTq+V9mKGWYpX8EnZ7NjoqAU7VemQ1E2HAG+W/u0wpY1x0OmbxAXfGKFHCspdJk8UKlwPGrpcB8nay3P8A==",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/otlp-exporter-base": "0.52.1",
-        "@opentelemetry/otlp-transformer": "0.52.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/otlp-exporter-base": "0.53.0",
+        "@opentelemetry/otlp-transformer": "0.53.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0"
       },
       "engines": {
         "node": ">=14"
@@ -10375,15 +10432,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.52.1.tgz",
-      "integrity": "sha512-pt6uX0noTQReHXNeEslQv7x311/F1gJzMnp1HD2qgypLRPbXDeMzzeTngRTUaUbP6hqWNtPxuLr4DEoZG+TcEQ==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.53.0.tgz",
+      "integrity": "sha512-T/bdXslwRKj23S96qbvGtaYOdfyew3TjPEKOk5mHjkCmkVl1O9C/YMdejwSsdLdOq2YW30KjR9kVi0YMxZushQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/otlp-exporter-base": "0.52.1",
-        "@opentelemetry/otlp-transformer": "0.52.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/otlp-exporter-base": "0.53.0",
+        "@opentelemetry/otlp-transformer": "0.53.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0"
       },
       "engines": {
         "node": ">=14"
@@ -10393,14 +10450,14 @@
       }
     },
     "node_modules/@opentelemetry/exporter-zipkin": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.25.1.tgz",
-      "integrity": "sha512-RmOwSvkimg7ETwJbUOPTMhJm9A9bG1U8s7Zo3ajDh4zM7eYcycQ0dM7FbLD6NXWbI2yj7UY4q8BKinKYBQksyw==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.26.0.tgz",
+      "integrity": "sha512-PW5R34n3SJHO4t0UetyHKiXL6LixIqWN6lWncg3eRXhKuT30x+b7m5sDJS0kEWRfHeS+kG7uCw2vBzmB2lk3Dw==",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
       },
       "engines": {
         "node": ">=14"
@@ -10418,12 +10475,12 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.52.1.tgz",
-      "integrity": "sha512-uXJbYU/5/MBHjMp1FqrILLRuiJCs3Ofk0MeRDk8g1S1gD47U8X3JnSwcMO1rtRo1x1a7zKaQHaoYu49p/4eSKw==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.53.0.tgz",
+      "integrity": "sha512-DMwg0hy4wzf7K73JJtl95m/e0boSoWhH07rfvHvYzQtBD3Bmv0Wc1x733vyZBqmFm8OjJD0/pfiUg1W3JjFX0A==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.52.1",
-        "@types/shimmer": "^1.0.2",
+        "@opentelemetry/api-logs": "0.53.0",
+        "@types/shimmer": "^1.2.0",
         "import-in-the-middle": "^1.8.1",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2",
@@ -10485,14 +10542,14 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-fetch": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.52.1.tgz",
-      "integrity": "sha512-EJDQXdv1ZGyBifox+8BK+hP0tg29abNPdScE+lW77bUVrThD5vn2dOo+blAS3Z8Od+eqTUTDzXVDIFjGgTK01w==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.53.0.tgz",
+      "integrity": "sha512-Sayp/Oypr0lyTgOKide/Dz4ovqDWPdmazapCMyfsVpXpV9zrH2kbdO2vAKUMx9vF98vxsqcxXucf4z54WXWZ8A==",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/instrumentation": "0.52.1",
-        "@opentelemetry/sdk-trace-web": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/instrumentation": "0.53.0",
+        "@opentelemetry/sdk-trace-web": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
       },
       "engines": {
         "node": ">=14"
@@ -10514,12 +10571,12 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-grpc": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.52.1.tgz",
-      "integrity": "sha512-EdSDiDSAO+XRXk/ZN128qQpBo1I51+Uay/LUPcPQhSRGf7fBPIEUBeOLQiItguGsug5MGOYjql2w/1wCQF3fdQ==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.53.0.tgz",
+      "integrity": "sha512-Ss338T92yE1UCgr9zXSY3cPuaAy27uQw+wAC5IwsQKCXL5wwkiOgkd+2Ngksa9EGsgUEMwGeHi76bDdHFJ5Rrw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "0.52.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/instrumentation": "0.53.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
       },
       "engines": {
         "node": ">=14"
@@ -10533,13 +10590,13 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.52.1.tgz",
-      "integrity": "sha512-dG/aevWhaP+7OLv4BQQSEKMJv8GyeOp3Wxl31NHqE8xo9/fYMfEljiZphUHIfyg4gnZ9swMyWjfOQs5GUQe54Q==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.53.0.tgz",
+      "integrity": "sha512-H74ErMeDuZfj7KgYCTOFGWF5W9AfaPnqLQQxeFq85+D29wwV2yqHbz2IKLYpkOh7EI6QwDEl7rZCIxjJLyc/CQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/instrumentation": "0.52.1",
-        "@opentelemetry/semantic-conventions": "1.25.1",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/instrumentation": "0.53.0",
+        "@opentelemetry/semantic-conventions": "1.27.0",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -10650,14 +10707,14 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-xml-http-request": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.52.1.tgz",
-      "integrity": "sha512-4a7WpbN+prdyIxoTqCA3m+ZuqQVrksWWeOP5iEyof9yrzEY1NJgM+plrPrzb5nn7U5T7RGkkpvaTPm08qfFu7w==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.53.0.tgz",
+      "integrity": "sha512-vkALs8zdEUU3GnGvq1rzP0RK3+Fsk2jyzY6X/a+ibbo/miCmmeQNHX+fBRNs/3Offquj19M0qD+olNU9CJloqg==",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/instrumentation": "0.52.1",
-        "@opentelemetry/sdk-trace-web": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/instrumentation": "0.53.0",
+        "@opentelemetry/sdk-trace-web": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
       },
       "engines": {
         "node": ">=14"
@@ -10666,13 +10723,18 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
+    "node_modules/@opentelemetry/instrumentation/node_modules/@types/shimmer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
+      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="
+    },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.52.1.tgz",
-      "integrity": "sha512-z175NXOtX5ihdlshtYBe5RpGeBoTXVCKPPLiQlD6FHvpM4Ch+p2B0yWKYSrBfLH24H9zjJiBdTrtD+hLlfnXEQ==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.53.0.tgz",
+      "integrity": "sha512-UCWPreGQEhD6FjBaeDuXhiMf6kkBODF0ZQzrk/tuQcaVDJ+dDQ/xhJp192H9yWnKxVpEjFrSSLnpqmX4VwX+eA==",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/otlp-transformer": "0.52.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/otlp-transformer": "0.53.0"
       },
       "engines": {
         "node": ">=14"
@@ -10682,14 +10744,14 @@
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.52.1.tgz",
-      "integrity": "sha512-zo/YrSDmKMjG+vPeA9aBBrsQM9Q/f2zo6N04WMB3yNldJRsgpRBeLLwvAt/Ba7dpehDLOEFBd1i2JCoaFtpCoQ==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.53.0.tgz",
+      "integrity": "sha512-F7RCN8VN+lzSa4fGjewit8Z5fEUpY/lmMVy5EWn2ZpbAabg3EE3sCLuTNfOiooNGnmvzimUPruoeqeko/5/TzQ==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/otlp-exporter-base": "0.52.1",
-        "@opentelemetry/otlp-transformer": "0.52.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/otlp-exporter-base": "0.53.0",
+        "@opentelemetry/otlp-transformer": "0.53.0"
       },
       "engines": {
         "node": ">=14"
@@ -10699,23 +10761,23 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.52.1.tgz",
-      "integrity": "sha512-I88uCZSZZtVa0XniRqQWKbjAUm73I8tpEy/uJYPPYw5d7BRdVk0RfTBQw8kSUl01oVWEuqxLDa802222MYyWHg==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.53.0.tgz",
+      "integrity": "sha512-rM0sDA9HD8dluwuBxLetUmoqGJKSAbWenwD65KY9iZhUxdBHRLrIdrABfNDP7aiTjcgK8XFyTn5fhDz7N+W6DA==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.52.1",
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-logs": "0.52.1",
-        "@opentelemetry/sdk-metrics": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/api-logs": "0.53.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-logs": "0.53.0",
+        "@opentelemetry/sdk-metrics": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
         "protobufjs": "^7.3.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@opentelemetry/plugin-react-load": {
@@ -10727,11 +10789,11 @@
       "link": true
     },
     "node_modules/@opentelemetry/propagator-aws-xray": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.25.1.tgz",
-      "integrity": "sha512-soZQdO9EAROMwa9bL2C0VLadbrfRjSA9t7g6X8sL0X1B8V59pzOayYMyTW9qTECn9uuJV98A7qOnJm6KH6yk8w==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.26.0.tgz",
+      "integrity": "sha512-Sex+JyEZ/xX328TArBqQjh1NZSfNyw5NdASUIi9hnPsnMBMSBaDe7B9JRnXv0swz7niNyAnXa6MY7yOCV76EvA==",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1"
+        "@opentelemetry/core": "1.26.0"
       },
       "engines": {
         "node": ">=14"
@@ -10741,11 +10803,11 @@
       }
     },
     "node_modules/@opentelemetry/propagator-aws-xray-lambda": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray-lambda/-/propagator-aws-xray-lambda-0.52.1.tgz",
-      "integrity": "sha512-LBAu/1SRVuWrsWTzqUxZmzWinsS76UH/qApgYjmaN6Q8RcObXeZOmR0+FLSwkRX7OLGhLLQKiu3CQmlgXbpNCw==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray-lambda/-/propagator-aws-xray-lambda-0.53.0.tgz",
+      "integrity": "sha512-B0+Cob9nmT49AjgMXCXn+bvvA/TsQ+vjc1tx3y7oXgq/VwJAFIq7NBoWZHMArtcC4yt3gXpUd/CRN6LzUa0ORA==",
       "dependencies": {
-        "@opentelemetry/propagator-aws-xray": "1.25.1"
+        "@opentelemetry/propagator-aws-xray": "1.26.0"
       },
       "engines": {
         "node": ">=14"
@@ -10755,11 +10817,12 @@
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.25.1.tgz",
-      "integrity": "sha512-p6HFscpjrv7//kE+7L+3Vn00VEDUJB0n6ZrjkTYHrJ58QZ8B3ajSJhRbCcY6guQ3PDjTbxWklyvIN2ojVbIb1A==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.26.0.tgz",
+      "integrity": "sha512-vvVkQLQ/lGGyEy9GT8uFnI047pajSOVnZI2poJqVGD3nJ+B9sFGdlHNnQKophE3lHfnIH0pw2ubrCTjZCgIj+Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1"
+        "@opentelemetry/core": "1.26.0"
       },
       "engines": {
         "node": ">=14"
@@ -10773,11 +10836,11 @@
       "link": true
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.25.1.tgz",
-      "integrity": "sha512-nBprRf0+jlgxks78G/xq72PipVK+4or9Ypntw0gVZYNTCSK8rg5SeaGV19tV920CMqBD/9UIOiFr23Li/Q8tiA==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.26.0.tgz",
+      "integrity": "sha512-DelFGkCdaxA1C/QA0Xilszfr0t4YbGd3DjxiCDPh34lfnFr+VkkrjV9S8ZTJvAzfdKERXhfOxIKBoGPJwoSz7Q==",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1"
+        "@opentelemetry/core": "1.26.0"
       },
       "engines": {
         "node": ">=14"
@@ -10823,12 +10886,12 @@
       "link": true
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
-      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.26.0.tgz",
+      "integrity": "sha512-CPNYchBE7MBecCSVy0HKpUISEeJOniWqcHaAHpmasZ3j9o6V3AyBzhRc90jdmemq0HOxDr6ylhUbDhBqqPpeNw==",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
       },
       "engines": {
         "node": ">=14"
@@ -10838,13 +10901,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.52.1.tgz",
-      "integrity": "sha512-MBYh+WcPPsN8YpRHRmK1Hsca9pVlyyKd4BxOC4SsgHACnl/bPp4Cri9hWhVm5+2tiQ9Zf4qSc1Jshw9tOLGWQA==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.53.0.tgz",
+      "integrity": "sha512-dhSisnEgIj/vJZXZV6f6KcTnyLDx/VuQ6l3ejuZpMpPlh9S1qMHiZU9NMmOkVkwwHkMy3G6mEBwdP23vUZVr4g==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.52.1",
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/resources": "1.25.1"
+        "@opentelemetry/api-logs": "0.53.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0"
       },
       "engines": {
         "node": ">=14"
@@ -10854,13 +10917,12 @@
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
-      "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.26.0.tgz",
+      "integrity": "sha512-0SvDXmou/JjzSDOjUmetAAvcKQW6ZrvosU0rkbDGpXvvZN+pQF6JbK/Kd4hNdK4q/22yeruqvukXEJyySTzyTQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/resources": "1.25.1",
-        "lodash.merge": "^4.6.2"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0"
       },
       "engines": {
         "node": ">=14"
@@ -10870,23 +10932,26 @@
       }
     },
     "node_modules/@opentelemetry/sdk-node": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.52.1.tgz",
-      "integrity": "sha512-uEG+gtEr6eKd8CVWeKMhH2olcCHM9dEK68pe0qE0be32BcCRsvYURhHaD1Srngh1SQcnQzZ4TP324euxqtBOJA==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.53.0.tgz",
+      "integrity": "sha512-0hsxfq3BKy05xGktwG8YdGdxV978++x40EAKyKr1CaHZRh8uqVlXnclnl7OMi9xLMJEcXUw7lGhiRlArFcovyg==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.52.1",
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.52.1",
-        "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
-        "@opentelemetry/exporter-zipkin": "1.25.1",
-        "@opentelemetry/instrumentation": "0.52.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-logs": "0.52.1",
-        "@opentelemetry/sdk-metrics": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/sdk-trace-node": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/api-logs": "0.53.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.53.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.53.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.53.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.53.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.53.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.53.0",
+        "@opentelemetry/exporter-zipkin": "1.26.0",
+        "@opentelemetry/instrumentation": "0.53.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-logs": "0.53.0",
+        "@opentelemetry/sdk-metrics": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/sdk-trace-node": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
       },
       "engines": {
         "node": ">=14"
@@ -10896,13 +10961,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
-      "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.26.0.tgz",
+      "integrity": "sha512-olWQldtvbK4v22ymrKLbIcBi9L2SpMO84sCPY54IVsJhP9fRsxJT194C/AVaAuJzLE30EdhhM1VmvVYR7az+cw==",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
       },
       "engines": {
         "node": ">=14"
@@ -10912,15 +10977,15 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.25.1.tgz",
-      "integrity": "sha512-nMcjFIKxnFqoez4gUmihdBrbpsEnAX/Xj16sGvZm+guceYE0NE00vLhpDVK6f3q8Q4VFI5xG8JjlXKMB/SkTTQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.26.0.tgz",
+      "integrity": "sha512-Fj5IVKrj0yeUwlewCRwzOVcr5avTuNnMHWf7GPc1t6WaT78J6CJyF3saZ/0RkZfdeNO8IcBl/bNcWMVZBMRW8Q==",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.25.1",
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/propagator-b3": "1.25.1",
-        "@opentelemetry/propagator-jaeger": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/context-async-hooks": "1.26.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/propagator-b3": "1.26.0",
+        "@opentelemetry/propagator-jaeger": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -10931,13 +10996,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-web": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.25.1.tgz",
-      "integrity": "sha512-SS6JaSkHngcBCNdWGthzcvaKGRnDw2AeP57HyTEileLToJ7WLMeV+064iRlVyoT4+e77MRp2T2dDSrmaUyxoNg==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.26.0.tgz",
+      "integrity": "sha512-sxeKPcG/gUyxZ8iB8X1MI8/grfSCGgo1n2kxOE73zjVaO9yW/7JuVC3gqUaWRjtZ6VD/V3lo2/ZSwMlm6n2mdg==",
       "dependencies": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
       },
       "engines": {
         "node": ">=14"
@@ -10947,9 +11012,10 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
-      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
+      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       }
@@ -12965,7 +13031,8 @@
     "node_modules/@types/shimmer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.3.tgz",
-      "integrity": "sha512-F/IjUGnV6pIN7R4ZV4npHJVoNtaLZWvb+2/9gctxjb99wkpI7Ozg8VPogwDiTRyjLwZXAYxjvdg1KS8LTHKdDA=="
+      "integrity": "sha512-F/IjUGnV6pIN7R4ZV4npHJVoNtaLZWvb+2/9gctxjb99wkpI7Ozg8VPogwDiTRyjLwZXAYxjvdg1KS8LTHKdDA==",
+      "dev": true
     },
     "node_modules/@types/sinon": {
       "version": "10.0.20",
@@ -25632,7 +25699,8 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "node_modules/lodash.mergewith": {
       "version": "4.6.2",
@@ -37687,9 +37755,9 @@
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/exporter-jaeger": "^1.3.1",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/resources": "^1.8.0",
-        "@opentelemetry/sdk-node": "^0.52.0",
+        "@opentelemetry/sdk-node": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
@@ -37711,7 +37779,7 @@
       "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.52.0",
+        "@opentelemetry/api-logs": "^0.53.0",
         "winston-transport": "4.*"
       },
       "devDependencies": {
@@ -37742,7 +37810,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
@@ -37781,7 +37849,7 @@
       "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
@@ -37815,7 +37883,7 @@
       "version": "0.11.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0"
+        "@opentelemetry/instrumentation": "^0.53.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37845,7 +37913,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0"
+        "@opentelemetry/instrumentation": "^0.53.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37875,7 +37943,7 @@
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.24.0"
       },
       "devDependencies": {
@@ -37905,7 +37973,7 @@
       "version": "0.39.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0"
+        "@opentelemetry/instrumentation": "^0.53.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37941,7 +38009,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
@@ -37977,7 +38045,7 @@
       "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0"
+        "@opentelemetry/instrumentation": "^0.53.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -38017,7 +38085,7 @@
       "version": "0.41.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
@@ -38266,7 +38334,7 @@
       "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/tedious": "^4.0.14"
       },
@@ -38468,7 +38536,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0"
+        "@opentelemetry/instrumentation": "^0.53.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.7.0",
@@ -38498,7 +38566,7 @@
       "version": "0.43.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/propagator-aws-xray": "^1.3.1",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -38531,7 +38599,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/propagation-utils": "^0.30.10",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
@@ -38578,14 +38646,14 @@
       "version": "0.40.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.52.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/api-logs": "^0.53.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@types/bunyan": "1.8.9"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/resources": "^1.8.0",
-        "@opentelemetry/sdk-logs": "^0.52.0",
+        "@opentelemetry/sdk-logs": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.23.0",
@@ -38621,7 +38689,7 @@
       "version": "0.40.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
@@ -38655,7 +38723,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/connect": "3.4.36"
       },
@@ -38693,7 +38761,7 @@
       "version": "0.38.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "semver": "^7.5.4"
       },
       "devDependencies": {
@@ -38726,7 +38794,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
@@ -38761,7 +38829,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
@@ -38769,7 +38837,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
-        "@opentelemetry/instrumentation-http": "^0.52.0",
+        "@opentelemetry/instrumentation-http": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/express": "4.17.21",
@@ -38803,7 +38871,7 @@
       "version": "0.38.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0"
+        "@opentelemetry/instrumentation": "^0.53.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -38834,7 +38902,7 @@
       "version": "0.42.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0"
+        "@opentelemetry/instrumentation": "^0.53.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -38869,7 +38937,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
@@ -38901,7 +38969,7 @@
       "version": "0.42.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/semantic-conventions": "^1.23.0"
       },
@@ -38937,7 +39005,7 @@
       "version": "0.39.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
@@ -38968,7 +39036,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
@@ -38976,7 +39044,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
-        "@opentelemetry/instrumentation-http": "^0.52.0",
+        "@opentelemetry/instrumentation-http": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/koa": "2.15.0",
@@ -39005,7 +39073,7 @@
       "version": "0.38.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.23.0",
         "@types/memcached": "^2.2.6"
       },
@@ -39037,7 +39105,7 @@
       "version": "0.46.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-metrics": "^1.9.1",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
@@ -39230,7 +39298,7 @@
       "version": "0.40.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/mysql": "2.15.26"
       },
@@ -39263,7 +39331,7 @@
       "version": "0.40.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
         "@opentelemetry/sql-common": "^0.40.1"
       },
@@ -39296,7 +39364,7 @@
       "version": "0.39.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.23.0"
       },
       "devDependencies": {
@@ -39336,7 +39404,7 @@
       "version": "0.38.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.23.0"
       },
       "devDependencies": {
@@ -39366,7 +39434,7 @@
       "version": "0.43.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
         "@opentelemetry/sql-common": "^0.40.1",
         "@types/pg": "8.6.1",
@@ -39405,9 +39473,9 @@
       "version": "0.41.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.52.0",
+        "@opentelemetry/api-logs": "^0.53.0",
         "@opentelemetry/core": "^1.25.0",
-        "@opentelemetry/instrumentation": "^0.52.0"
+        "@opentelemetry/instrumentation": "^0.53.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -39441,7 +39509,7 @@
       "version": "0.41.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
@@ -39475,7 +39543,7 @@
       "version": "0.41.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
@@ -39524,7 +39592,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
@@ -39557,7 +39625,7 @@
       "version": "0.39.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
       },
       "devDependencies": {
@@ -39586,8 +39654,8 @@
       "version": "0.39.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.52.0",
-        "@opentelemetry/instrumentation": "^0.52.0"
+        "@opentelemetry/api-logs": "^0.53.0",
+        "@opentelemetry/instrumentation": "^0.53.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -39622,7 +39690,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-web": "^1.15.0",
         "@opentelemetry/semantic-conventions": "^1.22.0"
@@ -39663,7 +39731,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-web": "^1.8.0"
       },
       "devDependencies": {
@@ -40274,7 +40342,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-web": "^1.8.0"
       },
       "devDependencies": {
@@ -40282,7 +40350,7 @@
         "@babel/preset-env": "7.24.6",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-zone-peer-dep": "^1.8.0",
-        "@opentelemetry/instrumentation-xml-http-request": "^0.52.0",
+        "@opentelemetry/instrumentation-xml-http-request": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@types/jquery": "3.5.30",
         "@types/mocha": "10.0.6",
@@ -40898,7 +40966,7 @@
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/propagator-b3": "1.25.1",
+        "@opentelemetry/propagator-b3": "1.26.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/react": "17.0.80",
@@ -50045,9 +50113,9 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
     },
     "@opentelemetry/api-logs": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.1.tgz",
-      "integrity": "sha512-qnSqB2DQ9TPP96dl8cDubDvrUyWc0/sK81xHTK8eSUspzDM3bsewX903qclQFvVhgStjRWdC5bLb3kQqMkfV5A==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.53.0.tgz",
+      "integrity": "sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==",
       "requires": {
         "@opentelemetry/api": "^1.0.0"
       }
@@ -50058,7 +50126,7 @@
         "@opentelemetry/api": "^1.4.1",
         "@opentelemetry/core": "^1.25.1",
         "@opentelemetry/propagator-aws-xray": "^1.25.1",
-        "@opentelemetry/propagator-aws-xray-lambda": "^0.52.1",
+        "@opentelemetry/propagator-aws-xray-lambda": "^0.53.0",
         "@opentelemetry/propagator-b3": "^1.25.1",
         "@opentelemetry/propagator-jaeger": "^1.25.1",
         "@opentelemetry/propagator-ot-trace": "^0.27.2",
@@ -50077,7 +50145,7 @@
       "version": "file:metapackages/auto-instrumentations-node",
       "requires": {
         "@opentelemetry/api": "^1.4.1",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/instrumentation-amqplib": "^0.41.0",
         "@opentelemetry/instrumentation-aws-lambda": "^0.43.0",
         "@opentelemetry/instrumentation-aws-sdk": "^0.43.1",
@@ -50092,9 +50160,9 @@
         "@opentelemetry/instrumentation-fs": "^0.14.0",
         "@opentelemetry/instrumentation-generic-pool": "^0.38.1",
         "@opentelemetry/instrumentation-graphql": "^0.42.0",
-        "@opentelemetry/instrumentation-grpc": "^0.52.0",
+        "@opentelemetry/instrumentation-grpc": "^0.53.0",
         "@opentelemetry/instrumentation-hapi": "^0.40.0",
-        "@opentelemetry/instrumentation-http": "^0.52.0",
+        "@opentelemetry/instrumentation-http": "^0.53.0",
         "@opentelemetry/instrumentation-ioredis": "^0.42.0",
         "@opentelemetry/instrumentation-kafkajs": "^0.2.0",
         "@opentelemetry/instrumentation-knex": "^0.39.0",
@@ -50123,7 +50191,7 @@
         "@opentelemetry/resource-detector-container": "^0.4.0",
         "@opentelemetry/resource-detector-gcp": "^0.29.10",
         "@opentelemetry/resources": "^1.24.0",
-        "@opentelemetry/sdk-node": "^0.52.0",
+        "@opentelemetry/sdk-node": "^0.53.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -50141,11 +50209,11 @@
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/instrumentation-document-load": "^0.39.0",
-        "@opentelemetry/instrumentation-fetch": "^0.52.0",
+        "@opentelemetry/instrumentation-fetch": "^0.53.0",
         "@opentelemetry/instrumentation-user-interaction": "^0.39.0",
-        "@opentelemetry/instrumentation-xml-http-request": "^0.52.0",
+        "@opentelemetry/instrumentation-xml-http-request": "^0.53.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -50608,24 +50676,24 @@
       }
     },
     "@opentelemetry/context-async-hooks": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.25.1.tgz",
-      "integrity": "sha512-UW/ge9zjvAEmRWVapOP0qyCvPulWU6cQxGxDbWEFfGOj1VBBZAuOqTo3X6yWmDTD3Xe15ysCZChHncr2xFMIfQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.26.0.tgz",
+      "integrity": "sha512-HedpXXYzzbaoutw6DFLWLDket2FwLkLpil4hGCZ1xYEIMTcivdfwEOISgdbLEWyG3HW52gTq2V9mOVJrONgiwg==",
       "requires": {}
     },
     "@opentelemetry/context-zone": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-1.25.1.tgz",
-      "integrity": "sha512-kHbMs95mKNJPpfd1LE1/IRxUw5D1fyTOM+0R1yDOOzffs9ZZsQqgQ1Q7q0bWZ/kVLWjL43fiALe+rPtQvRShdg==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-1.26.0.tgz",
+      "integrity": "sha512-ckBEUKo7jZnZ2jARcntv365413cTe9Ra7uMQWvdk10K3tWOUsLnBG8dSMRbkaA+XL9hWGrZ1MMI8UXrwnbp0FA==",
       "requires": {
-        "@opentelemetry/context-zone-peer-dep": "1.25.1",
+        "@opentelemetry/context-zone-peer-dep": "1.26.0",
         "zone.js": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
       }
     },
     "@opentelemetry/context-zone-peer-dep": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.25.1.tgz",
-      "integrity": "sha512-UxSY9K90xOg2eI7qZStx0HV6DZT6tcRX+IiAWTvROi6h9Td2c2vlQhBZ9F1JH7kINmNCZN1f1//O9rSioPEMlg==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.26.0.tgz",
+      "integrity": "sha512-Mgdy0WsHR52h5AnN2nhZJrelDK6unOFr8aSn3ToETk6DLSOijayOi0M0SZM72qhWr7iFrJ1oxGEIK8uzVaSC8Q==",
       "requires": {}
     },
     "@opentelemetry/contrib-test-utils": {
@@ -50634,9 +50702,9 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/exporter-jaeger": "^1.3.1",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/resources": "^1.8.0",
-        "@opentelemetry/sdk-node": "^0.52.0",
+        "@opentelemetry/sdk-node": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -50645,70 +50713,108 @@
       }
     },
     "@opentelemetry/core": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
-      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.26.0.tgz",
+      "integrity": "sha512-1iKxXXE8415Cdv0yjG3G6hQnB5eVEsJce3QaawX8SjDn0mAS0ZM8fAbZZJD4ajvhC15cePvosSCut404KrIIvQ==",
       "requires": {
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/semantic-conventions": "1.27.0"
       }
     },
     "@opentelemetry/exporter-jaeger": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.25.1.tgz",
-      "integrity": "sha512-6/HwzrwUx0fpkFXrouF0IJp+hpN8xkx8RqEk+BZfeoMAHydpyigyYsKyAtAZRwfJe45WWJbJUqoK8aBjiC9iLQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.26.0.tgz",
+      "integrity": "sha512-l5NMFwFr5NWWRNcURUS8/RdkBmR3+dPGE33f51XfamKXsEfZUkRC8V1L2D7hzKhXxcFmYLcprg4/sYpeKtYoAQ==",
       "requires": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0",
         "jaeger-client": "^3.15.0"
       }
     },
-    "@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.52.1.tgz",
-      "integrity": "sha512-pVkSH20crBwMTqB3nIN4jpQKUEoB0Z94drIHpYyEqs7UBr+I0cpYyOR3bqjA/UasQUMROb3GX8ZX4/9cVRqGBQ==",
+    "@opentelemetry/exporter-logs-otlp-grpc": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.53.0.tgz",
+      "integrity": "sha512-x5ygAQgWAQOI+UOhyV3z9eW7QU2dCfnfOuIBiyYmC2AWr74f6x/3JBnP27IAcEx6aihpqBYWKnpoUTztkVPAZw==",
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.52.1",
-        "@opentelemetry/otlp-transformer": "0.52.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.53.0",
+        "@opentelemetry/otlp-transformer": "0.53.0",
+        "@opentelemetry/sdk-logs": "0.53.0"
+      }
+    },
+    "@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.53.0.tgz",
+      "integrity": "sha512-cSRKgD/n8rb+Yd+Cif6EnHEL/VZg1o8lEcEwFji1lwene6BdH51Zh3feAD9p2TyVoBKrl6Q9Zm2WltSp2k9gWQ==",
+      "requires": {
+        "@opentelemetry/api-logs": "0.53.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/otlp-exporter-base": "0.53.0",
+        "@opentelemetry/otlp-transformer": "0.53.0",
+        "@opentelemetry/sdk-logs": "0.53.0"
+      }
+    },
+    "@opentelemetry/exporter-logs-otlp-proto": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.53.0.tgz",
+      "integrity": "sha512-jhEcVL1deeWNmTUP05UZMriZPSWUBcfg94ng7JuBb1q2NExgnADQFl1VQQ+xo62/JepK+MxQe4xAwlsDQFbISA==",
+      "requires": {
+        "@opentelemetry/api-logs": "0.53.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/otlp-exporter-base": "0.53.0",
+        "@opentelemetry/otlp-transformer": "0.53.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-logs": "0.53.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0"
+      }
+    },
+    "@opentelemetry/exporter-trace-otlp-grpc": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.53.0.tgz",
+      "integrity": "sha512-m6KSh6OBDwfDjpzPVbuJbMgMbkoZfpxYH2r262KckgX9cMYvooWXEKzlJYsNDC6ADr28A1rtRoUVRwNfIN4tUg==",
+      "requires": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.53.0",
+        "@opentelemetry/otlp-transformer": "0.53.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0"
       }
     },
     "@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.52.1.tgz",
-      "integrity": "sha512-05HcNizx0BxcFKKnS5rwOV+2GevLTVIRA0tRgWYyw4yCgR53Ic/xk83toYKts7kbzcI+dswInUg/4s8oyA+tqg==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.53.0.tgz",
+      "integrity": "sha512-m7F5ZTq+V9mKGWYpX8EnZ7NjoqAU7VemQ1E2HAG+W/u0wpY1x0OmbxAXfGKFHCspdJk8UKlwPGrpcB8nay3P8A==",
       "requires": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/otlp-exporter-base": "0.52.1",
-        "@opentelemetry/otlp-transformer": "0.52.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/otlp-exporter-base": "0.53.0",
+        "@opentelemetry/otlp-transformer": "0.53.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0"
       }
     },
     "@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.52.1.tgz",
-      "integrity": "sha512-pt6uX0noTQReHXNeEslQv7x311/F1gJzMnp1HD2qgypLRPbXDeMzzeTngRTUaUbP6hqWNtPxuLr4DEoZG+TcEQ==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.53.0.tgz",
+      "integrity": "sha512-T/bdXslwRKj23S96qbvGtaYOdfyew3TjPEKOk5mHjkCmkVl1O9C/YMdejwSsdLdOq2YW30KjR9kVi0YMxZushQ==",
       "requires": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/otlp-exporter-base": "0.52.1",
-        "@opentelemetry/otlp-transformer": "0.52.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/otlp-exporter-base": "0.53.0",
+        "@opentelemetry/otlp-transformer": "0.53.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0"
       }
     },
     "@opentelemetry/exporter-zipkin": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.25.1.tgz",
-      "integrity": "sha512-RmOwSvkimg7ETwJbUOPTMhJm9A9bG1U8s7Zo3ajDh4zM7eYcycQ0dM7FbLD6NXWbI2yj7UY4q8BKinKYBQksyw==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.26.0.tgz",
+      "integrity": "sha512-PW5R34n3SJHO4t0UetyHKiXL6LixIqWN6lWncg3eRXhKuT30x+b7m5sDJS0kEWRfHeS+kG7uCw2vBzmB2lk3Dw==",
       "requires": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
       }
     },
     "@opentelemetry/host-metrics": {
@@ -51182,16 +51288,23 @@
       }
     },
     "@opentelemetry/instrumentation": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.52.1.tgz",
-      "integrity": "sha512-uXJbYU/5/MBHjMp1FqrILLRuiJCs3Ofk0MeRDk8g1S1gD47U8X3JnSwcMO1rtRo1x1a7zKaQHaoYu49p/4eSKw==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.53.0.tgz",
+      "integrity": "sha512-DMwg0hy4wzf7K73JJtl95m/e0boSoWhH07rfvHvYzQtBD3Bmv0Wc1x733vyZBqmFm8OjJD0/pfiUg1W3JjFX0A==",
       "requires": {
-        "@opentelemetry/api-logs": "0.52.1",
-        "@types/shimmer": "^1.0.2",
+        "@opentelemetry/api-logs": "0.53.0",
+        "@types/shimmer": "^1.2.0",
         "import-in-the-middle": "^1.8.1",
         "require-in-the-middle": "^7.1.1",
         "semver": "^7.5.2",
         "shimmer": "^1.2.1"
+      },
+      "dependencies": {
+        "@types/shimmer": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
+          "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="
+        }
       }
     },
     "@opentelemetry/instrumentation-amqplib": {
@@ -51200,7 +51313,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/amqplib": "^0.5.17",
         "@types/lodash": "4.14.199",
@@ -51231,7 +51344,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/propagator-aws-xray": "^1.3.1",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/sdk-metrics": "^1.8.0",
@@ -51260,7 +51373,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/propagation-utils": "^0.30.10",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -51292,10 +51405,10 @@
       "version": "file:plugins/node/opentelemetry-instrumentation-bunyan",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/api-logs": "^0.52.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/api-logs": "^0.53.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/resources": "^1.8.0",
-        "@opentelemetry/sdk-logs": "^0.52.0",
+        "@opentelemetry/sdk-logs": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.23.0",
@@ -51329,7 +51442,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -51352,7 +51465,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -51383,7 +51496,7 @@
         "@cucumber/cucumber": "^9.0.0",
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/core": "^1.3.1",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.3.1",
         "@opentelemetry/sdk-trace-node": "^1.3.1",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -51406,7 +51519,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
@@ -51425,7 +51538,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
@@ -51449,7 +51562,7 @@
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-web": "^1.15.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -51482,7 +51595,7 @@
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -51508,8 +51621,8 @@
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
-        "@opentelemetry/instrumentation-http": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/instrumentation-http": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -51536,14 +51649,14 @@
       }
     },
     "@opentelemetry/instrumentation-fetch": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.52.1.tgz",
-      "integrity": "sha512-EJDQXdv1ZGyBifox+8BK+hP0tg29abNPdScE+lW77bUVrThD5vn2dOo+blAS3Z8Od+eqTUTDzXVDIFjGgTK01w==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.53.0.tgz",
+      "integrity": "sha512-Sayp/Oypr0lyTgOKide/Dz4ovqDWPdmazapCMyfsVpXpV9zrH2kbdO2vAKUMx9vF98vxsqcxXucf4z54WXWZ8A==",
       "requires": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/instrumentation": "0.52.1",
-        "@opentelemetry/sdk-trace-web": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/instrumentation": "0.53.0",
+        "@opentelemetry/sdk-trace-web": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
       }
     },
     "@opentelemetry/instrumentation-fs": {
@@ -51552,7 +51665,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
@@ -51572,7 +51685,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/generic-pool": "^3.1.9",
@@ -51592,7 +51705,7 @@
       "version": "file:plugins/node/opentelemetry-instrumentation-graphql",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/mocha": "8.2.3",
@@ -51615,12 +51728,12 @@
       }
     },
     "@opentelemetry/instrumentation-grpc": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.52.1.tgz",
-      "integrity": "sha512-EdSDiDSAO+XRXk/ZN128qQpBo1I51+Uay/LUPcPQhSRGf7fBPIEUBeOLQiItguGsug5MGOYjql2w/1wCQF3fdQ==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.53.0.tgz",
+      "integrity": "sha512-Ss338T92yE1UCgr9zXSY3cPuaAy27uQw+wAC5IwsQKCXL5wwkiOgkd+2Ngksa9EGsgUEMwGeHi76bDdHFJ5Rrw==",
       "requires": {
-        "@opentelemetry/instrumentation": "0.52.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/instrumentation": "0.53.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
       }
     },
     "@opentelemetry/instrumentation-hapi": {
@@ -51631,7 +51744,7 @@
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -51647,13 +51760,13 @@
       }
     },
     "@opentelemetry/instrumentation-http": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.52.1.tgz",
-      "integrity": "sha512-dG/aevWhaP+7OLv4BQQSEKMJv8GyeOp3Wxl31NHqE8xo9/fYMfEljiZphUHIfyg4gnZ9swMyWjfOQs5GUQe54Q==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.53.0.tgz",
+      "integrity": "sha512-H74ErMeDuZfj7KgYCTOFGWF5W9AfaPnqLQQxeFq85+D29wwV2yqHbz2IKLYpkOh7EI6QwDEl7rZCIxjJLyc/CQ==",
       "requires": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/instrumentation": "0.52.1",
-        "@opentelemetry/semantic-conventions": "1.25.1",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/instrumentation": "0.53.0",
+        "@opentelemetry/semantic-conventions": "1.27.0",
         "semver": "^7.5.2"
       }
     },
@@ -51663,7 +51776,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
@@ -51688,7 +51801,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.24.0",
         "@opentelemetry/semantic-conventions": "^1.24.0",
         "@types/mocha": "7.0.2",
@@ -51708,7 +51821,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -51731,8 +51844,8 @@
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
-        "@opentelemetry/instrumentation-http": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/instrumentation-http": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -51758,7 +51871,7 @@
         "@babel/preset-env": "7.24.6",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-web": "^1.8.0",
         "@types/mocha": "10.0.6",
@@ -52205,7 +52318,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@types/lru-cache": "7.10.10",
         "@types/mocha": "8.2.3",
         "@types/node": "18.6.5",
@@ -52233,7 +52346,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.23.0",
@@ -52255,7 +52368,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-metrics": "^1.9.1",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
@@ -52384,7 +52497,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/mocha": "8.2.3",
@@ -52413,7 +52526,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-metrics": "^1.8.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -52436,7 +52549,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
         "@opentelemetry/sql-common": "^0.40.1",
@@ -52463,7 +52576,7 @@
         "@nestjs/websockets": "9.4.3",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.23.0",
@@ -52488,7 +52601,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.23.0",
@@ -52509,7 +52622,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -52536,10 +52649,10 @@
       "version": "file:plugins/node/opentelemetry-instrumentation-pino",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/api-logs": "^0.52.0",
+        "@opentelemetry/api-logs": "^0.53.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
         "@opentelemetry/core": "^1.25.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -52564,7 +52677,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
@@ -52589,7 +52702,7 @@
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
@@ -52628,7 +52741,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -52651,7 +52764,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
@@ -52669,7 +52782,7 @@
       "version": "file:plugins/node/instrumentation-runtime-node",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-metrics": "^1.20.0",
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.11.2",
@@ -52702,7 +52815,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/mocha": "8.2.3",
@@ -52895,7 +53008,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/mocha": "7.0.2",
@@ -53020,7 +53133,7 @@
       "requires": {
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-metrics": "^1.8.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
@@ -53044,8 +53157,8 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-zone-peer-dep": "^1.8.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
-        "@opentelemetry/instrumentation-xml-http-request": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/instrumentation-xml-http-request": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-web": "^1.8.0",
         "@types/jquery": "3.5.30",
@@ -53492,9 +53605,9 @@
       "version": "file:plugins/node/opentelemetry-instrumentation-winston",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/api-logs": "^0.52.0",
+        "@opentelemetry/api-logs": "^0.53.0",
         "@opentelemetry/context-async-hooks": "^1.21.0",
-        "@opentelemetry/instrumentation": "^0.52.0",
+        "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.21.0",
         "@opentelemetry/sdk-trace-node": "^1.21.0",
         "@opentelemetry/winston-transport": "^0.5.0",
@@ -53514,47 +53627,47 @@
       }
     },
     "@opentelemetry/instrumentation-xml-http-request": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.52.1.tgz",
-      "integrity": "sha512-4a7WpbN+prdyIxoTqCA3m+ZuqQVrksWWeOP5iEyof9yrzEY1NJgM+plrPrzb5nn7U5T7RGkkpvaTPm08qfFu7w==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.53.0.tgz",
+      "integrity": "sha512-vkALs8zdEUU3GnGvq1rzP0RK3+Fsk2jyzY6X/a+ibbo/miCmmeQNHX+fBRNs/3Offquj19M0qD+olNU9CJloqg==",
       "requires": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/instrumentation": "0.52.1",
-        "@opentelemetry/sdk-trace-web": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/instrumentation": "0.53.0",
+        "@opentelemetry/sdk-trace-web": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
       }
     },
     "@opentelemetry/otlp-exporter-base": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.52.1.tgz",
-      "integrity": "sha512-z175NXOtX5ihdlshtYBe5RpGeBoTXVCKPPLiQlD6FHvpM4Ch+p2B0yWKYSrBfLH24H9zjJiBdTrtD+hLlfnXEQ==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.53.0.tgz",
+      "integrity": "sha512-UCWPreGQEhD6FjBaeDuXhiMf6kkBODF0ZQzrk/tuQcaVDJ+dDQ/xhJp192H9yWnKxVpEjFrSSLnpqmX4VwX+eA==",
       "requires": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/otlp-transformer": "0.52.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/otlp-transformer": "0.53.0"
       }
     },
     "@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.52.1.tgz",
-      "integrity": "sha512-zo/YrSDmKMjG+vPeA9aBBrsQM9Q/f2zo6N04WMB3yNldJRsgpRBeLLwvAt/Ba7dpehDLOEFBd1i2JCoaFtpCoQ==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.53.0.tgz",
+      "integrity": "sha512-F7RCN8VN+lzSa4fGjewit8Z5fEUpY/lmMVy5EWn2ZpbAabg3EE3sCLuTNfOiooNGnmvzimUPruoeqeko/5/TzQ==",
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/otlp-exporter-base": "0.52.1",
-        "@opentelemetry/otlp-transformer": "0.52.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/otlp-exporter-base": "0.53.0",
+        "@opentelemetry/otlp-transformer": "0.53.0"
       }
     },
     "@opentelemetry/otlp-transformer": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.52.1.tgz",
-      "integrity": "sha512-I88uCZSZZtVa0XniRqQWKbjAUm73I8tpEy/uJYPPYw5d7BRdVk0RfTBQw8kSUl01oVWEuqxLDa802222MYyWHg==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.53.0.tgz",
+      "integrity": "sha512-rM0sDA9HD8dluwuBxLetUmoqGJKSAbWenwD65KY9iZhUxdBHRLrIdrABfNDP7aiTjcgK8XFyTn5fhDz7N+W6DA==",
       "requires": {
-        "@opentelemetry/api-logs": "0.52.1",
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-logs": "0.52.1",
-        "@opentelemetry/sdk-metrics": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/api-logs": "0.53.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-logs": "0.53.0",
+        "@opentelemetry/sdk-metrics": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
         "protobufjs": "^7.3.0"
       }
     },
@@ -53566,7 +53679,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/context-zone": "^1.0.0",
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/propagator-b3": "1.25.1",
+        "@opentelemetry/propagator-b3": "1.26.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-web": "^1.0.0",
         "@types/mocha": "10.0.6",
@@ -54038,27 +54151,27 @@
       }
     },
     "@opentelemetry/propagator-aws-xray": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.25.1.tgz",
-      "integrity": "sha512-soZQdO9EAROMwa9bL2C0VLadbrfRjSA9t7g6X8sL0X1B8V59pzOayYMyTW9qTECn9uuJV98A7qOnJm6KH6yk8w==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.26.0.tgz",
+      "integrity": "sha512-Sex+JyEZ/xX328TArBqQjh1NZSfNyw5NdASUIi9hnPsnMBMSBaDe7B9JRnXv0swz7niNyAnXa6MY7yOCV76EvA==",
       "requires": {
-        "@opentelemetry/core": "1.25.1"
+        "@opentelemetry/core": "1.26.0"
       }
     },
     "@opentelemetry/propagator-aws-xray-lambda": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray-lambda/-/propagator-aws-xray-lambda-0.52.1.tgz",
-      "integrity": "sha512-LBAu/1SRVuWrsWTzqUxZmzWinsS76UH/qApgYjmaN6Q8RcObXeZOmR0+FLSwkRX7OLGhLLQKiu3CQmlgXbpNCw==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray-lambda/-/propagator-aws-xray-lambda-0.53.0.tgz",
+      "integrity": "sha512-B0+Cob9nmT49AjgMXCXn+bvvA/TsQ+vjc1tx3y7oXgq/VwJAFIq7NBoWZHMArtcC4yt3gXpUd/CRN6LzUa0ORA==",
       "requires": {
-        "@opentelemetry/propagator-aws-xray": "1.25.1"
+        "@opentelemetry/propagator-aws-xray": "1.26.0"
       }
     },
     "@opentelemetry/propagator-b3": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.25.1.tgz",
-      "integrity": "sha512-p6HFscpjrv7//kE+7L+3Vn00VEDUJB0n6ZrjkTYHrJ58QZ8B3ajSJhRbCcY6guQ3PDjTbxWklyvIN2ojVbIb1A==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.26.0.tgz",
+      "integrity": "sha512-vvVkQLQ/lGGyEy9GT8uFnI047pajSOVnZI2poJqVGD3nJ+B9sFGdlHNnQKophE3lHfnIH0pw2ubrCTjZCgIj+Q==",
       "requires": {
-        "@opentelemetry/core": "1.25.1"
+        "@opentelemetry/core": "1.26.0"
       }
     },
     "@opentelemetry/propagator-instana": {
@@ -54482,11 +54595,11 @@
       }
     },
     "@opentelemetry/propagator-jaeger": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.25.1.tgz",
-      "integrity": "sha512-nBprRf0+jlgxks78G/xq72PipVK+4or9Ypntw0gVZYNTCSK8rg5SeaGV19tV920CMqBD/9UIOiFr23Li/Q8tiA==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.26.0.tgz",
+      "integrity": "sha512-DelFGkCdaxA1C/QA0Xilszfr0t4YbGd3DjxiCDPh34lfnFr+VkkrjV9S8ZTJvAzfdKERXhfOxIKBoGPJwoSz7Q==",
       "requires": {
-        "@opentelemetry/core": "1.25.1"
+        "@opentelemetry/core": "1.26.0"
       }
     },
     "@opentelemetry/propagator-ot-trace": {
@@ -55119,7 +55232,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.40.0",
         "@opentelemetry/resources": "^1.10.0",
-        "@opentelemetry/sdk-node": "^0.52.0",
+        "@opentelemetry/sdk-node": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.22.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.6.5",
@@ -55141,91 +55254,93 @@
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
-      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.26.0.tgz",
+      "integrity": "sha512-CPNYchBE7MBecCSVy0HKpUISEeJOniWqcHaAHpmasZ3j9o6V3AyBzhRc90jdmemq0HOxDr6ylhUbDhBqqPpeNw==",
       "requires": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
       }
     },
     "@opentelemetry/sdk-logs": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.52.1.tgz",
-      "integrity": "sha512-MBYh+WcPPsN8YpRHRmK1Hsca9pVlyyKd4BxOC4SsgHACnl/bPp4Cri9hWhVm5+2tiQ9Zf4qSc1Jshw9tOLGWQA==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.53.0.tgz",
+      "integrity": "sha512-dhSisnEgIj/vJZXZV6f6KcTnyLDx/VuQ6l3ejuZpMpPlh9S1qMHiZU9NMmOkVkwwHkMy3G6mEBwdP23vUZVr4g==",
       "requires": {
-        "@opentelemetry/api-logs": "0.52.1",
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/resources": "1.25.1"
+        "@opentelemetry/api-logs": "0.53.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0"
       }
     },
     "@opentelemetry/sdk-metrics": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
-      "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.26.0.tgz",
+      "integrity": "sha512-0SvDXmou/JjzSDOjUmetAAvcKQW6ZrvosU0rkbDGpXvvZN+pQF6JbK/Kd4hNdK4q/22yeruqvukXEJyySTzyTQ==",
       "requires": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/resources": "1.25.1",
-        "lodash.merge": "^4.6.2"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0"
       }
     },
     "@opentelemetry/sdk-node": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.52.1.tgz",
-      "integrity": "sha512-uEG+gtEr6eKd8CVWeKMhH2olcCHM9dEK68pe0qE0be32BcCRsvYURhHaD1Srngh1SQcnQzZ4TP324euxqtBOJA==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.53.0.tgz",
+      "integrity": "sha512-0hsxfq3BKy05xGktwG8YdGdxV978++x40EAKyKr1CaHZRh8uqVlXnclnl7OMi9xLMJEcXUw7lGhiRlArFcovyg==",
       "requires": {
-        "@opentelemetry/api-logs": "0.52.1",
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.52.1",
-        "@opentelemetry/exporter-trace-otlp-http": "0.52.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.52.1",
-        "@opentelemetry/exporter-zipkin": "1.25.1",
-        "@opentelemetry/instrumentation": "0.52.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/sdk-logs": "0.52.1",
-        "@opentelemetry/sdk-metrics": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/sdk-trace-node": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/api-logs": "0.53.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.53.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.53.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.53.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.53.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.53.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.53.0",
+        "@opentelemetry/exporter-zipkin": "1.26.0",
+        "@opentelemetry/instrumentation": "0.53.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/sdk-logs": "0.53.0",
+        "@opentelemetry/sdk-metrics": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/sdk-trace-node": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
       }
     },
     "@opentelemetry/sdk-trace-base": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
-      "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.26.0.tgz",
+      "integrity": "sha512-olWQldtvbK4v22ymrKLbIcBi9L2SpMO84sCPY54IVsJhP9fRsxJT194C/AVaAuJzLE30EdhhM1VmvVYR7az+cw==",
       "requires": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/resources": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/resources": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
       }
     },
     "@opentelemetry/sdk-trace-node": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.25.1.tgz",
-      "integrity": "sha512-nMcjFIKxnFqoez4gUmihdBrbpsEnAX/Xj16sGvZm+guceYE0NE00vLhpDVK6f3q8Q4VFI5xG8JjlXKMB/SkTTQ==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.26.0.tgz",
+      "integrity": "sha512-Fj5IVKrj0yeUwlewCRwzOVcr5avTuNnMHWf7GPc1t6WaT78J6CJyF3saZ/0RkZfdeNO8IcBl/bNcWMVZBMRW8Q==",
       "requires": {
-        "@opentelemetry/context-async-hooks": "1.25.1",
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/propagator-b3": "1.25.1",
-        "@opentelemetry/propagator-jaeger": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "@opentelemetry/context-async-hooks": "1.26.0",
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/propagator-b3": "1.26.0",
+        "@opentelemetry/propagator-jaeger": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
         "semver": "^7.5.2"
       }
     },
     "@opentelemetry/sdk-trace-web": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.25.1.tgz",
-      "integrity": "sha512-SS6JaSkHngcBCNdWGthzcvaKGRnDw2AeP57HyTEileLToJ7WLMeV+064iRlVyoT4+e77MRp2T2dDSrmaUyxoNg==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.26.0.tgz",
+      "integrity": "sha512-sxeKPcG/gUyxZ8iB8X1MI8/grfSCGgo1n2kxOE73zjVaO9yW/7JuVC3gqUaWRjtZ6VD/V3lo2/ZSwMlm6n2mdg==",
       "requires": {
-        "@opentelemetry/core": "1.25.1",
-        "@opentelemetry/sdk-trace-base": "1.25.1",
-        "@opentelemetry/semantic-conventions": "1.25.1"
+        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/sdk-trace-base": "1.26.0",
+        "@opentelemetry/semantic-conventions": "1.27.0"
       }
     },
     "@opentelemetry/semantic-conventions": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
-      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ=="
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
+      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg=="
     },
     "@opentelemetry/sql-common": {
       "version": "file:packages/opentelemetry-sql-common",
@@ -55243,7 +55358,7 @@
     "@opentelemetry/winston-transport": {
       "version": "file:packages/winston-transport",
       "requires": {
-        "@opentelemetry/api-logs": "^0.52.0",
+        "@opentelemetry/api-logs": "^0.53.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -56952,7 +57067,8 @@
     "@types/shimmer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.3.tgz",
-      "integrity": "sha512-F/IjUGnV6pIN7R4ZV4npHJVoNtaLZWvb+2/9gctxjb99wkpI7Ozg8VPogwDiTRyjLwZXAYxjvdg1KS8LTHKdDA=="
+      "integrity": "sha512-F/IjUGnV6pIN7R4ZV4npHJVoNtaLZWvb+2/9gctxjb99wkpI7Ozg8VPogwDiTRyjLwZXAYxjvdg1KS8LTHKdDA==",
+      "dev": true
     },
     "@types/sinon": {
       "version": "10.0.20",
@@ -66988,7 +67104,8 @@
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "lodash.mergewith": {
       "version": "4.6.2",

--- a/packages/opentelemetry-test-utils/package.json
+++ b/packages/opentelemetry-test-utils/package.json
@@ -46,9 +46,9 @@
   "dependencies": {
     "@opentelemetry/core": "^1.0.0",
     "@opentelemetry/exporter-jaeger": "^1.3.1",
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/resources": "^1.8.0",
-    "@opentelemetry/sdk-node": "^0.52.0",
+    "@opentelemetry/sdk-node": "^0.53.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@opentelemetry/semantic-conventions": "^1.22.0"

--- a/packages/opentelemetry-test-utils/src/test-fixtures.ts
+++ b/packages/opentelemetry-test-utils/src/test-fixtures.ts
@@ -55,6 +55,15 @@ export function createTestNodeSdk(opts: {
   return sdk;
 }
 
+export enum OtlpSpanKind {
+  UNSPECIFIED = 0,
+  INTERNAL = 1,
+  SERVER = 2,
+  CLIENT = 3,
+  PRODUCER = 4,
+  CONSUMER = 5
+}
+
 // TestSpan is an OTLP span plus references to `resource` and
 // `instrumentationScope` that are shared between multiple spans in the
 // protocol.

--- a/packages/opentelemetry-test-utils/src/test-fixtures.ts
+++ b/packages/opentelemetry-test-utils/src/test-fixtures.ts
@@ -61,7 +61,7 @@ export enum OtlpSpanKind {
   SERVER = 2,
   CLIENT = 3,
   PRODUCER = 4,
-  CONSUMER = 5
+  CONSUMER = 5,
 }
 
 // TestSpan is an OTLP span plus references to `resource` and

--- a/packages/winston-transport/package.json
+++ b/packages/winston-transport/package.json
@@ -50,7 +50,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "^0.52.0",
+    "@opentelemetry/api-logs": "^0.53.0",
     "winston-transport": "4.*"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/winston-transport#readme"

--- a/plugins/node/instrumentation-amqplib/package.json
+++ b/plugins/node/instrumentation-amqplib/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "devDependencies": {

--- a/plugins/node/instrumentation-cucumber/package.json
+++ b/plugins/node/instrumentation-cucumber/package.json
@@ -63,7 +63,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-cucumber#readme"

--- a/plugins/node/instrumentation-dataloader/package.json
+++ b/plugins/node/instrumentation-dataloader/package.json
@@ -58,7 +58,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0"
+    "@opentelemetry/instrumentation": "^0.53.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-dataloader#readme"
 }

--- a/plugins/node/instrumentation-fs/package.json
+++ b/plugins/node/instrumentation-fs/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.52.0"
+    "@opentelemetry/instrumentation": "^0.53.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-fs#readme"
 }

--- a/plugins/node/instrumentation-kafkajs/package.json
+++ b/plugins/node/instrumentation-kafkajs/package.json
@@ -58,7 +58,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/semantic-conventions": "^1.24.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-kafkajs#readme"

--- a/plugins/node/instrumentation-lru-memoizer/package.json
+++ b/plugins/node/instrumentation-lru-memoizer/package.json
@@ -58,7 +58,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0"
+    "@opentelemetry/instrumentation": "^0.53.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-lru-memoizer#readme"
 }

--- a/plugins/node/instrumentation-mongoose/package.json
+++ b/plugins/node/instrumentation-mongoose/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-mongoose#readme"

--- a/plugins/node/instrumentation-runtime-node/package.json
+++ b/plugins/node/instrumentation-runtime-node/package.json
@@ -39,7 +39,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0"
+    "@opentelemetry/instrumentation": "^0.53.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",

--- a/plugins/node/instrumentation-socket.io/package.json
+++ b/plugins/node/instrumentation-socket.io/package.json
@@ -59,7 +59,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-socket.io#readme"

--- a/plugins/node/instrumentation-tedious/package.json
+++ b/plugins/node/instrumentation-tedious/package.json
@@ -63,7 +63,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/semantic-conventions": "^1.22.0",
     "@types/tedious": "^4.0.14"
   },

--- a/plugins/node/instrumentation-undici/package.json
+++ b/plugins/node/instrumentation-undici/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.52.0"
+    "@opentelemetry/instrumentation": "^0.53.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-undici",
   "sideEffects": false

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
@@ -57,7 +57,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/propagator-aws-xray": "^1.3.1",
     "@opentelemetry/resources": "^1.8.0",
     "@opentelemetry/semantic-conventions": "^1.22.0",

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/propagation-utils": "^0.30.10",
     "@opentelemetry/semantic-conventions": "^1.22.0"
   },

--- a/plugins/node/opentelemetry-instrumentation-bunyan/package.json
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/resources": "^1.8.0",
-    "@opentelemetry/sdk-logs": "^0.52.0",
+    "@opentelemetry/sdk-logs": "^0.53.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@opentelemetry/semantic-conventions": "^1.23.0",
@@ -63,8 +63,8 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "^0.52.0",
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/api-logs": "^0.53.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@types/bunyan": "1.8.9"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-bunyan#readme"

--- a/plugins/node/opentelemetry-instrumentation-bunyan/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/src/instrumentation.ts
@@ -96,7 +96,7 @@ export class BunyanInstrumentation extends InstrumentationBase<BunyanInstrumenta
   }
 
   override setConfig(config: BunyanInstrumentationConfig = {}) {
-    this._config = { ...DEFAULT_CONFIG, ...config };
+    super.setConfig({ ...DEFAULT_CONFIG, ...config });
   }
 
   private _getPatchedEmit() {

--- a/plugins/node/opentelemetry-instrumentation-bunyan/test/bunyan.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/test/bunyan.test.ts
@@ -56,7 +56,6 @@ loggerProvider.addLogRecordProcessor(new SimpleLogRecordProcessor(memExporter));
 logs.setGlobalLoggerProvider(loggerProvider);
 
 const instrumentation = new BunyanInstrumentation();
-instrumentation.enable();
 const Logger = require('bunyan');
 
 describe('BunyanInstrumentation', () => {

--- a/plugins/node/opentelemetry-instrumentation-bunyan/test/bunyan.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/test/bunyan.test.ts
@@ -56,6 +56,7 @@ loggerProvider.addLogRecordProcessor(new SimpleLogRecordProcessor(memExporter));
 logs.setGlobalLoggerProvider(loggerProvider);
 
 const instrumentation = new BunyanInstrumentation();
+instrumentation.enable();
 const Logger = require('bunyan');
 
 describe('BunyanInstrumentation', () => {

--- a/plugins/node/opentelemetry-instrumentation-cassandra/package.json
+++ b/plugins/node/opentelemetry-instrumentation-cassandra/package.json
@@ -62,7 +62,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-cassandra#readme"

--- a/plugins/node/opentelemetry-instrumentation-connect/package.json
+++ b/plugins/node/opentelemetry-instrumentation-connect/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/semantic-conventions": "^1.22.0",
     "@types/connect": "3.4.36"
   },

--- a/plugins/node/opentelemetry-instrumentation-dns/package.json
+++ b/plugins/node/opentelemetry-instrumentation-dns/package.json
@@ -60,7 +60,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "semver": "^7.5.4"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-dns#readme"

--- a/plugins/node/opentelemetry-instrumentation-express/package.json
+++ b/plugins/node/opentelemetry-instrumentation-express/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-express#readme"

--- a/plugins/node/opentelemetry-instrumentation-express/test/express.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-express/test/express.test.ts
@@ -620,20 +620,23 @@ describe('ExpressInstrumentation', () => {
         //     `- span 'middleware - simpleMiddleware'
         //     `- span 'request handler - /post/:id'
         const spans = collector.sortedSpans;
-        assert.strictEqual(spans[0].name, 'GET /post/:id');
-        assert.strictEqual(spans[0].kind, SpanKind.CLIENT);
-        assert.strictEqual(spans[1].name, 'middleware - query');
-        assert.strictEqual(spans[1].kind, SpanKind.SERVER);
+        assert.strictEqual(spans[0].name, 'GET');
+        assert.strictEqual(spans[0].kind, testUtils.OtlpSpanKind.CLIENT);
+        assert.strictEqual(spans[1].name, 'GET /post/:id');
+        assert.strictEqual(spans[1].kind, testUtils.OtlpSpanKind.SERVER);
         assert.strictEqual(spans[1].parentSpanId, spans[0].spanId);
-        assert.strictEqual(spans[2].name, 'middleware - expressInit');
-        assert.strictEqual(spans[2].kind, SpanKind.SERVER);
-        assert.strictEqual(spans[2].parentSpanId, spans[0].spanId);
-        assert.strictEqual(spans[3].name, 'middleware - simpleMiddleware');
-        assert.strictEqual(spans[3].kind, SpanKind.SERVER);
-        assert.strictEqual(spans[3].parentSpanId, spans[0].spanId);
-        assert.strictEqual(spans[4].name, 'request handler - /post/:id');
-        assert.strictEqual(spans[4].kind, SpanKind.SERVER);
-        assert.strictEqual(spans[4].parentSpanId, spans[0].spanId);
+        assert.strictEqual(spans[2].name, 'middleware - query');
+        assert.strictEqual(spans[2].kind, testUtils.OtlpSpanKind.INTERNAL);
+        assert.strictEqual(spans[2].parentSpanId, spans[1].spanId);
+        assert.strictEqual(spans[3].name, 'middleware - expressInit');
+        assert.strictEqual(spans[3].kind, testUtils.OtlpSpanKind.INTERNAL);
+        assert.strictEqual(spans[3].parentSpanId, spans[1].spanId);
+        assert.strictEqual(spans[4].name, 'middleware - simpleMiddleware');
+        assert.strictEqual(spans[4].kind, testUtils.OtlpSpanKind.INTERNAL);
+        assert.strictEqual(spans[4].parentSpanId, spans[1].spanId);
+        assert.strictEqual(spans[5].name, 'request handler - /post/:id');
+        assert.strictEqual(spans[5].kind, testUtils.OtlpSpanKind.INTERNAL);
+        assert.strictEqual(spans[5].parentSpanId, spans[1].spanId);
       },
     });
   });
@@ -654,23 +657,26 @@ describe('ExpressInstrumentation', () => {
       checkCollector: (collector: testUtils.TestCollector) => {
         const spans = collector.sortedSpans;
 
-        assert.strictEqual(spans[0].name, 'GET /\\/test\\/regex/');
-        assert.strictEqual(spans[0].kind, SpanKind.CLIENT);
-        assert.strictEqual(spans[1].name, 'middleware - query');
-        assert.strictEqual(spans[1].kind, SpanKind.SERVER);
+        assert.strictEqual(spans[0].name, 'GET');
+        assert.strictEqual(spans[0].kind, testUtils.OtlpSpanKind.CLIENT);
+        assert.strictEqual(spans[1].name, 'GET /\\/test\\/regex/');
         assert.strictEqual(spans[1].parentSpanId, spans[0].spanId);
-        assert.strictEqual(spans[2].name, 'middleware - expressInit');
-        assert.strictEqual(spans[2].kind, SpanKind.SERVER);
-        assert.strictEqual(spans[2].parentSpanId, spans[0].spanId);
-        assert.strictEqual(spans[3].name, 'middleware - simpleMiddleware');
-        assert.strictEqual(spans[3].kind, SpanKind.SERVER);
-        assert.strictEqual(spans[3].parentSpanId, spans[0].spanId);
+        assert.strictEqual(spans[1].kind, testUtils.OtlpSpanKind.SERVER);
+        assert.strictEqual(spans[2].name, 'middleware - query');
+        assert.strictEqual(spans[2].kind, testUtils.OtlpSpanKind.INTERNAL);
+        assert.strictEqual(spans[2].parentSpanId, spans[1].spanId);
+        assert.strictEqual(spans[3].name, 'middleware - expressInit');
+        assert.strictEqual(spans[3].kind, testUtils.OtlpSpanKind.INTERNAL);
+        assert.strictEqual(spans[3].parentSpanId, spans[1].spanId);
+        assert.strictEqual(spans[4].name, 'middleware - simpleMiddleware');
+        assert.strictEqual(spans[4].kind, testUtils.OtlpSpanKind.INTERNAL);
+        assert.strictEqual(spans[4].parentSpanId, spans[1].spanId);
         assert.strictEqual(
-          spans[4].name,
+          spans[5].name,
           'request handler - /\\/test\\/regex/'
         );
-        assert.strictEqual(spans[4].kind, SpanKind.SERVER);
-        assert.strictEqual(spans[4].parentSpanId, spans[0].spanId);
+        assert.strictEqual(spans[5].kind, SpanKind.SERVER);
+        assert.strictEqual(spans[5].parentSpanId, spans[1].spanId);
       },
     });
   });
@@ -691,20 +697,22 @@ describe('ExpressInstrumentation', () => {
       checkCollector: (collector: testUtils.TestCollector) => {
         const spans = collector.sortedSpans;
 
-        assert.strictEqual(spans[0].name, 'GET /test,6,/test/');
-        assert.strictEqual(spans[0].kind, SpanKind.CLIENT);
-        assert.strictEqual(spans[1].name, 'middleware - query');
-        assert.strictEqual(spans[1].kind, SpanKind.SERVER);
-        assert.strictEqual(spans[1].parentSpanId, spans[0].spanId);
-        assert.strictEqual(spans[2].name, 'middleware - expressInit');
-        assert.strictEqual(spans[2].kind, SpanKind.SERVER);
-        assert.strictEqual(spans[2].parentSpanId, spans[0].spanId);
-        assert.strictEqual(spans[3].name, 'middleware - simpleMiddleware');
-        assert.strictEqual(spans[3].kind, SpanKind.SERVER);
-        assert.strictEqual(spans[3].parentSpanId, spans[0].spanId);
-        assert.strictEqual(spans[4].name, 'request handler - /test,6,/test/');
-        assert.strictEqual(spans[4].kind, SpanKind.SERVER);
-        assert.strictEqual(spans[4].parentSpanId, spans[0].spanId);
+        assert.strictEqual(spans[0].name, 'GET');
+        assert.strictEqual(spans[0].kind, testUtils.OtlpSpanKind.CLIENT);
+        assert.strictEqual(spans[1].name, 'GET /test,6,/test/');
+        assert.strictEqual(spans[1].kind, testUtils.OtlpSpanKind.SERVER);
+        assert.strictEqual(spans[2].name, 'middleware - query');
+        assert.strictEqual(spans[2].kind, testUtils.OtlpSpanKind.INTERNAL);
+        assert.strictEqual(spans[2].parentSpanId, spans[1].spanId);
+        assert.strictEqual(spans[3].name, 'middleware - expressInit');
+        assert.strictEqual(spans[3].kind, testUtils.OtlpSpanKind.INTERNAL);
+        assert.strictEqual(spans[3].parentSpanId, spans[1].spanId);
+        assert.strictEqual(spans[4].name, 'middleware - simpleMiddleware');
+        assert.strictEqual(spans[4].kind, testUtils.OtlpSpanKind.INTERNAL);
+        assert.strictEqual(spans[4].parentSpanId, spans[1].spanId);
+        assert.strictEqual(spans[5].name, 'request handler - /test,6,/test/');
+        assert.strictEqual(spans[5].kind, testUtils.OtlpSpanKind.INTERNAL);
+        assert.strictEqual(spans[5].parentSpanId, spans[1].spanId);
       },
     });
   });
@@ -726,26 +734,28 @@ describe('ExpressInstrumentation', () => {
         checkCollector: (collector: testUtils.TestCollector) => {
           const spans = collector.sortedSpans;
 
+          assert.strictEqual(spans[0].name, 'GET');
+          assert.strictEqual(spans[0].kind, testUtils.OtlpSpanKind.CLIENT);
           assert.strictEqual(
-            spans[0].name,
+            spans[1].name,
             'GET /test/array1,/\\/test\\/array[2-9]/'
           );
-          assert.strictEqual(spans[0].kind, SpanKind.CLIENT);
-          assert.strictEqual(spans[1].name, 'middleware - query');
-          assert.strictEqual(spans[1].kind, SpanKind.SERVER);
-          assert.strictEqual(spans[1].parentSpanId, spans[0].spanId);
-          assert.strictEqual(spans[2].name, 'middleware - expressInit');
-          assert.strictEqual(spans[2].kind, SpanKind.SERVER);
-          assert.strictEqual(spans[2].parentSpanId, spans[0].spanId);
-          assert.strictEqual(spans[3].name, 'middleware - simpleMiddleware');
-          assert.strictEqual(spans[3].kind, SpanKind.SERVER);
-          assert.strictEqual(spans[3].parentSpanId, spans[0].spanId);
+          assert.strictEqual(spans[1].kind, testUtils.OtlpSpanKind.SERVER);
+          assert.strictEqual(spans[2].name, 'middleware - query');
+          assert.strictEqual(spans[2].kind, testUtils.OtlpSpanKind.INTERNAL);
+          assert.strictEqual(spans[2].parentSpanId, spans[1].spanId);
+          assert.strictEqual(spans[3].name, 'middleware - expressInit');
+          assert.strictEqual(spans[3].kind, testUtils.OtlpSpanKind.INTERNAL);
+          assert.strictEqual(spans[3].parentSpanId, spans[1].spanId);
+          assert.strictEqual(spans[4].name, 'middleware - simpleMiddleware');
+          assert.strictEqual(spans[4].kind, testUtils.OtlpSpanKind.INTERNAL);
+          assert.strictEqual(spans[4].parentSpanId, spans[1].spanId);
           assert.strictEqual(
-            spans[4].name,
+            spans[5].name,
             'request handler - /test/array1,/\\/test\\/array[2-9]/'
           );
-          assert.strictEqual(spans[4].kind, SpanKind.SERVER);
-          assert.strictEqual(spans[4].parentSpanId, spans[0].spanId);
+          assert.strictEqual(spans[5].kind, testUtils.OtlpSpanKind.INTERNAL);
+          assert.strictEqual(spans[5].parentSpanId, spans[1].spanId);
         },
       });
     });
@@ -777,26 +787,28 @@ describe('ExpressInstrumentation', () => {
         checkCollector: (collector: testUtils.TestCollector) => {
           const spans = collector.sortedSpans;
 
+          assert.strictEqual(spans[0].name, 'GET');
+          assert.strictEqual(spans[0].kind, testUtils.OtlpSpanKind.CLIENT);
           assert.strictEqual(
-            spans[0].name,
+            spans[1].name,
             'GET /test/arr/:id,/\\/test\\/arr[0-9]*\\/required(path)?(\\/optionalPath)?\\/(lastParam)?/'
           );
-          assert.strictEqual(spans[0].kind, SpanKind.CLIENT);
-          assert.strictEqual(spans[1].name, 'middleware - query');
-          assert.strictEqual(spans[1].kind, SpanKind.SERVER);
-          assert.strictEqual(spans[1].parentSpanId, spans[0].spanId);
-          assert.strictEqual(spans[2].name, 'middleware - expressInit');
-          assert.strictEqual(spans[2].kind, SpanKind.SERVER);
-          assert.strictEqual(spans[2].parentSpanId, spans[0].spanId);
-          assert.strictEqual(spans[3].name, 'middleware - simpleMiddleware');
-          assert.strictEqual(spans[3].kind, SpanKind.SERVER);
-          assert.strictEqual(spans[3].parentSpanId, spans[0].spanId);
+          assert.strictEqual(spans[1].kind, testUtils.OtlpSpanKind.SERVER);
+          assert.strictEqual(spans[2].name, 'middleware - query');
+          assert.strictEqual(spans[2].kind, testUtils.OtlpSpanKind.INTERNAL);
+          assert.strictEqual(spans[2].parentSpanId, spans[1].spanId);
+          assert.strictEqual(spans[3].name, 'middleware - expressInit');
+          assert.strictEqual(spans[3].kind, testUtils.OtlpSpanKind.INTERNAL);
+          assert.strictEqual(spans[3].parentSpanId, spans[1].spanId);
+          assert.strictEqual(spans[4].name, 'middleware - simpleMiddleware');
+          assert.strictEqual(spans[4].kind, testUtils.OtlpSpanKind.INTERNAL);
+          assert.strictEqual(spans[4].parentSpanId, spans[1].spanId);
           assert.strictEqual(
-            spans[4].name,
+            spans[5].name,
             'request handler - /test/arr/:id,/\\/test\\/arr[0-9]*\\/required(path)?(\\/optionalPath)?\\/(lastParam)?/'
           );
-          assert.strictEqual(spans[4].kind, SpanKind.SERVER);
-          assert.strictEqual(spans[4].parentSpanId, spans[0].spanId);
+          assert.strictEqual(spans[5].kind, testUtils.OtlpSpanKind.INTERNAL);
+          assert.strictEqual(spans[5].parentSpanId, spans[1].spanId);
         },
       });
     });

--- a/plugins/node/opentelemetry-instrumentation-fastify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-fastify/package.json
@@ -48,7 +48,7 @@
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/context-async-hooks": "^1.8.0",
     "@opentelemetry/contrib-test-utils": "^0.40.0",
-    "@opentelemetry/instrumentation-http": "^0.52.0",
+    "@opentelemetry/instrumentation-http": "^0.53.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/express": "4.17.21",
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-fastify#readme"

--- a/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
+++ b/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
@@ -60,7 +60,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0"
+    "@opentelemetry/instrumentation": "^0.53.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-generic-pool#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-graphql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-graphql/package.json
@@ -59,7 +59,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0"
+    "@opentelemetry/instrumentation": "^0.53.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-graphql#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-hapi/package.json
+++ b/plugins/node/opentelemetry-instrumentation-hapi/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-hapi#readme"

--- a/plugins/node/opentelemetry-instrumentation-ioredis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/package.json
@@ -68,7 +68,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/redis-common": "^0.36.2",
     "@opentelemetry/semantic-conventions": "^1.23.0"
   },

--- a/plugins/node/opentelemetry-instrumentation-knex/package.json
+++ b/plugins/node/opentelemetry-instrumentation-knex/package.json
@@ -58,7 +58,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-knex#readme"

--- a/plugins/node/opentelemetry-instrumentation-koa/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/package.json
@@ -50,7 +50,7 @@
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/context-async-hooks": "^1.8.0",
     "@opentelemetry/contrib-test-utils": "^0.40.0",
-    "@opentelemetry/instrumentation-http": "^0.52.0",
+    "@opentelemetry/instrumentation-http": "^0.53.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/koa": "2.15.0",
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-koa#readme"

--- a/plugins/node/opentelemetry-instrumentation-koa/test/koa.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/test/koa.test.ts
@@ -17,7 +17,7 @@
 import type { Middleware, ParameterizedContext, DefaultState } from 'koa';
 import type { RouterParamContext } from '@koa/router';
 import * as KoaRouter from '@koa/router';
-import { context, trace, Span, SpanKind } from '@opentelemetry/api';
+import { context, trace, Span } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import * as testUtils from '@opentelemetry/contrib-test-utils';
@@ -741,14 +741,16 @@ describe('Koa Instrumentation', () => {
         //    `- span 'middleware - simpleMiddleware'
         //       `- span 'router - /post/:id'
         const spans = collector.sortedSpans;
-        assert.strictEqual(spans[0].name, 'GET /post/:id');
-        assert.strictEqual(spans[0].kind, SpanKind.CLIENT);
-        assert.strictEqual(spans[1].name, 'middleware - simpleMiddleware');
-        assert.strictEqual(spans[1].kind, SpanKind.SERVER);
-        assert.strictEqual(spans[1].parentSpanId, spans[0].spanId);
-        assert.strictEqual(spans[2].name, 'router - /post/:id');
-        assert.strictEqual(spans[2].kind, SpanKind.SERVER);
+        assert.strictEqual(spans[0].name, 'GET');
+        assert.strictEqual(spans[0].kind, testUtils.OtlpSpanKind.CLIENT);
+        assert.strictEqual(spans[1].name, 'GET /post/:id');
+        assert.strictEqual(spans[1].kind, testUtils.OtlpSpanKind.SERVER);
+        assert.strictEqual(spans[2].name, 'middleware - simpleMiddleware');
+        assert.strictEqual(spans[2].kind, testUtils.OtlpSpanKind.INTERNAL);
         assert.strictEqual(spans[2].parentSpanId, spans[1].spanId);
+        assert.strictEqual(spans[3].name, 'router - /post/:id');
+        assert.strictEqual(spans[3].kind, testUtils.OtlpSpanKind.INTERNAL);
+        assert.strictEqual(spans[3].parentSpanId, spans[2].spanId);
       },
     });
   });

--- a/plugins/node/opentelemetry-instrumentation-memcached/package.json
+++ b/plugins/node/opentelemetry-instrumentation-memcached/package.json
@@ -60,7 +60,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/semantic-conventions": "^1.23.0",
     "@types/memcached": "^2.2.6"
   },

--- a/plugins/node/opentelemetry-instrumentation-mongodb/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/package.json
@@ -66,7 +66,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/sdk-metrics": "^1.9.1",
     "@opentelemetry/semantic-conventions": "^1.22.0"
   },

--- a/plugins/node/opentelemetry-instrumentation-mysql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql/package.json
@@ -59,7 +59,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/semantic-conventions": "^1.22.0",
     "@types/mysql": "2.15.26"
   },

--- a/plugins/node/opentelemetry-instrumentation-mysql2/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/package.json
@@ -61,7 +61,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/semantic-conventions": "^1.22.0",
     "@opentelemetry/sql-common": "^0.40.1"
   },

--- a/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
+++ b/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
@@ -70,7 +70,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/semantic-conventions": "^1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-nestjs-core#readme"

--- a/plugins/node/opentelemetry-instrumentation-net/package.json
+++ b/plugins/node/opentelemetry-instrumentation-net/package.json
@@ -59,7 +59,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/semantic-conventions": "^1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-net#readme"

--- a/plugins/node/opentelemetry-instrumentation-pg/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pg/package.json
@@ -72,7 +72,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/semantic-conventions": "^1.22.0",
     "@opentelemetry/sql-common": "^0.40.1",
     "@types/pg": "8.6.1",

--- a/plugins/node/opentelemetry-instrumentation-pino/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pino/package.json
@@ -65,9 +65,9 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "^0.52.0",
+    "@opentelemetry/api-logs": "^0.53.0",
     "@opentelemetry/core": "^1.25.0",
-    "@opentelemetry/instrumentation": "^0.52.0"
+    "@opentelemetry/instrumentation": "^0.53.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-pino#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-redis-4/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis-4/package.json
@@ -67,7 +67,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/redis-common": "^0.36.2",
     "@opentelemetry/semantic-conventions": "^1.22.0"
   },

--- a/plugins/node/opentelemetry-instrumentation-redis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis/package.json
@@ -67,7 +67,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/redis-common": "^0.36.2",
     "@opentelemetry/semantic-conventions": "^1.22.0"
   },

--- a/plugins/node/opentelemetry-instrumentation-restify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-restify/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-restify#readme"

--- a/plugins/node/opentelemetry-instrumentation-router/package.json
+++ b/plugins/node/opentelemetry-instrumentation-router/package.json
@@ -57,7 +57,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/semantic-conventions": "^1.22.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-router#readme"

--- a/plugins/node/opentelemetry-instrumentation-winston/package.json
+++ b/plugins/node/opentelemetry-instrumentation-winston/package.json
@@ -65,8 +65,8 @@
     "winston2": "npm:winston@2.4.7"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "^0.52.0",
-    "@opentelemetry/instrumentation": "^0.52.0"
+    "@opentelemetry/api-logs": "^0.53.0",
+    "@opentelemetry/instrumentation": "^0.53.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-winston#readme"
 }

--- a/plugins/web/opentelemetry-instrumentation-document-load/package.json
+++ b/plugins/web/opentelemetry-instrumentation-document-load/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/sdk-trace-base": "^1.0.0",
     "@opentelemetry/sdk-trace-web": "^1.15.0",
     "@opentelemetry/semantic-conventions": "^1.22.0"

--- a/plugins/web/opentelemetry-instrumentation-long-task/package.json
+++ b/plugins/web/opentelemetry-instrumentation-long-task/package.json
@@ -81,7 +81,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/sdk-trace-web": "^1.8.0"
   },
   "peerDependencies": {

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
@@ -53,7 +53,7 @@
     "@babel/preset-env": "7.24.6",
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/context-zone-peer-dep": "^1.8.0",
-    "@opentelemetry/instrumentation-xml-http-request": "^0.52.0",
+    "@opentelemetry/instrumentation-xml-http-request": "^0.53.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@types/jquery": "3.5.30",
     "@types/mocha": "10.0.6",
@@ -84,7 +84,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.52.0",
+    "@opentelemetry/instrumentation": "^0.53.0",
     "@opentelemetry/sdk-trace-web": "^1.8.0"
   },
   "peerDependencies": {

--- a/plugins/web/opentelemetry-plugin-react-load/package.json
+++ b/plugins/web/opentelemetry-plugin-react-load/package.json
@@ -52,7 +52,7 @@
     "@babel/core": "7.24.6",
     "@babel/preset-env": "7.24.6",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/propagator-b3": "1.25.1",
+    "@opentelemetry/propagator-b3": "1.26.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/react": "17.0.80",


### PR DESCRIPTION
    0.52.1 -> 0.53.0 @opentelemetry/api-logs (range-bump)
    0.52.1 -> 0.53.0 @opentelemetry/instrumentation (range-bump)
    0.52.1 -> 0.53.0 @opentelemetry/instrumentation-fetch (range-bump)
    0.52.1 -> 0.53.0 @opentelemetry/instrumentation-grpc (range-bump)
    0.52.1 -> 0.53.0 @opentelemetry/instrumentation-http (range-bump)
    0.52.1 -> 0.53.0 @opentelemetry/instrumentation-xml-http-request (range-bump)
    0.52.1 -> 0.53.0 @opentelemetry/propagator-aws-xray-lambda (range-bump)
    0.52.1 -> 0.53.0 @opentelemetry/sdk-logs (range-bump)
    0.52.1 -> 0.53.0 @opentelemetry/sdk-node (range-bump)
    1.25.1 -> 1.26.0 @opentelemetry/context-async-hooks
    1.25.1 -> 1.26.0 @opentelemetry/context-zone
    1.25.1 -> 1.26.0 @opentelemetry/context-zone-peer-dep
    1.25.1 -> 1.26.0 @opentelemetry/core
    1.25.1 -> 1.26.0 @opentelemetry/exporter-jaeger
    1.25.1 -> 1.26.0 @opentelemetry/propagator-aws-xray
    1.25.1 -> 1.26.0 @opentelemetry/propagator-b3
    1.25.1 -> 1.26.0 @opentelemetry/propagator-jaeger
    1.25.1 -> 1.26.0 @opentelemetry/resources
    1.25.1 -> 1.26.0 @opentelemetry/sdk-metrics
    1.25.1 -> 1.26.0 @opentelemetry/sdk-trace-base
    1.25.1 -> 1.26.0 @opentelemetry/sdk-trace-node
    1.25.1 -> 1.26.0 @opentelemetry/sdk-trace-web
    1.25.1 -> 1.27.0 @opentelemetry/semantic-conventions



BEGIN_COMMIT_OVERRIDE
fix(instrumentation-bunyan): avoid overrding parent _config in setConfig()
feat(contrib-test-utils): export OtlpSpanKind as it does not match the Trace SDK SpanKind enum
test(instrumentation-express): fix up tests to match fixed http instrumentation, use correct span kind
 test(instrumentation-koa): assert for correct SpanKind, account for http client span
END_COMMIT_OVERRIDE
