### PR TITLE
fix: losing this context on register handler function for hapi

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-hapi/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-hapi/src/instrumentation.ts
@@ -287,7 +287,7 @@ export class HapiInstrumentation extends InstrumentationBase {
           pluginName
         );
       });
-      return oldHandler(server, options);
+      return oldHandler.apply(this, [server, options]);
     };
     plugin.register = newRegisterHandler;
   }


### PR DESCRIPTION
## Which problem is this PR solving?

- When someone is using also a wrapper on the return function from register handler, due to wrapping by opentelemetry before it without retain the context, the following wrapper loses it.

## Short description of the changes

- Use apply to retain the `this` context of the original function.
