### PR TITLE
fix Added copy of HTTP_ROUTE to the metrics attribute

### DIFF
--- a/plugins/node/instrumentation-undici/src/undici.ts
+++ b/plugins/node/instrumentation-undici/src/undici.ts
@@ -470,6 +470,7 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
       SemanticAttributes.SERVER_PORT,
       SemanticAttributes.URL_SCHEME,
       SemanticAttributes.ERROR_TYPE,
+      SemanticAttributes.HTTP_ROUTE,
     ];
     keysToCopy.forEach(key => {
       if (key in attributes) {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

There is no way to set http.route for metrics

## Short description of the changes

Added copy from span of HTTP_ROUTE attribute. It is low cordiality attribute, which is very useful on metrics.
