### PR TITLE
fix(detector-gcp): suppress internal tracing

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-gcp/package.json
+++ b/detectors/node/opentelemetry-resource-detector-gcp/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.0.0",
-    "@opentelemetry/resources": "^1.0.0",
+    "@opentelemetry/resources": "^1.10.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
     "gcp-metadata": "^6.0.0"
   },

--- a/detectors/node/opentelemetry-resource-detector-gcp/src/detectors/GcpDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-gcp/src/detectors/GcpDetector.ts
@@ -51,7 +51,7 @@ class GcpDetector implements DetectorSync {
       );
       return new Resource({}, attributes);
     }
-    
+
     return new Resource({}, this._getAttributes());
   }
 

--- a/detectors/node/opentelemetry-resource-detector-gcp/src/detectors/GcpDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-gcp/src/detectors/GcpDetector.ts
@@ -15,7 +15,8 @@
  */
 
 import * as gcpMetadata from 'gcp-metadata';
-import { diag } from '@opentelemetry/api';
+import { context, diag } from '@opentelemetry/api';
+import { suppressTracing } from '@opentelemetry/core';
 import {
   DetectorSync,
   ResourceDetectionConfig,
@@ -44,7 +45,14 @@ import {
  */
 class GcpDetector implements DetectorSync {
   detect(_config?: ResourceDetectionConfig): IResource {
-    return new Resource({}, this._getAttribures());
+    if (Math.random() > 100) {
+      const attributes = context.with(suppressTracing(context.active()), () =>
+        this._getAttributes()
+      );
+      return new Resource({}, attributes);
+    }
+    
+    return new Resource({}, this._getAttributes());
   }
 
   /**
@@ -53,7 +61,7 @@ class GcpDetector implements DetectorSync {
    * object with instance metadata. Returns a promise containing an
    * empty {@link ResourceAttributes} if the connection or parsing of the metadata fails.
    */
-  private async _getAttribures(): Promise<ResourceAttributes> {
+  private async _getAttributes(): Promise<ResourceAttributes> {
     if (!(await gcpMetadata.isAvailable())) {
       diag.debug('GcpDetector failed: GCP Metadata unavailable.');
       return {};

--- a/detectors/node/opentelemetry-resource-detector-gcp/src/detectors/GcpDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-gcp/src/detectors/GcpDetector.ts
@@ -45,14 +45,10 @@ import {
  */
 class GcpDetector implements DetectorSync {
   detect(_config?: ResourceDetectionConfig): IResource {
-    if (Math.random() > 100) {
-      const attributes = context.with(suppressTracing(context.active()), () =>
-        this._getAttributes()
-      );
-      return new Resource({}, attributes);
-    }
-
-    return new Resource({}, this._getAttributes());
+    const attributes = context.with(suppressTracing(context.active()), () =>
+      this._getAttributes()
+    );
+    return new Resource({}, attributes);
   }
 
   /**

--- a/detectors/node/opentelemetry-resource-detector-gcp/test/detectors/GcpDetectorIntegration.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-gcp/test/detectors/GcpDetectorIntegration.test.ts
@@ -18,12 +18,17 @@
 // so SDK cannot instrument them. We make sure we load fresh copies so RITM hook does its work.
 // we remove all the require chain: detector -> gcp-metadata -> gaxios -> node-fetch
 // but kepp other cache entries to not slow down the test more than necessary
-const modules = ['opentelemetry-resource-detector-gcp', 'gcp-metadata', 'gaxios', 'node-fetch']
+const modules = [
+  'opentelemetry-resource-detector-gcp',
+  'gcp-metadata',
+  'gaxios',
+  'node-fetch',
+];
 Object.keys(require.cache)
-.filter((path) => modules.some((m) => path.includes(m)))
-.forEach((key) => {
-  delete require.cache[key];
-});
+  .filter(path => modules.some(m => path.includes(m)))
+  .forEach(key => {
+    delete require.cache[key];
+  });
 
 import * as assert from 'assert';
 

--- a/detectors/node/opentelemetry-resource-detector-gcp/test/detectors/GcpDetectorIntegration.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-gcp/test/detectors/GcpDetectorIntegration.test.ts
@@ -46,9 +46,7 @@ describe('[Integration] GcpDetector', () => {
     // internal tracing any change that delays these request will result in internal
     // tracing being exported. We do the detection outside the SDK constructor to have such
     // scenario.
-    const {
-      gcpDetector,
-    } = require('../../build/src/detectors/GcpDetector');
+    const { gcpDetector } = require('../../build/src/detectors/GcpDetector');
     const resource = gcpDetector.detect() as IResource;
     await resource.waitForAsyncAttributes?.();
 

--- a/detectors/node/opentelemetry-resource-detector-gcp/test/detectors/GcpDetectorIntegration.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-gcp/test/detectors/GcpDetectorIntegration.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+
+import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { IResource } from '@opentelemetry/resources';
+
+describe('[Integration] GcpDetector', () => {
+  it('should not start spans for detector requests', async () => {
+    const memoryExporter = new InMemorySpanExporter();
+    const sdk = new NodeSDK({
+      instrumentations: [new HttpInstrumentation()],
+      spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+    });
+
+    sdk.start();
+
+    process.env.METADATA_SERVER_DETECTION = 'assume-present';
+
+    // NOTE: detectors implementing the `DetectorSync` interface and starting
+    // HTTP requests within the `detect` method will produce Noop Spans since
+    // the SDK resolves the trace provider after resource detectors are triggered.
+    // Ref: https://github.com/open-telemetry/opentelemetry-js/blob/38f6689480d28dcbdafcb7b5ba4b14025328ffda/experimental/packages/opentelemetry-sdk-node/src/sdk.ts#L210-L240
+    //
+    // So having the detector in the config would result in no spans for Azure requests
+    // being exported which is what we want. Although we may think we're safe of sending
+    // internal tracing any change that delays these request will result in internal
+    // tracing being exported. We do the detection outside the SDK constructor to have such
+    // scenario.
+    const {
+      gcpDetector,
+    } = require('../../build/src/detectors/GcpDetector');
+    const resource = gcpDetector.detect() as IResource;
+    await resource.waitForAsyncAttributes?.();
+
+    console.log('XXX resource', resource.attributes);
+
+    // Wait for the next loop to let the span close properly
+    await new Promise(r => setTimeout(r, 0));
+    const spans = memoryExporter.getFinishedSpans();
+
+    assert.equal(spans.length, 0, 'no spans exported for GcpDetector');
+
+    await sdk.shutdown();
+  }).timeout(15000);
+});


### PR DESCRIPTION
## Which problem is this PR solving?

- this detector performs some request to get metadata from GCP. We should suppress the tracing for these requests

ref: #2320 

## Short description of the changes

- suppress tracing when resolving attributes
- add test
