### PR TITLE
chore(detector-contrainer): remove orphan codecov script

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-container/package.json
+++ b/detectors/node/opentelemetry-resource-detector-container/package.json
@@ -7,7 +7,6 @@
   "repository": "open-telemetry/opentelemetry-js-contrib",
   "scripts": {
     "clean": "rimraf build/*",
-    "codecov": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../",
     "compile": "tsc -p .",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",


### PR DESCRIPTION
## Which problem is this PR solving?

- we've switched to the codecov action, this script is unused and the dependency has also been removed already
