### PR TITLE
feat(deps): update deps matching '@opentelemetry/*'

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-aws/package.json
+++ b/detectors/node/opentelemetry-resource-detector-aws/package.json
@@ -40,7 +40,7 @@
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/contrib-test-utils": "^0.42.0",
     "@opentelemetry/instrumentation-fs": "^0.16.0",
-    "@opentelemetry/instrumentation-http": "^0.54.0",
+    "@opentelemetry/instrumentation-http": "^0.55.0",
     "@types/mocha": "8.2.3",
     "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",

--- a/detectors/node/opentelemetry-resource-detector-azure/package.json
+++ b/detectors/node/opentelemetry-resource-detector-azure/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/contrib-test-utils": "^0.42.0",
-    "@opentelemetry/instrumentation-http": "^0.54.0",
+    "@opentelemetry/instrumentation-http": "^0.55.0",
     "@types/mocha": "8.2.3",
     "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",

--- a/detectors/node/opentelemetry-resource-detector-gcp/package.json
+++ b/detectors/node/opentelemetry-resource-detector-gcp/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/contrib-test-utils": "^0.42.0",
-    "@opentelemetry/instrumentation-http": "^0.54.0",
+    "@opentelemetry/instrumentation-http": "^0.55.0",
     "@types/mocha": "8.2.3",
     "@types/node": "18.18.14",
     "@types/semver": "7.5.8",

--- a/detectors/node/opentelemetry-resource-detector-instana/package.json
+++ b/detectors/node/opentelemetry-resource-detector-instana/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/contrib-test-utils": "^0.42.0",
-    "@opentelemetry/sdk-node": "^0.54.0",
+    "@opentelemetry/sdk-node": "^0.55.0",
     "@types/mocha": "8.2.3",
     "@types/node": "18.18.14",
     "@types/semver": "7.5.8",

--- a/metapackages/auto-instrumentations-node/package.json
+++ b/metapackages/auto-instrumentations-node/package.json
@@ -46,7 +46,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/instrumentation-amqplib": "^0.43.0",
     "@opentelemetry/instrumentation-aws-lambda": "^0.47.0",
     "@opentelemetry/instrumentation-aws-sdk": "^0.46.0",
@@ -61,9 +61,9 @@
     "@opentelemetry/instrumentation-fs": "^0.16.0",
     "@opentelemetry/instrumentation-generic-pool": "^0.40.0",
     "@opentelemetry/instrumentation-graphql": "^0.44.0",
-    "@opentelemetry/instrumentation-grpc": "^0.54.0",
+    "@opentelemetry/instrumentation-grpc": "^0.55.0",
     "@opentelemetry/instrumentation-hapi": "^0.42.0",
-    "@opentelemetry/instrumentation-http": "^0.54.0",
+    "@opentelemetry/instrumentation-http": "^0.55.0",
     "@opentelemetry/instrumentation-ioredis": "^0.44.0",
     "@opentelemetry/instrumentation-kafkajs": "^0.4.0",
     "@opentelemetry/instrumentation-knex": "^0.41.0",
@@ -92,7 +92,7 @@
     "@opentelemetry/resource-detector-container": "^0.5.0",
     "@opentelemetry/resource-detector-gcp": "^0.29.13",
     "@opentelemetry/resources": "^1.24.0",
-    "@opentelemetry/sdk-node": "^0.54.0"
+    "@opentelemetry/sdk-node": "^0.55.0"
   },
   "files": [
     "build/src/**/*.js",

--- a/metapackages/auto-instrumentations-web/package.json
+++ b/metapackages/auto-instrumentations-web/package.json
@@ -60,11 +60,11 @@
     "webpack-merge": "5.10.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/instrumentation-document-load": "^0.41.0",
-    "@opentelemetry/instrumentation-fetch": "^0.54.0",
+    "@opentelemetry/instrumentation-fetch": "^0.55.0",
     "@opentelemetry/instrumentation-user-interaction": "^0.41.0",
-    "@opentelemetry/instrumentation-xml-http-request": "^0.54.0"
+    "@opentelemetry/instrumentation-xml-http-request": "^0.55.0"
   },
   "files": [
     "build/src/**/*.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
         "@opentelemetry/instrumentation-fs": "^0.16.0",
-        "@opentelemetry/instrumentation-http": "^0.54.0",
+        "@opentelemetry/instrumentation-http": "^0.55.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
@@ -140,7 +140,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
-        "@opentelemetry/instrumentation-http": "^0.54.0",
+        "@opentelemetry/instrumentation-http": "^0.55.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
@@ -229,7 +229,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
-        "@opentelemetry/instrumentation-http": "^0.54.0",
+        "@opentelemetry/instrumentation-http": "^0.55.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
@@ -310,7 +310,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
-        "@opentelemetry/sdk-node": "^0.54.0",
+        "@opentelemetry/sdk-node": "^0.55.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
@@ -384,7 +384,7 @@
       "version": "0.52.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/instrumentation-amqplib": "^0.43.0",
         "@opentelemetry/instrumentation-aws-lambda": "^0.47.0",
         "@opentelemetry/instrumentation-aws-sdk": "^0.46.0",
@@ -399,9 +399,9 @@
         "@opentelemetry/instrumentation-fs": "^0.16.0",
         "@opentelemetry/instrumentation-generic-pool": "^0.40.0",
         "@opentelemetry/instrumentation-graphql": "^0.44.0",
-        "@opentelemetry/instrumentation-grpc": "^0.54.0",
+        "@opentelemetry/instrumentation-grpc": "^0.55.0",
         "@opentelemetry/instrumentation-hapi": "^0.42.0",
-        "@opentelemetry/instrumentation-http": "^0.54.0",
+        "@opentelemetry/instrumentation-http": "^0.55.0",
         "@opentelemetry/instrumentation-ioredis": "^0.44.0",
         "@opentelemetry/instrumentation-kafkajs": "^0.4.0",
         "@opentelemetry/instrumentation-knex": "^0.41.0",
@@ -430,7 +430,7 @@
         "@opentelemetry/resource-detector-container": "^0.5.0",
         "@opentelemetry/resource-detector-gcp": "^0.29.13",
         "@opentelemetry/resources": "^1.24.0",
-        "@opentelemetry/sdk-node": "^0.54.0"
+        "@opentelemetry/sdk-node": "^0.55.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.4.1",
@@ -463,11 +463,11 @@
       "version": "0.42.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/instrumentation-document-load": "^0.41.0",
-        "@opentelemetry/instrumentation-fetch": "^0.54.0",
+        "@opentelemetry/instrumentation-fetch": "^0.55.0",
         "@opentelemetry/instrumentation-user-interaction": "^0.41.0",
-        "@opentelemetry/instrumentation-xml-http-request": "^0.54.0"
+        "@opentelemetry/instrumentation-xml-http-request": "^0.55.0"
       },
       "devDependencies": {
         "@babel/core": "7.24.6",
@@ -9954,9 +9954,10 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.54.2.tgz",
-      "integrity": "sha512-4MTVwwmLgUh5QrJnZpYo6YRO5IBLAggf2h8gWDblwRagDStY13aEvt7gGk3jewrMaPlHiF83fENhIx0HO97/cQ==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.55.0.tgz",
+      "integrity": "sha512-3cpa+qI45VHYcA5c0bHM6VHo9gicv3p5mlLHNG3rLyjQU8b7e0st1rWtrUn3JbZ3DwwCfhKop4eQ9UuYlC6Pkg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
       },
@@ -9981,9 +9982,10 @@
       "link": true
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.27.0.tgz",
-      "integrity": "sha512-CdZ3qmHCwNhFAzjTgHqrDQ44Qxcpz43cVxZRhOs+Ns/79ug+Mr84Bkb626bkJLkA3+BLimA5YAEVRlJC6pFb7g==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.28.0.tgz",
+      "integrity": "sha512-igcl4Ve+F1N2063PJUkesk/GkYyuGIWinYkSyAFTnIj3gzrOgvOA4k747XNdL47HRRL1w/qh7UW8NDuxOLvKFA==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       },
@@ -9992,10 +9994,11 @@
       }
     },
     "node_modules/@opentelemetry/context-zone-peer-dep": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.27.0.tgz",
-      "integrity": "sha512-gVeOOpqnLgP51F0EJGHeoAJmAHxXXroT1Tk2WVnMf/22jTiAunYzFFsMaqmcH8mNqjTYBLJb28Rz0tInO7uClg==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.28.0.tgz",
+      "integrity": "sha512-tGtZ+N/QlMpZmHlSpANJsCBsx04FAF7t1nvyocG+Hr1r9rEJFPbdJ23pRDPYdpHX7D5UislKEz3mP+kfsP9p/A==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
       },
@@ -10009,9 +10012,10 @@
       "link": true
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.27.0.tgz",
-      "integrity": "sha512-yQPKnK5e+76XuiqUH/gKyS8wv/7qITd5ln56QkBTf3uggr0VkXOXfcaAuG330UfdYu83wsyoBwqwxigpIG+Jkg==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.28.0.tgz",
+      "integrity": "sha512-ZLwRMV+fNDpVmF2WYUdBHlq0eOWtEaUJSusrzjGnBt7iSRvfjFE3RXYUZJrqou/wIDWV0DwQ5KIfYe9WXg9Xqw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.27.0"
       },
@@ -10023,12 +10027,13 @@
       }
     },
     "node_modules/@opentelemetry/exporter-jaeger": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.27.0.tgz",
-      "integrity": "sha512-ULWBtyNQDQQBWTkoCPfpGZTXZ9gLOFHeLZ3BoeZAkxYOgqqTH83IDRbtH8sHt6j84OPQfAcd18uHOb/lc9q0Bw==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.28.0.tgz",
+      "integrity": "sha512-w4wHFZjfxxHqUVUyERegruLCI3pGMwkg9t2XhHBVUjmmhuul6RjN1fn22/0ZBhONG76LsIUJpo2W+ejBPnphFA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/sdk-trace-base": "1.27.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/sdk-trace-base": "1.28.0",
         "@opentelemetry/semantic-conventions": "1.27.0",
         "jaeger-client": "^3.15.0"
       },
@@ -10040,15 +10045,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.54.2.tgz",
-      "integrity": "sha512-MQNmV5r96+5n3axLFgNYtVy62x8Ru7VERZH3zgC50KDcIKWCiQT3vHOtzakhzd1Wq0HqOgu6bzKdwzneSoDrEQ==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.55.0.tgz",
+      "integrity": "sha512-ykqawCL0ILJWyCJlxCPSAlqQXZ6x2bQsxAVUu8S3z22XNqY5SMx0rl2d93XnvnrOwtcfm+sM9ZhbGh/i5AZ9xw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.54.2",
-        "@opentelemetry/otlp-transformer": "0.54.2",
-        "@opentelemetry/sdk-logs": "0.54.2"
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.55.0",
+        "@opentelemetry/otlp-transformer": "0.55.0",
+        "@opentelemetry/sdk-logs": "0.55.0"
       },
       "engines": {
         "node": ">=14"
@@ -10058,15 +10064,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-http": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.54.2.tgz",
-      "integrity": "sha512-wYeCSbX2XWX2wFslnfQ/YFUolO0fj2nUiGI7oEQWpLKSg40Lc4xOOW14X/EXOkCCijhP7bigo6nvyEQlxEVLjA==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.55.0.tgz",
+      "integrity": "sha512-fpFObWWq+DoLVrBU2dyMEaVkibByEkmKQZIUIjW/4j7lwIsTgW7aJCoD9RYFVB/tButcqov5Es2C0J2wTjM2tg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.54.2",
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/otlp-exporter-base": "0.54.2",
-        "@opentelemetry/otlp-transformer": "0.54.2",
-        "@opentelemetry/sdk-logs": "0.54.2"
+        "@opentelemetry/api-logs": "0.55.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/otlp-exporter-base": "0.55.0",
+        "@opentelemetry/otlp-transformer": "0.55.0",
+        "@opentelemetry/sdk-logs": "0.55.0"
       },
       "engines": {
         "node": ">=14"
@@ -10076,17 +10083,18 @@
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.54.2.tgz",
-      "integrity": "sha512-agrzFbSNmIy6dhkyg41ERlEDUDqkaUJj2n/tVRFp9Tl+6wyNVPsqmwU5RWJOXpyK+lYH/znv6A47VpTeJF0lrw==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.55.0.tgz",
+      "integrity": "sha512-vjE+DxUr+cUpxikdKCPiLZM5Wx7g1bywjCG76TQocvsA7Tmbb9p0t1+8gPlu9AGH7VEzPwDxxpN4p1ajpOurzQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.54.2",
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/otlp-exporter-base": "0.54.2",
-        "@opentelemetry/otlp-transformer": "0.54.2",
-        "@opentelemetry/resources": "1.27.0",
-        "@opentelemetry/sdk-logs": "0.54.2",
-        "@opentelemetry/sdk-trace-base": "1.27.0"
+        "@opentelemetry/api-logs": "0.55.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/otlp-exporter-base": "0.55.0",
+        "@opentelemetry/otlp-transformer": "0.55.0",
+        "@opentelemetry/resources": "1.28.0",
+        "@opentelemetry/sdk-logs": "0.55.0",
+        "@opentelemetry/sdk-trace-base": "1.28.0"
       },
       "engines": {
         "node": ">=14"
@@ -10096,16 +10104,17 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.54.2.tgz",
-      "integrity": "sha512-tmxiCYhQdPrzwlM6O7VQeNP9PBjKhaiOo54wFxQFZQcoVaDiOOES4+6PwHU1eW+43mDsgdQHN5AHSRHVLe9jDA==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.55.0.tgz",
+      "integrity": "sha512-ohIkCLn2Wc3vhhFuf1bH8kOXHMEdcWiD847x7f3Qfygc+CGiatGLzQYscTcEYsWGMV22gVwB/kVcNcx5a3o8gA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.54.2",
-        "@opentelemetry/otlp-transformer": "0.54.2",
-        "@opentelemetry/resources": "1.27.0",
-        "@opentelemetry/sdk-trace-base": "1.27.0"
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.55.0",
+        "@opentelemetry/otlp-transformer": "0.55.0",
+        "@opentelemetry/resources": "1.28.0",
+        "@opentelemetry/sdk-trace-base": "1.28.0"
       },
       "engines": {
         "node": ">=14"
@@ -10115,15 +10124,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.54.2.tgz",
-      "integrity": "sha512-BgWKKyD/h2zpISdmYHN/sapwTjvt1P4p5yx4xeBV8XAEqh4OQUhOtSGFG80+nPQ1F8of3mKOT1DDoDbJp1u25w==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.55.0.tgz",
+      "integrity": "sha512-lMiNic63EVHpW+eChmLD2CieDmwQBFi72+LFbh8+5hY0ShrDGrsGP/zuT5MRh7M/vM/UZYO/2A/FYd7CMQGR7A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/otlp-exporter-base": "0.54.2",
-        "@opentelemetry/otlp-transformer": "0.54.2",
-        "@opentelemetry/resources": "1.27.0",
-        "@opentelemetry/sdk-trace-base": "1.27.0"
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/otlp-exporter-base": "0.55.0",
+        "@opentelemetry/otlp-transformer": "0.55.0",
+        "@opentelemetry/resources": "1.28.0",
+        "@opentelemetry/sdk-trace-base": "1.28.0"
       },
       "engines": {
         "node": ">=14"
@@ -10133,15 +10143,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.54.2.tgz",
-      "integrity": "sha512-XSmm1N2wAhoWDXP1q/N6kpLebWaxl6VIADv4WA5QWKHLRpF3gLz5NAWNJBR8ygsvv8jQcrwnXgwfnJ18H3v1fg==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.55.0.tgz",
+      "integrity": "sha512-qxiJFP+bBZW3+goHCGkE1ZdW9gJU0fR7eQ6OP+Rz5oGtEBbq4nkGodhb7C9FJlEFlE2siPtCxoeupV0gtYynag==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/otlp-exporter-base": "0.54.2",
-        "@opentelemetry/otlp-transformer": "0.54.2",
-        "@opentelemetry/resources": "1.27.0",
-        "@opentelemetry/sdk-trace-base": "1.27.0"
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/otlp-exporter-base": "0.55.0",
+        "@opentelemetry/otlp-transformer": "0.55.0",
+        "@opentelemetry/resources": "1.28.0",
+        "@opentelemetry/sdk-trace-base": "1.28.0"
       },
       "engines": {
         "node": ">=14"
@@ -10151,13 +10162,14 @@
       }
     },
     "node_modules/@opentelemetry/exporter-zipkin": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.27.0.tgz",
-      "integrity": "sha512-eGMY3s4QprspFZojqsuQyQpWNFpo+oNVE/aosTbtvAlrJBAlvXcwwsOROOHOd8Y9lkU4i0FpQW482rcXkgwCSw==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.28.0.tgz",
+      "integrity": "sha512-AMwr3eGXaPEH7gk8yhcUcen31VXy1yU5VJETu0pCfGpggGCYmhm0FKgYBpL5/vlIgQJWU/sW2vIjCL7aSilpKg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/resources": "1.27.0",
-        "@opentelemetry/sdk-trace-base": "1.27.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/resources": "1.28.0",
+        "@opentelemetry/sdk-trace-base": "1.28.0",
         "@opentelemetry/semantic-conventions": "1.27.0"
       },
       "engines": {
@@ -10176,11 +10188,12 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.54.2.tgz",
-      "integrity": "sha512-go6zpOVoZVztT9r1aPd79Fr3OWiD4N24bCPJsIKkBses8oyFo12F/Ew3UBTdIu6hsW4HC4MVEJygG6TEyJI/lg==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.55.0.tgz",
+      "integrity": "sha512-YDCMlaQRZkziLL3t6TONRgmmGxDx6MyQDXRD0dknkkgUZtOK5+8MWft1OXzmNu6XfBOdT12MKN5rz+jHUkafKQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.54.2",
+        "@opentelemetry/api-logs": "0.55.0",
         "@types/shimmer": "^1.2.0",
         "import-in-the-middle": "^1.8.1",
         "require-in-the-middle": "^7.1.1",
@@ -10243,13 +10256,14 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-fetch": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.54.2.tgz",
-      "integrity": "sha512-7G2mn0K5BJ41AIarIMGuMDDcdJ13DQdk4go2CIL7QZkY0TgZmmq6wO6fHwdocZlPPkZ47Mflo4DwSQtMLykfyQ==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.55.0.tgz",
+      "integrity": "sha512-wkybQE85HzInYX2csZ4UuMlCIMCyGGHcNqL9TcoZgAZC2EuXFReTsLytoszknhcaX+P7UT9Ee3915t8KC6XP4w==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/instrumentation": "0.54.2",
-        "@opentelemetry/sdk-trace-web": "1.27.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/instrumentation": "0.55.0",
+        "@opentelemetry/sdk-trace-web": "1.28.0",
         "@opentelemetry/semantic-conventions": "1.27.0"
       },
       "engines": {
@@ -10272,11 +10286,12 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-grpc": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.54.2.tgz",
-      "integrity": "sha512-KhSzerCaaqVH2zfDro7nTunWUZXt1pQISQpE83LuQTOKGk7mN3G60T1wliQ3Qdg0X3UUuhCXEC7u6IAVfDxkUQ==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.55.0.tgz",
+      "integrity": "sha512-n2ZH4pRwOy0Vhag/3eKqiyDBwcpUnGgJI9iiIRX7vivE0FMncaLazWphNFezRRaM/LuKwq1TD8pVUvieP68mow==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "0.54.2",
+        "@opentelemetry/instrumentation": "0.55.0",
         "@opentelemetry/semantic-conventions": "1.27.0"
       },
       "engines": {
@@ -10291,12 +10306,13 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.54.2.tgz",
-      "integrity": "sha512-mABjJ34UcU32pg8g18L9xBh0U3JON/2F6/57BYYy8AZJp2a71lZjcKr0T00pICoic50TW5HvcTrmyfMil+AiXQ==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.55.0.tgz",
+      "integrity": "sha512-AO27XSjkgNicfy/YBthskFAwx9VfaO7tChrLaTONTfOWv14GlB3Rs2eTYpywZIHWsW2cR5hvVkcDte4GV0stoA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/instrumentation": "0.54.2",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/instrumentation": "0.55.0",
         "@opentelemetry/semantic-conventions": "1.27.0",
         "forwarded-parse": "2.1.2",
         "semver": "^7.5.2"
@@ -10409,13 +10425,14 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-xml-http-request": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.54.2.tgz",
-      "integrity": "sha512-Y07iCr4OuXQwiPft2GqXpp7hNpIDa/72wzwfDRP/fh1DZcm2MjXgvcOos45VFoXPW5YxHs/ONobT4UTrS/yovA==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.55.0.tgz",
+      "integrity": "sha512-Wlz4LzDpBFxHpb24RAM6RoiGspJ7J16ux0Xw5KVLtK3zzpQaxMYEVF0XQNC61WJJa3tRNt3XRjiQ8mrXJZxVQg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/instrumentation": "0.54.2",
-        "@opentelemetry/sdk-trace-web": "1.27.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/instrumentation": "0.55.0",
+        "@opentelemetry/sdk-trace-web": "1.28.0",
         "@opentelemetry/semantic-conventions": "1.27.0"
       },
       "engines": {
@@ -10428,15 +10445,17 @@
     "node_modules/@opentelemetry/instrumentation/node_modules/@types/shimmer": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
-      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="
+      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
+      "license": "MIT"
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.54.2.tgz",
-      "integrity": "sha512-NrNyxu6R/bGAwanhz1HI0aJWKR6xUED4TjCH4iWMlAfyRukGbI9Kt/Akd2sYLwRKNhfS+sKetKGCUQPMDyYYMA==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.55.0.tgz",
+      "integrity": "sha512-iHQI0Zzq3h1T6xUJTVFwmFl5Dt5y1es+fl4kM+k5T/3YvmVyeYkSiF+wHCg6oKrlUAJfk+t55kaAu3sYmt7ZYA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/otlp-transformer": "0.54.2"
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/otlp-transformer": "0.55.0"
       },
       "engines": {
         "node": ">=14"
@@ -10446,14 +10465,15 @@
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.54.2.tgz",
-      "integrity": "sha512-HZtACQuLhgDcgNa9arGnVVGV28sSGQ+iwRgICWikFKiVxUsoWffqBvTxPa6G3DUTg5R+up97j/zxubEyxSAOHg==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.55.0.tgz",
+      "integrity": "sha512-gebbjl9FiSp52igWXuGjcWQKfB6IBwFGt5z1VFwTcVZVeEZevB6bJIqoFrhH4A02m7OUlpJ7l4EfRi3UtkNANQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/otlp-exporter-base": "0.54.2",
-        "@opentelemetry/otlp-transformer": "0.54.2"
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/otlp-exporter-base": "0.55.0",
+        "@opentelemetry/otlp-transformer": "0.55.0"
       },
       "engines": {
         "node": ">=14"
@@ -10463,16 +10483,17 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.54.2.tgz",
-      "integrity": "sha512-2tIjahJlMRRUz0A2SeE+qBkeBXBFkSjR0wqJ08kuOqaL8HNGan5iZf+A8cfrfmZzPUuMKCyY9I+okzFuFs6gKQ==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.55.0.tgz",
+      "integrity": "sha512-kVqEfxtp6mSN2Dhpy0REo1ghP4PYhC1kMHQJ2qVlO99Pc+aigELjZDfg7/YKmL71gR6wVGIeJfiql/eXL7sQPA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.54.2",
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/resources": "1.27.0",
-        "@opentelemetry/sdk-logs": "0.54.2",
-        "@opentelemetry/sdk-metrics": "1.27.0",
-        "@opentelemetry/sdk-trace-base": "1.27.0",
+        "@opentelemetry/api-logs": "0.55.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/resources": "1.28.0",
+        "@opentelemetry/sdk-logs": "0.55.0",
+        "@opentelemetry/sdk-metrics": "1.28.0",
+        "@opentelemetry/sdk-trace-base": "1.28.0",
         "protobufjs": "^7.3.0"
       },
       "engines": {
@@ -10499,11 +10520,12 @@
       "link": true
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.27.0.tgz",
-      "integrity": "sha512-pTsko3gnMioe3FeWcwTQR3omo5C35tYsKKwjgTCTVCgd3EOWL9BZrMfgLBmszrwXABDfUrlAEFN/0W0FfQGynQ==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.28.0.tgz",
+      "integrity": "sha512-Q7HVDIMwhN5RxL4bECMT4BdbyYSAKkC6U/RGn4NpO/cbqP6ZRg+BS7fPo/pGZi2w8AHfpIGQFXQmE8d2PC5xxQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.27.0"
+        "@opentelemetry/core": "1.28.0"
       },
       "engines": {
         "node": ">=14"
@@ -10517,11 +10539,12 @@
       "link": true
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.27.0.tgz",
-      "integrity": "sha512-EI1bbK0wn0yIuKlc2Qv2LKBRw6LiUWevrjCF80fn/rlaB+7StAi8Y5s8DBqAYNpY7v1q86+NjU18v7hj2ejU3A==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.28.0.tgz",
+      "integrity": "sha512-wKJ94+s8467CnIRgoSRh0yXm/te0QMOwTq9J01PfG/RzYZvlvN8aRisN2oZ9SznB45dDGnMj3BhUlchSA9cEKA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.27.0"
+        "@opentelemetry/core": "1.28.0"
       },
       "engines": {
         "node": ">=14"
@@ -10567,11 +10590,12 @@
       "link": true
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.27.0.tgz",
-      "integrity": "sha512-jOwt2VJ/lUD5BLc+PMNymDrUCpm5PKi1E9oSVYAvz01U/VdndGmrtV3DU1pG4AwlYhJRHbHfOUIlpBeXCPw6QQ==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.28.0.tgz",
+      "integrity": "sha512-cIyXSVJjGeTICENN40YSvLDAq4Y2502hGK3iN7tfdynQLKWb3XWZQEkPc+eSx47kiy11YeFAlYkEfXwR1w8kfw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.27.0",
+        "@opentelemetry/core": "1.28.0",
         "@opentelemetry/semantic-conventions": "1.27.0"
       },
       "engines": {
@@ -10582,13 +10606,14 @@
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.54.2.tgz",
-      "integrity": "sha512-yIbYqDLS/AtBbPjCjh6eSToGNRMqW2VR8RrKEy+G+J7dFG7pKoptTH5T+XlKPleP9NY8JZYIpgJBlI+Osi0rFw==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.55.0.tgz",
+      "integrity": "sha512-TSx+Yg/d48uWW6HtjS1AD5x6WPfLhDWLl/WxC7I2fMevaiBuKCuraxTB8MDXieCNnBI24bw9ytyXrDCswFfWgA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.54.2",
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/resources": "1.27.0"
+        "@opentelemetry/api-logs": "0.55.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/resources": "1.28.0"
       },
       "engines": {
         "node": ">=14"
@@ -10598,12 +10623,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.27.0.tgz",
-      "integrity": "sha512-JzWgzlutoXCydhHWIbLg+r76m+m3ncqvkCcsswXAQ4gqKS+LOHKhq+t6fx1zNytvLuaOUBur7EvWxECc4jPQKg==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.28.0.tgz",
+      "integrity": "sha512-43tqMK/0BcKTyOvm15/WQ3HLr0Vu/ucAl/D84NO7iSlv6O4eOprxSHa3sUtmYkaZWHqdDJV0AHVz/R6u4JALVQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/resources": "1.27.0"
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/resources": "1.28.0"
       },
       "engines": {
         "node": ">=14"
@@ -10613,25 +10639,26 @@
       }
     },
     "node_modules/@opentelemetry/sdk-node": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.54.2.tgz",
-      "integrity": "sha512-afn8GBpA7Gb55aU0LUxIQ+oe6QxLhsf+Te9iw12Non3ZAspzdoCcfz5+hqecwpuVpEDdnj5iSalF7VVaL2pDeg==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.55.0.tgz",
+      "integrity": "sha512-gSXQWV23+9vhbjsvAIeM0LxY3W8DTKI3MZlzFp61noIb1jSr46ET+qoUjHlfZ1Yymebv9KXWeZsqhft81HBXuQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.54.2",
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/exporter-logs-otlp-grpc": "0.54.2",
-        "@opentelemetry/exporter-logs-otlp-http": "0.54.2",
-        "@opentelemetry/exporter-logs-otlp-proto": "0.54.2",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.54.2",
-        "@opentelemetry/exporter-trace-otlp-http": "0.54.2",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.54.2",
-        "@opentelemetry/exporter-zipkin": "1.27.0",
-        "@opentelemetry/instrumentation": "0.54.2",
-        "@opentelemetry/resources": "1.27.0",
-        "@opentelemetry/sdk-logs": "0.54.2",
-        "@opentelemetry/sdk-metrics": "1.27.0",
-        "@opentelemetry/sdk-trace-base": "1.27.0",
-        "@opentelemetry/sdk-trace-node": "1.27.0",
+        "@opentelemetry/api-logs": "0.55.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.55.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.55.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.55.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.55.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.55.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.55.0",
+        "@opentelemetry/exporter-zipkin": "1.28.0",
+        "@opentelemetry/instrumentation": "0.55.0",
+        "@opentelemetry/resources": "1.28.0",
+        "@opentelemetry/sdk-logs": "0.55.0",
+        "@opentelemetry/sdk-metrics": "1.28.0",
+        "@opentelemetry/sdk-trace-base": "1.28.0",
+        "@opentelemetry/sdk-trace-node": "1.28.0",
         "@opentelemetry/semantic-conventions": "1.27.0"
       },
       "engines": {
@@ -10642,12 +10669,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.27.0.tgz",
-      "integrity": "sha512-btz6XTQzwsyJjombpeqCX6LhiMQYpzt2pIYNPnw0IPO/3AhT6yjnf8Mnv3ZC2A4eRYOjqrg+bfaXg9XHDRJDWQ==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.28.0.tgz",
+      "integrity": "sha512-ceUVWuCpIao7Y5xE02Xs3nQi0tOGmMea17ecBdwtCvdo9ekmO+ijc9RFDgfifMl7XCBf41zne/1POM3LqSTZDA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/resources": "1.27.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/resources": "1.28.0",
         "@opentelemetry/semantic-conventions": "1.27.0"
       },
       "engines": {
@@ -10658,15 +10686,16 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.27.0.tgz",
-      "integrity": "sha512-dWZp/dVGdUEfRBjBq2BgNuBlFqHCxyyMc8FsN0NX15X07mxSUO0SZRLyK/fdAVrde8nqFI/FEdMH4rgU9fqJfQ==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.28.0.tgz",
+      "integrity": "sha512-N0sYfYXvHpP0FNIyc+UfhLnLSTOuZLytV0qQVrDWIlABeD/DWJIGttS7nYeR14gQLXch0M1DW8zm3VeN6Opwtg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.27.0",
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/propagator-b3": "1.27.0",
-        "@opentelemetry/propagator-jaeger": "1.27.0",
-        "@opentelemetry/sdk-trace-base": "1.27.0",
+        "@opentelemetry/context-async-hooks": "1.28.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/propagator-b3": "1.28.0",
+        "@opentelemetry/propagator-jaeger": "1.28.0",
+        "@opentelemetry/sdk-trace-base": "1.28.0",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -10677,12 +10706,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-web": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.27.0.tgz",
-      "integrity": "sha512-ORZfG8Sm5IkJeI+P8MyW8v4m5OcmjEtD7VsjBghv5sDKH3f5p2mQpEEoJWlCr5GiW50Y1MaI2R4uFGIsxmDE9A==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.28.0.tgz",
+      "integrity": "sha512-/QOIrJc/A/caKbA9voLua4isf///cjQKB6gomEzX2fL18TBqZhIkm9k2DpjlbtrQoYCJDZ9x7Phrec22aQGpQw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/sdk-trace-base": "1.27.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/sdk-trace-base": "1.28.0",
         "@opentelemetry/semantic-conventions": "1.27.0"
       },
       "engines": {
@@ -35575,11 +35605,11 @@
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/exporter-jaeger": "^1.3.1",
-        "@opentelemetry/instrumentation": "^0.54.0",
-        "@opentelemetry/otlp-transformer": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/otlp-transformer": "^0.55.0",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/sdk-metrics": "^1.27.0",
-        "@opentelemetry/sdk-node": "^0.54.0",
+        "@opentelemetry/sdk-node": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
@@ -35610,7 +35640,7 @@
       "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.54.0",
+        "@opentelemetry/api-logs": "^0.55.0",
         "winston-transport": "4.*"
       },
       "devDependencies": {
@@ -35648,7 +35678,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -35694,7 +35724,7 @@
       "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -35727,7 +35757,7 @@
       "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0"
+        "@opentelemetry/instrumentation": "^0.55.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -35764,7 +35794,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0"
+        "@opentelemetry/instrumentation": "^0.55.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -35801,7 +35831,7 @@
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -35838,7 +35868,7 @@
       "version": "0.41.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0"
+        "@opentelemetry/instrumentation": "^0.55.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -35881,7 +35911,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -35924,7 +35954,7 @@
       "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0"
+        "@opentelemetry/instrumentation": "^0.55.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -36463,7 +36493,7 @@
       "version": "0.43.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -36719,7 +36749,7 @@
       "version": "0.15.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/tedious": "^4.0.14"
       },
@@ -36874,7 +36904,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0"
+        "@opentelemetry/instrumentation": "^0.55.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.7.0",
@@ -36911,7 +36941,7 @@
       "version": "0.47.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/aws-lambda": "8.10.143"
       },
@@ -36951,7 +36981,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/propagation-utils": "^0.30.12",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
@@ -37007,14 +37037,14 @@
       "version": "0.42.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.54.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/api-logs": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@types/bunyan": "1.8.9"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/resources": "^1.8.0",
-        "@opentelemetry/sdk-logs": "^0.54.0",
+        "@opentelemetry/sdk-logs": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -37056,7 +37086,7 @@
       "version": "0.42.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37097,7 +37127,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/connect": "3.4.36"
       },
@@ -37141,7 +37171,7 @@
       "version": "0.40.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0"
+        "@opentelemetry/instrumentation": "^0.55.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37180,7 +37210,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37222,7 +37252,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37230,7 +37260,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
-        "@opentelemetry/instrumentation-http": "^0.54.0",
+        "@opentelemetry/instrumentation-http": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/express": "4.17.21",
@@ -37262,7 +37292,7 @@
       "version": "0.40.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0"
+        "@opentelemetry/instrumentation": "^0.55.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37300,7 +37330,7 @@
       "version": "0.44.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0"
+        "@opentelemetry/instrumentation": "^0.55.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37342,7 +37372,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37381,7 +37411,7 @@
       "version": "0.44.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
@@ -37424,7 +37454,7 @@
       "version": "0.41.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37462,7 +37492,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37470,7 +37500,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
-        "@opentelemetry/instrumentation-http": "^0.54.0",
+        "@opentelemetry/instrumentation-http": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/koa": "2.15.0",
@@ -37506,7 +37536,7 @@
       "version": "0.40.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/memcached": "^2.2.6"
       },
@@ -37545,7 +37575,7 @@
       "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37772,7 +37802,7 @@
       "version": "0.42.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mysql": "2.15.26"
       },
@@ -37812,7 +37842,7 @@
       "version": "0.42.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@opentelemetry/sql-common": "^0.40.1"
       },
@@ -37852,7 +37882,7 @@
       "version": "0.41.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37896,7 +37926,7 @@
       "version": "0.40.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37934,7 +37964,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.26.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "1.27.0",
         "@opentelemetry/sql-common": "^0.40.1",
         "@types/pg": "8.6.1",
@@ -37980,9 +38010,9 @@
       "version": "0.43.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.54.0",
+        "@opentelemetry/api-logs": "^0.55.0",
         "@opentelemetry/core": "^1.25.0",
-        "@opentelemetry/instrumentation": "^0.54.0"
+        "@opentelemetry/instrumentation": "^0.55.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -38023,7 +38053,7 @@
       "version": "0.43.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
@@ -38055,7 +38085,7 @@
       "version": "0.43.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
@@ -38120,7 +38150,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -38160,7 +38190,7 @@
       "version": "0.41.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -38196,8 +38226,8 @@
       "version": "0.41.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.54.0",
-        "@opentelemetry/instrumentation": "^0.54.0"
+        "@opentelemetry/api-logs": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.55.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -38239,7 +38269,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-web": "^1.15.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
@@ -38289,7 +38319,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0"
+        "@opentelemetry/instrumentation": "^0.55.0"
       },
       "devDependencies": {
         "@babel/core": "7.24.6",
@@ -38465,7 +38495,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-web": "^1.8.0"
       },
       "devDependencies": {
@@ -38473,7 +38503,7 @@
         "@babel/preset-env": "7.24.6",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-zone-peer-dep": "^1.8.0",
-        "@opentelemetry/instrumentation-xml-http-request": "^0.54.0",
+        "@opentelemetry/instrumentation-xml-http-request": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@types/jquery": "3.5.30",
         "@types/mocha": "10.0.6",
@@ -46757,9 +46787,9 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
     },
     "@opentelemetry/api-logs": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.54.2.tgz",
-      "integrity": "sha512-4MTVwwmLgUh5QrJnZpYo6YRO5IBLAggf2h8gWDblwRagDStY13aEvt7gGk3jewrMaPlHiF83fENhIx0HO97/cQ==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.55.0.tgz",
+      "integrity": "sha512-3cpa+qI45VHYcA5c0bHM6VHo9gicv3p5mlLHNG3rLyjQU8b7e0st1rWtrUn3JbZ3DwwCfhKop4eQ9UuYlC6Pkg==",
       "requires": {
         "@opentelemetry/api": "^1.3.0"
       }
@@ -46798,7 +46828,7 @@
       "version": "file:metapackages/auto-instrumentations-node",
       "requires": {
         "@opentelemetry/api": "^1.4.1",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/instrumentation-amqplib": "^0.43.0",
         "@opentelemetry/instrumentation-aws-lambda": "^0.47.0",
         "@opentelemetry/instrumentation-aws-sdk": "^0.46.0",
@@ -46813,9 +46843,9 @@
         "@opentelemetry/instrumentation-fs": "^0.16.0",
         "@opentelemetry/instrumentation-generic-pool": "^0.40.0",
         "@opentelemetry/instrumentation-graphql": "^0.44.0",
-        "@opentelemetry/instrumentation-grpc": "^0.54.0",
+        "@opentelemetry/instrumentation-grpc": "^0.55.0",
         "@opentelemetry/instrumentation-hapi": "^0.42.0",
-        "@opentelemetry/instrumentation-http": "^0.54.0",
+        "@opentelemetry/instrumentation-http": "^0.55.0",
         "@opentelemetry/instrumentation-ioredis": "^0.44.0",
         "@opentelemetry/instrumentation-kafkajs": "^0.4.0",
         "@opentelemetry/instrumentation-knex": "^0.41.0",
@@ -46844,7 +46874,7 @@
         "@opentelemetry/resource-detector-container": "^0.5.0",
         "@opentelemetry/resource-detector-gcp": "^0.29.13",
         "@opentelemetry/resources": "^1.24.0",
-        "@opentelemetry/sdk-node": "^0.54.0",
+        "@opentelemetry/sdk-node": "^0.55.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
@@ -46871,11 +46901,11 @@
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/instrumentation-document-load": "^0.41.0",
-        "@opentelemetry/instrumentation-fetch": "^0.54.0",
+        "@opentelemetry/instrumentation-fetch": "^0.55.0",
         "@opentelemetry/instrumentation-user-interaction": "^0.41.0",
-        "@opentelemetry/instrumentation-xml-http-request": "^0.54.0",
+        "@opentelemetry/instrumentation-xml-http-request": "^0.55.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
@@ -47039,15 +47069,15 @@
       }
     },
     "@opentelemetry/context-async-hooks": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.27.0.tgz",
-      "integrity": "sha512-CdZ3qmHCwNhFAzjTgHqrDQ44Qxcpz43cVxZRhOs+Ns/79ug+Mr84Bkb626bkJLkA3+BLimA5YAEVRlJC6pFb7g==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.28.0.tgz",
+      "integrity": "sha512-igcl4Ve+F1N2063PJUkesk/GkYyuGIWinYkSyAFTnIj3gzrOgvOA4k747XNdL47HRRL1w/qh7UW8NDuxOLvKFA==",
       "requires": {}
     },
     "@opentelemetry/context-zone-peer-dep": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.27.0.tgz",
-      "integrity": "sha512-gVeOOpqnLgP51F0EJGHeoAJmAHxXXroT1Tk2WVnMf/22jTiAunYzFFsMaqmcH8mNqjTYBLJb28Rz0tInO7uClg==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.28.0.tgz",
+      "integrity": "sha512-tGtZ+N/QlMpZmHlSpANJsCBsx04FAF7t1nvyocG+Hr1r9rEJFPbdJ23pRDPYdpHX7D5UislKEz3mP+kfsP9p/A==",
       "dev": true,
       "requires": {}
     },
@@ -47057,11 +47087,11 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/exporter-jaeger": "^1.3.1",
-        "@opentelemetry/instrumentation": "^0.54.0",
-        "@opentelemetry/otlp-transformer": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/otlp-transformer": "^0.55.0",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/sdk-metrics": "^1.27.0",
-        "@opentelemetry/sdk-node": "^0.54.0",
+        "@opentelemetry/sdk-node": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -47081,107 +47111,107 @@
       }
     },
     "@opentelemetry/core": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.27.0.tgz",
-      "integrity": "sha512-yQPKnK5e+76XuiqUH/gKyS8wv/7qITd5ln56QkBTf3uggr0VkXOXfcaAuG330UfdYu83wsyoBwqwxigpIG+Jkg==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.28.0.tgz",
+      "integrity": "sha512-ZLwRMV+fNDpVmF2WYUdBHlq0eOWtEaUJSusrzjGnBt7iSRvfjFE3RXYUZJrqou/wIDWV0DwQ5KIfYe9WXg9Xqw==",
       "requires": {
         "@opentelemetry/semantic-conventions": "1.27.0"
       }
     },
     "@opentelemetry/exporter-jaeger": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.27.0.tgz",
-      "integrity": "sha512-ULWBtyNQDQQBWTkoCPfpGZTXZ9gLOFHeLZ3BoeZAkxYOgqqTH83IDRbtH8sHt6j84OPQfAcd18uHOb/lc9q0Bw==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.28.0.tgz",
+      "integrity": "sha512-w4wHFZjfxxHqUVUyERegruLCI3pGMwkg9t2XhHBVUjmmhuul6RjN1fn22/0ZBhONG76LsIUJpo2W+ejBPnphFA==",
       "requires": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/sdk-trace-base": "1.27.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/sdk-trace-base": "1.28.0",
         "@opentelemetry/semantic-conventions": "1.27.0",
         "jaeger-client": "^3.15.0"
       }
     },
     "@opentelemetry/exporter-logs-otlp-grpc": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.54.2.tgz",
-      "integrity": "sha512-MQNmV5r96+5n3axLFgNYtVy62x8Ru7VERZH3zgC50KDcIKWCiQT3vHOtzakhzd1Wq0HqOgu6bzKdwzneSoDrEQ==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.55.0.tgz",
+      "integrity": "sha512-ykqawCL0ILJWyCJlxCPSAlqQXZ6x2bQsxAVUu8S3z22XNqY5SMx0rl2d93XnvnrOwtcfm+sM9ZhbGh/i5AZ9xw==",
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.54.2",
-        "@opentelemetry/otlp-transformer": "0.54.2",
-        "@opentelemetry/sdk-logs": "0.54.2"
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.55.0",
+        "@opentelemetry/otlp-transformer": "0.55.0",
+        "@opentelemetry/sdk-logs": "0.55.0"
       }
     },
     "@opentelemetry/exporter-logs-otlp-http": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.54.2.tgz",
-      "integrity": "sha512-wYeCSbX2XWX2wFslnfQ/YFUolO0fj2nUiGI7oEQWpLKSg40Lc4xOOW14X/EXOkCCijhP7bigo6nvyEQlxEVLjA==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.55.0.tgz",
+      "integrity": "sha512-fpFObWWq+DoLVrBU2dyMEaVkibByEkmKQZIUIjW/4j7lwIsTgW7aJCoD9RYFVB/tButcqov5Es2C0J2wTjM2tg==",
       "requires": {
-        "@opentelemetry/api-logs": "0.54.2",
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/otlp-exporter-base": "0.54.2",
-        "@opentelemetry/otlp-transformer": "0.54.2",
-        "@opentelemetry/sdk-logs": "0.54.2"
+        "@opentelemetry/api-logs": "0.55.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/otlp-exporter-base": "0.55.0",
+        "@opentelemetry/otlp-transformer": "0.55.0",
+        "@opentelemetry/sdk-logs": "0.55.0"
       }
     },
     "@opentelemetry/exporter-logs-otlp-proto": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.54.2.tgz",
-      "integrity": "sha512-agrzFbSNmIy6dhkyg41ERlEDUDqkaUJj2n/tVRFp9Tl+6wyNVPsqmwU5RWJOXpyK+lYH/znv6A47VpTeJF0lrw==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.55.0.tgz",
+      "integrity": "sha512-vjE+DxUr+cUpxikdKCPiLZM5Wx7g1bywjCG76TQocvsA7Tmbb9p0t1+8gPlu9AGH7VEzPwDxxpN4p1ajpOurzQ==",
       "requires": {
-        "@opentelemetry/api-logs": "0.54.2",
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/otlp-exporter-base": "0.54.2",
-        "@opentelemetry/otlp-transformer": "0.54.2",
-        "@opentelemetry/resources": "1.27.0",
-        "@opentelemetry/sdk-logs": "0.54.2",
-        "@opentelemetry/sdk-trace-base": "1.27.0"
+        "@opentelemetry/api-logs": "0.55.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/otlp-exporter-base": "0.55.0",
+        "@opentelemetry/otlp-transformer": "0.55.0",
+        "@opentelemetry/resources": "1.28.0",
+        "@opentelemetry/sdk-logs": "0.55.0",
+        "@opentelemetry/sdk-trace-base": "1.28.0"
       }
     },
     "@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.54.2.tgz",
-      "integrity": "sha512-tmxiCYhQdPrzwlM6O7VQeNP9PBjKhaiOo54wFxQFZQcoVaDiOOES4+6PwHU1eW+43mDsgdQHN5AHSRHVLe9jDA==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.55.0.tgz",
+      "integrity": "sha512-ohIkCLn2Wc3vhhFuf1bH8kOXHMEdcWiD847x7f3Qfygc+CGiatGLzQYscTcEYsWGMV22gVwB/kVcNcx5a3o8gA==",
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.54.2",
-        "@opentelemetry/otlp-transformer": "0.54.2",
-        "@opentelemetry/resources": "1.27.0",
-        "@opentelemetry/sdk-trace-base": "1.27.0"
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.55.0",
+        "@opentelemetry/otlp-transformer": "0.55.0",
+        "@opentelemetry/resources": "1.28.0",
+        "@opentelemetry/sdk-trace-base": "1.28.0"
       }
     },
     "@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.54.2.tgz",
-      "integrity": "sha512-BgWKKyD/h2zpISdmYHN/sapwTjvt1P4p5yx4xeBV8XAEqh4OQUhOtSGFG80+nPQ1F8of3mKOT1DDoDbJp1u25w==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.55.0.tgz",
+      "integrity": "sha512-lMiNic63EVHpW+eChmLD2CieDmwQBFi72+LFbh8+5hY0ShrDGrsGP/zuT5MRh7M/vM/UZYO/2A/FYd7CMQGR7A==",
       "requires": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/otlp-exporter-base": "0.54.2",
-        "@opentelemetry/otlp-transformer": "0.54.2",
-        "@opentelemetry/resources": "1.27.0",
-        "@opentelemetry/sdk-trace-base": "1.27.0"
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/otlp-exporter-base": "0.55.0",
+        "@opentelemetry/otlp-transformer": "0.55.0",
+        "@opentelemetry/resources": "1.28.0",
+        "@opentelemetry/sdk-trace-base": "1.28.0"
       }
     },
     "@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.54.2.tgz",
-      "integrity": "sha512-XSmm1N2wAhoWDXP1q/N6kpLebWaxl6VIADv4WA5QWKHLRpF3gLz5NAWNJBR8ygsvv8jQcrwnXgwfnJ18H3v1fg==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.55.0.tgz",
+      "integrity": "sha512-qxiJFP+bBZW3+goHCGkE1ZdW9gJU0fR7eQ6OP+Rz5oGtEBbq4nkGodhb7C9FJlEFlE2siPtCxoeupV0gtYynag==",
       "requires": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/otlp-exporter-base": "0.54.2",
-        "@opentelemetry/otlp-transformer": "0.54.2",
-        "@opentelemetry/resources": "1.27.0",
-        "@opentelemetry/sdk-trace-base": "1.27.0"
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/otlp-exporter-base": "0.55.0",
+        "@opentelemetry/otlp-transformer": "0.55.0",
+        "@opentelemetry/resources": "1.28.0",
+        "@opentelemetry/sdk-trace-base": "1.28.0"
       }
     },
     "@opentelemetry/exporter-zipkin": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.27.0.tgz",
-      "integrity": "sha512-eGMY3s4QprspFZojqsuQyQpWNFpo+oNVE/aosTbtvAlrJBAlvXcwwsOROOHOd8Y9lkU4i0FpQW482rcXkgwCSw==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.28.0.tgz",
+      "integrity": "sha512-AMwr3eGXaPEH7gk8yhcUcen31VXy1yU5VJETu0pCfGpggGCYmhm0FKgYBpL5/vlIgQJWU/sW2vIjCL7aSilpKg==",
       "requires": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/resources": "1.27.0",
-        "@opentelemetry/sdk-trace-base": "1.27.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/resources": "1.28.0",
+        "@opentelemetry/sdk-trace-base": "1.28.0",
         "@opentelemetry/semantic-conventions": "1.27.0"
       }
     },
@@ -47357,11 +47387,11 @@
       }
     },
     "@opentelemetry/instrumentation": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.54.2.tgz",
-      "integrity": "sha512-go6zpOVoZVztT9r1aPd79Fr3OWiD4N24bCPJsIKkBses8oyFo12F/Ew3UBTdIu6hsW4HC4MVEJygG6TEyJI/lg==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.55.0.tgz",
+      "integrity": "sha512-YDCMlaQRZkziLL3t6TONRgmmGxDx6MyQDXRD0dknkkgUZtOK5+8MWft1OXzmNu6XfBOdT12MKN5rz+jHUkafKQ==",
       "requires": {
-        "@opentelemetry/api-logs": "0.54.2",
+        "@opentelemetry/api-logs": "0.55.0",
         "@types/shimmer": "^1.2.0",
         "import-in-the-middle": "^1.8.1",
         "require-in-the-middle": "^7.1.1",
@@ -47382,7 +47412,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/amqplib": "^0.5.17",
         "@types/lodash": "4.14.199",
@@ -47420,7 +47450,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/propagator-aws-xray": "^1.25.1",
         "@opentelemetry/propagator-aws-xray-lambda": "^0.53.0",
         "@opentelemetry/sdk-metrics": "^1.8.0",
@@ -47459,7 +47489,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/propagation-utils": "^0.30.12",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -47499,10 +47529,10 @@
       "version": "file:plugins/node/opentelemetry-instrumentation-bunyan",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/api-logs": "^0.54.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/api-logs": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/resources": "^1.8.0",
-        "@opentelemetry/sdk-logs": "^0.54.0",
+        "@opentelemetry/sdk-logs": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -47542,7 +47572,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -47574,7 +47604,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -47612,7 +47642,7 @@
         "@cucumber/messages": "^22.0.0",
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/core": "^1.3.1",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.3.1",
         "@opentelemetry/sdk-trace-node": "^1.3.1",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -47633,7 +47663,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
@@ -47661,7 +47691,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
@@ -47693,7 +47723,7 @@
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-web": "^1.15.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -47735,7 +47765,7 @@
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -47770,8 +47800,8 @@
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
-        "@opentelemetry/instrumentation-http": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation-http": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -47796,13 +47826,13 @@
       }
     },
     "@opentelemetry/instrumentation-fetch": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.54.2.tgz",
-      "integrity": "sha512-7G2mn0K5BJ41AIarIMGuMDDcdJ13DQdk4go2CIL7QZkY0TgZmmq6wO6fHwdocZlPPkZ47Mflo4DwSQtMLykfyQ==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.55.0.tgz",
+      "integrity": "sha512-wkybQE85HzInYX2csZ4UuMlCIMCyGGHcNqL9TcoZgAZC2EuXFReTsLytoszknhcaX+P7UT9Ee3915t8KC6XP4w==",
       "requires": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/instrumentation": "0.54.2",
-        "@opentelemetry/sdk-trace-web": "1.27.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/instrumentation": "0.55.0",
+        "@opentelemetry/sdk-trace-web": "1.28.0",
         "@opentelemetry/semantic-conventions": "1.27.0"
       }
     },
@@ -47812,7 +47842,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
@@ -47841,7 +47871,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/generic-pool": "^3.1.9",
@@ -47870,7 +47900,7 @@
       "version": "file:plugins/node/opentelemetry-instrumentation-graphql",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
@@ -47900,11 +47930,11 @@
       }
     },
     "@opentelemetry/instrumentation-grpc": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.54.2.tgz",
-      "integrity": "sha512-KhSzerCaaqVH2zfDro7nTunWUZXt1pQISQpE83LuQTOKGk7mN3G60T1wliQ3Qdg0X3UUuhCXEC7u6IAVfDxkUQ==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.55.0.tgz",
+      "integrity": "sha512-n2ZH4pRwOy0Vhag/3eKqiyDBwcpUnGgJI9iiIRX7vivE0FMncaLazWphNFezRRaM/LuKwq1TD8pVUvieP68mow==",
       "requires": {
-        "@opentelemetry/instrumentation": "0.54.2",
+        "@opentelemetry/instrumentation": "0.55.0",
         "@opentelemetry/semantic-conventions": "1.27.0"
       }
     },
@@ -47916,7 +47946,7 @@
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -47941,12 +47971,12 @@
       }
     },
     "@opentelemetry/instrumentation-http": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.54.2.tgz",
-      "integrity": "sha512-mABjJ34UcU32pg8g18L9xBh0U3JON/2F6/57BYYy8AZJp2a71lZjcKr0T00pICoic50TW5HvcTrmyfMil+AiXQ==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.55.0.tgz",
+      "integrity": "sha512-AO27XSjkgNicfy/YBthskFAwx9VfaO7tChrLaTONTfOWv14GlB3Rs2eTYpywZIHWsW2cR5hvVkcDte4GV0stoA==",
       "requires": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/instrumentation": "0.54.2",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/instrumentation": "0.55.0",
         "@opentelemetry/semantic-conventions": "1.27.0",
         "forwarded-parse": "2.1.2",
         "semver": "^7.5.2"
@@ -47958,7 +47988,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
@@ -47992,7 +48022,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.24.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "7.0.2",
@@ -48021,7 +48051,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -48053,8 +48083,8 @@
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
-        "@opentelemetry/instrumentation-http": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation-http": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -48089,7 +48119,7 @@
         "@babel/preset-env": "7.24.6",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-web": "^1.8.0",
         "@types/mocha": "10.0.6",
@@ -48230,7 +48260,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@types/lru-cache": "7.10.10",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
@@ -48265,7 +48295,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -48296,7 +48326,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-metrics": "^1.9.1",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
@@ -48451,7 +48481,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
@@ -48487,7 +48517,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-metrics": "^1.8.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -48519,7 +48549,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@opentelemetry/sql-common": "^0.40.1",
@@ -48552,7 +48582,7 @@
         "@nestjs/core": "9.4.3",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -48586,7 +48616,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -48617,7 +48647,7 @@
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
         "@opentelemetry/core": "^1.26.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "1.27.0",
@@ -48653,10 +48683,10 @@
       "version": "file:plugins/node/opentelemetry-instrumentation-pino",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/api-logs": "^0.54.0",
+        "@opentelemetry/api-logs": "^0.55.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
         "@opentelemetry/core": "^1.25.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -48690,7 +48720,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
@@ -48724,7 +48754,7 @@
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
@@ -48770,7 +48800,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -48802,7 +48832,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -48829,7 +48859,7 @@
       "version": "file:plugins/node/instrumentation-runtime-node",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-metrics": "^1.20.0",
         "@types/mocha": "^10.0.6",
         "@types/node": "18.18.14",
@@ -49220,7 +49250,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
@@ -49420,7 +49450,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "7.0.2",
@@ -49525,7 +49555,7 @@
       "requires": {
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-metrics": "^1.8.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
@@ -49558,8 +49588,8 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-zone-peer-dep": "^1.8.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
-        "@opentelemetry/instrumentation-xml-http-request": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation-xml-http-request": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-web": "^1.8.0",
         "@types/jquery": "3.5.30",
@@ -49700,9 +49730,9 @@
       "version": "file:plugins/node/opentelemetry-instrumentation-winston",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/api-logs": "^0.54.0",
+        "@opentelemetry/api-logs": "^0.55.0",
         "@opentelemetry/context-async-hooks": "^1.21.0",
-        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.21.0",
         "@opentelemetry/sdk-trace-node": "^1.21.0",
         "@opentelemetry/winston-transport": "^0.7.0",
@@ -49731,47 +49761,47 @@
       }
     },
     "@opentelemetry/instrumentation-xml-http-request": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.54.2.tgz",
-      "integrity": "sha512-Y07iCr4OuXQwiPft2GqXpp7hNpIDa/72wzwfDRP/fh1DZcm2MjXgvcOos45VFoXPW5YxHs/ONobT4UTrS/yovA==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.55.0.tgz",
+      "integrity": "sha512-Wlz4LzDpBFxHpb24RAM6RoiGspJ7J16ux0Xw5KVLtK3zzpQaxMYEVF0XQNC61WJJa3tRNt3XRjiQ8mrXJZxVQg==",
       "requires": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/instrumentation": "0.54.2",
-        "@opentelemetry/sdk-trace-web": "1.27.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/instrumentation": "0.55.0",
+        "@opentelemetry/sdk-trace-web": "1.28.0",
         "@opentelemetry/semantic-conventions": "1.27.0"
       }
     },
     "@opentelemetry/otlp-exporter-base": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.54.2.tgz",
-      "integrity": "sha512-NrNyxu6R/bGAwanhz1HI0aJWKR6xUED4TjCH4iWMlAfyRukGbI9Kt/Akd2sYLwRKNhfS+sKetKGCUQPMDyYYMA==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.55.0.tgz",
+      "integrity": "sha512-iHQI0Zzq3h1T6xUJTVFwmFl5Dt5y1es+fl4kM+k5T/3YvmVyeYkSiF+wHCg6oKrlUAJfk+t55kaAu3sYmt7ZYA==",
       "requires": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/otlp-transformer": "0.54.2"
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/otlp-transformer": "0.55.0"
       }
     },
     "@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.54.2.tgz",
-      "integrity": "sha512-HZtACQuLhgDcgNa9arGnVVGV28sSGQ+iwRgICWikFKiVxUsoWffqBvTxPa6G3DUTg5R+up97j/zxubEyxSAOHg==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.55.0.tgz",
+      "integrity": "sha512-gebbjl9FiSp52igWXuGjcWQKfB6IBwFGt5z1VFwTcVZVeEZevB6bJIqoFrhH4A02m7OUlpJ7l4EfRi3UtkNANQ==",
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/otlp-exporter-base": "0.54.2",
-        "@opentelemetry/otlp-transformer": "0.54.2"
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/otlp-exporter-base": "0.55.0",
+        "@opentelemetry/otlp-transformer": "0.55.0"
       }
     },
     "@opentelemetry/otlp-transformer": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.54.2.tgz",
-      "integrity": "sha512-2tIjahJlMRRUz0A2SeE+qBkeBXBFkSjR0wqJ08kuOqaL8HNGan5iZf+A8cfrfmZzPUuMKCyY9I+okzFuFs6gKQ==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.55.0.tgz",
+      "integrity": "sha512-kVqEfxtp6mSN2Dhpy0REo1ghP4PYhC1kMHQJ2qVlO99Pc+aigELjZDfg7/YKmL71gR6wVGIeJfiql/eXL7sQPA==",
       "requires": {
-        "@opentelemetry/api-logs": "0.54.2",
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/resources": "1.27.0",
-        "@opentelemetry/sdk-logs": "0.54.2",
-        "@opentelemetry/sdk-metrics": "1.27.0",
-        "@opentelemetry/sdk-trace-base": "1.27.0",
+        "@opentelemetry/api-logs": "0.55.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/resources": "1.28.0",
+        "@opentelemetry/sdk-logs": "0.55.0",
+        "@opentelemetry/sdk-metrics": "1.28.0",
+        "@opentelemetry/sdk-trace-base": "1.28.0",
         "protobufjs": "^7.3.0"
       }
     },
@@ -50111,11 +50141,11 @@
       }
     },
     "@opentelemetry/propagator-b3": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.27.0.tgz",
-      "integrity": "sha512-pTsko3gnMioe3FeWcwTQR3omo5C35tYsKKwjgTCTVCgd3EOWL9BZrMfgLBmszrwXABDfUrlAEFN/0W0FfQGynQ==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.28.0.tgz",
+      "integrity": "sha512-Q7HVDIMwhN5RxL4bECMT4BdbyYSAKkC6U/RGn4NpO/cbqP6ZRg+BS7fPo/pGZi2w8AHfpIGQFXQmE8d2PC5xxQ==",
       "requires": {
-        "@opentelemetry/core": "1.27.0"
+        "@opentelemetry/core": "1.28.0"
       }
     },
     "@opentelemetry/propagator-instana": {
@@ -50216,11 +50246,11 @@
       }
     },
     "@opentelemetry/propagator-jaeger": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.27.0.tgz",
-      "integrity": "sha512-EI1bbK0wn0yIuKlc2Qv2LKBRw6LiUWevrjCF80fn/rlaB+7StAi8Y5s8DBqAYNpY7v1q86+NjU18v7hj2ejU3A==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.28.0.tgz",
+      "integrity": "sha512-wKJ94+s8467CnIRgoSRh0yXm/te0QMOwTq9J01PfG/RzYZvlvN8aRisN2oZ9SznB45dDGnMj3BhUlchSA9cEKA==",
       "requires": {
-        "@opentelemetry/core": "1.27.0"
+        "@opentelemetry/core": "1.28.0"
       }
     },
     "@opentelemetry/propagator-ot-trace": {
@@ -50428,7 +50458,7 @@
         "@opentelemetry/contrib-test-utils": "^0.42.0",
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/instrumentation-fs": "^0.16.0",
-        "@opentelemetry/instrumentation-http": "^0.54.0",
+        "@opentelemetry/instrumentation-http": "^0.55.0",
         "@opentelemetry/resources": "^1.10.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
@@ -50464,7 +50494,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
         "@opentelemetry/core": "^1.25.1",
-        "@opentelemetry/instrumentation-http": "^0.54.0",
+        "@opentelemetry/instrumentation-http": "^0.55.0",
         "@opentelemetry/resources": "^1.10.1",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
@@ -50536,7 +50566,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation-http": "^0.54.0",
+        "@opentelemetry/instrumentation-http": "^0.55.0",
         "@opentelemetry/resources": "^1.10.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
@@ -50603,7 +50633,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.42.0",
         "@opentelemetry/resources": "^1.10.0",
-        "@opentelemetry/sdk-node": "^0.54.0",
+        "@opentelemetry/sdk-node": "^0.55.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
@@ -50632,86 +50662,86 @@
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.27.0.tgz",
-      "integrity": "sha512-jOwt2VJ/lUD5BLc+PMNymDrUCpm5PKi1E9oSVYAvz01U/VdndGmrtV3DU1pG4AwlYhJRHbHfOUIlpBeXCPw6QQ==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.28.0.tgz",
+      "integrity": "sha512-cIyXSVJjGeTICENN40YSvLDAq4Y2502hGK3iN7tfdynQLKWb3XWZQEkPc+eSx47kiy11YeFAlYkEfXwR1w8kfw==",
       "requires": {
-        "@opentelemetry/core": "1.27.0",
+        "@opentelemetry/core": "1.28.0",
         "@opentelemetry/semantic-conventions": "1.27.0"
       }
     },
     "@opentelemetry/sdk-logs": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.54.2.tgz",
-      "integrity": "sha512-yIbYqDLS/AtBbPjCjh6eSToGNRMqW2VR8RrKEy+G+J7dFG7pKoptTH5T+XlKPleP9NY8JZYIpgJBlI+Osi0rFw==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.55.0.tgz",
+      "integrity": "sha512-TSx+Yg/d48uWW6HtjS1AD5x6WPfLhDWLl/WxC7I2fMevaiBuKCuraxTB8MDXieCNnBI24bw9ytyXrDCswFfWgA==",
       "requires": {
-        "@opentelemetry/api-logs": "0.54.2",
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/resources": "1.27.0"
+        "@opentelemetry/api-logs": "0.55.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/resources": "1.28.0"
       }
     },
     "@opentelemetry/sdk-metrics": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.27.0.tgz",
-      "integrity": "sha512-JzWgzlutoXCydhHWIbLg+r76m+m3ncqvkCcsswXAQ4gqKS+LOHKhq+t6fx1zNytvLuaOUBur7EvWxECc4jPQKg==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.28.0.tgz",
+      "integrity": "sha512-43tqMK/0BcKTyOvm15/WQ3HLr0Vu/ucAl/D84NO7iSlv6O4eOprxSHa3sUtmYkaZWHqdDJV0AHVz/R6u4JALVQ==",
       "requires": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/resources": "1.27.0"
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/resources": "1.28.0"
       }
     },
     "@opentelemetry/sdk-node": {
-      "version": "0.54.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.54.2.tgz",
-      "integrity": "sha512-afn8GBpA7Gb55aU0LUxIQ+oe6QxLhsf+Te9iw12Non3ZAspzdoCcfz5+hqecwpuVpEDdnj5iSalF7VVaL2pDeg==",
+      "version": "0.55.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.55.0.tgz",
+      "integrity": "sha512-gSXQWV23+9vhbjsvAIeM0LxY3W8DTKI3MZlzFp61noIb1jSr46ET+qoUjHlfZ1Yymebv9KXWeZsqhft81HBXuQ==",
       "requires": {
-        "@opentelemetry/api-logs": "0.54.2",
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/exporter-logs-otlp-grpc": "0.54.2",
-        "@opentelemetry/exporter-logs-otlp-http": "0.54.2",
-        "@opentelemetry/exporter-logs-otlp-proto": "0.54.2",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.54.2",
-        "@opentelemetry/exporter-trace-otlp-http": "0.54.2",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.54.2",
-        "@opentelemetry/exporter-zipkin": "1.27.0",
-        "@opentelemetry/instrumentation": "0.54.2",
-        "@opentelemetry/resources": "1.27.0",
-        "@opentelemetry/sdk-logs": "0.54.2",
-        "@opentelemetry/sdk-metrics": "1.27.0",
-        "@opentelemetry/sdk-trace-base": "1.27.0",
-        "@opentelemetry/sdk-trace-node": "1.27.0",
+        "@opentelemetry/api-logs": "0.55.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.55.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.55.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.55.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.55.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.55.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.55.0",
+        "@opentelemetry/exporter-zipkin": "1.28.0",
+        "@opentelemetry/instrumentation": "0.55.0",
+        "@opentelemetry/resources": "1.28.0",
+        "@opentelemetry/sdk-logs": "0.55.0",
+        "@opentelemetry/sdk-metrics": "1.28.0",
+        "@opentelemetry/sdk-trace-base": "1.28.0",
+        "@opentelemetry/sdk-trace-node": "1.28.0",
         "@opentelemetry/semantic-conventions": "1.27.0"
       }
     },
     "@opentelemetry/sdk-trace-base": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.27.0.tgz",
-      "integrity": "sha512-btz6XTQzwsyJjombpeqCX6LhiMQYpzt2pIYNPnw0IPO/3AhT6yjnf8Mnv3ZC2A4eRYOjqrg+bfaXg9XHDRJDWQ==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.28.0.tgz",
+      "integrity": "sha512-ceUVWuCpIao7Y5xE02Xs3nQi0tOGmMea17ecBdwtCvdo9ekmO+ijc9RFDgfifMl7XCBf41zne/1POM3LqSTZDA==",
       "requires": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/resources": "1.27.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/resources": "1.28.0",
         "@opentelemetry/semantic-conventions": "1.27.0"
       }
     },
     "@opentelemetry/sdk-trace-node": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.27.0.tgz",
-      "integrity": "sha512-dWZp/dVGdUEfRBjBq2BgNuBlFqHCxyyMc8FsN0NX15X07mxSUO0SZRLyK/fdAVrde8nqFI/FEdMH4rgU9fqJfQ==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.28.0.tgz",
+      "integrity": "sha512-N0sYfYXvHpP0FNIyc+UfhLnLSTOuZLytV0qQVrDWIlABeD/DWJIGttS7nYeR14gQLXch0M1DW8zm3VeN6Opwtg==",
       "requires": {
-        "@opentelemetry/context-async-hooks": "1.27.0",
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/propagator-b3": "1.27.0",
-        "@opentelemetry/propagator-jaeger": "1.27.0",
-        "@opentelemetry/sdk-trace-base": "1.27.0",
+        "@opentelemetry/context-async-hooks": "1.28.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/propagator-b3": "1.28.0",
+        "@opentelemetry/propagator-jaeger": "1.28.0",
+        "@opentelemetry/sdk-trace-base": "1.28.0",
         "semver": "^7.5.2"
       }
     },
     "@opentelemetry/sdk-trace-web": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.27.0.tgz",
-      "integrity": "sha512-ORZfG8Sm5IkJeI+P8MyW8v4m5OcmjEtD7VsjBghv5sDKH3f5p2mQpEEoJWlCr5GiW50Y1MaI2R4uFGIsxmDE9A==",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.28.0.tgz",
+      "integrity": "sha512-/QOIrJc/A/caKbA9voLua4isf///cjQKB6gomEzX2fL18TBqZhIkm9k2DpjlbtrQoYCJDZ9x7Phrec22aQGpQw==",
       "requires": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/sdk-trace-base": "1.27.0",
+        "@opentelemetry/core": "1.28.0",
+        "@opentelemetry/sdk-trace-base": "1.28.0",
         "@opentelemetry/semantic-conventions": "1.27.0"
       }
     },
@@ -50745,7 +50775,7 @@
     "@opentelemetry/winston-transport": {
       "version": "file:packages/winston-transport",
       "requires": {
-        "@opentelemetry/api-logs": "^0.54.0",
+        "@opentelemetry/api-logs": "^0.55.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",

--- a/packages/opentelemetry-test-utils/package.json
+++ b/packages/opentelemetry-test-utils/package.json
@@ -45,11 +45,11 @@
   "dependencies": {
     "@opentelemetry/core": "^1.0.0",
     "@opentelemetry/exporter-jaeger": "^1.3.1",
-    "@opentelemetry/instrumentation": "^0.54.0",
-    "@opentelemetry/otlp-transformer": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/otlp-transformer": "^0.55.0",
     "@opentelemetry/resources": "^1.8.0",
     "@opentelemetry/sdk-metrics": "^1.27.0",
-    "@opentelemetry/sdk-node": "^0.54.0",
+    "@opentelemetry/sdk-node": "^0.55.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"

--- a/packages/winston-transport/package.json
+++ b/packages/winston-transport/package.json
@@ -47,7 +47,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "^0.54.0",
+    "@opentelemetry/api-logs": "^0.55.0",
     "winston-transport": "4.*"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/winston-transport#readme"

--- a/plugins/node/instrumentation-amqplib/package.json
+++ b/plugins/node/instrumentation-amqplib/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "devDependencies": {

--- a/plugins/node/instrumentation-cucumber/package.json
+++ b/plugins/node/instrumentation-cucumber/package.json
@@ -61,7 +61,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-cucumber#readme"

--- a/plugins/node/instrumentation-dataloader/package.json
+++ b/plugins/node/instrumentation-dataloader/package.json
@@ -55,7 +55,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0"
+    "@opentelemetry/instrumentation": "^0.55.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-dataloader#readme"
 }

--- a/plugins/node/instrumentation-fs/package.json
+++ b/plugins/node/instrumentation-fs/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.54.0"
+    "@opentelemetry/instrumentation": "^0.55.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-fs#readme"
 }

--- a/plugins/node/instrumentation-kafkajs/package.json
+++ b/plugins/node/instrumentation-kafkajs/package.json
@@ -55,7 +55,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-kafkajs#readme"

--- a/plugins/node/instrumentation-lru-memoizer/package.json
+++ b/plugins/node/instrumentation-lru-memoizer/package.json
@@ -55,7 +55,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0"
+    "@opentelemetry/instrumentation": "^0.55.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-lru-memoizer#readme"
 }

--- a/plugins/node/instrumentation-mongoose/package.json
+++ b/plugins/node/instrumentation-mongoose/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-mongoose#readme"

--- a/plugins/node/instrumentation-runtime-node/package.json
+++ b/plugins/node/instrumentation-runtime-node/package.json
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0"
+    "@opentelemetry/instrumentation": "^0.55.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",

--- a/plugins/node/instrumentation-socket.io/package.json
+++ b/plugins/node/instrumentation-socket.io/package.json
@@ -56,7 +56,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-socket.io#readme"

--- a/plugins/node/instrumentation-tedious/package.json
+++ b/plugins/node/instrumentation-tedious/package.json
@@ -60,7 +60,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
     "@types/tedious": "^4.0.14"
   },

--- a/plugins/node/instrumentation-undici/package.json
+++ b/plugins/node/instrumentation-undici/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.54.0"
+    "@opentelemetry/instrumentation": "^0.55.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-undici",
   "sideEffects": false

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
@@ -56,7 +56,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
     "@types/aws-lambda": "8.10.143"
   },

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/propagation-utils": "^0.30.12",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
@@ -57,10 +57,10 @@
     "@aws-sdk/client-sns": "3.85.0",
     "@aws-sdk/client-sqs": "3.85.0",
     "@aws-sdk/types": "3.78.0",
-    "@smithy/node-http-handler": "2.4.0",
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/contrib-test-utils": "^0.42.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
+    "@smithy/node-http-handler": "2.4.0",
     "@types/mocha": "8.2.3",
     "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",

--- a/plugins/node/opentelemetry-instrumentation-bunyan/package.json
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/resources": "^1.8.0",
-    "@opentelemetry/sdk-logs": "^0.54.0",
+    "@opentelemetry/sdk-logs": "^0.55.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -60,8 +60,8 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "^0.54.0",
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/api-logs": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@types/bunyan": "1.8.9"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-bunyan#readme"

--- a/plugins/node/opentelemetry-instrumentation-cassandra/package.json
+++ b/plugins/node/opentelemetry-instrumentation-cassandra/package.json
@@ -59,7 +59,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-cassandra#readme"

--- a/plugins/node/opentelemetry-instrumentation-connect/package.json
+++ b/plugins/node/opentelemetry-instrumentation-connect/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
     "@types/connect": "3.4.36"
   },

--- a/plugins/node/opentelemetry-instrumentation-dns/package.json
+++ b/plugins/node/opentelemetry-instrumentation-dns/package.json
@@ -57,7 +57,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0"
+    "@opentelemetry/instrumentation": "^0.55.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-dns#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-express/package.json
+++ b/plugins/node/opentelemetry-instrumentation-express/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-express#readme"

--- a/plugins/node/opentelemetry-instrumentation-fastify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-fastify/package.json
@@ -47,7 +47,7 @@
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/context-async-hooks": "^1.8.0",
     "@opentelemetry/contrib-test-utils": "^0.42.0",
-    "@opentelemetry/instrumentation-http": "^0.54.0",
+    "@opentelemetry/instrumentation-http": "^0.55.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/express": "4.17.21",
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-fastify#readme"

--- a/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
+++ b/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
@@ -57,7 +57,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0"
+    "@opentelemetry/instrumentation": "^0.55.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-generic-pool#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-graphql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-graphql/package.json
@@ -56,7 +56,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0"
+    "@opentelemetry/instrumentation": "^0.55.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-graphql#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-hapi/package.json
+++ b/plugins/node/opentelemetry-instrumentation-hapi/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-hapi#readme"

--- a/plugins/node/opentelemetry-instrumentation-ioredis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/package.json
@@ -65,7 +65,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/redis-common": "^0.36.2",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },

--- a/plugins/node/opentelemetry-instrumentation-knex/package.json
+++ b/plugins/node/opentelemetry-instrumentation-knex/package.json
@@ -55,7 +55,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-knex#readme"

--- a/plugins/node/opentelemetry-instrumentation-koa/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/package.json
@@ -49,7 +49,7 @@
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/context-async-hooks": "^1.8.0",
     "@opentelemetry/contrib-test-utils": "^0.42.0",
-    "@opentelemetry/instrumentation-http": "^0.54.0",
+    "@opentelemetry/instrumentation-http": "^0.55.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/koa": "2.15.0",
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-koa#readme"

--- a/plugins/node/opentelemetry-instrumentation-memcached/package.json
+++ b/plugins/node/opentelemetry-instrumentation-memcached/package.json
@@ -57,7 +57,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
     "@types/memcached": "^2.2.6"
   },

--- a/plugins/node/opentelemetry-instrumentation-mongodb/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/package.json
@@ -64,7 +64,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-mongodb#readme"

--- a/plugins/node/opentelemetry-instrumentation-mysql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql/package.json
@@ -56,7 +56,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
     "@types/mysql": "2.15.26"
   },

--- a/plugins/node/opentelemetry-instrumentation-mysql2/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/package.json
@@ -58,7 +58,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
     "@opentelemetry/sql-common": "^0.40.1"
   },

--- a/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
+++ b/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
@@ -64,7 +64,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-nestjs-core#readme"

--- a/plugins/node/opentelemetry-instrumentation-net/package.json
+++ b/plugins/node/opentelemetry-instrumentation-net/package.json
@@ -56,7 +56,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-net#readme"

--- a/plugins/node/opentelemetry-instrumentation-pg/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pg/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.26.0",
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/semantic-conventions": "1.27.0",
     "@opentelemetry/sql-common": "^0.40.1",
     "@types/pg": "8.6.1",

--- a/plugins/node/opentelemetry-instrumentation-pino/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pino/package.json
@@ -62,9 +62,9 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "^0.54.0",
+    "@opentelemetry/api-logs": "^0.55.0",
     "@opentelemetry/core": "^1.25.0",
-    "@opentelemetry/instrumentation": "^0.54.0"
+    "@opentelemetry/instrumentation": "^0.55.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-pino#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-redis-4/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis-4/package.json
@@ -64,7 +64,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/redis-common": "^0.36.2",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },

--- a/plugins/node/opentelemetry-instrumentation-redis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis/package.json
@@ -64,7 +64,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/redis-common": "^0.36.2",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },

--- a/plugins/node/opentelemetry-instrumentation-restify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-restify/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-restify#readme"

--- a/plugins/node/opentelemetry-instrumentation-router/package.json
+++ b/plugins/node/opentelemetry-instrumentation-router/package.json
@@ -54,7 +54,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-router#readme"

--- a/plugins/node/opentelemetry-instrumentation-winston/package.json
+++ b/plugins/node/opentelemetry-instrumentation-winston/package.json
@@ -62,8 +62,8 @@
     "winston2": "npm:winston@2.4.7"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "^0.54.0",
-    "@opentelemetry/instrumentation": "^0.54.0"
+    "@opentelemetry/api-logs": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.55.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-winston#readme"
 }

--- a/plugins/web/opentelemetry-instrumentation-document-load/package.json
+++ b/plugins/web/opentelemetry-instrumentation-document-load/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/sdk-trace-web": "^1.15.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },

--- a/plugins/web/opentelemetry-instrumentation-long-task/package.json
+++ b/plugins/web/opentelemetry-instrumentation-long-task/package.json
@@ -78,7 +78,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.54.0"
+    "@opentelemetry/instrumentation": "^0.55.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
@@ -52,7 +52,7 @@
     "@babel/preset-env": "7.24.6",
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/context-zone-peer-dep": "^1.8.0",
-    "@opentelemetry/instrumentation-xml-http-request": "^0.54.0",
+    "@opentelemetry/instrumentation-xml-http-request": "^0.55.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@types/jquery": "3.5.30",
     "@types/mocha": "10.0.6",
@@ -80,7 +80,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.54.0",
+    "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/sdk-trace-web": "^1.8.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
    0.54.2 -> 0.55.0 @opentelemetry/api-logs (range-bump)
    0.54.2 -> 0.55.0 @opentelemetry/instrumentation (range-bump)
    0.54.2 -> 0.55.0 @opentelemetry/instrumentation-fetch (range-bump)
    0.54.2 -> 0.55.0 @opentelemetry/instrumentation-grpc (range-bump)
    0.54.2 -> 0.55.0 @opentelemetry/instrumentation-http (range-bump)
    0.54.2 -> 0.55.0 @opentelemetry/instrumentation-xml-http-request (range-bump)
    0.54.2 -> 0.55.0 @opentelemetry/otlp-transformer (range-bump)
    0.54.2 -> 0.55.0 @opentelemetry/sdk-logs (range-bump)
    0.54.2 -> 0.55.0 @opentelemetry/sdk-node (range-bump)
    1.27.0 -> 1.28.0 @opentelemetry/context-async-hooks
    1.27.0 -> 1.28.0 @opentelemetry/context-zone-peer-dep
    1.27.0 -> 1.28.0 @opentelemetry/core
    1.27.0 -> 1.28.0 @opentelemetry/exporter-jaeger
    1.27.0 -> 1.28.0 @opentelemetry/propagator-b3
    1.27.0 -> 1.28.0 @opentelemetry/propagator-jaeger
    1.27.0 -> 1.28.0 @opentelemetry/resources
    1.27.0 -> 1.28.0 @opentelemetry/sdk-metrics
    1.27.0 -> 1.28.0 @opentelemetry/sdk-trace-base
    1.27.0 -> 1.28.0 @opentelemetry/sdk-trace-node
    1.27.0 -> 1.28.0 @opentelemetry/sdk-trace-web
