### PR TITLE
chore: clean up some deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39206,7 +39206,7 @@
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/propagator-b3": "1.26.0",
+        "@opentelemetry/propagator-b3": "^1.26.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.18.14",
         "@types/react": "17.0.80",
@@ -39692,11 +39692,9 @@
       "name": "@opentelemetry/propagator-aws-xray",
       "version": "1.26.0",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "1.26.0"
-      },
       "devDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
+        "@opentelemetry/core": "^1.0.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -39730,7 +39728,7 @@
       "version": "0.53.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/propagator-aws-xray": "1.26.0"
+        "@opentelemetry/propagator-aws-xray": "^1.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.21.8",
@@ -49944,7 +49942,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/context-zone": "^1.0.0",
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/propagator-b3": "1.26.0",
+        "@opentelemetry/propagator-b3": "^1.26.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-web": "^1.0.0",
         "@types/mocha": "10.0.6",
@@ -50121,7 +50119,7 @@
       "version": "file:propagators/propagator-aws-xray",
       "requires": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "@opentelemetry/core": "1.26.0",
+        "@opentelemetry/core": "^1.0.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",
@@ -50212,7 +50210,7 @@
         "@babel/core": "^7.21.8",
         "@babel/preset-env": "7.24.6",
         "@opentelemetry/api": "1.9.0",
-        "@opentelemetry/propagator-aws-xray": "1.26.0",
+        "@opentelemetry/propagator-aws-xray": "^1.0.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.6.5",
         "@types/sinon": "10.0.20",

--- a/plugins/web/opentelemetry-plugin-react-load/package.json
+++ b/plugins/web/opentelemetry-plugin-react-load/package.json
@@ -52,7 +52,7 @@
     "@babel/core": "7.24.6",
     "@babel/preset-env": "7.24.6",
     "@opentelemetry/api": "^1.0.0",
-    "@opentelemetry/propagator-b3": "1.26.0",
+    "@opentelemetry/propagator-b3": "^1.26.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.18.14",
     "@types/react": "17.0.80",

--- a/propagators/propagator-aws-xray-lambda/package.json
+++ b/propagators/propagator-aws-xray-lambda/package.json
@@ -59,7 +59,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/propagator-aws-xray": "1.26.0"
+    "@opentelemetry/propagator-aws-xray": "^1.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js/tree/main/propagators/propagator-aws-xray-lambda#readme"
 }

--- a/propagators/propagator-aws-xray/package.json
+++ b/propagators/propagator-aws-xray/package.json
@@ -57,6 +57,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": ">=1.0.0 <1.10.0",
+    "@opentelemetry/core": "^1.0.0",
     "@types/mocha": "10.0.6",
     "@types/node": "18.6.5",
     "@types/sinon": "10.0.20",
@@ -77,9 +78,6 @@
     "webpack": "5.95.0",
     "webpack-cli": "5.1.4",
     "webpack-merge": "5.10.0"
-  },
-  "dependencies": {
-    "@opentelemetry/core": "1.26.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/propagators/propagator-aws-xray#readme"
 }


### PR DESCRIPTION
- Use range deps for `@opentelemetry/*` deps (with some exceptions for
  /api and /semantic-conventions). This allows
  scripts/update-otel-deps.js to be able to do its thing.
- "propagators/propagator-aws-xray/" only needed `@opentelemetry/core`
  for tests
