### PR TITLE
chore: remove usages of Span constructor

### DIFF
--- a/packages/baggage-span-processor/src/index.ts
+++ b/packages/baggage-span-processor/src/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export * from './baggage-span-processor';
-export * from './types';
+export { BaggageSpanProcessor } from './baggage-span-processor';
+export { ALLOW_ALL_BAGGAGE_KEYS, BaggageKeyPredicate } from './types';

--- a/packages/baggage-span-processor/test/baggage-span-processor.test.ts
+++ b/packages/baggage-span-processor/test/baggage-span-processor.test.ts
@@ -16,12 +16,7 @@
 
 import { BaggageSpanProcessor } from '../src/baggage-span-processor';
 import { ALLOW_ALL_BAGGAGE_KEYS } from '../src/types';
-import {
-  propagation,
-  ROOT_CONTEXT,
-  SpanKind,
-  TraceFlags,
-} from '@opentelemetry/api';
+import { propagation, ROOT_CONTEXT, SpanKind } from '@opentelemetry/api';
 import { BasicTracerProvider, Span } from '@opentelemetry/sdk-trace-base';
 import { expect } from 'expect';
 
@@ -39,24 +34,21 @@ describe('BaggageSpanProcessor with all keys filter', () => {
   let span: Span;
 
   beforeEach(() => {
-    span = new Span(
-      new BasicTracerProvider().getTracer('baggage-testing'),
-      ROOT_CONTEXT,
+    const tracer = new BasicTracerProvider().getTracer('baggage-testing');
+    span = tracer.startSpan(
       'Edward W. Span',
       {
-        traceId: 'e4cda95b652f4a1592b449d5929fda1b',
-        spanId: '7e0c63257de34c92',
-        traceFlags: TraceFlags.SAMPLED,
+        kind: SpanKind.SERVER,
       },
-      SpanKind.SERVER
-    );
+      ROOT_CONTEXT
+    ) as unknown as Span;
   });
 
   it('onStart adds current Baggage entries to a span as attributes', () => {
     expect(span.attributes).toEqual({});
     const ctx = propagation.setBaggage(ROOT_CONTEXT, bag);
 
-    baggageProcessor.onStart(span, ctx);
+    baggageProcessor.onStart(span as Span, ctx);
 
     expect(span.attributes).toEqual(expectedAttrs);
   });
@@ -91,17 +83,14 @@ describe('BaggageSpanProcessor with startWith key filter', () => {
   let span: Span;
 
   beforeEach(() => {
-    span = new Span(
-      new BasicTracerProvider().getTracer('baggage-testing'),
-      ROOT_CONTEXT,
+    const tracer = new BasicTracerProvider().getTracer('baggage-testing');
+    span = tracer.startSpan(
       'Edward W. Span',
       {
-        traceId: 'e4cda95b652f4a1592b449d5929fda1b',
-        spanId: '7e0c63257de34c92',
-        traceFlags: TraceFlags.SAMPLED,
+        kind: SpanKind.SERVER,
       },
-      SpanKind.SERVER
-    );
+      ROOT_CONTEXT
+    ) as unknown as Span;
   });
 
   it('should only add baggage entries that match filter', () => {
@@ -131,17 +120,14 @@ describe('BaggageSpanProcessor with regex key filter', () => {
   let span: Span;
 
   beforeEach(() => {
-    span = new Span(
-      new BasicTracerProvider().getTracer('baggage-testing'),
-      ROOT_CONTEXT,
+    const tracer = new BasicTracerProvider().getTracer('baggage-testing');
+    span = tracer.startSpan(
       'Edward W. Span',
       {
-        traceId: 'e4cda95b652f4a1592b449d5929fda1b',
-        spanId: '7e0c63257de34c92',
-        traceFlags: TraceFlags.SAMPLED,
+        kind: SpanKind.SERVER,
       },
-      SpanKind.SERVER
-    );
+      ROOT_CONTEXT
+    ) as unknown as Span;
   });
 
   it('should only add baggage entries that match filter', () => {

--- a/plugins/node/opentelemetry-instrumentation-dns/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/src/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
+export { DnsInstrumentation } from './instrumentation';
+export { DnsInstrumentationConfig, IgnoreMatcher } from './types';

--- a/plugins/node/opentelemetry-instrumentation-dns/test/functionals/utils.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/test/functionals/utils.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { diag, ROOT_CONTEXT, SpanKind, TraceFlags } from '@opentelemetry/api';
+import { diag, ROOT_CONTEXT, SpanKind } from '@opentelemetry/api';
 import { BasicTracerProvider, Span } from '@opentelemetry/sdk-trace-base';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
@@ -154,13 +154,14 @@ describe('Utility', () => {
   describe('setError()', () => {
     it('should have error attributes', () => {
       const errorMessage = 'test error';
-      const span = new Span(
-        new BasicTracerProvider().getTracer('default'),
-        ROOT_CONTEXT,
+      const tracer = new BasicTracerProvider().getTracer('default');
+      const span = tracer.startSpan(
         'test',
-        { spanId: '', traceId: '', traceFlags: TraceFlags.NONE },
-        SpanKind.INTERNAL
-      );
+        {
+          kind: SpanKind.INTERNAL,
+        },
+        ROOT_CONTEXT
+      ) as unknown as Span;
       utils.setError(new Error(errorMessage), span);
       const attributes = span.attributes;
       assert.strictEqual(


### PR DESCRIPTION
## Which problem is this PR solving?

The Span constructor from ' @opentelemetry/sdk-trace-base` is planned for removal from the public API ([ref](https://github.com/open-telemetry/opentelemetry-js/issues/3597)).

This PR anticipates the possible breaking changes derived from it

## Short description of the changes

- Remove usage of `new Span` constructor in favour of `Tracer.startSpan`
