### PR TITLE
feat(auto-instrumentations-node): enable runtime-node

### DIFF
--- a/metapackages/auto-instrumentations-node/README.md
+++ b/metapackages/auto-instrumentations-node/README.md
@@ -192,6 +192,7 @@ registerInstrumentations({
 - [@opentelemetry/instrumentation-pino](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-pino)
 - [@opentelemetry/instrumentation-redis](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-redis)
 - [@opentelemetry/instrumentation-restify](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-restify)
+- [@opentelemetry/instrumentation-runtime-node](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-runtime-node)
 - [@opentelemetry/instrumentation-socket.io](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-socket.io)
 - [@opentelemetry/instrumentation-undici](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-undici)
 - [@opentelemetry/instrumentation-winston](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-winston)

--- a/metapackages/auto-instrumentations-node/package.json
+++ b/metapackages/auto-instrumentations-node/package.json
@@ -82,6 +82,7 @@
     "@opentelemetry/instrumentation-redis-4": "^0.43.0",
     "@opentelemetry/instrumentation-restify": "^0.42.0",
     "@opentelemetry/instrumentation-router": "^0.41.0",
+    "@opentelemetry/instrumentation-runtime-node": "^0.9.0",
     "@opentelemetry/instrumentation-socket.io": "^0.43.0",
     "@opentelemetry/instrumentation-tedious": "^0.15.0",
     "@opentelemetry/instrumentation-undici": "^0.7.1",

--- a/metapackages/auto-instrumentations-node/src/utils.ts
+++ b/metapackages/auto-instrumentations-node/src/utils.ts
@@ -52,6 +52,7 @@ import { RedisInstrumentation as RedisInstrumentationV2 } from '@opentelemetry/i
 import { RedisInstrumentation as RedisInstrumentationV4 } from '@opentelemetry/instrumentation-redis-4';
 import { RestifyInstrumentation } from '@opentelemetry/instrumentation-restify';
 import { RouterInstrumentation } from '@opentelemetry/instrumentation-router';
+import { RuntimeNodeInstrumentation } from '@opentelemetry/instrumentation-runtime-node';
 import { SocketIoInstrumentation } from '@opentelemetry/instrumentation-socket.io';
 import { TediousInstrumentation } from '@opentelemetry/instrumentation-tedious';
 import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici';
@@ -130,6 +131,7 @@ const InstrumentationMap = {
   '@opentelemetry/instrumentation-redis-4': RedisInstrumentationV4,
   '@opentelemetry/instrumentation-restify': RestifyInstrumentation,
   '@opentelemetry/instrumentation-router': RouterInstrumentation,
+  '@opentelemetry/instrumentation-runtime-node': RuntimeNodeInstrumentation,
   '@opentelemetry/instrumentation-socket.io': SocketIoInstrumentation,
   '@opentelemetry/instrumentation-tedious': TediousInstrumentation,
   '@opentelemetry/instrumentation-undici': UndiciInstrumentation,


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- I want to use gc and heap metric functions with auto-instrumentations-node.
- merge below, so I just need to work on a few lines.
- https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2136

## Short description of the changes

- This PR adds @opentelemetry/instrumentation-runtime-node to the @opentelemetry/auto-instrumentations-node meta package
