### PR TITLE
chore: fix broken links for aws propgators

### DIFF
--- a/metapackages/auto-configuration-propagators/README.md
+++ b/metapackages/auto-configuration-propagators/README.md
@@ -34,8 +34,8 @@ The specification defines a list of [known propagators][env-var-url] for the `OT
 - "b3": [B3 Single](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-b3)
 - "b3multi": [B3 Multi](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-b3)
 - "jaeger": [Jaeger](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-jaeger)
-- "xray": [AWS X-Ray (third party)](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/propagator-aws-xray)
-- "xray-lambda": [AWS X-Ray Lambda (third party)](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/propagator-aws-xray-lambda)
+- "xray": [AWS X-Ray (third party)](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/propagators/propagator-aws-xray)
+- "xray-lambda": [AWS X-Ray Lambda (third party)](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/propagators/propagator-aws-xray-lambda)
 - "ottrace": [OT Trace (third party)](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/propagators/opentelemetry-propagator-ot-trace)
 
 ## Useful links


### PR DESCRIPTION
Following #2411 , the links in the `auto-configuration-propagators` README are now broken, this PR sets them to the new up-to-date location