### PR TITLE
fix(instrumentation-undici): Fix RequestType

### DIFF
--- a/plugins/node/instrumentation-undici/src/types.ts
+++ b/plugins/node/instrumentation-undici/src/types.ts
@@ -53,7 +53,7 @@ export interface RequestHookFunction<T = UndiciRequest> {
 }
 
 export interface ResponseHookFunction<
-  RequestType = UndiciResponse,
+  RequestType = UndiciRequest,
   ResponseType = UndiciResponse
 > {
   (span: Span, info: { request: RequestType; response: ResponseType }): void;


### PR DESCRIPTION
- Previously RequestType was accidentally assigned with UndiciResponse while the correct type is UndiciRequest

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- `ResponseHookFunction<RequestType>` had incorrect type

## Short description of the changes

- Use correct type `UndiciRequest` for `RequestType` instead of wrong type `UndiciResponse`
