### PR TITLE
fix(detector-container): suppress internal tracing

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-container/src/detectors/ContainerDetector.ts
+++ b/detectors/node/opentelemetry-resource-detector-container/src/detectors/ContainerDetector.ts
@@ -25,7 +25,8 @@ import { SEMRESATTRS_CONTAINER_ID } from '@opentelemetry/semantic-conventions';
 
 import * as fs from 'fs';
 import * as util from 'util';
-import { diag } from '@opentelemetry/api';
+import { context, diag } from '@opentelemetry/api';
+import { suppressTracing } from '@opentelemetry/core';
 import { extractContainerIdFromLine } from './utils';
 
 export class ContainerDetector implements DetectorSync {
@@ -43,7 +44,10 @@ export class ContainerDetector implements DetectorSync {
   private static readFileAsync = util.promisify(fs.readFile);
 
   detect(_config?: ResourceDetectionConfig): IResource {
-    return new Resource({}, this._getAttributes());
+    const attributes = context.with(suppressTracing(context.active()), () =>
+      this._getAttributes()
+    );
+    return new Resource({}, attributes);
   }
 
   /**

--- a/detectors/node/opentelemetry-resource-detector-container/test/ContainerDetectorIntegration.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-container/test/ContainerDetectorIntegration.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from 'assert';
+
+import { FsInstrumentation } from '@opentelemetry/instrumentation-fs';
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { IResource } from '@opentelemetry/resources';
+
+describe('[Integration] ContainerDetector', () => {
+  it('should not start spans for detector reads to filesystem', async () => {
+    const memoryExporter = new InMemorySpanExporter();
+    const sdk = new NodeSDK({
+      instrumentations: [new FsInstrumentation()],
+      spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+    });
+
+    sdk.start();
+
+    // NOTE: detectors implementing the `DetectorSync` interface and starting
+    // HTTP requests within the `detect` method will produce Noop Spans since
+    // the SDK resolves the trace provider after resource detectors are triggered.
+    // Ref: https://github.com/open-telemetry/opentelemetry-js/blob/38f6689480d28dcbdafcb7b5ba4b14025328ffda/experimental/packages/opentelemetry-sdk-node/src/sdk.ts#L210-L240
+    //
+    // So having the detector in the config would result in no spans for Azure requests
+    // being exported which is what we want. Although we may think we're safe of sending
+    // internal tracing any change that delays these request will result in internal
+    // tracing being exported. We do the detection outside the SDK constructor to have such
+    // scenario.
+    const {
+      containerDetector,
+    } = require('../build/src/detectors/ContainerDetector');
+
+    // NOTE: the require process makes use of the fs API so spans are being exported.
+    // We need to check no new spans are exported when `detect` is called.
+    await new Promise(r => setTimeout(r, 0));
+    const numSpansAfterRequire = memoryExporter.getFinishedSpans().length;
+
+    const resource = containerDetector.detect() as IResource;
+    await resource.waitForAsyncAttributes?.();
+
+    // Wait for the next loop to let the span close properly
+    await new Promise(r => setTimeout(r, 0));
+    const spans = memoryExporter.getFinishedSpans();
+
+    assert.equal(
+      spans.length,
+      numSpansAfterRequire,
+      'no spans exported for ContainerDetector'
+    );
+
+    await sdk.shutdown();
+  });
+});


### PR DESCRIPTION
## Which problem is this PR solving?

- this detector performs some `fs` operatoins to get metadata. We should suppress the tracing for these requests
ref: #2320 

## Short description of the changes

- suppress tracing when resolving attributes
- add test
