### PR TITLE
test(instrumentation-express): pass correct type to app.get()

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-express/test/fixtures/use-express-regex.mjs
+++ b/plugins/node/opentelemetry-instrumentation-express/test/fixtures/use-express-regex.mjs
@@ -61,7 +61,7 @@ app.get(['/test/array1', /\/test\/array[2-9]/], (_req, res) => {
   res.send({ response: 'response 3' });
 });
 
-app.get(['/test', 6, /test/], (_req, res) => {
+app.get(['/test', '6', /test/], (_req, res) => {
   res.send({ response: 'response 4' });
 });
 


### PR DESCRIPTION
## Which problem is this PR solving?

- TAV is failing as we pass an incorrect type (number) to `app.get()`

## Short description of the changes

- changes that `number` to be a `string` instead
