### PR TITLE
fix: add missing @opentelemetry/core dependency

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-alibaba-cloud/package.json
+++ b/detectors/node/opentelemetry-resource-detector-alibaba-cloud/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "@opentelemetry/resources": "^1.10.0",
+    "@opentelemetry/core": "^1.26.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-alibaba-cloud#readme"

--- a/detectors/node/opentelemetry-resource-detector-container/package.json
+++ b/detectors/node/opentelemetry-resource-detector-container/package.json
@@ -51,6 +51,7 @@
   },
   "dependencies": {
     "@opentelemetry/resources": "^1.10.0",
+    "@opentelemetry/core": "^1.26.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-container#readme"

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
       "version": "0.29.2",
       "license": "Apache-2.0",
       "dependencies": {
+        "@opentelemetry/core": "^1.26.0",
         "@opentelemetry/resources": "^1.10.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
@@ -175,6 +176,7 @@
       "version": "0.4.2",
       "license": "Apache-2.0",
       "dependencies": {
+        "@opentelemetry/core": "^1.26.0",
         "@opentelemetry/resources": "^1.10.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
@@ -39776,8 +39778,9 @@
       "version": "0.45.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@opentelemetry/core": "^1.26.0",
         "@opentelemetry/instrumentation": "^0.53.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "1.27.0",
         "@opentelemetry/sql-common": "^0.40.1",
         "@types/pg": "8.6.1",
         "@types/pg-pool": "2.0.6"
@@ -52702,10 +52705,11 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.41.0",
+        "@opentelemetry/core": "^1.26.0",
         "@opentelemetry/instrumentation": "^0.53.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "1.27.0",
         "@opentelemetry/sql-common": "^0.40.1",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
@@ -55023,6 +55027,7 @@
       "requires": {
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.41.0",
+        "@opentelemetry/core": "^1.26.0",
         "@opentelemetry/resources": "^1.10.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
@@ -55132,6 +55137,7 @@
       "requires": {
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.41.0",
+        "@opentelemetry/core": "^1.26.0",
         "@opentelemetry/resources": "^1.10.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",

--- a/plugins/node/opentelemetry-instrumentation-pg/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pg/package.json
@@ -73,8 +73,9 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.53.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "1.27.0",
     "@opentelemetry/sql-common": "^0.40.1",
+    "@opentelemetry/core": "^1.26.0",
     "@types/pg": "8.6.1",
     "@types/pg-pool": "2.0.6"
   },


### PR DESCRIPTION
## Which problem is this PR solving?

See #2472, we're using `@opentelemetry/core` but don't have it listed as a dependency in some packages.

## Short description of the changes

- adds the dependency to the packages where it's missing (identified through comparing https://github.com/open-telemetry/opentelemetry-js-contrib/compare/auto-instrumentations-node-v0.50.0...auto-instrumentations-node-v0.50.1)
- pins the `@opentelemetry/semantic-conventions` dependency for `@opentelemetry/instrumentation-pg`  as it's using the `incubating` entrypoint, which may break on minor bumps.
