### PR TITLE
test: update mssql envvar to MSSQL_SA_PASSWORD

### DIFF
--- a/.github/workflows/test-all-versions.yml
+++ b/.github/workflows/test-all-versions.yml
@@ -28,12 +28,12 @@ jobs:
       mssql:
         image: mcr.microsoft.com/mssql/server:2022-latest
         env:
-          SA_PASSWORD: mssql_passw0rd
+          MSSQL_SA_PASSWORD: mssql_passw0rd
           ACCEPT_EULA: Y
         ports:
         - 1433:1433
         options: >-
-          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P $SA_PASSWORD -C -Q 'select 1' -b -o /dev/null"
+          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P $MSSQL_SA_PASSWORD -C -Q 'select 1' -b -o /dev/null"
           --health-interval 1s
           --health-timeout 30s
           --health-start-period 10s

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -26,12 +26,12 @@ jobs:
       mssql:
         image: mcr.microsoft.com/mssql/server:2022-latest
         env:
-          SA_PASSWORD: mssql_passw0rd
+          MSSQL_SA_PASSWORD: mssql_passw0rd
           ACCEPT_EULA: Y
         ports:
         - 1433:1433
         options: >-
-          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P $SA_PASSWORD -C -Q 'select 1' -b -o /dev/null"
+          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P $MSSQL_SA_PASSWORD -C -Q 'select 1' -b -o /dev/null"
           --health-interval 1s
           --health-timeout 30s
           --health-start-period 10s

--- a/packages/opentelemetry-test-utils/src/test-utils.ts
+++ b/packages/opentelemetry-test-utils/src/test-utils.ts
@@ -39,7 +39,7 @@ const dockerRunCmds = {
   memcached:
     'docker run --rm -d --name otel-memcached -p 11211:11211 memcached:1.6.9-alpine',
   mssql:
-    'docker run --rm -d --name otel-mssql -p 1433:1433 -e SA_PASSWORD=mssql_passw0rd -e ACCEPT_EULA=Y mcr.microsoft.com/mssql/server:2022-latest',
+    'docker run --rm -d --name otel-mssql -p 1433:1433 -e MSSQL_SA_PASSWORD=mssql_passw0rd -e ACCEPT_EULA=Y mcr.microsoft.com/mssql/server:2022-latest',
   mysql:
     'docker run --rm -d --name otel-mysql -p 33306:3306 -e MYSQL_ROOT_PASSWORD=rootpw -e MYSQL_DATABASE=test_db -e MYSQL_USER=otel -e MYSQL_PASSWORD=secret mysql:5.7 --log_output=TABLE --general_log=ON',
   postgres:


### PR DESCRIPTION
Per https://learn.microsoft.com/en-us/sql/linux/sql-server-linux-configure-environment-variables
SA_PASSWORD (without the prefix) is deprecated.
