### PR TITLE
feat(instrumentation-fastify): Enable Fastify v5

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-fastify/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-fastify/.tav.yml
@@ -3,6 +3,10 @@
   # releases.
   - versions: "4.0.0 || >=4.24.3 <5"
     commands: npm run test
+  - versions: ">=5 <6"
+    commands: npm run test
+    peerDependencies: "@fastify/express@4.0.1"
+    node: '>=20'
 
 # Fastify versions after 4.18.0 require a typescript greater than 4.4.4.
 "typescript":

--- a/plugins/node/opentelemetry-instrumentation-fastify/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-fastify/src/instrumentation.ts
@@ -55,7 +55,7 @@ export class FastifyInstrumentation extends InstrumentationBase<FastifyInstrumen
     return [
       new InstrumentationNodeModuleDefinition(
         'fastify',
-        ['>=3.0.0 <5'],
+        ['>=3.0.0 <6'],
         moduleExports => {
           return this._patchConstructor(moduleExports);
         }


### PR DESCRIPTION
Resolves: https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2438
Related: https://github.com/getsentry/sentry-javascript/issues/13774

Enables instrumentation on Fastify versions 5.x.x

Looking at [Fastify's v5 migration guide](https://fastify.dev/docs/latest/Guides/Migration-Guide-V5/), the breaking changes of this major release are mainly about removing deprecated methods. Those related to this SDK already seem to be covered.

The current set of tests is passing as is.

The newly introduced support for [Diagnostic Channels](https://fastify.dev/docs/latest/Guides/Migration-Guide-V5/#diagnostic-channel-support) can be implemented with a follow-up PR if OTEL maintainers decide to do so.