### PR TITLE
feat(instrumentation-aws-lambda): take care of ESM based (`.mjs`) handlers

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -97,23 +97,23 @@ export class AwsLambdaInstrumentation extends InstrumentationBase<AwsLambdaInstr
     // Lambda loads user function using an absolute path.
     let filename = path.resolve(taskRoot, moduleRoot, module);
     if (!filename.endsWith('.js')) {
-      // Its impossible to know in advance if the user has a js, cjs or mjs file.
-      // Check that the .js file exists otherwise fallback to the next known possibilities (.cjs, .mjs).
+      // It's impossible to know in advance if the user has a js, mjs or cjs file.
+      // Check that the .js file exists otherwise fallback to the next known possibilities (.mjs, .cjs).
       try {
         fs.statSync(`${filename}.js`);
         filename += '.js';
       } catch (e) {
         try {
-          fs.statSync(`${filename}.cjs`);
-          // fallback to .cjs (CommonJS)
-          filename += '.cjs';
+          fs.statSync(`${filename}.mjs`);
+          // fallback to .mjs (ESM)
+          filename += '.mjs';
         } catch (e2) {
           try {
-            fs.statSync(`${filename}.mjs`);
-            // fallback to .mjs (ESM)
-            filename += '.mjs';
+            fs.statSync(`${filename}.cjs`);
+            // fallback to .cjs (CommonJS)
+            filename += '.cjs';
           } catch (e3) {
-            diag.error(
+            this._diag.warn(
               'No handler file was able to resolved with one of the known extensions for the file',
               filename
             );


### PR DESCRIPTION
## Which problem is this PR solving?

Currently, ESM based handlers with `.mjs` file extension are not taken care of by AWS Lambda instrumentation, but ESM based handlers are supported since long time (https://aws.amazon.com/tr/about-aws/whats-new/2022/01/aws-lambda-es-modules-top-level-await-node-js-14/).

## Short description of the changes

For the fix, while handler file is being resolved, in addition to `.js` and `.cjs` file extensions, `.mjs` file extension is also checked.

This PR is the contrib counter part of the https://github.com/open-telemetry/opentelemetry-js/pull/5094
