### PR TITLE
chore: update @types/node to 18.18.14

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-alibaba-cloud/package.json
+++ b/detectors/node/opentelemetry-resource-detector-alibaba-cloud/package.json
@@ -42,7 +42,7 @@
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/contrib-test-utils": "^0.41.0",
     "@types/mocha": "8.2.3",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "mocha": "7.2.0",
     "nock": "13.3.3",

--- a/detectors/node/opentelemetry-resource-detector-aws/package.json
+++ b/detectors/node/opentelemetry-resource-detector-aws/package.json
@@ -41,7 +41,7 @@
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/contrib-test-utils": "^0.41.0",
     "@types/mocha": "8.2.3",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "mocha": "7.2.0",
     "nock": "13.3.3",

--- a/detectors/node/opentelemetry-resource-detector-azure/package.json
+++ b/detectors/node/opentelemetry-resource-detector-azure/package.json
@@ -34,7 +34,7 @@
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/contrib-test-utils": "^0.41.0",
     "@types/mocha": "8.2.3",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "mocha": "7.2.0",
     "nock": "13.3.3",

--- a/detectors/node/opentelemetry-resource-detector-container/package.json
+++ b/detectors/node/opentelemetry-resource-detector-container/package.json
@@ -36,7 +36,7 @@
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/contrib-test-utils": "^0.41.0",
     "@types/mocha": "8.2.3",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "eslint-plugin-header": "^3.1.1",
     "mocha": "7.2.0",

--- a/detectors/node/opentelemetry-resource-detector-gcp/package.json
+++ b/detectors/node/opentelemetry-resource-detector-gcp/package.json
@@ -41,7 +41,7 @@
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/contrib-test-utils": "^0.41.0",
     "@types/mocha": "8.2.3",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/semver": "7.5.8",
     "mocha": "7.2.0",
     "nock": "13.3.3",

--- a/detectors/node/opentelemetry-resource-detector-github/package.json
+++ b/detectors/node/opentelemetry-resource-detector-github/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
     "@types/mocha": "8.2.3",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "mocha": "7.2.0",
     "nyc": "15.1.0",

--- a/detectors/node/opentelemetry-resource-detector-instana/package.json
+++ b/detectors/node/opentelemetry-resource-detector-instana/package.json
@@ -41,7 +41,7 @@
     "@opentelemetry/contrib-test-utils": "^0.41.0",
     "@opentelemetry/sdk-node": "^0.53.0",
     "@types/mocha": "8.2.3",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/semver": "7.5.8",
     "mocha": "7.2.0",
     "nock": "13.3.3",

--- a/incubator/opentelemetry-sampler-aws-xray/package.json
+++ b/incubator/opentelemetry-sampler-aws-xray/package.json
@@ -52,7 +52,7 @@
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/contrib-test-utils": "^0.35.0",
     "@types/mocha": "8.2.3",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "@typescript-eslint/eslint-plugin": "5.8.1",
     "@typescript-eslint/parser": "5.8.1",

--- a/metapackages/auto-configuration-propagators/package.json
+++ b/metapackages/auto-configuration-propagators/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.4.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "mocha": "7.2.0",
     "nyc": "15.1.0",

--- a/metapackages/auto-instrumentations-node/package.json
+++ b/metapackages/auto-instrumentations-node/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.4.1",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "mocha": "7.2.0",
     "nyc": "15.1.0",

--- a/metapackages/auto-instrumentations-web/package.json
+++ b/metapackages/auto-instrumentations-web/package.json
@@ -39,7 +39,7 @@
     "@babel/preset-env": "7.24.6",
     "@opentelemetry/api": "^1.3.0",
     "@types/mocha": "10.0.6",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "@types/webpack-env": "1.16.3",
     "assert": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.41.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "mocha": "7.2.0",
         "nock": "13.3.3",
@@ -72,6 +72,15 @@
       "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
     },
+    "detectors/node/opentelemetry-resource-detector-alibaba-cloud/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "detectors/node/opentelemetry-resource-detector-aws": {
       "name": "@opentelemetry/resource-detector-aws",
       "version": "1.6.1",
@@ -85,7 +94,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.41.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "mocha": "7.2.0",
         "nock": "13.3.3",
@@ -108,6 +117,15 @@
       "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
     },
+    "detectors/node/opentelemetry-resource-detector-aws/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "detectors/node/opentelemetry-resource-detector-azure": {
       "name": "@opentelemetry/resource-detector-azure",
       "version": "0.2.11",
@@ -121,7 +139,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.41.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "mocha": "7.2.0",
         "nock": "13.3.3",
@@ -143,6 +161,15 @@
       "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
     },
+    "detectors/node/opentelemetry-resource-detector-azure/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "detectors/node/opentelemetry-resource-detector-container": {
       "name": "@opentelemetry/resource-detector-container",
       "version": "0.4.1",
@@ -155,7 +182,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.41.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "eslint-plugin-header": "^3.1.1",
         "mocha": "7.2.0",
@@ -179,6 +206,15 @@
       "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
     },
+    "detectors/node/opentelemetry-resource-detector-container/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "detectors/node/opentelemetry-resource-detector-gcp": {
       "name": "@opentelemetry/resource-detector-gcp",
       "version": "0.29.11",
@@ -193,7 +229,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.41.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
         "mocha": "7.2.0",
         "nock": "13.3.3",
@@ -215,6 +251,15 @@
       "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
     },
+    "detectors/node/opentelemetry-resource-detector-gcp/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "detectors/node/opentelemetry-resource-detector-github": {
       "name": "@opentelemetry/resource-detector-github",
       "version": "0.29.0",
@@ -225,7 +270,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -247,6 +292,15 @@
       "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
     },
+    "detectors/node/opentelemetry-resource-detector-github/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "detectors/node/opentelemetry-resource-detector-instana": {
       "name": "@opentelemetry/resource-detector-instana",
       "version": "0.12.0",
@@ -260,7 +314,7 @@
         "@opentelemetry/contrib-test-utils": "^0.41.0",
         "@opentelemetry/sdk-node": "^0.53.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
         "mocha": "7.2.0",
         "nock": "13.3.3",
@@ -282,6 +336,15 @@
       "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
     },
+    "detectors/node/opentelemetry-resource-detector-instana/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "metapackages/auto-configuration-propagators": {
       "name": "@opentelemetry/auto-configuration-propagators",
       "version": "0.3.0",
@@ -297,7 +360,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.4.1",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -311,6 +374,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.4.1"
+      }
+    },
+    "metapackages/auto-configuration-propagators/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "metapackages/auto-instrumentations-node": {
@@ -369,7 +441,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.4.1",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -383,6 +455,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.4.1"
+      }
+    },
+    "metapackages/auto-instrumentations-node/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "metapackages/auto-instrumentations-web": {
@@ -401,7 +482,7 @@
         "@babel/preset-env": "7.24.6",
         "@opentelemetry/api": "^1.3.0",
         "@types/mocha": "10.0.6",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "@types/webpack-env": "1.16.3",
         "assert": "2.0.0",
@@ -486,6 +567,15 @@
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
       "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
       "dev": true
+    },
+    "metapackages/auto-instrumentations-web/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "metapackages/auto-instrumentations-web/node_modules/@types/sinon": {
       "version": "17.0.3",
@@ -35576,8 +35666,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -37045,7 +37134,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "expect": "29.2.0",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -37066,6 +37155,15 @@
       "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
     },
+    "packages/baggage-span-processor/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "packages/opentelemetry-host-metrics": {
       "name": "@opentelemetry/host-metrics",
       "version": "0.35.3",
@@ -37077,7 +37175,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -37099,6 +37197,15 @@
       "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
     },
+    "packages/opentelemetry-host-metrics/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "packages/opentelemetry-id-generator-aws-xray": {
       "name": "@opentelemetry/id-generator-aws-xray",
       "version": "1.2.2",
@@ -37111,7 +37218,7 @@
         "@babel/preset-env": "7.24.6",
         "@opentelemetry/api": "^1.0.0",
         "@types/mocha": "10.0.6",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "@types/webpack-env": "1.16.3",
         "assert": "2.0.0",
@@ -37195,6 +37302,15 @@
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
       "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
       "dev": true
+    },
+    "packages/opentelemetry-id-generator-aws-xray/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "packages/opentelemetry-id-generator-aws-xray/node_modules/@types/sinon": {
       "version": "17.0.3",
@@ -37612,7 +37728,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.41.0",
         "@types/mocha": "^9.1.1",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "^10.0.11",
         "expect": "29.2.0",
         "mocha": "7.2.0",
@@ -37634,13 +37750,22 @@
       "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "dev": true
     },
+    "packages/opentelemetry-propagation-utils/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "packages/opentelemetry-redis-common": {
       "name": "@opentelemetry/redis-common",
       "version": "0.36.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/mocha": "^9.1.1",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
         "ts-mocha": "10.0.0",
@@ -37656,6 +37781,15 @@
       "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
       "dev": true
     },
+    "packages/opentelemetry-redis-common/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "packages/opentelemetry-sql-common": {
       "name": "@opentelemetry/sql-common",
       "version": "0.40.1",
@@ -37666,7 +37800,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.1.0",
         "@types/mocha": "^7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
         "ts-mocha": "10.0.0",
@@ -37677,6 +37811,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0"
+      }
+    },
+    "packages/opentelemetry-sql-common/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "packages/opentelemetry-test-utils": {
@@ -37695,7 +37838,7 @@
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "typescript": "4.4.4"
       },
       "engines": {
@@ -37703,6 +37846,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "packages/opentelemetry-test-utils/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "packages/winston-transport": {
@@ -37715,7 +37867,7 @@
       },
       "devDependencies": {
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "@types/triple-beam": "1.3.2",
         "mocha": "7.2.0",
@@ -37727,6 +37879,15 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "packages/winston-transport/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "packages/winston-transport/node_modules/@types/triple-beam": {
@@ -37750,7 +37911,7 @@
         "@types/amqplib": "^0.5.17",
         "@types/lodash": "4.14.199",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "amqplib": "0.8.0",
         "expect": "29.2.0",
@@ -37774,6 +37935,15 @@
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
       "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
+    },
+    "plugins/node/instrumentation-amqplib/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "plugins/node/instrumentation-cucumber": {
       "name": "@opentelemetry/instrumentation-cucumber",
@@ -37822,7 +37992,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "dataloader": "2.2.2",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -37836,6 +38006,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/instrumentation-dataloader/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "plugins/node/instrumentation-fs": {
@@ -37853,7 +38032,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "^10.0.11",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -37869,6 +38048,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/instrumentation-fs/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "plugins/node/instrumentation-kafkajs": {
       "name": "@opentelemetry/instrumentation-kafkajs",
       "version": "0.3.0",
@@ -37882,7 +38070,7 @@
         "@opentelemetry/contrib-test-utils": "^0.41.0",
         "@opentelemetry/sdk-trace-base": "^1.24.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "^10.0.11",
         "kafkajs": "^2.2.4",
         "mocha": "7.2.0",
@@ -37899,6 +38087,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/instrumentation-kafkajs/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "plugins/node/instrumentation-lru-memoizer": {
       "name": "@opentelemetry/instrumentation-lru-memoizer",
       "version": "0.40.0",
@@ -37911,7 +38108,7 @@
         "@opentelemetry/contrib-test-utils": "^0.41.0",
         "@types/lru-cache": "7.10.10",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "expect": "29.2.0",
         "lru-memoizer": "2.1.4",
         "mocha": "7.2.0",
@@ -37934,6 +38131,15 @@
       "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
     },
+    "plugins/node/instrumentation-lru-memoizer/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "plugins/node/instrumentation-mongoose": {
       "name": "@opentelemetry/instrumentation-mongoose",
       "version": "0.42.0",
@@ -37948,7 +38154,7 @@
         "@opentelemetry/contrib-test-utils": "^0.41.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "expect": "29.2.0",
         "mocha": "7.2.0",
         "mongoose": "6.13.0",
@@ -37970,6 +38176,15 @@
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
       "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
+    },
+    "plugins/node/instrumentation-mongoose/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "plugins/node/instrumentation-runtime-node": {
       "name": "@opentelemetry/instrumentation-runtime-node",
@@ -38024,7 +38239,7 @@
         "@opentelemetry/contrib-test-utils": "^0.41.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "expect": "27.4.2",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -38063,6 +38278,15 @@
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
       "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
+    },
+    "plugins/node/instrumentation-socket.io/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "plugins/node/instrumentation-socket.io/node_modules/@types/yargs": {
       "version": "16.0.9",
@@ -38275,7 +38499,7 @@
         "@opentelemetry/contrib-test-utils": "^0.41.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
         "rimraf": "5.0.10",
@@ -38290,6 +38514,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/instrumentation-tedious/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "plugins/node/instrumentation-tedious/node_modules/bl": {
@@ -38475,7 +38708,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
         "rimraf": "5.0.10",
@@ -38490,6 +38723,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.7.0"
+      }
+    },
+    "plugins/node/instrumentation-undici/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "plugins/node/opentelemetry-instrumentation-aws-lambda": {
@@ -38510,7 +38752,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
         "rimraf": "5.0.10",
@@ -38522,6 +38764,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "plugins/node/opentelemetry-instrumentation-aws-sdk": {
@@ -38545,7 +38796,7 @@
         "@opentelemetry/contrib-test-utils": "^0.41.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "aws-sdk": "2.1008.0",
         "eslint": "8.7.0",
@@ -38572,6 +38823,15 @@
       "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
     },
+    "plugins/node/opentelemetry-instrumentation-aws-sdk/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-bunyan": {
       "name": "@opentelemetry/instrumentation-bunyan",
       "version": "0.41.0",
@@ -38589,7 +38849,7 @@
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "bunyan": "1.8.15",
         "mocha": "7.2.0",
@@ -38615,6 +38875,14 @@
         "@types/node": "*"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-bunyan/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-cassandra": {
       "name": "@opentelemetry/instrumentation-cassandra-driver",
       "version": "0.41.0",
@@ -38630,7 +38898,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
         "@types/sinon": "10.0.20",
         "cassandra-driver": "4.6.4",
@@ -38646,6 +38914,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-cassandra/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "plugins/node/opentelemetry-instrumentation-connect": {
@@ -38664,7 +38941,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "connect": "3.7.0",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -38687,6 +38964,14 @@
         "@types/node": "*"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-connect/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-dns": {
       "name": "@opentelemetry/instrumentation-dns",
       "version": "0.39.0",
@@ -38701,7 +38986,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
         "@types/shimmer": "1.0.3",
         "@types/sinon": "10.0.20",
@@ -38717,6 +39002,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-dns/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "plugins/node/opentelemetry-instrumentation-express": {
@@ -38736,7 +39030,7 @@
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/express": "4.17.21",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "express": "4.20.0",
         "mocha": "7.2.0",
@@ -38752,6 +39046,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-express/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "plugins/node/opentelemetry-instrumentation-fastify": {
@@ -38811,7 +39114,7 @@
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/generic-pool": "^3.1.9",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
         "generic-pool": "3.8.2",
         "mocha": "7.2.0",
@@ -38828,6 +39131,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-generic-pool/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-graphql": {
       "name": "@opentelemetry/instrumentation-graphql",
       "version": "0.43.0",
@@ -38840,7 +39152,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "graphql": "^16.5.0",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -38862,6 +39174,15 @@
       "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
     },
+    "plugins/node/opentelemetry-instrumentation-graphql/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-hapi": {
       "name": "@opentelemetry/instrumentation-hapi",
       "version": "0.41.0",
@@ -38879,7 +39200,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "joi": "17.12.2",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -38893,6 +39214,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-hapi/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "plugins/node/opentelemetry-instrumentation-ioredis": {
@@ -38912,7 +39242,7 @@
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/ioredis4": "npm:@types/ioredis@4.28.10",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "cross-env": "7.0.3",
         "ioredis": "5.2.2",
@@ -38931,6 +39261,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-ioredis/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-knex": {
       "name": "@opentelemetry/instrumentation-knex",
       "version": "0.40.0",
@@ -38945,7 +39284,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "knex": "0.95.9",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -38959,6 +39298,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-knex/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "plugins/node/opentelemetry-instrumentation-koa": {
@@ -38981,7 +39329,7 @@
         "@types/koa": "2.15.0",
         "@types/koa__router": "12.0.4",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "koa": "2.13.1",
         "mocha": "7.2.0",
@@ -38997,6 +39345,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-koa/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "plugins/node/opentelemetry-instrumentation-memcached": {
@@ -39015,7 +39372,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "cross-env": "7.0.3",
         "memcached": "2.2.2",
         "mocha": "7.2.0",
@@ -39029,6 +39386,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-memcached/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "plugins/node/opentelemetry-instrumentation-mongodb": {
@@ -39048,7 +39414,7 @@
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/bson": "4.0.5",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "mocha": "7.2.0",
         "mongodb": "6.8.0",
         "nyc": "15.1.0",
@@ -39062,6 +39428,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-mongodb/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "plugins/node/opentelemetry-instrumentation-mongodb/node_modules/@types/whatwg-url": {
@@ -39240,7 +39615,7 @@
         "@opentelemetry/sdk-metrics": "^1.8.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "mocha": "7.2.0",
         "mysql": "2.18.1",
@@ -39255,6 +39630,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-mysql/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "plugins/node/opentelemetry-instrumentation-mysql2": {
@@ -39272,7 +39656,7 @@
         "@opentelemetry/contrib-test-utils": "^0.41.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
         "mocha": "7.2.0",
         "mysql2": "2.3.3",
@@ -39288,6 +39672,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-mysql2/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "plugins/node/opentelemetry-instrumentation-nestjs-core": {
@@ -39309,7 +39702,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
         "cross-env": "7.0.3",
         "mocha": "7.2.0",
@@ -39330,6 +39723,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-nestjs-core/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-net": {
       "name": "@opentelemetry/instrumentation-net",
       "version": "0.39.0",
@@ -39344,7 +39746,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -39358,6 +39760,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-net/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "plugins/node/opentelemetry-instrumentation-pg": {
@@ -39378,7 +39789,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "cross-env": "7.0.3",
         "mocha": "7.2.0",
@@ -39399,6 +39810,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-pg/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-pino": {
       "name": "@opentelemetry/instrumentation-pino",
       "version": "0.42.0",
@@ -39415,7 +39835,7 @@
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
         "@types/sinon": "10.0.20",
         "mocha": "7.2.0",
@@ -39435,6 +39855,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-pino/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-redis": {
       "name": "@opentelemetry/instrumentation-redis",
       "version": "0.42.0",
@@ -39451,7 +39880,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/redis": "2.8.32",
         "cross-env": "7.0.3",
         "mocha": "7.2.0",
@@ -39486,7 +39915,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "cross-env": "7.0.3",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -39503,6 +39932,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-redis-4/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-redis-4/node_modules/redis": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/redis/-/redis-4.1.0.tgz",
@@ -39515,6 +39953,15 @@
         "@redis/json": "1.0.3",
         "@redis/search": "1.0.6",
         "@redis/time-series": "1.0.3"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-redis/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "plugins/node/opentelemetry-instrumentation-restify": {
@@ -39532,7 +39979,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/restify": "4.3.12",
         "@types/semver": "7.5.8",
         "mocha": "7.2.0",
@@ -39551,6 +39998,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-restify/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-router": {
       "name": "@opentelemetry/instrumentation-router",
       "version": "0.40.0",
@@ -39565,7 +40021,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
         "rimraf": "5.0.10",
@@ -39578,6 +40034,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-router/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "plugins/node/opentelemetry-instrumentation-winston": {
@@ -39595,7 +40060,7 @@
         "@opentelemetry/sdk-trace-node": "^1.21.0",
         "@opentelemetry/winston-transport": "^0.6.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "@types/triple-beam": "^1.3.2",
         "mocha": "7.2.0",
@@ -39613,6 +40078,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-winston/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "plugins/web/opentelemetry-instrumentation-document-load": {
@@ -39634,7 +40108,7 @@
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@types/chai": "^4.3.10",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "@web/dev-server-esbuild": "^1.0.1",
         "@web/dev-server-rollup": "^0.6.1",
@@ -39656,6 +40130,15 @@
       "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
       "dev": true
     },
+    "plugins/web/opentelemetry-instrumentation-document-load/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "plugins/web/opentelemetry-instrumentation-long-task": {
       "name": "@opentelemetry/instrumentation-long-task",
       "version": "0.40.0",
@@ -39671,7 +40154,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@types/mocha": "10.0.6",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "@types/webpack-env": "1.16.3",
         "assert": "2.0.0",
@@ -39756,6 +40239,15 @@
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
       "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
       "dev": true
+    },
+    "plugins/web/opentelemetry-instrumentation-long-task/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "plugins/web/opentelemetry-instrumentation-long-task/node_modules/@types/sinon": {
       "version": "17.0.3",
@@ -40183,7 +40675,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@types/jquery": "3.5.30",
         "@types/mocha": "10.0.6",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "@types/webpack-env": "1.16.3",
         "assert": "2.0.0",
@@ -40269,6 +40761,15 @@
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
       "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
       "dev": true
+    },
+    "plugins/web/opentelemetry-instrumentation-user-interaction/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "plugins/web/opentelemetry-instrumentation-user-interaction/node_modules/@types/sinon": {
       "version": "17.0.3",
@@ -40695,7 +41196,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/propagator-b3": "1.26.0",
         "@types/mocha": "10.0.6",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/react": "17.0.80",
         "@types/react-addons-test-utils": "0.14.26",
         "@types/react-dom": "18.0.2",
@@ -40785,6 +41286,15 @@
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
       "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
       "dev": true
+    },
+    "plugins/web/opentelemetry-plugin-react-load/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "plugins/web/opentelemetry-plugin-react-load/node_modules/@types/sinon": {
       "version": "17.0.3",
@@ -41227,7 +41737,7 @@
         "@babel/preset-env": "7.24.6",
         "@opentelemetry/api": "^1.0.0",
         "@types/mocha": "10.0.6",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "@types/webpack-env": "1.16.3",
         "assert": "2.0.0",
@@ -41301,6 +41811,15 @@
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
       "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
       "dev": true
+    },
+    "propagators/opentelemetry-propagator-instana/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "propagators/opentelemetry-propagator-instana/node_modules/@types/sinon": {
       "version": "17.0.3",
@@ -41700,7 +42219,7 @@
         "@babel/preset-env": "7.24.6",
         "@opentelemetry/api": "^1.0.0",
         "@types/mocha": "10.0.6",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "@types/webpack-env": "1.16.3",
         "assert": "2.0.0",
@@ -41783,6 +42302,15 @@
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
       "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
       "dev": true
+    },
+    "propagators/opentelemetry-propagator-ot-trace/node_modules/@types/node": {
+      "version": "18.18.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "propagators/opentelemetry-propagator-ot-trace/node_modules/@types/sinon": {
       "version": "17.0.3",
@@ -49552,7 +50080,7 @@
         "@opentelemetry/propagator-jaeger": "^1.25.1",
         "@opentelemetry/propagator-ot-trace": "^0.27.2",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -49560,6 +50088,17 @@
         "sinon": "15.2.0",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/auto-instrumentations-node": {
@@ -49614,7 +50153,7 @@
         "@opentelemetry/resources": "^1.24.0",
         "@opentelemetry/sdk-node": "^0.53.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -49622,6 +50161,17 @@
         "sinon": "15.2.0",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/auto-instrumentations-web": {
@@ -49636,7 +50186,7 @@
         "@opentelemetry/instrumentation-user-interaction": "^0.40.0",
         "@opentelemetry/instrumentation-xml-http-request": "^0.53.0",
         "@types/mocha": "10.0.6",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "@types/webpack-env": "1.16.3",
         "assert": "2.0.0",
@@ -49706,6 +50256,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
           "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         },
         "@types/sinon": {
           "version": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
@@ -50008,7 +50567,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "expect": "29.2.0",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -50022,6 +50581,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
           "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         }
       }
     },
@@ -50058,8 +50626,19 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/core": {
@@ -50173,7 +50752,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/sdk-metrics": "^1.8.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -50189,6 +50768,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
           "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         }
       }
     },
@@ -50200,7 +50788,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/core": "^1.0.0",
         "@types/mocha": "10.0.6",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "@types/webpack-env": "1.16.3",
         "assert": "2.0.0",
@@ -50270,6 +50858,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
           "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         },
         "@types/sinon": {
           "version": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
@@ -50597,7 +51194,7 @@
         "@types/amqplib": "^0.5.17",
         "@types/lodash": "4.14.199",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "amqplib": "0.8.0",
         "expect": "29.2.0",
@@ -50615,6 +51212,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
           "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         }
       }
     },
@@ -50632,12 +51238,23 @@
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/aws-lambda": "8.10.143",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
         "rimraf": "5.0.10",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-aws-sdk": {
@@ -50657,7 +51274,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "aws-sdk": "2.1008.0",
         "eslint": "8.7.0",
@@ -50677,6 +51294,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
           "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         }
       }
     },
@@ -50693,7 +51319,7 @@
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/bunyan": "1.8.9",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "bunyan": "1.8.15",
         "mocha": "7.2.0",
@@ -50712,6 +51338,14 @@
           "requires": {
             "@types/node": "*"
           }
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         }
       }
     },
@@ -50726,7 +51360,7 @@
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
         "@types/sinon": "10.0.20",
         "cassandra-driver": "4.6.4",
@@ -50736,6 +51370,17 @@
         "sinon": "15.2.0",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-connect": {
@@ -50750,7 +51395,7 @@
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/connect": "3.4.36",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "connect": "3.7.0",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -50765,6 +51410,14 @@
           "integrity": "sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==",
           "requires": {
             "@types/node": "*"
+          }
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "requires": {
+            "undici-types": "~5.26.4"
           }
         }
       }
@@ -50802,7 +51455,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "dataloader": "2.2.2",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -50810,6 +51463,17 @@
         "test-all-versions": "6.1.0",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-dns": {
@@ -50821,7 +51485,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
         "@types/shimmer": "1.0.3",
         "@types/sinon": "10.0.20",
@@ -50832,6 +51496,17 @@
         "sinon": "15.2.0",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-document-load": {
@@ -50849,7 +51524,7 @@
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@types/chai": "^4.3.10",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "@web/dev-server-esbuild": "^1.0.1",
         "@web/dev-server-rollup": "^0.6.1",
@@ -50864,6 +51539,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
           "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         }
       }
     },
@@ -50880,7 +51564,7 @@
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/express": "4.17.21",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "express": "4.20.0",
         "mocha": "7.2.0",
@@ -50890,6 +51574,17 @@
         "test-all-versions": "6.1.0",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-fastify": {
@@ -50949,7 +51644,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "^10.0.11",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -50957,6 +51652,17 @@
         "sinon": "15.2.0",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-generic-pool": {
@@ -50969,7 +51675,7 @@
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/generic-pool": "^3.1.9",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
         "generic-pool": "3.8.2",
         "mocha": "7.2.0",
@@ -50978,6 +51684,17 @@
         "semver": "7.6.3",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-graphql": {
@@ -50988,7 +51705,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "graphql": "^16.5.0",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -51003,6 +51720,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
           "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         }
       }
     },
@@ -51028,7 +51754,7 @@
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "joi": "17.12.2",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -51036,6 +51762,17 @@
         "test-all-versions": "6.1.0",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-http": {
@@ -51062,7 +51799,7 @@
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/ioredis4": "npm:@types/ioredis@4.28.10",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "cross-env": "7.0.3",
         "ioredis": "5.2.2",
@@ -51073,6 +51810,17 @@
         "test-all-versions": "6.1.0",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-kafkajs": {
@@ -51084,7 +51832,7 @@
         "@opentelemetry/sdk-trace-base": "^1.24.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "^10.0.11",
         "kafkajs": "^2.2.4",
         "mocha": "7.2.0",
@@ -51093,6 +51841,17 @@
         "sinon": "15.2.0",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-knex": {
@@ -51105,7 +51864,7 @@
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "knex": "0.95.9",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -51113,6 +51872,17 @@
         "sqlite3": "5.1.7",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-koa": {
@@ -51131,7 +51901,7 @@
         "@types/koa": "2.15.0",
         "@types/koa__router": "12.0.4",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "koa": "2.13.1",
         "mocha": "7.2.0",
@@ -51141,6 +51911,17 @@
         "test-all-versions": "6.1.0",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-long-task": {
@@ -51154,7 +51935,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-web": "^1.8.0",
         "@types/mocha": "10.0.6",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "@types/webpack-env": "1.16.3",
         "assert": "2.0.0",
@@ -51225,6 +52006,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
           "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         },
         "@types/sinon": {
           "version": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
@@ -51529,7 +52319,7 @@
         "@opentelemetry/instrumentation": "^0.53.0",
         "@types/lru-cache": "7.10.10",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "expect": "29.2.0",
         "lru-memoizer": "2.1.4",
         "mocha": "7.2.0",
@@ -51545,6 +52335,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
           "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         }
       }
     },
@@ -51560,7 +52359,7 @@
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/memcached": "^2.2.6",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "cross-env": "7.0.3",
         "memcached": "2.2.2",
         "mocha": "7.2.0",
@@ -51568,6 +52367,17 @@
         "rimraf": "5.0.10",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-mongodb": {
@@ -51583,7 +52393,7 @@
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/bson": "4.0.5",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "mocha": "7.2.0",
         "mongodb": "6.8.0",
         "nyc": "15.1.0",
@@ -51593,6 +52403,15 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        },
         "@types/whatwg-url": {
           "version": "11.0.4",
           "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.4.tgz",
@@ -51709,7 +52528,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "expect": "29.2.0",
         "mocha": "7.2.0",
         "mongoose": "6.13.0",
@@ -51725,6 +52544,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
           "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         }
       }
     },
@@ -51740,7 +52568,7 @@
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "7.0.2",
         "@types/mysql": "2.15.26",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "mocha": "7.2.0",
         "mysql": "2.18.1",
@@ -51749,6 +52577,17 @@
         "sinon": "15.2.0",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-mysql2": {
@@ -51762,7 +52601,7 @@
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@opentelemetry/sql-common": "^0.40.1",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
         "mocha": "7.2.0",
         "mysql2": "2.3.3",
@@ -51772,6 +52611,17 @@
         "test-all-versions": "6.1.0",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-nestjs-core": {
@@ -51789,7 +52639,7 @@
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
         "cross-env": "7.0.3",
         "mocha": "7.2.0",
@@ -51802,6 +52652,17 @@
         "test-all-versions": "6.1.0",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-net": {
@@ -51814,7 +52675,7 @@
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -51822,6 +52683,17 @@
         "sinon": "15.2.0",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-pg": {
@@ -51836,7 +52708,7 @@
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@opentelemetry/sql-common": "^0.40.1",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/pg": "8.6.1",
         "@types/pg-pool": "2.0.6",
         "@types/sinon": "10.0.20",
@@ -51851,6 +52723,17 @@
         "test-all-versions": "6.1.0",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-pino": {
@@ -51865,7 +52748,7 @@
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
         "@types/sinon": "10.0.20",
         "mocha": "7.2.0",
@@ -51877,6 +52760,17 @@
         "test-all-versions": "6.1.0",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-redis": {
@@ -51891,7 +52785,7 @@
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/redis": "2.8.32",
         "cross-env": "7.0.3",
         "mocha": "7.2.0",
@@ -51901,6 +52795,17 @@
         "test-all-versions": "6.1.0",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-redis-4": {
@@ -51916,7 +52821,7 @@
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "cross-env": "7.0.3",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -51927,6 +52832,15 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        },
         "redis": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/redis/-/redis-4.1.0.tgz",
@@ -51954,7 +52868,7 @@
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/restify": "4.3.12",
         "@types/semver": "7.5.8",
         "mocha": "7.2.0",
@@ -51965,6 +52879,17 @@
         "test-all-versions": "^6.0.0",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-router": {
@@ -51977,13 +52902,24 @@
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
         "rimraf": "5.0.10",
         "router": "1.3.8",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-runtime-node": {
@@ -52027,7 +52963,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "expect": "27.4.2",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -52057,6 +52993,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
           "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         },
         "@types/yargs": {
           "version": "16.0.9",
@@ -52220,7 +53165,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/tedious": "^4.0.14",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -52232,6 +53177,15 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        },
         "bl": {
           "version": "6.0.12",
           "resolved": "https://registry.npmjs.org/bl/-/bl-6.0.12.tgz",
@@ -52346,7 +53300,7 @@
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
         "rimraf": "5.0.10",
@@ -52355,6 +53309,17 @@
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4",
         "undici": "6.11.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-user-interaction": {
@@ -52371,7 +53336,7 @@
         "@opentelemetry/sdk-trace-web": "^1.8.0",
         "@types/jquery": "3.5.30",
         "@types/mocha": "10.0.6",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "@types/webpack-env": "1.16.3",
         "assert": "2.0.0",
@@ -52442,6 +53407,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
           "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         },
         "@types/sinon": {
           "version": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
@@ -52749,7 +53723,7 @@
         "@opentelemetry/sdk-trace-node": "^1.21.0",
         "@opentelemetry/winston-transport": "^0.6.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "@types/triple-beam": "^1.3.2",
         "mocha": "7.2.0",
@@ -52761,6 +53735,17 @@
         "typescript": "4.4.4",
         "winston": "3.3.3",
         "winston2": "npm:winston@2.4.7"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/instrumentation-xml-http-request": {
@@ -52820,7 +53805,7 @@
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-web": "^1.0.0",
         "@types/mocha": "10.0.6",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/react": "17.0.80",
         "@types/react-addons-test-utils": "0.14.26",
         "@types/react-dom": "18.0.2",
@@ -52896,6 +53881,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
           "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         },
         "@types/sinon": {
           "version": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
@@ -53198,7 +54192,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.41.0",
         "@types/mocha": "^9.1.1",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "^10.0.11",
         "expect": "29.2.0",
         "mocha": "7.2.0",
@@ -53213,6 +54207,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
           "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         }
       }
     },
@@ -53247,7 +54250,7 @@
         "@babel/preset-env": "7.24.6",
         "@opentelemetry/api": "^1.0.0",
         "@types/mocha": "10.0.6",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "@types/webpack-env": "1.16.3",
         "assert": "2.0.0",
@@ -53307,6 +54310,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
           "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         },
         "@types/sinon": {
           "version": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
@@ -53604,7 +54616,7 @@
         "@babel/preset-env": "7.24.6",
         "@opentelemetry/api": "^1.0.0",
         "@types/mocha": "10.0.6",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "@types/webpack-env": "1.16.3",
         "assert": "2.0.0",
@@ -53673,6 +54685,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
           "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         },
         "@types/sinon": {
           "version": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
@@ -53973,7 +54994,7 @@
       "version": "file:packages/opentelemetry-redis-common",
       "requires": {
         "@types/mocha": "^9.1.1",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
         "ts-mocha": "10.0.0",
@@ -53985,6 +55006,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-9.1.1.tgz",
           "integrity": "sha512-Z61JK7DKDtdKTWwLeElSEBcWGRLY8g95ic5FoQqI9CMx0ns/Ghep3B4DfcEimiKMvtamNVULVNKEsiwV3aQmXw==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         }
       }
     },
@@ -53996,7 +55026,7 @@
         "@opentelemetry/resources": "^1.10.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "mocha": "7.2.0",
         "nock": "13.3.3",
@@ -54012,6 +55042,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
           "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         }
       }
     },
@@ -54024,7 +55063,7 @@
         "@opentelemetry/resources": "^1.10.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "mocha": "7.2.0",
         "nock": "13.3.3",
@@ -54040,6 +55079,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
           "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         }
       }
     },
@@ -54052,7 +55100,7 @@
         "@opentelemetry/resources": "^1.10.1",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "mocha": "7.2.0",
         "nock": "13.3.3",
@@ -54067,6 +55115,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
           "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         }
       }
     },
@@ -54078,7 +55135,7 @@
         "@opentelemetry/resources": "^1.10.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "eslint-plugin-header": "^3.1.1",
         "mocha": "7.2.0",
@@ -54095,6 +55152,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
           "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         }
       }
     },
@@ -54107,7 +55173,7 @@
         "@opentelemetry/resources": "^1.10.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
         "gcp-metadata": "^6.0.0",
         "mocha": "7.2.0",
@@ -54123,6 +55189,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
           "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         }
       }
     },
@@ -54132,7 +55207,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/resources": "^1.10.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
@@ -54147,6 +55222,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
           "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         }
       }
     },
@@ -54159,7 +55243,7 @@
         "@opentelemetry/sdk-node": "^0.53.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
         "mocha": "7.2.0",
         "nock": "13.3.3",
@@ -54174,6 +55258,15 @@
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
           "integrity": "sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==",
           "dev": true
+        },
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
         }
       }
     },
@@ -54272,11 +55365,22 @@
         "@opentelemetry/api": "^1.1.0",
         "@opentelemetry/core": "^1.1.0",
         "@types/mocha": "^7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "mocha": "7.2.0",
         "nyc": "15.1.0",
         "ts-mocha": "10.0.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        }
       }
     },
     "@opentelemetry/winston-transport": {
@@ -54284,7 +55388,7 @@
       "requires": {
         "@opentelemetry/api-logs": "^0.53.0",
         "@types/mocha": "7.0.2",
-        "@types/node": "18.6.5",
+        "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
         "@types/triple-beam": "1.3.2",
         "mocha": "7.2.0",
@@ -54296,6 +55400,15 @@
         "winston-transport": "4.*"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "18.18.14",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
+          "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
+          "dev": true,
+          "requires": {
+            "undici-types": "~5.26.4"
+          }
+        },
         "@types/triple-beam": {
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.2.tgz",
@@ -73730,8 +74843,7 @@
     "undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/packages/baggage-span-processor/package.json
+++ b/packages/baggage-span-processor/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
     "@types/mocha": "8.2.3",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "expect": "29.2.0",
     "mocha": "7.2.0",
     "nyc": "15.1.0",

--- a/packages/opentelemetry-host-metrics/package.json
+++ b/packages/opentelemetry-host-metrics/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
     "@types/mocha": "8.2.3",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "mocha": "7.2.0",
     "nyc": "15.1.0",

--- a/packages/opentelemetry-id-generator-aws-xray/package.json
+++ b/packages/opentelemetry-id-generator-aws-xray/package.json
@@ -55,7 +55,7 @@
     "@babel/preset-env": "7.24.6",
     "@opentelemetry/api": "^1.0.0",
     "@types/mocha": "10.0.6",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "@types/webpack-env": "1.16.3",
     "assert": "2.0.0",

--- a/packages/opentelemetry-propagation-utils/package.json
+++ b/packages/opentelemetry-propagation-utils/package.json
@@ -45,7 +45,7 @@
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/contrib-test-utils": "^0.41.0",
     "@types/mocha": "^9.1.1",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "^10.0.11",
     "expect": "29.2.0",
     "mocha": "7.2.0",

--- a/packages/opentelemetry-redis-common/package.json
+++ b/packages/opentelemetry-redis-common/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/redis-common#readme",
   "devDependencies": {
     "@types/mocha": "^9.1.1",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "ts-mocha": "10.0.0",

--- a/packages/opentelemetry-sql-common/package.json
+++ b/packages/opentelemetry-sql-common/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.1.0",
     "@types/mocha": "^7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "ts-mocha": "10.0.0",

--- a/packages/opentelemetry-test-utils/package.json
+++ b/packages/opentelemetry-test-utils/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "typescript": "4.4.4"
   },
   "dependencies": {

--- a/packages/winston-transport/package.json
+++ b/packages/winston-transport/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "@types/triple-beam": "1.3.2",
     "mocha": "7.2.0",

--- a/plugins/node/instrumentation-amqplib/package.json
+++ b/plugins/node/instrumentation-amqplib/package.json
@@ -55,7 +55,7 @@
     "@types/amqplib": "^0.5.17",
     "@types/lodash": "4.14.199",
     "@types/mocha": "8.2.3",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "amqplib": "0.8.0",
     "expect": "29.2.0",

--- a/plugins/node/instrumentation-amqplib/src/utils.ts
+++ b/plugins/node/instrumentation-amqplib/src/utils.ts
@@ -55,7 +55,7 @@ export type InstrumentationConsumeChannel = amqp.Channel & {
     msg: amqp.ConsumeMessage;
     timeOfConsume: HrTime;
   }[];
-  [CHANNEL_CONSUME_TIMEOUT_TIMER]?: NodeJS.Timer;
+  [CHANNEL_CONSUME_TIMEOUT_TIMER]?: NodeJS.Timeout;
 };
 export type InstrumentationMessage = amqp.Message & {
   [MESSAGE_STORED_SPAN]?: Span;

--- a/plugins/node/instrumentation-dataloader/package.json
+++ b/plugins/node/instrumentation-dataloader/package.json
@@ -48,7 +48,7 @@
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "dataloader": "2.2.2",
     "mocha": "7.2.0",
     "nyc": "15.1.0",

--- a/plugins/node/instrumentation-fs/package.json
+++ b/plugins/node/instrumentation-fs/package.json
@@ -49,7 +49,7 @@
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "^10.0.11",
     "mocha": "7.2.0",
     "nyc": "15.1.0",

--- a/plugins/node/instrumentation-kafkajs/package.json
+++ b/plugins/node/instrumentation-kafkajs/package.json
@@ -47,7 +47,7 @@
     "@opentelemetry/contrib-test-utils": "^0.41.0",
     "@opentelemetry/sdk-trace-base": "^1.24.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "^10.0.11",
     "kafkajs": "^2.2.4",
     "mocha": "7.2.0",

--- a/plugins/node/instrumentation-lru-memoizer/package.json
+++ b/plugins/node/instrumentation-lru-memoizer/package.json
@@ -47,7 +47,7 @@
     "@opentelemetry/contrib-test-utils": "^0.41.0",
     "@types/lru-cache": "7.10.10",
     "@types/mocha": "8.2.3",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "expect": "29.2.0",
     "lru-memoizer": "2.1.4",
     "mocha": "7.2.0",

--- a/plugins/node/instrumentation-mongoose/package.json
+++ b/plugins/node/instrumentation-mongoose/package.json
@@ -52,7 +52,7 @@
     "@opentelemetry/contrib-test-utils": "^0.41.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@types/mocha": "8.2.3",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "expect": "29.2.0",
     "mocha": "7.2.0",
     "mongoose": "6.13.0",

--- a/plugins/node/instrumentation-socket.io/package.json
+++ b/plugins/node/instrumentation-socket.io/package.json
@@ -47,7 +47,7 @@
     "@opentelemetry/contrib-test-utils": "^0.41.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@types/mocha": "8.2.3",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "expect": "27.4.2",
     "mocha": "7.2.0",
     "nyc": "15.1.0",

--- a/plugins/node/instrumentation-tedious/package.json
+++ b/plugins/node/instrumentation-tedious/package.json
@@ -52,7 +52,7 @@
     "@opentelemetry/contrib-test-utils": "^0.41.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "rimraf": "5.0.10",

--- a/plugins/node/instrumentation-undici/package.json
+++ b/plugins/node/instrumentation-undici/package.json
@@ -46,7 +46,7 @@
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "rimraf": "5.0.10",

--- a/plugins/node/instrumentation-undici/src/internal-types.ts
+++ b/plugins/node/instrumentation-undici/src/internal-types.ts
@@ -20,7 +20,7 @@ import { UndiciRequest, UndiciResponse } from './types';
 export interface ListenerRecord {
   name: string;
   channel: Channel;
-  onMessage: (message: any, name: string) => void;
+  onMessage: (message: any, name: string | symbol) => void;
 }
 
 export interface RequestMessage {

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
@@ -49,7 +49,7 @@
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "rimraf": "5.0.10",

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
@@ -61,7 +61,7 @@
     "@opentelemetry/contrib-test-utils": "^0.41.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@types/mocha": "8.2.3",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "aws-sdk": "2.1008.0",
     "eslint": "8.7.0",

--- a/plugins/node/opentelemetry-instrumentation-bunyan/package.json
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/package.json
@@ -51,7 +51,7 @@
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "bunyan": "1.8.15",
     "mocha": "7.2.0",

--- a/plugins/node/opentelemetry-instrumentation-cassandra/package.json
+++ b/plugins/node/opentelemetry-instrumentation-cassandra/package.json
@@ -50,7 +50,7 @@
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/semver": "7.5.8",
     "@types/sinon": "10.0.20",
     "cassandra-driver": "4.6.4",

--- a/plugins/node/opentelemetry-instrumentation-connect/package.json
+++ b/plugins/node/opentelemetry-instrumentation-connect/package.json
@@ -48,7 +48,7 @@
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "connect": "3.7.0",
     "mocha": "7.2.0",
     "nyc": "15.1.0",

--- a/plugins/node/opentelemetry-instrumentation-dns/package.json
+++ b/plugins/node/opentelemetry-instrumentation-dns/package.json
@@ -48,7 +48,7 @@
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/semver": "7.5.8",
     "@types/shimmer": "1.0.3",
     "@types/sinon": "10.0.20",

--- a/plugins/node/opentelemetry-instrumentation-express/package.json
+++ b/plugins/node/opentelemetry-instrumentation-express/package.json
@@ -52,7 +52,7 @@
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/express": "4.17.21",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "express": "4.20.0",
     "mocha": "7.2.0",

--- a/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
+++ b/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
@@ -49,7 +49,7 @@
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/generic-pool": "^3.1.9",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/semver": "7.5.8",
     "generic-pool": "3.8.2",
     "mocha": "7.2.0",

--- a/plugins/node/opentelemetry-instrumentation-graphql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-graphql/package.json
@@ -49,7 +49,7 @@
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
     "@types/mocha": "8.2.3",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "graphql": "^16.5.0",
     "mocha": "7.2.0",
     "nyc": "15.1.0",

--- a/plugins/node/opentelemetry-instrumentation-hapi/package.json
+++ b/plugins/node/opentelemetry-instrumentation-hapi/package.json
@@ -51,7 +51,7 @@
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "joi": "17.12.2",
     "mocha": "7.2.0",
     "nyc": "15.1.0",

--- a/plugins/node/opentelemetry-instrumentation-ioredis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/package.json
@@ -55,7 +55,7 @@
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/ioredis4": "npm:@types/ioredis@4.28.10",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "cross-env": "7.0.3",
     "ioredis": "5.2.2",

--- a/plugins/node/opentelemetry-instrumentation-knex/package.json
+++ b/plugins/node/opentelemetry-instrumentation-knex/package.json
@@ -48,7 +48,7 @@
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "knex": "0.95.9",
     "mocha": "7.2.0",
     "nyc": "15.1.0",

--- a/plugins/node/opentelemetry-instrumentation-koa/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/package.json
@@ -56,7 +56,7 @@
     "@types/koa": "2.15.0",
     "@types/koa__router": "12.0.4",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "koa": "2.13.1",
     "mocha": "7.2.0",

--- a/plugins/node/opentelemetry-instrumentation-memcached/package.json
+++ b/plugins/node/opentelemetry-instrumentation-memcached/package.json
@@ -50,7 +50,7 @@
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "cross-env": "7.0.3",
     "memcached": "2.2.2",
     "mocha": "7.2.0",

--- a/plugins/node/opentelemetry-instrumentation-mongodb/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/package.json
@@ -56,7 +56,7 @@
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/bson": "4.0.5",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "mocha": "7.2.0",
     "mongodb": "6.8.0",
     "nyc": "15.1.0",

--- a/plugins/node/opentelemetry-instrumentation-mysql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql/package.json
@@ -48,7 +48,7 @@
     "@opentelemetry/sdk-metrics": "^1.8.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "mocha": "7.2.0",
     "mysql": "2.18.1",

--- a/plugins/node/opentelemetry-instrumentation-mysql2/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/package.json
@@ -49,7 +49,7 @@
     "@opentelemetry/contrib-test-utils": "^0.41.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/semver": "7.5.8",
     "mocha": "7.2.0",
     "mysql2": "2.3.3",

--- a/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
+++ b/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
@@ -55,7 +55,7 @@
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/semver": "7.5.8",
     "cross-env": "7.0.3",
     "mocha": "7.2.0",

--- a/plugins/node/opentelemetry-instrumentation-net/package.json
+++ b/plugins/node/opentelemetry-instrumentation-net/package.json
@@ -49,7 +49,7 @@
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "mocha": "7.2.0",
     "nyc": "15.1.0",

--- a/plugins/node/opentelemetry-instrumentation-pg/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pg/package.json
@@ -57,7 +57,7 @@
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "cross-env": "7.0.3",
     "mocha": "7.2.0",

--- a/plugins/node/opentelemetry-instrumentation-pino/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pino/package.json
@@ -51,7 +51,7 @@
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/semver": "7.5.8",
     "@types/sinon": "10.0.20",
     "mocha": "7.2.0",

--- a/plugins/node/opentelemetry-instrumentation-redis-4/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis-4/package.json
@@ -56,7 +56,7 @@
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "cross-env": "7.0.3",
     "mocha": "7.2.0",
     "nyc": "15.1.0",

--- a/plugins/node/opentelemetry-instrumentation-redis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis/package.json
@@ -55,7 +55,7 @@
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/redis": "2.8.32",
     "cross-env": "7.0.3",
     "mocha": "7.2.0",

--- a/plugins/node/opentelemetry-instrumentation-restify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-restify/package.json
@@ -49,7 +49,7 @@
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/restify": "4.3.12",
     "@types/semver": "7.5.8",
     "mocha": "7.2.0",

--- a/plugins/node/opentelemetry-instrumentation-router/package.json
+++ b/plugins/node/opentelemetry-instrumentation-router/package.json
@@ -48,7 +48,7 @@
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "mocha": "7.2.0",
     "nyc": "15.1.0",
     "rimraf": "5.0.10",

--- a/plugins/node/opentelemetry-instrumentation-winston/package.json
+++ b/plugins/node/opentelemetry-instrumentation-winston/package.json
@@ -51,7 +51,7 @@
     "@opentelemetry/sdk-trace-node": "^1.21.0",
     "@opentelemetry/winston-transport": "^0.6.0",
     "@types/mocha": "7.0.2",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "@types/triple-beam": "^1.3.2",
     "mocha": "7.2.0",

--- a/plugins/web/opentelemetry-instrumentation-document-load/package.json
+++ b/plugins/web/opentelemetry-instrumentation-document-load/package.json
@@ -59,7 +59,7 @@
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@types/chai": "^4.3.10",
     "@types/mocha": "8.2.3",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "@web/dev-server-esbuild": "^1.0.1",
     "@web/dev-server-rollup": "^0.6.1",

--- a/plugins/web/opentelemetry-instrumentation-long-task/package.json
+++ b/plugins/web/opentelemetry-instrumentation-long-task/package.json
@@ -54,7 +54,7 @@
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@types/mocha": "10.0.6",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "@types/webpack-env": "1.16.3",
     "assert": "2.0.0",

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
@@ -57,7 +57,7 @@
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@types/jquery": "3.5.30",
     "@types/mocha": "10.0.6",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "@types/webpack-env": "1.16.3",
     "assert": "2.0.0",

--- a/plugins/web/opentelemetry-plugin-react-load/package.json
+++ b/plugins/web/opentelemetry-plugin-react-load/package.json
@@ -54,7 +54,7 @@
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/propagator-b3": "1.26.0",
     "@types/mocha": "10.0.6",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/react": "17.0.80",
     "@types/react-addons-test-utils": "0.14.26",
     "@types/react-dom": "18.0.2",

--- a/propagators/opentelemetry-propagator-instana/package.json
+++ b/propagators/opentelemetry-propagator-instana/package.json
@@ -51,7 +51,7 @@
     "@babel/preset-env": "7.24.6",
     "@opentelemetry/api": "^1.0.0",
     "@types/mocha": "10.0.6",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "@types/webpack-env": "1.16.3",
     "assert": "2.0.0",

--- a/propagators/opentelemetry-propagator-ot-trace/package.json
+++ b/propagators/opentelemetry-propagator-ot-trace/package.json
@@ -51,7 +51,7 @@
     "@babel/preset-env": "7.24.6",
     "@opentelemetry/api": "^1.0.0",
     "@types/mocha": "10.0.6",
-    "@types/node": "18.6.5",
+    "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",
     "@types/webpack-env": "1.16.3",
     "assert": "2.0.0",


### PR DESCRIPTION
## Short description of the changes

- bump `@types/node` in all packages to `18.18.14`
- fix a type error in `plugins/node/instrumentation-amqplib/src/utils.ts`
