### PR TITLE
docs(multiple): update readme for semantic convention

### DIFF
--- a/plugins/node/instrumentation-dataloader/README.md
+++ b/plugins/node/instrumentation-dataloader/README.md
@@ -53,6 +53,10 @@ Each call to `.load` or `.loadMany` will create a child span for the current act
 
 The batch load function of the dataloader also creates a span, which links to spans created as part of `.load` and `.loadMany`, it is a child span of whatever the active span is during which the dataloader is created.
 
+## Semantic Conventions
+
+This package does not currently generate any attributes from semantic conventions.
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/plugins/node/instrumentation-fs/README.md
+++ b/plugins/node/instrumentation-fs/README.md
@@ -50,6 +50,10 @@ You can set the following:
 | `endHook`           | `( functionName: FMember \| FPMember, info: { args: ArrayLike<unknown>; span: api.Span } ) => void` | Function called just before the span is ended. Useful for adding attributes.                                    |
 | `requireParentSpan` | `boolean`                                                                                           | Require parent to create fs span, default when unset is `false`.                                                |
 
+## Semantic Conventions
+
+This package does not currently generate any attributes from semantic conventions.
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/plugins/web/opentelemetry-instrumentation-long-task/README.md
+++ b/plugins/web/opentelemetry-instrumentation-long-task/README.md
@@ -58,6 +58,10 @@ longtaskInstrumentationConfig = {
 }
 ```
 
+## Semantic Conventions
+
+This package does not currently generate any attributes from semantic conventions.
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/README.md
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/README.md
@@ -152,6 +152,10 @@ registerInstrumentations({
 ![Screenshot of the running example](images/main-sync.jpg)
 ![Screenshot of the running example](images/click-sync.jpg)
 
+## Semantic Conventions
+
+This package does not currently generate any attributes from semantic conventions.
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- updates #1778 

## Short description of the changes

- updates readme to include section for semantic convention for those readme that do not have semantic convention usage. 
- Following readme where updated:

1. plugins/node/instrumentation-dataloader/README.md
2. plugins/node/instrumentation-fs/README.md
3. plugins/web/opentelemetry-instrumentation-long-task/README.md
4. plugins/web/opentelemetry-instrumentation-user-interaction/README.md