### PR TITLE
fix(detector-aws): Get ECS Container ID from metadata

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-aws/test/detectors/AwsEcsDetector.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/test/detectors/AwsEcsDetector.test.ts
@@ -25,6 +25,7 @@ import {
 } from '@opentelemetry/contrib-test-utils';
 import { Resource } from '@opentelemetry/resources';
 import {
+  SEMRESATTRS_CONTAINER_ID,
   SEMRESATTRS_CLOUD_PLATFORM,
   SEMRESATTRS_AWS_ECS_CONTAINER_ARN,
   SEMRESATTRS_AWS_ECS_CLUSTER_ARN,
@@ -51,6 +52,7 @@ interface EcsResourceAttributes {
   readonly zone?: string;
   readonly clusterArn?: string;
   readonly containerArn?: string;
+  readonly containerId?: string;
   readonly launchType?: 'ec2' | 'fargate';
   readonly taskArn?: string;
   readonly taskFamily?: string;
@@ -79,6 +81,11 @@ const assertEcsResource = (
     assert.strictEqual(
       resource.attributes[SEMRESATTRS_AWS_ECS_CONTAINER_ARN],
       validations.containerArn
+    );
+  if (validations.containerId)
+    assert.strictEqual(
+      resource.attributes[SEMRESATTRS_CONTAINER_ID],
+      validations.containerId
     );
   assert.strictEqual(
     resource.attributes[AdditionalSemanticResourceAttributes.CLOUD_RESOURCE_ID],
@@ -343,6 +350,7 @@ describe('AwsEcsResourceDetector', () => {
             clusterArn: 'arn:aws:ecs:us-west-2:111122223333:cluster/default',
             containerArn:
               'arn:aws:ecs:us-west-2:111122223333:container/0206b271-b33f-47ab-86c6-a0ba208a70a9',
+            containerId: 'ea32192c8553fbff06c9340478a2ff089b2bb5646fb718b4ee206641c9086d66',
             launchType: 'ec2',
             taskArn:
               'arn:aws:ecs:us-west-2:111122223333:task/default/158d1c8083dd49d6b527399fd6414f5c',
@@ -369,6 +377,7 @@ describe('AwsEcsResourceDetector', () => {
             clusterArn: 'arn:aws:ecs:us-west-2:111122223333:cluster/default',
             containerArn:
               'arn:aws:ecs:us-west-2:111122223333:container/05966557-f16c-49cb-9352-24b3a0dcd0e1',
+            containerId: 'cd189a933e5849daa93386466019ab50-2495160603',
             launchType: 'fargate',
             taskArn:
               'arn:aws:ecs:us-west-2:111122223333:task/default/e9028f8d5d8e4f258373e7b93ce9a3c3',
@@ -391,6 +400,7 @@ describe('AwsEcsResourceDetector', () => {
               clusterArn: 'arn:aws:ecs:us-west-2:111122223333:cluster/default',
               containerArn:
                 'arn:aws:ecs:us-west-2:111122223333:container/05966557-f16c-49cb-9352-24b3a0dcd0e1',
+              containerId: 'cd189a933e5849daa93386466019ab50-2495160603',
               launchType: 'fargate',
               taskArn:
                 'arn:aws:ecs:us-west-2:111122223333:task/default/e9028f8d5d8e4f258373e7b93ce9a3c3',

--- a/detectors/node/opentelemetry-resource-detector-aws/test/detectors/AwsEcsDetectorSync.test.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/test/detectors/AwsEcsDetectorSync.test.ts
@@ -25,6 +25,7 @@ import {
 } from '@opentelemetry/contrib-test-utils';
 import { Resource } from '@opentelemetry/resources';
 import {
+  SEMRESATTRS_CONTAINER_ID,
   SEMRESATTRS_CLOUD_PLATFORM,
   SEMRESATTRS_AWS_ECS_CONTAINER_ARN,
   SEMRESATTRS_AWS_ECS_CLUSTER_ARN,
@@ -51,6 +52,7 @@ interface EcsResourceAttributes {
   readonly zone?: string;
   readonly clusterArn?: string;
   readonly containerArn?: string;
+  readonly containerId?: string;
   readonly launchType?: 'ec2' | 'fargate';
   readonly taskArn?: string;
   readonly taskFamily?: string;
@@ -79,6 +81,11 @@ const assertEcsResource = (
     assert.strictEqual(
       resource.attributes[SEMRESATTRS_AWS_ECS_CONTAINER_ARN],
       validations.containerArn
+    );
+  if (validations.containerId)
+    assert.strictEqual(
+      resource.attributes[SEMRESATTRS_CONTAINER_ID],
+      validations.containerId
     );
   assert.strictEqual(
     resource.attributes[AdditionalSemanticResourceAttributes.CLOUD_RESOURCE_ID],
@@ -343,6 +350,7 @@ describe('AwsEcsResourceDetectorSync', () => {
             clusterArn: 'arn:aws:ecs:us-west-2:111122223333:cluster/default',
             containerArn:
               'arn:aws:ecs:us-west-2:111122223333:container/0206b271-b33f-47ab-86c6-a0ba208a70a9',
+            containerId: 'ea32192c8553fbff06c9340478a2ff089b2bb5646fb718b4ee206641c9086d66',
             launchType: 'ec2',
             taskArn:
               'arn:aws:ecs:us-west-2:111122223333:task/default/158d1c8083dd49d6b527399fd6414f5c',
@@ -369,6 +377,7 @@ describe('AwsEcsResourceDetectorSync', () => {
             clusterArn: 'arn:aws:ecs:us-west-2:111122223333:cluster/default',
             containerArn:
               'arn:aws:ecs:us-west-2:111122223333:container/05966557-f16c-49cb-9352-24b3a0dcd0e1',
+            containerId: 'cd189a933e5849daa93386466019ab50-2495160603',
             launchType: 'fargate',
             taskArn:
               'arn:aws:ecs:us-west-2:111122223333:task/default/e9028f8d5d8e4f258373e7b93ce9a3c3',
@@ -391,6 +400,7 @@ describe('AwsEcsResourceDetectorSync', () => {
               clusterArn: 'arn:aws:ecs:us-west-2:111122223333:cluster/default',
               containerArn:
                 'arn:aws:ecs:us-west-2:111122223333:container/05966557-f16c-49cb-9352-24b3a0dcd0e1',
+              containerId: 'cd189a933e5849daa93386466019ab50-2495160603',
               launchType: 'fargate',
               taskArn:
                 'arn:aws:ecs:us-west-2:111122223333:task/default/e9028f8d5d8e4f258373e7b93ce9a3c3',


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?
- The AWS ECS Resource detector is munging the container ID when running in AWS ECS Fargate
  ref: #2032

## Short description of the changes

- Get ECS container ID from ECS metadata. This will get the correct value whether running in ECS Fargate or ECS on EC2