### PR TITLE
fix: auto-config of baggage propagator

### DIFF
--- a/metapackages/auto-configuration-propagators/src/utils.ts
+++ b/metapackages/auto-configuration-propagators/src/utils.ts
@@ -30,7 +30,7 @@ type PropagatorFactoryFunction = () => TextMapPropagator;
 
 const propagatorMap = new Map<string, PropagatorFactoryFunction>([
   ['tracecontext', () => new W3CTraceContextPropagator()],
-  ['baggage', () => new W3CTraceContextPropagator()],
+  ['baggage', () => new W3CBaggagePropagator()],
   [
     'b3',
     () => new B3Propagator({ injectEncoding: B3InjectEncoding.SINGLE_HEADER }),


### PR DESCRIPTION
## Which problem is this PR solving?

- When supplying `OTEL_PROPAGATORS` via an env var, `baggage` is mistakenly mapped to to the `W3CTraceContextPropagator`

## Short description of the changes

- properly map `baggage` to to the `W3CBaggagePropagator `
