### PR TITLE
chore(deps): bump @opentelemetry/semantic-conventions to 1.28

### DIFF
--- a/archive/opentelemetry-browser-extension-autoinjection/package.json
+++ b/archive/opentelemetry-browser-extension-autoinjection/package.json
@@ -74,7 +74,7 @@
     "@opentelemetry/resources": "^1.8.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-web": "^1.8.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "change-case": "4.1.2",
     "json5": "2.2.0",
     "react": "17.0.2",

--- a/detectors/node/opentelemetry-resource-detector-alibaba-cloud/package.json
+++ b/detectors/node/opentelemetry-resource-detector-alibaba-cloud/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.26.0",
     "@opentelemetry/resources": "^1.10.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-alibaba-cloud#readme"
 }

--- a/detectors/node/opentelemetry-resource-detector-aws/package.json
+++ b/detectors/node/opentelemetry-resource-detector-aws/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.0.0",
     "@opentelemetry/resources": "^1.10.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-aws#readme"
 }

--- a/detectors/node/opentelemetry-resource-detector-azure/package.json
+++ b/detectors/node/opentelemetry-resource-detector-azure/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.25.1",
     "@opentelemetry/resources": "^1.10.1",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-azure#readme"
 }

--- a/detectors/node/opentelemetry-resource-detector-container/package.json
+++ b/detectors/node/opentelemetry-resource-detector-container/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.26.0",
     "@opentelemetry/resources": "^1.10.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-container#readme"
 }

--- a/detectors/node/opentelemetry-resource-detector-gcp/package.json
+++ b/detectors/node/opentelemetry-resource-detector-gcp/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.0.0",
     "@opentelemetry/resources": "^1.10.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "gcp-metadata": "^6.0.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-gcp#readme"

--- a/detectors/node/opentelemetry-resource-detector-instana/package.json
+++ b/detectors/node/opentelemetry-resource-detector-instana/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@opentelemetry/resources": "^1.10.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/examples/connect/package.json
+++ b/examples/connect/package.json
@@ -45,7 +45,7 @@
     "@opentelemetry/instrumentation-http": "^0.25.0",
     "@opentelemetry/sdk-trace-node": "^0.25.0",
     "@opentelemetry/resources": "^0.25.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "@opentelemetry/sdk-trace-base": "^0.25.0",
     "axios": "^0.21.1",
     "cross-env": "^7.0.3",

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -36,7 +36,7 @@
     "@opentelemetry/resources": "^1.27.0",
     "@opentelemetry/sdk-trace-base": "^1.27.0",
     "@opentelemetry/sdk-trace-node": "^1.27.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "axios": "^1.6.0",
     "express": "^4.17.1"
   },

--- a/examples/fastify/package.json
+++ b/examples/fastify/package.json
@@ -45,7 +45,7 @@
     "@opentelemetry/instrumentation-fastify": "^0.32.6",
     "@opentelemetry/sdk-trace-node": "~1.19.0",
     "@opentelemetry/resources": "~1.19.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "@opentelemetry/sdk-trace-base": "~1.19.0",
     "cross-env": "^7.0.3",
     "axios": "^1.6.4",

--- a/examples/graphql/package.json
+++ b/examples/graphql/package.json
@@ -44,7 +44,7 @@
     "@opentelemetry/resources": "~1.0.0",
     "@opentelemetry/sdk-trace-base": "~1.0.0",
     "@opentelemetry/sdk-trace-node": "~1.0.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "apollo-server": "^2.18.1",
     "cross-fetch": "^3.0.5",
     "express": "^4.17.1",

--- a/examples/koa/package.json
+++ b/examples/koa/package.json
@@ -39,7 +39,7 @@
     "@opentelemetry/instrumentation-koa": "^0.31.0",
     "@opentelemetry/sdk-trace-node": "^1.0.0",
     "@opentelemetry/sdk-trace-base": "^1.0.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "axios": "^1.6.0",
     "koa": "^2.13.0"
   },

--- a/examples/memcached/package.json
+++ b/examples/memcached/package.json
@@ -34,7 +34,7 @@
     "@opentelemetry/resources": "^1.23.0",
     "@opentelemetry/sdk-trace-base": "^0.25.0",
     "@opentelemetry/sdk-trace-node": "^0.25.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "memcached": "^2.2.2"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib#readme"

--- a/examples/mongodb/package.json
+++ b/examples/mongodb/package.json
@@ -38,7 +38,7 @@
     "@opentelemetry/instrumentation-mongodb": "^0.32.0",
     "@opentelemetry/sdk-trace-node": "^1.0.0",
     "@opentelemetry/sdk-trace-base": "^1.0.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "mongodb": "^3.6.11"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib#readme",

--- a/examples/mysql/package.json
+++ b/examples/mysql/package.json
@@ -37,7 +37,7 @@
     "@opentelemetry/instrumentation-mysql": "^0.31.0",
     "@opentelemetry/sdk-trace-base": "^1.0.0",
     "@opentelemetry/sdk-trace-node": "^1.0.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "@types/node": "^18.18.14",
     "mysql": "^2.18.1"
   },

--- a/examples/react-load/react/package.json
+++ b/examples/react-load/react/package.json
@@ -43,7 +43,7 @@
     "@opentelemetry/plugin-react-load": "^0.23.0",
     "@opentelemetry/sdk-trace-base": "^0.25.0",
     "@opentelemetry/sdk-trace-web": "^0.25.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",

--- a/examples/redis/package.json
+++ b/examples/redis/package.json
@@ -39,7 +39,7 @@
     "@opentelemetry/instrumentation-redis": "^0.32.0",
     "@opentelemetry/sdk-trace-base": "^1.0.0",
     "@opentelemetry/sdk-trace-node": "^1.0.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "axios": "^1.6.0",
     "express": "^4.17.1",
     "redis": "^3.1.1"

--- a/examples/web/package.json
+++ b/examples/web/package.json
@@ -46,7 +46,7 @@
     "@opentelemetry/instrumentation-xml-http-request": "^0.39.1",
     "@opentelemetry/propagator-b3": "^1.13.0",
     "@opentelemetry/sdk-trace-web": "^1.13.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib#readme"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38244,7 +38244,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.26.0",
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@opentelemetry/semantic-conventions": "1.28.0",
         "@opentelemetry/sql-common": "^0.40.1",
         "@types/pg": "8.6.1",
         "@types/pg-pool": "2.0.6"
@@ -49115,7 +49115,7 @@
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.28.0",
+        "@opentelemetry/semantic-conventions": "1.28.0",
         "@opentelemetry/sql-common": "^0.40.1",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.26.0",
         "@opentelemetry/resources": "^1.10.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
@@ -66,6 +66,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "detectors/node/opentelemetry-resource-detector-alibaba-cloud/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "detectors/node/opentelemetry-resource-detector-alibaba-cloud/node_modules/@types/mocha": {
@@ -90,7 +99,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/resources": "^1.10.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
@@ -111,6 +120,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "detectors/node/opentelemetry-resource-detector-aws/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "detectors/node/opentelemetry-resource-detector-aws/node_modules/@types/mocha": {
@@ -135,7 +153,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.25.1",
         "@opentelemetry/resources": "^1.10.1",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
@@ -154,6 +172,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "detectors/node/opentelemetry-resource-detector-azure/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "detectors/node/opentelemetry-resource-detector-azure/node_modules/@types/mocha": {
@@ -178,7 +205,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.26.0",
         "@opentelemetry/resources": "^1.10.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
@@ -199,6 +226,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "detectors/node/opentelemetry-resource-detector-container/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "detectors/node/opentelemetry-resource-detector-container/node_modules/@types/mocha": {
@@ -223,7 +259,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/resources": "^1.10.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "gcp-metadata": "^6.0.0"
       },
       "devDependencies": {
@@ -243,6 +279,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "detectors/node/opentelemetry-resource-detector-gcp/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "detectors/node/opentelemetry-resource-detector-gcp/node_modules/@types/mocha": {
@@ -305,7 +350,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/resources": "^1.10.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -324,6 +369,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "detectors/node/opentelemetry-resource-detector-instana/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "detectors/node/opentelemetry-resource-detector-instana/node_modules/@types/mocha": {
@@ -35610,7 +35664,7 @@
         "@opentelemetry/sdk-node": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -35622,6 +35676,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "packages/opentelemetry-test-utils/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "packages/opentelemetry-test-utils/node_modules/@types/node": {
@@ -35677,7 +35740,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -35702,6 +35765,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/instrumentation-amqplib/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "plugins/node/instrumentation-amqplib/node_modules/@types/mocha": {
       "version": "8.2.3",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
@@ -35723,7 +35795,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@cucumber/cucumber": "^9.0.0",
@@ -35748,6 +35820,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "plugins/node/instrumentation-cucumber/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "plugins/node/instrumentation-dataloader": {
@@ -35830,7 +35911,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -35850,6 +35931,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/instrumentation-kafkajs/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "plugins/node/instrumentation-kafkajs/node_modules/@types/node": {
@@ -35910,7 +36000,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -35930,6 +36020,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/instrumentation-mongoose/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "plugins/node/instrumentation-mongoose/node_modules/@types/mocha": {
@@ -36492,7 +36591,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -36529,6 +36628,15 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "plugins/node/instrumentation-socket.io/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "plugins/node/instrumentation-socket.io/node_modules/@types/mocha": {
@@ -36748,7 +36856,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/tedious": "^4.0.14"
       },
       "devDependencies": {
@@ -36770,6 +36878,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/instrumentation-tedious/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "plugins/node/instrumentation-tedious/node_modules/@types/node": {
@@ -36940,7 +37057,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/aws-lambda": "8.10.143"
       },
       "devDependencies": {
@@ -36964,6 +37081,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-aws-lambda/node_modules/@types/node": {
       "version": "18.18.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -36981,7 +37107,7 @@
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/propagation-utils": "^0.30.13",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@aws-sdk/client-dynamodb": "3.85.0",
@@ -37015,6 +37141,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-aws-sdk/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-aws-sdk/node_modules/@types/mocha": {
       "version": "8.2.3",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
@@ -37045,7 +37180,7 @@
         "@opentelemetry/sdk-logs": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
@@ -37061,6 +37196,16 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-bunyan/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "plugins/node/opentelemetry-instrumentation-bunyan/node_modules/@types/bunyan": {
@@ -37085,7 +37230,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37110,6 +37255,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-cassandra/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-cassandra/node_modules/@types/node": {
       "version": "18.18.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -37126,7 +37280,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/connect": "3.4.36"
       },
       "devDependencies": {
@@ -37146,6 +37300,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-connect/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "plugins/node/opentelemetry-instrumentation-connect/node_modules/@types/connect": {
@@ -37209,7 +37372,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37235,6 +37398,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-express/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-express/node_modules/@types/node": {
       "version": "18.18.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -37251,7 +37423,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@fastify/express": "^3.0.0",
@@ -37277,6 +37449,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-fastify/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "plugins/node/opentelemetry-instrumentation-fastify/node_modules/@types/node": {
@@ -37333,7 +37514,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
         "graphql": "^16.5.0",
@@ -37347,6 +37528,16 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-graphql/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "plugins/node/opentelemetry-instrumentation-graphql/node_modules/@types/mocha": {
@@ -37371,7 +37562,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@hapi/hapi": "21.3.10",
@@ -37395,6 +37586,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-hapi/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-hapi/node_modules/@types/node": {
       "version": "18.18.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -37411,7 +37611,7 @@
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/redis-common": "^0.36.2",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37438,6 +37638,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-ioredis/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-ioredis/node_modules/@types/node": {
       "version": "18.18.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -37453,7 +37662,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37475,6 +37684,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-knex/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-knex/node_modules/@types/node": {
       "version": "18.18.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -37491,7 +37709,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@koa/router": "13.1.0",
@@ -37520,6 +37738,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-koa/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-koa/node_modules/@types/node": {
       "version": "18.18.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -37535,7 +37762,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/memcached": "^2.2.6"
       },
       "devDependencies": {
@@ -37559,6 +37786,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-memcached/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-memcached/node_modules/@types/node": {
       "version": "18.18.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -37574,7 +37810,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37597,6 +37833,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-mongodb/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "plugins/node/opentelemetry-instrumentation-mongodb/node_modules/@types/node": {
@@ -37801,7 +38046,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mysql": "2.15.26"
       },
       "devDependencies": {
@@ -37826,6 +38071,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-mysql/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-mysql/node_modules/@types/node": {
       "version": "18.18.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -37841,7 +38095,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@opentelemetry/sql-common": "^0.40.1"
       },
       "devDependencies": {
@@ -37866,6 +38120,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-mysql2/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-mysql2/node_modules/@types/node": {
       "version": "18.18.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -37881,7 +38144,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@nestjs/common": "9.4.3",
@@ -37910,6 +38173,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-nestjs-core/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-nestjs-core/node_modules/@types/node": {
       "version": "18.18.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -37925,7 +38197,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37947,6 +38219,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-net/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-net/node_modules/@types/node": {
       "version": "18.18.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -37963,7 +38244,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.26.0",
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@opentelemetry/sql-common": "^0.40.1",
         "@types/pg": "8.6.1",
         "@types/pg-pool": "2.0.6"
@@ -37994,6 +38275,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-pg/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-pg/node_modules/@types/node": {
       "version": "18.18.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -38017,7 +38307,7 @@
         "@opentelemetry/contrib-test-utils": "^0.43.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
@@ -38037,6 +38327,16 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-pino/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-pino/node_modules/@types/node": {
       "version": "18.18.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -38053,7 +38353,7 @@
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/redis-common": "^0.36.2",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -38085,7 +38385,7 @@
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/redis-common": "^0.36.2",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -38108,6 +38408,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-redis-4/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "plugins/node/opentelemetry-instrumentation-redis-4/node_modules/@types/node": {
@@ -38133,6 +38442,15 @@
         "@redis/time-series": "1.0.3"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-redis/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-redis/node_modules/@types/node": {
       "version": "18.18.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -38149,7 +38467,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -38174,6 +38492,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-restify/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-restify/node_modules/@types/node": {
       "version": "18.18.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -38189,7 +38516,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -38208,6 +38535,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-router/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "plugins/node/opentelemetry-instrumentation-router/node_modules/@types/node": {
@@ -38269,7 +38605,7 @@
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-web": "^1.15.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/semantic-conventions": "^1.28.0"
       },
       "devDependencies": {
         "@babel/core": "7.22.17",
@@ -38294,6 +38630,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/web/opentelemetry-instrumentation-document-load/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "plugins/web/opentelemetry-instrumentation-document-load/node_modules/@types/mocha": {
@@ -47090,11 +47435,16 @@
         "@opentelemetry/sdk-node": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/node": "18.18.14",
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -47409,7 +47759,7 @@
         "@opentelemetry/contrib-test-utils": "^0.43.0",
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/amqplib": "^0.5.17",
         "@types/lodash": "4.14.199",
         "@types/mocha": "8.2.3",
@@ -47424,6 +47774,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/mocha": {
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
@@ -47452,7 +47807,7 @@
         "@opentelemetry/sdk-metrics": "^1.8.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/aws-lambda": "8.10.143",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
@@ -47461,6 +47816,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -47488,7 +47848,7 @@
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/propagation-utils": "^0.30.13",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@smithy/node-http-handler": "2.4.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
@@ -47504,6 +47864,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/mocha": {
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
@@ -47531,7 +47896,7 @@
         "@opentelemetry/sdk-logs": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/bunyan": "1.8.9",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
@@ -47544,6 +47909,12 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+          "dev": true
+        },
         "@types/bunyan": {
           "version": "1.8.9",
           "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.9.tgz",
@@ -47571,7 +47942,7 @@
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
@@ -47583,6 +47954,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -47603,7 +47979,7 @@
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/connect": "3.4.36",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
@@ -47613,6 +47989,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/connect": {
           "version": "3.4.36",
           "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.36.tgz",
@@ -47641,7 +48022,7 @@
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.3.1",
         "@opentelemetry/sdk-trace-node": "^1.3.1",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "7.0.2",
         "@types/semver": "7.5.8",
         "@types/shimmer": "1.0.3",
@@ -47652,6 +48033,13 @@
         "sinon": "15.2.0",
         "test-all-versions": "6.1.0",
         "typescript": "4.4.4"
+      },
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        }
       }
     },
     "@opentelemetry/instrumentation-dataloader": {
@@ -47722,7 +48110,7 @@
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-web": "^1.15.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@rollup/plugin-commonjs": "^26.0.0",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@types/chai": "^4.3.10",
@@ -47737,6 +48125,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/mocha": {
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
@@ -47764,7 +48157,7 @@
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/express": "4.17.21",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
@@ -47777,6 +48170,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -47800,7 +48198,7 @@
         "@opentelemetry/instrumentation-http": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/express": "4.17.21",
         "@types/mocha": "7.0.2",
         "@types/node": "18.15.3",
@@ -47813,6 +48211,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.15.3",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
@@ -47898,7 +48301,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
         "graphql": "^16.5.0",
@@ -47908,6 +48311,12 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+          "dev": true
+        },
         "@types/mocha": {
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
@@ -47945,7 +48354,7 @@
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
         "joi": "17.12.2",
@@ -47955,6 +48364,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -47988,7 +48402,7 @@
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/ioredis4": "npm:@types/ioredis@4.28.10",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
@@ -48002,6 +48416,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -48020,7 +48439,7 @@
         "@opentelemetry/contrib-test-utils": "^0.43.0",
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.24.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
         "@types/sinon": "^10.0.11",
@@ -48031,6 +48450,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -48050,7 +48474,7 @@
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
         "knex": "0.95.9",
@@ -48060,6 +48484,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -48083,7 +48512,7 @@
         "@opentelemetry/instrumentation-http": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/koa": "2.15.0",
         "@types/koa__router": "12.0.4",
         "@types/mocha": "7.0.2",
@@ -48097,6 +48526,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -48294,7 +48728,7 @@
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/memcached": "^2.2.6",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
@@ -48305,6 +48739,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -48326,7 +48765,7 @@
         "@opentelemetry/sdk-metrics": "^1.9.1",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/bson": "4.0.5",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
@@ -48337,6 +48776,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -48479,7 +48923,7 @@
         "@opentelemetry/core": "^1.8.0",
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
         "expect": "29.2.0",
@@ -48490,6 +48934,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/mocha": {
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
@@ -48516,7 +48965,7 @@
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-metrics": "^1.8.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "7.0.2",
         "@types/mysql": "2.15.26",
         "@types/node": "18.18.14",
@@ -48528,6 +48977,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -48547,7 +49001,7 @@
         "@opentelemetry/contrib-test-utils": "^0.43.0",
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@opentelemetry/sql-common": "^0.40.1",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
@@ -48560,6 +49014,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -48581,7 +49040,7 @@
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
@@ -48596,6 +49055,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -48615,7 +49079,7 @@
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
@@ -48625,6 +49089,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -48646,7 +49115,7 @@
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@opentelemetry/sql-common": "^0.40.1",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
@@ -48664,6 +49133,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -48685,7 +49159,7 @@
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
@@ -48699,6 +49173,12 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+          "dev": true
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -48720,7 +49200,7 @@
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
         "@types/redis": "2.8.32",
@@ -48732,6 +49212,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -48754,7 +49239,7 @@
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
         "cross-env": "7.0.3",
@@ -48765,6 +49250,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -48799,7 +49289,7 @@
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
         "@types/restify": "4.3.12",
@@ -48812,6 +49302,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -48831,7 +49326,7 @@
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
         "nyc": "15.1.0",
@@ -48840,6 +49335,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -49248,7 +49748,7 @@
         "@opentelemetry/contrib-test-utils": "^0.43.0",
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
         "expect": "27.4.2",
@@ -49272,6 +49772,11 @@
             "@types/yargs": "^16.0.0",
             "chalk": "^4.0.0"
           }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
         },
         "@types/mocha": {
           "version": "8.2.3",
@@ -49448,7 +49953,7 @@
         "@opentelemetry/contrib-test-utils": "^0.43.0",
         "@opentelemetry/instrumentation": "^0.55.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
         "@types/tedious": "^4.0.14",
@@ -49460,6 +49965,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -50419,7 +50929,7 @@
         "@opentelemetry/contrib-test-utils": "^0.43.0",
         "@opentelemetry/core": "^1.26.0",
         "@opentelemetry/resources": "^1.10.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
@@ -50430,6 +50940,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/mocha": {
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
@@ -50456,7 +50971,7 @@
         "@opentelemetry/instrumentation-fs": "^0.17.0",
         "@opentelemetry/instrumentation-http": "^0.55.0",
         "@opentelemetry/resources": "^1.10.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
@@ -50467,6 +50982,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/mocha": {
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
@@ -50492,7 +51012,7 @@
         "@opentelemetry/core": "^1.25.1",
         "@opentelemetry/instrumentation-http": "^0.55.0",
         "@opentelemetry/resources": "^1.10.1",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
@@ -50502,6 +51022,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/mocha": {
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
@@ -50527,7 +51052,7 @@
         "@opentelemetry/core": "^1.26.0",
         "@opentelemetry/instrumentation-fs": "^0.17.0",
         "@opentelemetry/resources": "^1.10.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
@@ -50539,6 +51064,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/mocha": {
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
@@ -50564,7 +51094,7 @@
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/instrumentation-http": "^0.55.0",
         "@opentelemetry/resources": "^1.10.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
@@ -50575,6 +51105,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/mocha": {
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
@@ -50630,7 +51165,7 @@
         "@opentelemetry/contrib-test-utils": "^0.43.0",
         "@opentelemetry/resources": "^1.10.0",
         "@opentelemetry/sdk-node": "^0.55.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
@@ -50640,6 +51175,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/mocha": {
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",

--- a/packages/opentelemetry-test-utils/package.json
+++ b/packages/opentelemetry-test-utils/package.json
@@ -52,6 +52,6 @@
     "@opentelemetry/sdk-node": "^0.55.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   }
 }

--- a/plugins/node/instrumentation-amqplib/package.json
+++ b/plugins/node/instrumentation-amqplib/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",

--- a/plugins/node/instrumentation-cucumber/package.json
+++ b/plugins/node/instrumentation-cucumber/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-cucumber#readme"
 }

--- a/plugins/node/instrumentation-kafkajs/package.json
+++ b/plugins/node/instrumentation-kafkajs/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-kafkajs#readme"
 }

--- a/plugins/node/instrumentation-mongoose/package.json
+++ b/plugins/node/instrumentation-mongoose/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-mongoose#readme"
 }

--- a/plugins/node/instrumentation-socket.io/package.json
+++ b/plugins/node/instrumentation-socket.io/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-socket.io#readme"
 }

--- a/plugins/node/instrumentation-tedious/package.json
+++ b/plugins/node/instrumentation-tedious/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "@types/tedious": "^4.0.14"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-tedious#readme"

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "@types/aws-lambda": "8.10.143"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-aws-lambda#readme"

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
@@ -47,7 +47,7 @@
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/propagation-utils": "^0.30.13",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "3.85.0",

--- a/plugins/node/opentelemetry-instrumentation-bunyan/package.json
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/package.json
@@ -48,7 +48,7 @@
     "@opentelemetry/sdk-logs": "^0.55.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "@types/mocha": "7.0.2",
     "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",

--- a/plugins/node/opentelemetry-instrumentation-cassandra/package.json
+++ b/plugins/node/opentelemetry-instrumentation-cassandra/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-cassandra#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-connect/package.json
+++ b/plugins/node/opentelemetry-instrumentation-connect/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "@types/connect": "3.4.36"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-connect#readme"

--- a/plugins/node/opentelemetry-instrumentation-express/package.json
+++ b/plugins/node/opentelemetry-instrumentation-express/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-express#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-fastify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-fastify/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-fastify#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-graphql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-graphql/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "@types/mocha": "8.2.3",
     "@types/node": "18.18.14",
     "graphql": "^16.5.0",

--- a/plugins/node/opentelemetry-instrumentation-hapi/package.json
+++ b/plugins/node/opentelemetry-instrumentation-hapi/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-hapi#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-ioredis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/redis-common": "^0.36.2",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-ioredis#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-knex/package.json
+++ b/plugins/node/opentelemetry-instrumentation-knex/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-knex#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-koa/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-koa#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-memcached/package.json
+++ b/plugins/node/opentelemetry-instrumentation-memcached/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "@types/memcached": "^2.2.6"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-memcached#readme"

--- a/plugins/node/opentelemetry-instrumentation-mongodb/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-mongodb#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-mysql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "@types/mysql": "2.15.26"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-mysql#readme"

--- a/plugins/node/opentelemetry-instrumentation-mysql2/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "@opentelemetry/sql-common": "^0.40.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-mysql2#readme"

--- a/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
+++ b/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-nestjs-core#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-net/package.json
+++ b/plugins/node/opentelemetry-instrumentation-net/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-net#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-pg/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pg/package.json
@@ -71,7 +71,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.26.0",
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "@opentelemetry/sql-common": "^0.40.1",
     "@types/pg": "8.6.1",
     "@types/pg-pool": "2.0.6"

--- a/plugins/node/opentelemetry-instrumentation-pg/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pg/package.json
@@ -71,7 +71,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.26.0",
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "^1.28.0",
+    "@opentelemetry/semantic-conventions": "1.28.0",
     "@opentelemetry/sql-common": "^0.40.1",
     "@types/pg": "8.6.1",
     "@types/pg-pool": "2.0.6"

--- a/plugins/node/opentelemetry-instrumentation-pino/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pino/package.json
@@ -48,7 +48,7 @@
     "@opentelemetry/contrib-test-utils": "^0.43.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.28.0",
     "@types/mocha": "7.0.2",
     "@types/node": "18.18.14",
     "@types/semver": "7.5.8",

--- a/plugins/node/opentelemetry-instrumentation-redis-4/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis-4/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/redis-common": "^0.36.2",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-redis-4#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-redis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/redis-common": "^0.36.2",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-redis#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-restify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-restify/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-restify#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-router/package.json
+++ b/plugins/node/opentelemetry-instrumentation-router/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-router#readme"
 }

--- a/plugins/web/opentelemetry-instrumentation-document-load/package.json
+++ b/plugins/web/opentelemetry-instrumentation-document-load/package.json
@@ -72,7 +72,7 @@
     "@opentelemetry/core": "^1.8.0",
     "@opentelemetry/instrumentation": "^0.55.0",
     "@opentelemetry/sdk-trace-web": "^1.15.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0"
+    "@opentelemetry/semantic-conventions": "^1.28.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/web/opentelemetry-instrumentation-document-load#readme"
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- https://github.com/open-telemetry/opentelemetry-js/releases/tag/semconv%2Fv1.28.0

## Short description of the changes

- Updates `@opentelemetry/semantic-conventions` to 1.28
