### PR TITLE
fix(host-metrics): widen MeterProvider type restriction in BaseMetrics class

### DIFF
--- a/packages/opentelemetry-host-metrics/src/BaseMetrics.ts
+++ b/packages/opentelemetry-host-metrics/src/BaseMetrics.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { Meter, diag, metrics } from '@opentelemetry/api';
-import { MeterProvider } from '@opentelemetry/sdk-metrics';
+import { Meter, MeterProvider, diag, metrics } from '@opentelemetry/api';
 
 import { PACKAGE_NAME, PACKAGE_VERSION } from './version';
 


### PR DESCRIPTION
Instead of requiring the `MeterProvider` class implementation as exported by `@opentelemetry/sdk-metrics`, change to simply require the `MeterProvider` interface as exported by `@opentelemtry/api`. This makes `HostMetrics` easier to initialize with the meter provider returned by `metrics.getMeterProvider()`

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Initializing the `HostMetrics` object with a `meterProvider` as returned by `metrics.getMeterProvider()` files a type check:

```typescript
import { metrics } from "@opentelemetry/api";
import { HostMetrics } from "@opentelemetry/host-metrics";

const hostMetrics = new HostMetrics({ meterProvider: metrics.getMeterProvider() }); // <-- fails with TS2739
```

The compile-time error is:

```
Type 'MeterProvider' is missing the following properties from type 'MeterProvider': _sharedState, _shutdown, addMetricReader, shutdown, forceFlush [2739]
```

## Short description of the changes

Instead of requiring the `MeterProvider` class implementation as exported by `@opentelemetry/sdk-metrics`, I've changed the `BaseMetrics` abstract class to simply require the `MeterProvider` interface as exported by `@opentelemtry/api`. This matches the existing behavior where, if no `meterProvider` is specified, it uses `metrics.getMeterProvider()` as the default (but emits a warning).

