### PR TITLE
fix: change span names for socket-io

### DIFF
--- a/plugins/node/instrumentation-socket.io/src/socket.io.ts
+++ b/plugins/node/instrumentation-socket.io/src/socket.io.ts
@@ -292,14 +292,9 @@ export class SocketIoInstrumentation extends InstrumentationBase<SocketIoInstrum
         }
         const wrappedListener = function (this: any, ...args: any[]) {
           const eventName = ev;
-          const defaultNamespace = '/';
           const namespace = this.name || this.adapter?.nsp?.name;
-          const destination =
-            namespace === defaultNamespace
-              ? eventName
-              : `${namespace} ${eventName}`;
           const span: Span = self.tracer.startSpan(
-            `${destination} ${MESSAGINGOPERATIONVALUES_RECEIVE}`,
+            `${MESSAGINGOPERATIONVALUES_RECEIVE} ${namespace}`,
             {
               kind: SpanKind.CONSUMER,
               attributes: {
@@ -393,8 +388,7 @@ export class SocketIoInstrumentation extends InstrumentationBase<SocketIoInstrum
             namespace;
           attributes[SEMATTRS_MESSAGING_DESTINATION] = namespace;
         }
-        const spanRooms = rooms.length ? `[${rooms.join()}]` : '';
-        const span = self.tracer.startSpan(`${namespace}${spanRooms} send`, {
+        const span = self.tracer.startSpan(`send ${namespace}`, {
           kind: SpanKind.PRODUCER,
           attributes,
         });

--- a/plugins/node/instrumentation-socket.io/test/utils.ts
+++ b/plugins/node/instrumentation-socket.io/test/utils.ts
@@ -73,3 +73,15 @@ export const expectSpan = (
     callback(span);
   }
 };
+
+export const expectSpans = (
+  spanNames: string,
+  callback?: (spans: ReadableSpan[]) => void,
+  spanCount?: number
+) => {
+  const spans = getSocketIoSpans();
+  expect(spans.length).toEqual(spanCount || 1);
+  const foundSpans = spans.filter(span => spanNames.includes(span.name));
+  expect(foundSpans).toBeDefined();
+  callback?.(foundSpans);
+};


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Socket io span names might contain high cardinality data. I'm removing roomId from span names so it doesn't.

Issue: https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1937

## Short description of the changes

- I refactored names so It follows messaging semconv,  it's "send ${namespace}" / "receive ${namespace}"  instead of `... receive`. 

One question about should it be "receive", I think we might need to change it to "process"?

Given:

> “Receive” spans SHOULD be created for operations of passing messages to the application when those operations are initiated by the application code (pull-based scenarios).

>“Process” spans SHOULD be created for operations of passing messages to the application when those operations are not initiated by the application code (push-based scenarios). Such “Process” span covers the duration of such an operation, which is usually a callback or handler.

Ref: https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/#consumer-spans
