### PR TITLE
fix: update references to logging exporter

### DIFF
--- a/examples/mysql/docker/collector/otel-collector-config.yaml
+++ b/examples/mysql/docker/collector/otel-collector-config.yaml
@@ -9,8 +9,8 @@ exporters:
     const_labels:
       label1: value1
 
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
 
   zipkin:
     endpoint: "http://zipkin-all-in-one:9411/api/v2/spans"
@@ -37,8 +37,8 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging, prometheus]
+      exporters: [debug, prometheus]


### PR DESCRIPTION
This exporter has been replaced by the debug exporter and will be removed soon. Related to https://github.com/open-telemetry/opentelemetry-collector/pull/11037
