### PR TITLE
chore(instrumentation-fastify): mark instrumentation as unmaintained

### DIFF
--- a/.github/component-label-map.yml
+++ b/.github/component-label-map.yml
@@ -282,6 +282,7 @@ pkg-status:unmaintained:
           - plugins/node/instrumentation-tedious/**
           - plugins/node/opentelemetry-instrumentation-connect/**
           - plugins/node/opentelemetry-instrumentation-dns/**
+          - plugins/node/opentelemetry-instrumentation-fastify/**
           - plugins/node/opentelemetry-instrumentation-generic-pool/**
           - plugins/node/opentelemetry-instrumentation-hapi/**
           - plugins/node/opentelemetry-instrumentation-knex/**

--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -85,8 +85,8 @@ components:
   plugins/node/opentelemetry-instrumentation-express:
     - JamieDanielson
     - pkanal
-  plugins/node/opentelemetry-instrumentation-fastify:
-    - pichlermarc
+  plugins/node/opentelemetry-instrumentation-fastify: []
+    # Unmaintained
   plugins/node/opentelemetry-instrumentation-generic-pool: []
     # Unmaintained
   plugins/node/opentelemetry-instrumentation-graphql:


### PR DESCRIPTION
## Which problem is this PR solving?

I had initially picked up ownership for the fastify instrumentation package from a previously unknown owner to keep it alive for a bit longer in case we were to go ahead and remove unmaintained packages.

However, with all the other responsibilities that come with maintaining the JS SIGs two repositories (https://github.com/open-telemetry/opentelemetry-js-contrib, https://github.com/open-telemetry/opentelemetry-js), I don't have a lot of time to dedicate to this instrumentation as other things tend to be higher priority (handling releases, issues, fixing bugs in core components, general repo maintenance). As such, with me as an owner, the instrumentation is effectively unmaintained as I never find enough time to actually work on it. Therefore this PR removes me as an owner to bring more visibility to the fact that this instrumentation is essentially owner-less. 
