### PR TITLE
chore(aws-sdk): migrate `SEMATTRS_*` to `ATTR_*`

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/aws-sdk.ts
@@ -59,7 +59,7 @@ import {
 } from './utils';
 import { propwrap } from './propwrap';
 import { RequestMetadata } from './services/ServiceExtension';
-import { SEMATTRS_HTTP_STATUS_CODE } from '@opentelemetry/semantic-conventions';
+import { ATTR_HTTP_STATUS_CODE } from '@opentelemetry/semantic-conventions/incubating';
 
 const V3_CLIENT_CONFIG_KEY = Symbol(
   'opentelemetry.instrumentation.aws-sdk.client.config'
@@ -348,7 +348,7 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
 
         const httpStatusCode = response.httpResponse?.statusCode;
         if (httpStatusCode) {
-          span.setAttribute(SEMATTRS_HTTP_STATUS_CODE, httpStatusCode);
+          span.setAttribute(ATTR_HTTP_STATUS_CODE, httpStatusCode);
         }
         span.end();
       });
@@ -501,10 +501,7 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
                   const httpStatusCode =
                     response.output?.$metadata?.httpStatusCode;
                   if (httpStatusCode) {
-                    span.setAttribute(
-                      SEMATTRS_HTTP_STATUS_CODE,
-                      httpStatusCode
-                    );
+                    span.setAttribute(ATTR_HTTP_STATUS_CODE, httpStatusCode);
                   }
 
                   const extendedRequestId =
@@ -538,10 +535,7 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
 
                   const httpStatusCode = err?.$metadata?.httpStatusCode;
                   if (httpStatusCode) {
-                    span.setAttribute(
-                      SEMATTRS_HTTP_STATUS_CODE,
-                      httpStatusCode
-                    );
+                    span.setAttribute(ATTR_HTTP_STATUS_CODE, httpStatusCode);
                   }
 
                   const extendedRequestId = err?.extendedRequestId;

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/dynamodb.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/dynamodb.ts
@@ -22,33 +22,33 @@ import {
 } from '@opentelemetry/api';
 import { RequestMetadata, ServiceExtension } from './ServiceExtension';
 import {
-  DBSYSTEMVALUES_DYNAMODB,
-  SEMATTRS_AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS,
-  SEMATTRS_AWS_DYNAMODB_CONSISTENT_READ,
-  SEMATTRS_AWS_DYNAMODB_CONSUMED_CAPACITY,
-  SEMATTRS_AWS_DYNAMODB_COUNT,
-  SEMATTRS_AWS_DYNAMODB_EXCLUSIVE_START_TABLE,
-  SEMATTRS_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES,
-  SEMATTRS_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES,
-  SEMATTRS_AWS_DYNAMODB_INDEX_NAME,
-  SEMATTRS_AWS_DYNAMODB_ITEM_COLLECTION_METRICS,
-  SEMATTRS_AWS_DYNAMODB_LIMIT,
-  SEMATTRS_AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES,
-  SEMATTRS_AWS_DYNAMODB_PROJECTION,
-  SEMATTRS_AWS_DYNAMODB_PROVISIONED_READ_CAPACITY,
-  SEMATTRS_AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY,
-  SEMATTRS_AWS_DYNAMODB_SCAN_FORWARD,
-  SEMATTRS_AWS_DYNAMODB_SCANNED_COUNT,
-  SEMATTRS_AWS_DYNAMODB_SEGMENT,
-  SEMATTRS_AWS_DYNAMODB_SELECT,
-  SEMATTRS_AWS_DYNAMODB_TABLE_COUNT,
-  SEMATTRS_AWS_DYNAMODB_TABLE_NAMES,
-  SEMATTRS_AWS_DYNAMODB_TOTAL_SEGMENTS,
-  SEMATTRS_DB_NAME,
-  SEMATTRS_DB_OPERATION,
-  SEMATTRS_DB_STATEMENT,
-  SEMATTRS_DB_SYSTEM,
-} from '@opentelemetry/semantic-conventions';
+  ATTR_AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS,
+  ATTR_AWS_DYNAMODB_CONSISTENT_READ,
+  ATTR_AWS_DYNAMODB_CONSUMED_CAPACITY,
+  ATTR_AWS_DYNAMODB_COUNT,
+  ATTR_AWS_DYNAMODB_EXCLUSIVE_START_TABLE,
+  ATTR_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES,
+  ATTR_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES,
+  ATTR_AWS_DYNAMODB_INDEX_NAME,
+  ATTR_AWS_DYNAMODB_ITEM_COLLECTION_METRICS,
+  ATTR_AWS_DYNAMODB_LIMIT,
+  ATTR_AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES,
+  ATTR_AWS_DYNAMODB_PROJECTION,
+  ATTR_AWS_DYNAMODB_PROVISIONED_READ_CAPACITY,
+  ATTR_AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY,
+  ATTR_AWS_DYNAMODB_SCAN_FORWARD,
+  ATTR_AWS_DYNAMODB_SCANNED_COUNT,
+  ATTR_AWS_DYNAMODB_SEGMENT,
+  ATTR_AWS_DYNAMODB_SELECT,
+  ATTR_AWS_DYNAMODB_TABLE_COUNT,
+  ATTR_AWS_DYNAMODB_TABLE_NAMES,
+  ATTR_AWS_DYNAMODB_TOTAL_SEGMENTS,
+  ATTR_DB_NAME,
+  ATTR_DB_OPERATION,
+  ATTR_DB_STATEMENT,
+  ATTR_DB_SYSTEM,
+  DB_SYSTEM_VALUE_DYNAMODB,
+} from '@opentelemetry/semantic-conventions/incubating';
 import {
   AwsSdkInstrumentationConfig,
   NormalizedRequest,
@@ -71,9 +71,9 @@ export class DynamodbServiceExtension implements ServiceExtension {
     const operation = normalizedRequest.commandName;
 
     const spanAttributes: Attributes = {
-      [SEMATTRS_DB_SYSTEM]: DBSYSTEMVALUES_DYNAMODB,
-      [SEMATTRS_DB_NAME]: normalizedRequest.commandInput?.TableName,
-      [SEMATTRS_DB_OPERATION]: operation,
+      [ATTR_DB_SYSTEM]: DB_SYSTEM_VALUE_DYNAMODB,
+      [ATTR_DB_NAME]: normalizedRequest.commandInput?.TableName,
+      [ATTR_DB_OPERATION]: operation,
     };
 
     if (config.dynamoDBStatementSerializer) {
@@ -84,7 +84,7 @@ export class DynamodbServiceExtension implements ServiceExtension {
         );
 
         if (typeof sanitizedStatement === 'string') {
-          spanAttributes[SEMATTRS_DB_STATEMENT] = sanitizedStatement;
+          spanAttributes[ATTR_DB_STATEMENT] = sanitizedStatement;
         }
       } catch (err) {
         diag.error('failed to sanitize DynamoDB statement', err);
@@ -96,11 +96,11 @@ export class DynamodbServiceExtension implements ServiceExtension {
     if (normalizedRequest.commandInput?.TableName) {
       // Necessary for commands with only 1 table name (example: CreateTable). Attribute is TableName not keys of RequestItems
       // single table name returned for operations like CreateTable
-      spanAttributes[SEMATTRS_AWS_DYNAMODB_TABLE_NAMES] = [
+      spanAttributes[ATTR_AWS_DYNAMODB_TABLE_NAMES] = [
         normalizedRequest.commandInput.TableName,
       ];
     } else if (normalizedRequest.commandInput?.RequestItems) {
-      spanAttributes[SEMATTRS_AWS_DYNAMODB_TABLE_NAMES] = Object.keys(
+      spanAttributes[ATTR_AWS_DYNAMODB_TABLE_NAMES] = Object.keys(
         normalizedRequest.commandInput.RequestItems
       );
     }
@@ -108,9 +108,9 @@ export class DynamodbServiceExtension implements ServiceExtension {
     if (operation === 'CreateTable' || operation === 'UpdateTable') {
       // only check for ProvisionedThroughput since ReadCapacityUnits and WriteCapacity units are required attributes
       if (normalizedRequest.commandInput?.ProvisionedThroughput) {
-        spanAttributes[SEMATTRS_AWS_DYNAMODB_PROVISIONED_READ_CAPACITY] =
+        spanAttributes[ATTR_AWS_DYNAMODB_PROVISIONED_READ_CAPACITY] =
           normalizedRequest.commandInput.ProvisionedThroughput.ReadCapacityUnits;
-        spanAttributes[SEMATTRS_AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY] =
+        spanAttributes[ATTR_AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY] =
           normalizedRequest.commandInput.ProvisionedThroughput.WriteCapacityUnits;
       }
     }
@@ -121,28 +121,28 @@ export class DynamodbServiceExtension implements ServiceExtension {
       operation === 'Query'
     ) {
       if (normalizedRequest.commandInput?.ConsistentRead) {
-        spanAttributes[SEMATTRS_AWS_DYNAMODB_CONSISTENT_READ] =
+        spanAttributes[ATTR_AWS_DYNAMODB_CONSISTENT_READ] =
           normalizedRequest.commandInput.ConsistentRead;
       }
     }
 
     if (operation === 'Query' || operation === 'Scan') {
       if (normalizedRequest.commandInput?.ProjectionExpression) {
-        spanAttributes[SEMATTRS_AWS_DYNAMODB_PROJECTION] =
+        spanAttributes[ATTR_AWS_DYNAMODB_PROJECTION] =
           normalizedRequest.commandInput.ProjectionExpression;
       }
     }
 
     if (operation === 'CreateTable') {
       if (normalizedRequest.commandInput?.GlobalSecondaryIndexes) {
-        spanAttributes[SEMATTRS_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES] =
+        spanAttributes[ATTR_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES] =
           this.toArray(
             normalizedRequest.commandInput.GlobalSecondaryIndexes
           ).map((x: { [DictionaryKey: string]: any }) => JSON.stringify(x));
       }
 
       if (normalizedRequest.commandInput?.LocalSecondaryIndexes) {
-        spanAttributes[SEMATTRS_AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES] =
+        spanAttributes[ATTR_AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES] =
           this.toArray(
             normalizedRequest.commandInput.LocalSecondaryIndexes
           ).map((x: { [DictionaryKey: string]: any }) => JSON.stringify(x));
@@ -155,67 +155,66 @@ export class DynamodbServiceExtension implements ServiceExtension {
       operation === 'Scan'
     ) {
       if (normalizedRequest.commandInput?.Limit) {
-        spanAttributes[SEMATTRS_AWS_DYNAMODB_LIMIT] =
+        spanAttributes[ATTR_AWS_DYNAMODB_LIMIT] =
           normalizedRequest.commandInput.Limit;
       }
     }
 
     if (operation === 'ListTables') {
       if (normalizedRequest.commandInput?.ExclusiveStartTableName) {
-        spanAttributes[SEMATTRS_AWS_DYNAMODB_EXCLUSIVE_START_TABLE] =
+        spanAttributes[ATTR_AWS_DYNAMODB_EXCLUSIVE_START_TABLE] =
           normalizedRequest.commandInput.ExclusiveStartTableName;
       }
     }
 
     if (operation === 'Query') {
       if (normalizedRequest.commandInput?.ScanIndexForward) {
-        spanAttributes[SEMATTRS_AWS_DYNAMODB_SCAN_FORWARD] =
+        spanAttributes[ATTR_AWS_DYNAMODB_SCAN_FORWARD] =
           normalizedRequest.commandInput.ScanIndexForward;
       }
 
       if (normalizedRequest.commandInput?.IndexName) {
-        spanAttributes[SEMATTRS_AWS_DYNAMODB_INDEX_NAME] =
+        spanAttributes[ATTR_AWS_DYNAMODB_INDEX_NAME] =
           normalizedRequest.commandInput.IndexName;
       }
 
       if (normalizedRequest.commandInput?.Select) {
-        spanAttributes[SEMATTRS_AWS_DYNAMODB_SELECT] =
+        spanAttributes[ATTR_AWS_DYNAMODB_SELECT] =
           normalizedRequest.commandInput.Select;
       }
     }
 
     if (operation === 'Scan') {
       if (normalizedRequest.commandInput?.Segment) {
-        spanAttributes[SEMATTRS_AWS_DYNAMODB_SEGMENT] =
+        spanAttributes[ATTR_AWS_DYNAMODB_SEGMENT] =
           normalizedRequest.commandInput?.Segment;
       }
 
       if (normalizedRequest.commandInput?.TotalSegments) {
-        spanAttributes[SEMATTRS_AWS_DYNAMODB_TOTAL_SEGMENTS] =
+        spanAttributes[ATTR_AWS_DYNAMODB_TOTAL_SEGMENTS] =
           normalizedRequest.commandInput?.TotalSegments;
       }
 
       if (normalizedRequest.commandInput?.IndexName) {
-        spanAttributes[SEMATTRS_AWS_DYNAMODB_INDEX_NAME] =
+        spanAttributes[ATTR_AWS_DYNAMODB_INDEX_NAME] =
           normalizedRequest.commandInput.IndexName;
       }
 
       if (normalizedRequest.commandInput?.Select) {
-        spanAttributes[SEMATTRS_AWS_DYNAMODB_SELECT] =
+        spanAttributes[ATTR_AWS_DYNAMODB_SELECT] =
           normalizedRequest.commandInput.Select;
       }
     }
 
     if (operation === 'UpdateTable') {
       if (normalizedRequest.commandInput?.AttributeDefinitions) {
-        spanAttributes[SEMATTRS_AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS] =
-          this.toArray(normalizedRequest.commandInput.AttributeDefinitions).map(
-            (x: { [DictionaryKey: string]: any }) => JSON.stringify(x)
-          );
+        spanAttributes[ATTR_AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS] = this.toArray(
+          normalizedRequest.commandInput.AttributeDefinitions
+        ).map((x: { [DictionaryKey: string]: any }) => JSON.stringify(x));
       }
 
       if (normalizedRequest.commandInput?.GlobalSecondaryIndexUpdates) {
-        spanAttributes[SEMATTRS_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES] =
+        spanAttributes[ATTR_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES] =
           this.toArray(
             normalizedRequest.commandInput.GlobalSecondaryIndexUpdates
           ).map((x: { [DictionaryKey: string]: any }) => JSON.stringify(x));
@@ -238,7 +237,7 @@ export class DynamodbServiceExtension implements ServiceExtension {
   ) {
     if (response.data?.ConsumedCapacity) {
       span.setAttribute(
-        SEMATTRS_AWS_DYNAMODB_CONSUMED_CAPACITY,
+        ATTR_AWS_DYNAMODB_CONSUMED_CAPACITY,
         toArray(response.data.ConsumedCapacity).map(
           (x: { [DictionaryKey: string]: any }) => JSON.stringify(x)
         )
@@ -247,7 +246,7 @@ export class DynamodbServiceExtension implements ServiceExtension {
 
     if (response.data?.ItemCollectionMetrics) {
       span.setAttribute(
-        SEMATTRS_AWS_DYNAMODB_ITEM_COLLECTION_METRICS,
+        ATTR_AWS_DYNAMODB_ITEM_COLLECTION_METRICS,
         this.toArray(response.data.ItemCollectionMetrics).map(
           (x: { [DictionaryKey: string]: any }) => JSON.stringify(x)
         )
@@ -256,18 +255,18 @@ export class DynamodbServiceExtension implements ServiceExtension {
 
     if (response.data?.TableNames) {
       span.setAttribute(
-        SEMATTRS_AWS_DYNAMODB_TABLE_COUNT,
+        ATTR_AWS_DYNAMODB_TABLE_COUNT,
         response.data?.TableNames.length
       );
     }
 
     if (response.data?.Count) {
-      span.setAttribute(SEMATTRS_AWS_DYNAMODB_COUNT, response.data?.Count);
+      span.setAttribute(ATTR_AWS_DYNAMODB_COUNT, response.data?.Count);
     }
 
     if (response.data?.ScannedCount) {
       span.setAttribute(
-        SEMATTRS_AWS_DYNAMODB_SCANNED_COUNT,
+        ATTR_AWS_DYNAMODB_SCANNED_COUNT,
         response.data?.ScannedCount
       );
     }

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/lambda.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/lambda.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { Span, SpanKind, Tracer, diag, Attributes } from '@opentelemetry/api';
+import { SEMATTRS_FAAS_EXECUTION } from '@opentelemetry/semantic-conventions';
 import {
   ATTR_FAAS_INVOCATION_ID,
   ATTR_FAAS_INVOKED_NAME,
@@ -85,6 +86,7 @@ export class LambdaServiceExtension implements ServiceExtension {
     switch (response.request.commandName) {
       case LambdaCommands.Invoke:
         {
+          span.setAttribute(SEMATTRS_FAAS_EXECUTION, response.requestId);
           span.setAttribute(ATTR_FAAS_INVOCATION_ID, response.requestId);
         }
         break;

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/lambda.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/lambda.ts
@@ -15,11 +15,11 @@
  */
 import { Span, SpanKind, Tracer, diag, Attributes } from '@opentelemetry/api';
 import {
-  SEMATTRS_FAAS_EXECUTION,
-  SEMATTRS_FAAS_INVOKED_NAME,
-  SEMATTRS_FAAS_INVOKED_PROVIDER,
-  SEMATTRS_FAAS_INVOKED_REGION,
-} from '@opentelemetry/semantic-conventions';
+  ATTR_FAAS_INVOCATION_ID,
+  ATTR_FAAS_INVOKED_NAME,
+  ATTR_FAAS_INVOKED_PROVIDER,
+  ATTR_FAAS_INVOKED_REGION,
+} from '@opentelemetry/semantic-conventions/incubating';
 import {
   AwsSdkInstrumentationConfig,
   NormalizedRequest,
@@ -45,11 +45,11 @@ export class LambdaServiceExtension implements ServiceExtension {
     switch (request.commandName) {
       case 'Invoke':
         spanAttributes = {
-          [SEMATTRS_FAAS_INVOKED_NAME]: functionName,
-          [SEMATTRS_FAAS_INVOKED_PROVIDER]: 'aws',
+          [ATTR_FAAS_INVOKED_NAME]: functionName,
+          [ATTR_FAAS_INVOKED_PROVIDER]: 'aws',
         };
         if (request.region) {
-          spanAttributes[SEMATTRS_FAAS_INVOKED_REGION] = request.region;
+          spanAttributes[ATTR_FAAS_INVOKED_REGION] = request.region;
         }
         spanName = `${functionName} ${LambdaCommands.Invoke}`;
         break;
@@ -85,7 +85,7 @@ export class LambdaServiceExtension implements ServiceExtension {
     switch (response.request.commandName) {
       case LambdaCommands.Invoke:
         {
-          span.setAttribute(SEMATTRS_FAAS_EXECUTION, response.requestId);
+          span.setAttribute(ATTR_FAAS_INVOCATION_ID, response.requestId);
         }
         break;
     }

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sns.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sns.ts
@@ -16,10 +16,12 @@
 import { Span, Tracer, SpanKind, Attributes } from '@opentelemetry/api';
 import {
   MESSAGINGDESTINATIONKINDVALUES_TOPIC,
-  SEMATTRS_MESSAGING_DESTINATION,
   SEMATTRS_MESSAGING_DESTINATION_KIND,
-  SEMATTRS_MESSAGING_SYSTEM,
 } from '@opentelemetry/semantic-conventions';
+import {
+  ATTR_MESSAGING_DESTINATION_NAME,
+  ATTR_MESSAGING_SYSTEM,
+} from '@opentelemetry/semantic-conventions/incubating';
 import {
   NormalizedRequest,
   NormalizedResponse,
@@ -36,7 +38,7 @@ export class SnsServiceExtension implements ServiceExtension {
     let spanKind: SpanKind = SpanKind.CLIENT;
     let spanName = `SNS ${request.commandName}`;
     const spanAttributes: Attributes = {
-      [SEMATTRS_MESSAGING_SYSTEM]: 'aws.sns',
+      [ATTR_MESSAGING_SYSTEM]: 'aws.sns',
     };
 
     if (request.commandName === 'Publish') {
@@ -45,16 +47,13 @@ export class SnsServiceExtension implements ServiceExtension {
       spanAttributes[SEMATTRS_MESSAGING_DESTINATION_KIND] =
         MESSAGINGDESTINATIONKINDVALUES_TOPIC;
       const { TopicArn, TargetArn, PhoneNumber } = request.commandInput;
-      spanAttributes[SEMATTRS_MESSAGING_DESTINATION] =
+      spanAttributes[ATTR_MESSAGING_DESTINATION_NAME] =
         this.extractDestinationName(TopicArn, TargetArn, PhoneNumber);
-      // ToDO: Use SEMATTRS_MESSAGING_DESTINATION_NAME when implemented
-      spanAttributes['messaging.destination.name'] =
-        TopicArn || TargetArn || PhoneNumber || 'unknown';
 
       spanName = `${
         PhoneNumber
           ? 'phone_number'
-          : spanAttributes[SEMATTRS_MESSAGING_DESTINATION]
+          : spanAttributes[ATTR_MESSAGING_DESTINATION_NAME]
       } send`;
     }
 

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sns.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sns.ts
@@ -16,6 +16,7 @@
 import { Span, Tracer, SpanKind, Attributes } from '@opentelemetry/api';
 import {
   MESSAGINGDESTINATIONKINDVALUES_TOPIC,
+  SEMATTRS_MESSAGING_DESTINATION,
   SEMATTRS_MESSAGING_DESTINATION_KIND,
 } from '@opentelemetry/semantic-conventions';
 import {
@@ -47,13 +48,15 @@ export class SnsServiceExtension implements ServiceExtension {
       spanAttributes[SEMATTRS_MESSAGING_DESTINATION_KIND] =
         MESSAGINGDESTINATIONKINDVALUES_TOPIC;
       const { TopicArn, TargetArn, PhoneNumber } = request.commandInput;
-      spanAttributes[ATTR_MESSAGING_DESTINATION_NAME] =
+      spanAttributes[SEMATTRS_MESSAGING_DESTINATION] =
         this.extractDestinationName(TopicArn, TargetArn, PhoneNumber);
+      spanAttributes[ATTR_MESSAGING_DESTINATION_NAME] =
+        TopicArn || TargetArn || PhoneNumber || 'unknown';
 
       spanName = `${
         PhoneNumber
           ? 'phone_number'
-          : spanAttributes[ATTR_MESSAGING_DESTINATION_NAME]
+          : spanAttributes[SEMATTRS_MESSAGING_DESTINATION]
       } send`;
     }
 

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sqs.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sqs.ts
@@ -35,13 +35,15 @@ import {
   MESSAGINGDESTINATIONKINDVALUES_QUEUE,
   MESSAGINGOPERATIONVALUES_PROCESS,
   MESSAGINGOPERATIONVALUES_RECEIVE,
-  SEMATTRS_MESSAGING_DESTINATION,
   SEMATTRS_MESSAGING_DESTINATION_KIND,
-  SEMATTRS_MESSAGING_MESSAGE_ID,
-  SEMATTRS_MESSAGING_OPERATION,
-  SEMATTRS_MESSAGING_SYSTEM,
   SEMATTRS_MESSAGING_URL,
 } from '@opentelemetry/semantic-conventions';
+import {
+  ATTR_MESSAGING_DESTINATION_NAME,
+  ATTR_MESSAGING_MESSAGE_ID,
+  ATTR_MESSAGING_OPERATION,
+  ATTR_MESSAGING_SYSTEM,
+} from '@opentelemetry/semantic-conventions/incubating';
 import {
   contextGetter,
   extractPropagationContext,
@@ -60,10 +62,10 @@ export class SqsServiceExtension implements ServiceExtension {
     let spanName: string | undefined;
 
     const spanAttributes: Attributes = {
-      [SEMATTRS_MESSAGING_SYSTEM]: 'aws.sqs',
+      [ATTR_MESSAGING_SYSTEM]: 'aws.sqs',
       [SEMATTRS_MESSAGING_DESTINATION_KIND]:
         MESSAGINGDESTINATIONKINDVALUES_QUEUE,
-      [SEMATTRS_MESSAGING_DESTINATION]: queueName,
+      [ATTR_MESSAGING_DESTINATION_NAME]: queueName,
       [SEMATTRS_MESSAGING_URL]: queueUrl,
     };
 
@@ -75,7 +77,7 @@ export class SqsServiceExtension implements ServiceExtension {
           isIncoming = true;
           spanKind = SpanKind.CONSUMER;
           spanName = `${queueName} receive`;
-          spanAttributes[SEMATTRS_MESSAGING_OPERATION] =
+          spanAttributes[ATTR_MESSAGING_OPERATION] =
             MESSAGINGOPERATIONVALUES_RECEIVE;
 
           request.commandInput.MessageAttributeNames =
@@ -139,10 +141,7 @@ export class SqsServiceExtension implements ServiceExtension {
   ) => {
     switch (response.request.commandName) {
       case 'SendMessage':
-        span.setAttribute(
-          SEMATTRS_MESSAGING_MESSAGE_ID,
-          response?.data?.MessageId
-        );
+        span.setAttribute(ATTR_MESSAGING_MESSAGE_ID, response?.data?.MessageId);
         break;
 
       case 'SendMessageBatch':
@@ -170,14 +169,13 @@ export class SqsServiceExtension implements ServiceExtension {
                 contextGetter
               ),
               attributes: {
-                [SEMATTRS_MESSAGING_SYSTEM]: 'aws.sqs',
-                [SEMATTRS_MESSAGING_DESTINATION]: queueName,
+                [ATTR_MESSAGING_SYSTEM]: 'aws.sqs',
+                [ATTR_MESSAGING_DESTINATION_NAME]: queueName,
                 [SEMATTRS_MESSAGING_DESTINATION_KIND]:
                   MESSAGINGDESTINATIONKINDVALUES_QUEUE,
-                [SEMATTRS_MESSAGING_MESSAGE_ID]: message.MessageId,
+                [ATTR_MESSAGING_MESSAGE_ID]: message.MessageId,
                 [SEMATTRS_MESSAGING_URL]: queueUrl,
-                [SEMATTRS_MESSAGING_OPERATION]:
-                  MESSAGINGOPERATIONVALUES_PROCESS,
+                [ATTR_MESSAGING_OPERATION]: MESSAGINGOPERATIONVALUES_PROCESS,
               },
             }),
             processHook: (span: Span, message: SQS.Message) =>

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sqs.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sqs.ts
@@ -35,6 +35,7 @@ import {
   MESSAGINGDESTINATIONKINDVALUES_QUEUE,
   MESSAGINGOPERATIONVALUES_PROCESS,
   MESSAGINGOPERATIONVALUES_RECEIVE,
+  SEMATTRS_MESSAGING_DESTINATION,
   SEMATTRS_MESSAGING_DESTINATION_KIND,
   SEMATTRS_MESSAGING_URL,
 } from '@opentelemetry/semantic-conventions';
@@ -65,6 +66,7 @@ export class SqsServiceExtension implements ServiceExtension {
       [ATTR_MESSAGING_SYSTEM]: 'aws.sqs',
       [SEMATTRS_MESSAGING_DESTINATION_KIND]:
         MESSAGINGDESTINATIONKINDVALUES_QUEUE,
+      [SEMATTRS_MESSAGING_DESTINATION]: queueName,
       [ATTR_MESSAGING_DESTINATION_NAME]: queueName,
       [SEMATTRS_MESSAGING_URL]: queueUrl,
     };
@@ -170,6 +172,7 @@ export class SqsServiceExtension implements ServiceExtension {
               ),
               attributes: {
                 [ATTR_MESSAGING_SYSTEM]: 'aws.sqs',
+                [SEMATTRS_MESSAGING_DESTINATION]: queueName,
                 [ATTR_MESSAGING_DESTINATION_NAME]: queueName,
                 [SEMATTRS_MESSAGING_DESTINATION_KIND]:
                   MESSAGINGDESTINATIONKINDVALUES_QUEUE,

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/utils.ts
@@ -15,10 +15,10 @@
  */
 import { Attributes, Context, context } from '@opentelemetry/api';
 import {
-  SEMATTRS_RPC_METHOD,
-  SEMATTRS_RPC_SERVICE,
-  SEMATTRS_RPC_SYSTEM,
-} from '@opentelemetry/semantic-conventions';
+  ATTR_RPC_METHOD,
+  ATTR_RPC_SERVICE,
+  ATTR_RPC_SYSTEM,
+} from '@opentelemetry/semantic-conventions/incubating';
 import { AttributeNames } from './enums';
 import { NormalizedRequest } from './types';
 
@@ -66,9 +66,9 @@ export const extractAttributesFromNormalizedRequest = (
   normalizedRequest: NormalizedRequest
 ): Attributes => {
   return {
-    [SEMATTRS_RPC_SYSTEM]: 'aws-api',
-    [SEMATTRS_RPC_METHOD]: normalizedRequest.commandName,
-    [SEMATTRS_RPC_SERVICE]: normalizedRequest.serviceName,
+    [ATTR_RPC_SYSTEM]: 'aws-api',
+    [ATTR_RPC_METHOD]: normalizedRequest.commandName,
+    [ATTR_RPC_SERVICE]: normalizedRequest.serviceName,
     [AttributeNames.AWS_REGION]: normalizedRequest.region,
   };
 };

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/aws-sdk-v2.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/aws-sdk-v2.test.ts
@@ -32,7 +32,7 @@ import { SpanStatusCode, Span, SpanKind } from '@opentelemetry/api';
 import { AttributeNames } from '../src/enums';
 import { mockV2AwsSend } from './testing-utils';
 import { expect } from 'expect';
-import { SEMATTRS_HTTP_STATUS_CODE } from '@opentelemetry/semantic-conventions';
+import { ATTR_HTTP_STATUS_CODE } from '@opentelemetry/semantic-conventions/incubating';
 import { AWSError } from 'aws-sdk';
 import { HttpResponse } from 'aws-sdk/lib/http_response';
 
@@ -131,9 +131,7 @@ describe('instrumentation-aws-sdk-v2', () => {
         expect(spanCreateBucket.attributes[AttributeNames.AWS_REGION]).toBe(
           'us-east-1'
         );
-        expect(spanCreateBucket.attributes[SEMATTRS_HTTP_STATUS_CODE]).toBe(
-          200
-        );
+        expect(spanCreateBucket.attributes[ATTR_HTTP_STATUS_CODE]).toBe(200);
 
         expect(spanCreateBucket.name).toBe('S3.CreateBucket');
         expect(spanCreateBucket.kind).toEqual(SpanKind.CLIENT);
@@ -159,7 +157,7 @@ describe('instrumentation-aws-sdk-v2', () => {
           'us-east-1'
         );
         expect(spanPutObject.name).toBe('S3.PutObject');
-        expect(spanPutObject.attributes[SEMATTRS_HTTP_STATUS_CODE]).toBe(200);
+        expect(spanPutObject.attributes[ATTR_HTTP_STATUS_CODE]).toBe(200);
       });
 
       it('adds proper number of spans with correct attributes if both, promise and callback were used', async () => {
@@ -208,7 +206,7 @@ describe('instrumentation-aws-sdk-v2', () => {
         expect(spanPutObjectCb.attributes[AttributeNames.AWS_REGION]).toBe(
           'us-east-1'
         );
-        expect(spanPutObjectCb.attributes[SEMATTRS_HTTP_STATUS_CODE]).toBe(200);
+        expect(spanPutObjectCb.attributes[ATTR_HTTP_STATUS_CODE]).toBe(200);
       });
 
       it('adds proper number of spans with correct attributes if only promise was used', async () => {
@@ -244,7 +242,7 @@ describe('instrumentation-aws-sdk-v2', () => {
         expect(spanPutObjectCb.attributes[AttributeNames.AWS_REGION]).toBe(
           'us-east-1'
         );
-        expect(spanPutObjectCb.attributes[SEMATTRS_HTTP_STATUS_CODE]).toBe(200);
+        expect(spanPutObjectCb.attributes[ATTR_HTTP_STATUS_CODE]).toBe(200);
       });
 
       it('should create span if no callback is supplied', done => {
@@ -298,9 +296,7 @@ describe('instrumentation-aws-sdk-v2', () => {
           })
         );
 
-        expect(spanCreateBucket.attributes[SEMATTRS_HTTP_STATUS_CODE]).toBe(
-          400
-        );
+        expect(spanCreateBucket.attributes[ATTR_HTTP_STATUS_CODE]).toBe(400);
       });
     });
   });

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/aws-sdk-v3.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/aws-sdk-v3.test.ts
@@ -44,17 +44,19 @@ import { context, SpanStatusCode, trace, Span } from '@opentelemetry/api';
 import {
   MESSAGINGDESTINATIONKINDVALUES_QUEUE,
   MESSAGINGOPERATIONVALUES_RECEIVE,
-  SEMATTRS_HTTP_STATUS_CODE,
-  SEMATTRS_MESSAGING_DESTINATION,
   SEMATTRS_MESSAGING_DESTINATION_KIND,
-  SEMATTRS_MESSAGING_MESSAGE_ID,
-  SEMATTRS_MESSAGING_OPERATION,
-  SEMATTRS_MESSAGING_SYSTEM,
   SEMATTRS_MESSAGING_URL,
-  SEMATTRS_RPC_METHOD,
-  SEMATTRS_RPC_SERVICE,
-  SEMATTRS_RPC_SYSTEM,
 } from '@opentelemetry/semantic-conventions';
+import {
+  ATTR_HTTP_STATUS_CODE,
+  ATTR_MESSAGING_DESTINATION_NAME,
+  ATTR_MESSAGING_MESSAGE_ID,
+  ATTR_MESSAGING_OPERATION,
+  ATTR_MESSAGING_SYSTEM,
+  ATTR_RPC_METHOD,
+  ATTR_RPC_SERVICE,
+  ATTR_RPC_SYSTEM,
+} from '@opentelemetry/semantic-conventions/incubating';
 import { AttributeNames } from '../src/enums';
 import { expect } from 'expect';
 import * as fs from 'fs';
@@ -81,16 +83,16 @@ describe('instrumentation-aws-sdk-v3', () => {
       await s3Client.putObject(params);
       expect(getTestSpans().length).toBe(1);
       const [span] = getTestSpans();
-      expect(span.attributes[SEMATTRS_RPC_SYSTEM]).toEqual('aws-api');
-      expect(span.attributes[SEMATTRS_RPC_METHOD]).toEqual('PutObject');
-      expect(span.attributes[SEMATTRS_RPC_SERVICE]).toEqual('S3');
+      expect(span.attributes[ATTR_RPC_SYSTEM]).toEqual('aws-api');
+      expect(span.attributes[ATTR_RPC_METHOD]).toEqual('PutObject');
+      expect(span.attributes[ATTR_RPC_SERVICE]).toEqual('S3');
       expect(span.attributes[AttributeNames.AWS_S3_BUCKET]).toEqual(
         'ot-demo-test'
       );
       expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
       expect(span.name).toEqual('S3.PutObject');
       expect(span.kind).toEqual(SpanKind.CLIENT);
-      expect(span.attributes[SEMATTRS_HTTP_STATUS_CODE]).toEqual(200);
+      expect(span.attributes[ATTR_HTTP_STATUS_CODE]).toEqual(200);
     });
 
     it('callback interface', done => {
@@ -108,15 +110,15 @@ describe('instrumentation-aws-sdk-v3', () => {
       s3Client.putObject(params, (err: any, data?: PutObjectCommandOutput) => {
         expect(getTestSpans().length).toBe(1);
         const [span] = getTestSpans();
-        expect(span.attributes[SEMATTRS_RPC_SYSTEM]).toEqual('aws-api');
-        expect(span.attributes[SEMATTRS_RPC_METHOD]).toEqual('PutObject');
-        expect(span.attributes[SEMATTRS_RPC_SERVICE]).toEqual('S3');
+        expect(span.attributes[ATTR_RPC_SYSTEM]).toEqual('aws-api');
+        expect(span.attributes[ATTR_RPC_METHOD]).toEqual('PutObject');
+        expect(span.attributes[ATTR_RPC_SERVICE]).toEqual('S3');
         expect(span.attributes[AttributeNames.AWS_S3_BUCKET]).toEqual(
           'ot-demo-test'
         );
         expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
         expect(span.name).toEqual('S3.PutObject');
-        expect(span.attributes[SEMATTRS_HTTP_STATUS_CODE]).toEqual(200);
+        expect(span.attributes[ATTR_HTTP_STATUS_CODE]).toEqual(200);
         done();
       });
     });
@@ -137,15 +139,15 @@ describe('instrumentation-aws-sdk-v3', () => {
       await client.send(new PutObjectCommand(params));
       expect(getTestSpans().length).toBe(1);
       const [span] = getTestSpans();
-      expect(span.attributes[SEMATTRS_RPC_SYSTEM]).toEqual('aws-api');
-      expect(span.attributes[SEMATTRS_RPC_METHOD]).toEqual('PutObject');
-      expect(span.attributes[SEMATTRS_RPC_SERVICE]).toEqual('S3');
+      expect(span.attributes[ATTR_RPC_SYSTEM]).toEqual('aws-api');
+      expect(span.attributes[ATTR_RPC_METHOD]).toEqual('PutObject');
+      expect(span.attributes[ATTR_RPC_SERVICE]).toEqual('S3');
       expect(span.attributes[AttributeNames.AWS_S3_BUCKET]).toEqual(
         'ot-demo-test'
       );
       expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
       expect(span.name).toEqual('S3.PutObject');
-      expect(span.attributes[SEMATTRS_HTTP_STATUS_CODE]).toEqual(200);
+      expect(span.attributes[ATTR_HTTP_STATUS_CODE]).toEqual(200);
     });
 
     it('aws error', async () => {
@@ -173,13 +175,13 @@ describe('instrumentation-aws-sdk-v3', () => {
         expect(span.events.length).toBe(1);
         expect(span.events[0].name).toEqual('exception');
 
-        expect(span.attributes[SEMATTRS_RPC_SYSTEM]).toEqual('aws-api');
-        expect(span.attributes[SEMATTRS_RPC_METHOD]).toEqual('PutObject');
-        expect(span.attributes[SEMATTRS_RPC_SERVICE]).toEqual('S3');
+        expect(span.attributes[ATTR_RPC_SYSTEM]).toEqual('aws-api');
+        expect(span.attributes[ATTR_RPC_METHOD]).toEqual('PutObject');
+        expect(span.attributes[ATTR_RPC_SERVICE]).toEqual('S3');
         expect(span.attributes[AttributeNames.AWS_S3_BUCKET]).toEqual(
           'invalid-bucket-name'
         );
-        expect(span.attributes[SEMATTRS_HTTP_STATUS_CODE]).toEqual(403);
+        expect(span.attributes[ATTR_HTTP_STATUS_CODE]).toEqual(403);
         expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
         expect(span.attributes[AttributeNames.AWS_REQUEST_ID]).toEqual(
           'MS95GTS7KXQ34X2S'
@@ -317,26 +319,26 @@ describe('instrumentation-aws-sdk-v3', () => {
         const [span] = getTestSpans();
 
         // make sure we have the general aws attributes:
-        expect(span.attributes[SEMATTRS_RPC_SYSTEM]).toEqual('aws-api');
-        expect(span.attributes[SEMATTRS_RPC_METHOD]).toEqual('SendMessage');
-        expect(span.attributes[SEMATTRS_RPC_SERVICE]).toEqual('SQS');
+        expect(span.attributes[ATTR_RPC_SYSTEM]).toEqual('aws-api');
+        expect(span.attributes[ATTR_RPC_METHOD]).toEqual('SendMessage');
+        expect(span.attributes[ATTR_RPC_SERVICE]).toEqual('SQS');
         expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
 
         // custom messaging attributes
-        expect(span.attributes[SEMATTRS_MESSAGING_SYSTEM]).toEqual('aws.sqs');
+        expect(span.attributes[ATTR_MESSAGING_SYSTEM]).toEqual('aws.sqs');
         expect(span.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]).toEqual(
           MESSAGINGDESTINATIONKINDVALUES_QUEUE
         );
-        expect(span.attributes[SEMATTRS_MESSAGING_DESTINATION]).toEqual(
+        expect(span.attributes[ATTR_MESSAGING_DESTINATION_NAME]).toEqual(
           'otel-demo-aws-sdk'
         );
         expect(span.attributes[SEMATTRS_MESSAGING_URL]).toEqual(
           params.QueueUrl
         );
-        expect(span.attributes[SEMATTRS_MESSAGING_MESSAGE_ID]).toEqual(
+        expect(span.attributes[ATTR_MESSAGING_MESSAGE_ID]).toEqual(
           response.MessageId
         );
-        expect(span.attributes[SEMATTRS_HTTP_STATUS_CODE]).toEqual(200);
+        expect(span.attributes[ATTR_HTTP_STATUS_CODE]).toEqual(200);
       });
 
       it('sqs send message batch attributes', async () => {
@@ -375,25 +377,23 @@ describe('instrumentation-aws-sdk-v3', () => {
         const [span] = getTestSpans();
 
         // make sure we have the general aws attributes:
-        expect(span.attributes[SEMATTRS_RPC_SYSTEM]).toEqual('aws-api');
-        expect(span.attributes[SEMATTRS_RPC_METHOD]).toEqual(
-          'SendMessageBatch'
-        );
-        expect(span.attributes[SEMATTRS_RPC_SERVICE]).toEqual('SQS');
+        expect(span.attributes[ATTR_RPC_SYSTEM]).toEqual('aws-api');
+        expect(span.attributes[ATTR_RPC_METHOD]).toEqual('SendMessageBatch');
+        expect(span.attributes[ATTR_RPC_SERVICE]).toEqual('SQS');
         expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
 
         // messaging semantic attributes
-        expect(span.attributes[SEMATTRS_MESSAGING_SYSTEM]).toEqual('aws.sqs');
+        expect(span.attributes[ATTR_MESSAGING_SYSTEM]).toEqual('aws.sqs');
         expect(span.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]).toEqual(
           MESSAGINGDESTINATIONKINDVALUES_QUEUE
         );
-        expect(span.attributes[SEMATTRS_MESSAGING_DESTINATION]).toEqual(
+        expect(span.attributes[ATTR_MESSAGING_DESTINATION_NAME]).toEqual(
           'otel-demo-aws-sdk'
         );
         expect(span.attributes[SEMATTRS_MESSAGING_URL]).toEqual(
           params.QueueUrl
         );
-        expect(span.attributes[SEMATTRS_HTTP_STATUS_CODE]).toEqual(200);
+        expect(span.attributes[ATTR_HTTP_STATUS_CODE]).toEqual(200);
       });
 
       it('sqs receive add messaging attributes', done => {
@@ -422,13 +422,11 @@ describe('instrumentation-aws-sdk-v3', () => {
           const [span] = getTestSpans();
 
           // make sure we have the general aws attributes:
-          expect(span.attributes[SEMATTRS_RPC_SYSTEM]).toEqual('aws-api');
-          expect(span.attributes[SEMATTRS_RPC_METHOD]).toEqual(
-            'ReceiveMessage'
-          );
-          expect(span.attributes[SEMATTRS_RPC_SERVICE]).toEqual('SQS');
+          expect(span.attributes[ATTR_RPC_SYSTEM]).toEqual('aws-api');
+          expect(span.attributes[ATTR_RPC_METHOD]).toEqual('ReceiveMessage');
+          expect(span.attributes[ATTR_RPC_SERVICE]).toEqual('SQS');
           expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
-          expect(span.attributes[SEMATTRS_HTTP_STATUS_CODE]).toEqual(200);
+          expect(span.attributes[ATTR_HTTP_STATUS_CODE]).toEqual(200);
           done();
         });
       });
@@ -462,7 +460,7 @@ describe('instrumentation-aws-sdk-v3', () => {
           expect(receiveCallbackSpan).toBeDefined();
           const attributes = (receiveCallbackSpan as unknown as ReadableSpan)
             .attributes;
-          expect(attributes[SEMATTRS_MESSAGING_OPERATION]).toMatch(
+          expect(attributes[ATTR_MESSAGING_OPERATION]).toMatch(
             MESSAGINGOPERATIONVALUES_RECEIVE
           );
           done();

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/dynamodb.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/dynamodb.test.ts
@@ -29,34 +29,34 @@ import * as AWS from 'aws-sdk';
 import { AWSError } from 'aws-sdk';
 
 import { mockV2AwsSend } from './testing-utils';
+import { DBSYSTEMVALUES_DYNAMODB } from '@opentelemetry/semantic-conventions';
 import {
-  DBSYSTEMVALUES_DYNAMODB,
-  SEMATTRS_AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS,
-  SEMATTRS_AWS_DYNAMODB_CONSISTENT_READ,
-  SEMATTRS_AWS_DYNAMODB_CONSUMED_CAPACITY,
-  SEMATTRS_AWS_DYNAMODB_COUNT,
-  SEMATTRS_AWS_DYNAMODB_EXCLUSIVE_START_TABLE,
-  SEMATTRS_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES,
-  SEMATTRS_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES,
-  SEMATTRS_AWS_DYNAMODB_INDEX_NAME,
-  SEMATTRS_AWS_DYNAMODB_ITEM_COLLECTION_METRICS,
-  SEMATTRS_AWS_DYNAMODB_LIMIT,
-  SEMATTRS_AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES,
-  SEMATTRS_AWS_DYNAMODB_PROJECTION,
-  SEMATTRS_AWS_DYNAMODB_PROVISIONED_READ_CAPACITY,
-  SEMATTRS_AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY,
-  SEMATTRS_AWS_DYNAMODB_SCAN_FORWARD,
-  SEMATTRS_AWS_DYNAMODB_SCANNED_COUNT,
-  SEMATTRS_AWS_DYNAMODB_SEGMENT,
-  SEMATTRS_AWS_DYNAMODB_SELECT,
-  SEMATTRS_AWS_DYNAMODB_TABLE_COUNT,
-  SEMATTRS_AWS_DYNAMODB_TABLE_NAMES,
-  SEMATTRS_AWS_DYNAMODB_TOTAL_SEGMENTS,
-  SEMATTRS_DB_NAME,
-  SEMATTRS_DB_OPERATION,
-  SEMATTRS_DB_STATEMENT,
-  SEMATTRS_DB_SYSTEM,
-} from '@opentelemetry/semantic-conventions';
+  ATTR_AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS,
+  ATTR_AWS_DYNAMODB_CONSISTENT_READ,
+  ATTR_AWS_DYNAMODB_CONSUMED_CAPACITY,
+  ATTR_AWS_DYNAMODB_COUNT,
+  ATTR_AWS_DYNAMODB_EXCLUSIVE_START_TABLE,
+  ATTR_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES,
+  ATTR_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES,
+  ATTR_AWS_DYNAMODB_INDEX_NAME,
+  ATTR_AWS_DYNAMODB_ITEM_COLLECTION_METRICS,
+  ATTR_AWS_DYNAMODB_LIMIT,
+  ATTR_AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES,
+  ATTR_AWS_DYNAMODB_PROJECTION,
+  ATTR_AWS_DYNAMODB_PROVISIONED_READ_CAPACITY,
+  ATTR_AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY,
+  ATTR_AWS_DYNAMODB_SCAN_FORWARD,
+  ATTR_AWS_DYNAMODB_SCANNED_COUNT,
+  ATTR_AWS_DYNAMODB_SEGMENT,
+  ATTR_AWS_DYNAMODB_SELECT,
+  ATTR_AWS_DYNAMODB_TABLE_COUNT,
+  ATTR_AWS_DYNAMODB_TABLE_NAMES,
+  ATTR_AWS_DYNAMODB_TOTAL_SEGMENTS,
+  ATTR_DB_NAME,
+  ATTR_DB_OPERATION,
+  ATTR_DB_STATEMENT,
+  ATTR_DB_SYSTEM,
+} from '@opentelemetry/semantic-conventions/incubating';
 import { expect } from 'expect';
 import type { ConsumedCapacity as ConsumedCapacityV2 } from 'aws-sdk/clients/dynamodb';
 import type { ConsumedCapacity as ConsumedCapacityV3 } from '@aws-sdk/client-dynamodb';
@@ -114,27 +114,23 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SEMATTRS_DB_SYSTEM]).toStrictEqual(
-            DBSYSTEMVALUES_DYNAMODB
-          );
-          expect(attrs[SEMATTRS_DB_NAME]).toStrictEqual('test-table');
-          expect(attrs[SEMATTRS_DB_OPERATION]).toStrictEqual('Query');
-          expect(attrs[SEMATTRS_AWS_DYNAMODB_SCAN_FORWARD]).toStrictEqual(true);
-          expect(attrs[SEMATTRS_AWS_DYNAMODB_CONSISTENT_READ]).toStrictEqual(
-            true
-          );
-          expect(attrs[SEMATTRS_AWS_DYNAMODB_INDEX_NAME]).toStrictEqual(
+          expect(attrs[ATTR_DB_SYSTEM]).toStrictEqual(DBSYSTEMVALUES_DYNAMODB);
+          expect(attrs[ATTR_DB_NAME]).toStrictEqual('test-table');
+          expect(attrs[ATTR_DB_OPERATION]).toStrictEqual('Query');
+          expect(attrs[ATTR_AWS_DYNAMODB_SCAN_FORWARD]).toStrictEqual(true);
+          expect(attrs[ATTR_AWS_DYNAMODB_CONSISTENT_READ]).toStrictEqual(true);
+          expect(attrs[ATTR_AWS_DYNAMODB_INDEX_NAME]).toStrictEqual(
             'name_to_group'
           );
-          expect(attrs[SEMATTRS_AWS_DYNAMODB_SELECT]).toStrictEqual(
+          expect(attrs[ATTR_AWS_DYNAMODB_SELECT]).toStrictEqual(
             'ALL_ATTRIBUTES'
           );
-          expect(attrs[SEMATTRS_AWS_DYNAMODB_LIMIT]).toStrictEqual(10);
-          expect(attrs[SEMATTRS_AWS_DYNAMODB_TABLE_NAMES]).toStrictEqual([
+          expect(attrs[ATTR_AWS_DYNAMODB_LIMIT]).toStrictEqual(10);
+          expect(attrs[ATTR_AWS_DYNAMODB_TABLE_NAMES]).toStrictEqual([
             'test-table',
           ]);
-          expect(attrs[SEMATTRS_AWS_DYNAMODB_PROJECTION]).toStrictEqual('id');
-          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
+          expect(attrs[ATTR_AWS_DYNAMODB_PROJECTION]).toStrictEqual('id');
+          expect(attrs).not.toHaveProperty(ATTR_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -175,29 +171,25 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SEMATTRS_DB_SYSTEM]).toStrictEqual(
-            DBSYSTEMVALUES_DYNAMODB
-          );
-          expect(attrs[SEMATTRS_DB_NAME]).toStrictEqual('test-table');
-          expect(attrs[SEMATTRS_DB_OPERATION]).toStrictEqual('Scan');
-          expect(attrs[SEMATTRS_AWS_DYNAMODB_SEGMENT]).toStrictEqual(10);
-          expect(attrs[SEMATTRS_AWS_DYNAMODB_TOTAL_SEGMENTS]).toStrictEqual(
-            100
-          );
-          expect(attrs[SEMATTRS_AWS_DYNAMODB_INDEX_NAME]).toStrictEqual(
+          expect(attrs[ATTR_DB_SYSTEM]).toStrictEqual(DBSYSTEMVALUES_DYNAMODB);
+          expect(attrs[ATTR_DB_NAME]).toStrictEqual('test-table');
+          expect(attrs[ATTR_DB_OPERATION]).toStrictEqual('Scan');
+          expect(attrs[ATTR_AWS_DYNAMODB_SEGMENT]).toStrictEqual(10);
+          expect(attrs[ATTR_AWS_DYNAMODB_TOTAL_SEGMENTS]).toStrictEqual(100);
+          expect(attrs[ATTR_AWS_DYNAMODB_INDEX_NAME]).toStrictEqual(
             'index_name'
           );
-          expect(attrs[SEMATTRS_AWS_DYNAMODB_SELECT]).toStrictEqual(
+          expect(attrs[ATTR_AWS_DYNAMODB_SELECT]).toStrictEqual(
             'ALL_ATTRIBUTES'
           );
-          expect(attrs[SEMATTRS_AWS_DYNAMODB_COUNT]).toStrictEqual(10);
-          expect(attrs[SEMATTRS_AWS_DYNAMODB_SCANNED_COUNT]).toStrictEqual(50);
-          expect(attrs[SEMATTRS_AWS_DYNAMODB_LIMIT]).toStrictEqual(10);
-          expect(attrs[SEMATTRS_AWS_DYNAMODB_TABLE_NAMES]).toStrictEqual([
+          expect(attrs[ATTR_AWS_DYNAMODB_COUNT]).toStrictEqual(10);
+          expect(attrs[ATTR_AWS_DYNAMODB_SCANNED_COUNT]).toStrictEqual(50);
+          expect(attrs[ATTR_AWS_DYNAMODB_LIMIT]).toStrictEqual(10);
+          expect(attrs[ATTR_AWS_DYNAMODB_TABLE_NAMES]).toStrictEqual([
             'test-table',
           ]);
-          expect(attrs[SEMATTRS_AWS_DYNAMODB_PROJECTION]).toStrictEqual('id');
-          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
+          expect(attrs[ATTR_AWS_DYNAMODB_PROJECTION]).toStrictEqual('id');
+          expect(attrs).not.toHaveProperty(ATTR_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -234,16 +226,14 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SEMATTRS_DB_SYSTEM]).toStrictEqual(
-            DBSYSTEMVALUES_DYNAMODB
-          );
+          expect(attrs[ATTR_DB_SYSTEM]).toStrictEqual(DBSYSTEMVALUES_DYNAMODB);
           expect(
-            attrs[SEMATTRS_AWS_DYNAMODB_ITEM_COLLECTION_METRICS]
+            attrs[ATTR_AWS_DYNAMODB_ITEM_COLLECTION_METRICS]
           ).toStrictEqual([
             JSON.stringify({ ItemCollectionKey: [], SizeEstimateRangeGB: [0] }),
           ]);
 
-          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
+          expect(attrs).not.toHaveProperty(ATTR_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -329,29 +319,27 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SEMATTRS_DB_SYSTEM]).toStrictEqual(
-            DBSYSTEMVALUES_DYNAMODB
-          );
+          expect(attrs[ATTR_DB_SYSTEM]).toStrictEqual(DBSYSTEMVALUES_DYNAMODB);
           expect(
-            attrs[SEMATTRS_AWS_DYNAMODB_ITEM_COLLECTION_METRICS]
+            attrs[ATTR_AWS_DYNAMODB_ITEM_COLLECTION_METRICS]
           ).toStrictEqual([
             JSON.stringify({ ItemCollectionKey: [], SizeEstimateRangeGB: [0] }),
           ]);
 
           expect(
-            attrs[SEMATTRS_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES]
+            attrs[ATTR_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES]
           ).toStrictEqual([JSON.stringify(globalSecondaryIndexMockData)]);
 
           expect(
-            attrs[SEMATTRS_AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES]
+            attrs[ATTR_AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES]
           ).toStrictEqual([JSON.stringify(localSecondaryIndexMockData)]);
           expect(
-            attrs[SEMATTRS_AWS_DYNAMODB_PROVISIONED_READ_CAPACITY]
+            attrs[ATTR_AWS_DYNAMODB_PROVISIONED_READ_CAPACITY]
           ).toStrictEqual(20);
           expect(
-            attrs[SEMATTRS_AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY]
+            attrs[ATTR_AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY]
           ).toStrictEqual(30);
-          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
+          expect(attrs).not.toHaveProperty(ATTR_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -402,12 +390,10 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SEMATTRS_DB_SYSTEM]).toStrictEqual(
-            DBSYSTEMVALUES_DYNAMODB
-          );
+          expect(attrs[ATTR_DB_SYSTEM]).toStrictEqual(DBSYSTEMVALUES_DYNAMODB);
 
           expect(
-            attrs[SEMATTRS_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES]
+            attrs[ATTR_AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES]
           ).toStrictEqual([
             JSON.stringify({
               Update: {
@@ -419,21 +405,19 @@ describe('DynamoDB', () => {
               },
             }),
           ]);
-          expect(
-            attrs[SEMATTRS_AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS]
-          ).toStrictEqual([
+          expect(attrs[ATTR_AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS]).toStrictEqual([
             JSON.stringify({
               AttributeName: 'test_attr',
               AttributeType: 'S',
             }),
           ]);
           expect(
-            attrs[SEMATTRS_AWS_DYNAMODB_PROVISIONED_READ_CAPACITY]
+            attrs[ATTR_AWS_DYNAMODB_PROVISIONED_READ_CAPACITY]
           ).toStrictEqual(10);
           expect(
-            attrs[SEMATTRS_AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY]
+            attrs[ATTR_AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY]
           ).toStrictEqual(15);
-          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
+          expect(attrs).not.toHaveProperty(ATTR_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -461,17 +445,15 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SEMATTRS_DB_SYSTEM]).toStrictEqual(
-            DBSYSTEMVALUES_DYNAMODB
+          expect(attrs[ATTR_DB_SYSTEM]).toStrictEqual(DBSYSTEMVALUES_DYNAMODB);
+
+          expect(attrs[ATTR_AWS_DYNAMODB_EXCLUSIVE_START_TABLE]).toStrictEqual(
+            'start_table'
           );
+          expect(attrs[ATTR_AWS_DYNAMODB_LIMIT]).toStrictEqual(10);
+          expect(attrs[ATTR_AWS_DYNAMODB_TABLE_COUNT]).toStrictEqual(3);
 
-          expect(
-            attrs[SEMATTRS_AWS_DYNAMODB_EXCLUSIVE_START_TABLE]
-          ).toStrictEqual('start_table');
-          expect(attrs[SEMATTRS_AWS_DYNAMODB_LIMIT]).toStrictEqual(10);
-          expect(attrs[SEMATTRS_AWS_DYNAMODB_TABLE_COUNT]).toStrictEqual(3);
-
-          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
+          expect(attrs).not.toHaveProperty(ATTR_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -513,17 +495,13 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SEMATTRS_DB_SYSTEM]).toStrictEqual(
-            DBSYSTEMVALUES_DYNAMODB
-          );
-          expect(attrs[SEMATTRS_DB_OPERATION]).toStrictEqual('BatchGetItem');
-          expect(attrs[SEMATTRS_AWS_DYNAMODB_TABLE_NAMES]).toStrictEqual([
+          expect(attrs[ATTR_DB_SYSTEM]).toStrictEqual(DBSYSTEMVALUES_DYNAMODB);
+          expect(attrs[ATTR_DB_OPERATION]).toStrictEqual('BatchGetItem');
+          expect(attrs[ATTR_AWS_DYNAMODB_TABLE_NAMES]).toStrictEqual([
             'test-table',
           ]);
-          expect(
-            attrs[SEMATTRS_AWS_DYNAMODB_CONSUMED_CAPACITY]
-          ).toBeUndefined();
-          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
+          expect(attrs[ATTR_AWS_DYNAMODB_CONSUMED_CAPACITY]).toBeUndefined();
+          expect(attrs).not.toHaveProperty(ATTR_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -556,19 +534,17 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SEMATTRS_DB_SYSTEM]).toStrictEqual(
-            DBSYSTEMVALUES_DYNAMODB
-          );
-          expect(attrs[SEMATTRS_DB_OPERATION]).toStrictEqual('BatchGetItem');
-          expect(attrs[SEMATTRS_AWS_DYNAMODB_TABLE_NAMES]).toStrictEqual([
+          expect(attrs[ATTR_DB_SYSTEM]).toStrictEqual(DBSYSTEMVALUES_DYNAMODB);
+          expect(attrs[ATTR_DB_OPERATION]).toStrictEqual('BatchGetItem');
+          expect(attrs[ATTR_AWS_DYNAMODB_TABLE_NAMES]).toStrictEqual([
             'test-table',
           ]);
-          expect(attrs[SEMATTRS_AWS_DYNAMODB_CONSUMED_CAPACITY]).toStrictEqual(
+          expect(attrs[ATTR_AWS_DYNAMODB_CONSUMED_CAPACITY]).toStrictEqual(
             consumedCapacityResponseMockData.map((x: ConsumedCapacity) =>
               JSON.stringify(x)
             )
           );
-          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
+          expect(attrs).not.toHaveProperty(ATTR_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -601,15 +577,13 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SEMATTRS_DB_SYSTEM]).toStrictEqual('dynamodb');
-          expect(attrs[SEMATTRS_DB_OPERATION]).toStrictEqual('BatchGetItem');
-          expect(attrs[SEMATTRS_AWS_DYNAMODB_TABLE_NAMES]).toStrictEqual([
+          expect(attrs[ATTR_DB_SYSTEM]).toStrictEqual('dynamodb');
+          expect(attrs[ATTR_DB_OPERATION]).toStrictEqual('BatchGetItem');
+          expect(attrs[ATTR_AWS_DYNAMODB_TABLE_NAMES]).toStrictEqual([
             'test-table',
           ]);
-          expect(
-            attrs[SEMATTRS_AWS_DYNAMODB_CONSUMED_CAPACITY]
-          ).toBeUndefined();
-          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
+          expect(attrs[ATTR_AWS_DYNAMODB_CONSUMED_CAPACITY]).toBeUndefined();
+          expect(attrs).not.toHaveProperty(ATTR_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -638,11 +612,9 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SEMATTRS_DB_SYSTEM]).toStrictEqual(
-            DBSYSTEMVALUES_DYNAMODB
-          );
-          expect(attrs[SEMATTRS_DB_OPERATION]).toStrictEqual('PutItem');
-          expect(attrs[SEMATTRS_AWS_DYNAMODB_CONSUMED_CAPACITY]).toStrictEqual([
+          expect(attrs[ATTR_DB_SYSTEM]).toStrictEqual(DBSYSTEMVALUES_DYNAMODB);
+          expect(attrs[ATTR_DB_OPERATION]).toStrictEqual('PutItem');
+          expect(attrs[ATTR_AWS_DYNAMODB_CONSUMED_CAPACITY]).toStrictEqual([
             JSON.stringify({
               TableName: 'test-table',
               CapacityUnits: 0.5,
@@ -671,13 +643,9 @@ describe('DynamoDB', () => {
           const spans = getTestSpans();
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
-          expect(attrs[SEMATTRS_DB_SYSTEM]).toStrictEqual(
-            DBSYSTEMVALUES_DYNAMODB
-          );
-          expect(attrs[SEMATTRS_DB_OPERATION]).toStrictEqual('PutItem');
-          expect(attrs).not.toHaveProperty(
-            SEMATTRS_AWS_DYNAMODB_CONSUMED_CAPACITY
-          );
+          expect(attrs[ATTR_DB_SYSTEM]).toStrictEqual(DBSYSTEMVALUES_DYNAMODB);
+          expect(attrs[ATTR_DB_OPERATION]).toStrictEqual('PutItem');
+          expect(attrs).not.toHaveProperty(ATTR_AWS_DYNAMODB_CONSUMED_CAPACITY);
           expect(err).toBeFalsy();
           done();
         }
@@ -741,7 +709,7 @@ describe('DynamoDB', () => {
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
 
-          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
+          expect(attrs).not.toHaveProperty(ATTR_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -784,7 +752,7 @@ describe('DynamoDB', () => {
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
 
-          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
+          expect(attrs).not.toHaveProperty(ATTR_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -827,7 +795,7 @@ describe('DynamoDB', () => {
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
 
-          expect(attrs).not.toHaveProperty(SEMATTRS_DB_STATEMENT);
+          expect(attrs).not.toHaveProperty(ATTR_DB_STATEMENT);
           expect(err).toBeFalsy();
           done();
         }
@@ -927,7 +895,7 @@ describe('DynamoDB', () => {
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
 
-          expect(attrs[SEMATTRS_DB_STATEMENT]).toStrictEqual(
+          expect(attrs[ATTR_DB_STATEMENT]).toStrictEqual(
             SERIALIZED_DB_STATEMENT
           );
           expect(err).toBeFalsy();
@@ -1011,7 +979,7 @@ describe('DynamoDB', () => {
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
 
-          expect(attrs[SEMATTRS_DB_STATEMENT]).toStrictEqual(
+          expect(attrs[ATTR_DB_STATEMENT]).toStrictEqual(
             SERIALIZED_DB_STATEMENT
           );
           expect(err).toBeFalsy();
@@ -1060,7 +1028,7 @@ describe('DynamoDB', () => {
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
 
-          expect(attrs[SEMATTRS_DB_STATEMENT]).toStrictEqual(
+          expect(attrs[ATTR_DB_STATEMENT]).toStrictEqual(
             SERIALIZED_DB_STATEMENT
           );
           expect(err).toBeFalsy();
@@ -1089,7 +1057,7 @@ describe('DynamoDB', () => {
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
 
-          expect(attrs[SEMATTRS_DB_STATEMENT]).toStrictEqual(
+          expect(attrs[ATTR_DB_STATEMENT]).toStrictEqual(
             SERIALIZED_DB_STATEMENT
           );
           expect(err).toBeFalsy();
@@ -1124,7 +1092,7 @@ describe('DynamoDB', () => {
           expect(spans.length).toStrictEqual(1);
           const attrs = spans[0].attributes;
 
-          expect(attrs[SEMATTRS_DB_STATEMENT]).toStrictEqual(
+          expect(attrs[ATTR_DB_STATEMENT]).toStrictEqual(
             SERIALIZED_DB_STATEMENT
           );
           expect(err).toBeFalsy();

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/lambda.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/lambda.test.ts
@@ -21,6 +21,7 @@ import {
 } from '@opentelemetry/contrib-test-utils';
 registerInstrumentationTesting(new AwsInstrumentation());
 
+import { SEMATTRS_FAAS_EXECUTION } from '@opentelemetry/semantic-conventions';
 import {
   ATTR_FAAS_INVOCATION_ID,
   ATTR_FAAS_INVOKED_NAME,
@@ -385,6 +386,9 @@ describe('Lambda', () => {
       expect(getTestSpans().length).toBe(1);
       const [span] = getTestSpans();
 
+      expect(span.attributes[SEMATTRS_FAAS_EXECUTION]).toEqual(
+        '95882c2b-3fd2-485d-ada3-9fcb1ca65459'
+      );
       expect(span.attributes[ATTR_FAAS_INVOCATION_ID]).toEqual(
         '95882c2b-3fd2-485d-ada3-9fcb1ca65459'
       );

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/lambda.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/lambda.test.ts
@@ -22,10 +22,10 @@ import {
 registerInstrumentationTesting(new AwsInstrumentation());
 
 import {
-  SEMATTRS_FAAS_EXECUTION,
-  SEMATTRS_FAAS_INVOKED_NAME,
-  SEMATTRS_FAAS_INVOKED_PROVIDER,
-} from '@opentelemetry/semantic-conventions';
+  ATTR_FAAS_INVOCATION_ID,
+  ATTR_FAAS_INVOKED_NAME,
+  ATTR_FAAS_INVOKED_PROVIDER,
+} from '@opentelemetry/semantic-conventions/incubating';
 import { SpanKind } from '@opentelemetry/api';
 
 import { Lambda, InvocationType } from '@aws-sdk/client-lambda';
@@ -94,7 +94,7 @@ describe('Lambda', () => {
         };
         const span = await getInvokedSpan(params);
 
-        expect(span.attributes[SEMATTRS_FAAS_INVOKED_PROVIDER]).toEqual('aws');
+        expect(span.attributes[ATTR_FAAS_INVOKED_PROVIDER]).toEqual('aws');
       });
 
       it('should add the function name as a semantic attribute', async () => {
@@ -109,7 +109,7 @@ describe('Lambda', () => {
         };
         const span = await getInvokedSpan(params);
 
-        expect(span.attributes[SEMATTRS_FAAS_INVOKED_NAME]).toEqual(
+        expect(span.attributes[ATTR_FAAS_INVOKED_NAME]).toEqual(
           'ot-test-function-name'
         );
       });
@@ -349,10 +349,10 @@ describe('Lambda', () => {
         const [span] = getTestSpans();
 
         expect(span.kind).toEqual(SpanKind.CLIENT);
-        expect(span.attributes[SEMATTRS_FAAS_INVOKED_NAME]).toEqual(
+        expect(span.attributes[ATTR_FAAS_INVOKED_NAME]).toEqual(
           'ot-test-function-name'
         );
-        expect(span.attributes[SEMATTRS_FAAS_INVOKED_PROVIDER]).toEqual('aws');
+        expect(span.attributes[ATTR_FAAS_INVOKED_PROVIDER]).toEqual('aws');
       });
     });
 
@@ -385,7 +385,7 @@ describe('Lambda', () => {
       expect(getTestSpans().length).toBe(1);
       const [span] = getTestSpans();
 
-      expect(span.attributes[SEMATTRS_FAAS_EXECUTION]).toEqual(
+      expect(span.attributes[ATTR_FAAS_INVOCATION_ID]).toEqual(
         '95882c2b-3fd2-485d-ada3-9fcb1ca65459'
       );
     });

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/sns.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/sns.test.ts
@@ -32,11 +32,13 @@ import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import * as sinon from 'sinon';
 import {
   MESSAGINGDESTINATIONKINDVALUES_TOPIC,
-  SEMATTRS_MESSAGING_DESTINATION,
   SEMATTRS_MESSAGING_DESTINATION_KIND,
-  SEMATTRS_MESSAGING_SYSTEM,
-  SEMATTRS_RPC_METHOD,
 } from '@opentelemetry/semantic-conventions';
+import {
+  ATTR_MESSAGING_DESTINATION_NAME,
+  ATTR_MESSAGING_SYSTEM,
+  ATTR_RPC_METHOD,
+} from '@opentelemetry/semantic-conventions/incubating';
 import { SpanKind } from '@opentelemetry/api';
 
 const responseMockSuccess = {
@@ -84,14 +86,11 @@ describe('SNS - v2', () => {
       expect(publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]).toBe(
         MESSAGINGDESTINATIONKINDVALUES_TOPIC
       );
-      expect(publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]).toBe(
+      expect(publishSpan.attributes[ATTR_MESSAGING_DESTINATION_NAME]).toBe(
         topicName
       );
-      expect(publishSpan.attributes['messaging.destination.name']).toBe(
-        fakeARN
-      );
-      expect(publishSpan.attributes[SEMATTRS_RPC_METHOD]).toBe('Publish');
-      expect(publishSpan.attributes[SEMATTRS_MESSAGING_SYSTEM]).toBe('aws.sns');
+      expect(publishSpan.attributes[ATTR_RPC_METHOD]).toBe('Publish');
+      expect(publishSpan.attributes[ATTR_MESSAGING_SYSTEM]).toBe('aws.sns');
       expect(publishSpan.kind).toBe(SpanKind.PRODUCER);
     });
 
@@ -110,10 +109,7 @@ describe('SNS - v2', () => {
       );
       expect(publishSpans.length).toBe(1);
       const publishSpan = publishSpans[0];
-      expect(publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]).toBe(
-        PhoneNumber
-      );
-      expect(publishSpan.attributes['messaging.destination.name']).toBe(
+      expect(publishSpan.attributes[ATTR_MESSAGING_DESTINATION_NAME]).toBe(
         PhoneNumber
       );
     });
@@ -160,10 +156,7 @@ describe('SNS - v2', () => {
         createTopicSpan.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]
       ).toBeUndefined();
       expect(
-        createTopicSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]
-      ).toBeUndefined();
-      expect(
-        createTopicSpan.attributes['messaging.destination.name']
+        createTopicSpan.attributes[ATTR_MESSAGING_DESTINATION_NAME]
       ).toBeUndefined();
       expect(createTopicSpan.kind).toBe(SpanKind.CLIENT);
     });
@@ -208,14 +201,11 @@ describe('SNS - v3', () => {
       expect(publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]).toBe(
         MESSAGINGDESTINATIONKINDVALUES_TOPIC
       );
-      expect(publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]).toBe(
+      expect(publishSpan.attributes[ATTR_MESSAGING_DESTINATION_NAME]).toBe(
         topicV3Name
       );
-      expect(publishSpan.attributes['messaging.destination.name']).toBe(
-        topicV3ARN
-      );
-      expect(publishSpan.attributes[SEMATTRS_RPC_METHOD]).toBe('Publish');
-      expect(publishSpan.attributes[SEMATTRS_MESSAGING_SYSTEM]).toBe('aws.sns');
+      expect(publishSpan.attributes[ATTR_RPC_METHOD]).toBe('Publish');
+      expect(publishSpan.attributes[ATTR_MESSAGING_SYSTEM]).toBe('aws.sns');
       expect(publishSpan.kind).toBe(SpanKind.PRODUCER);
     });
 
@@ -231,7 +221,7 @@ describe('SNS - v3', () => {
       );
       expect(publishSpans.length).toBe(1);
       const publishSpan = publishSpans[0];
-      expect(publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]).toBe(
+      expect(publishSpan.attributes[ATTR_MESSAGING_DESTINATION_NAME]).toBe(
         PhoneNumber
       );
     });

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/sns.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/sns.test.ts
@@ -32,6 +32,7 @@ import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import * as sinon from 'sinon';
 import {
   MESSAGINGDESTINATIONKINDVALUES_TOPIC,
+  SEMATTRS_MESSAGING_DESTINATION,
   SEMATTRS_MESSAGING_DESTINATION_KIND,
 } from '@opentelemetry/semantic-conventions';
 import {
@@ -86,8 +87,11 @@ describe('SNS - v2', () => {
       expect(publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]).toBe(
         MESSAGINGDESTINATIONKINDVALUES_TOPIC
       );
-      expect(publishSpan.attributes[ATTR_MESSAGING_DESTINATION_NAME]).toBe(
+      expect(publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]).toBe(
         topicName
+      );
+      expect(publishSpan.attributes[ATTR_MESSAGING_DESTINATION_NAME]).toBe(
+        fakeARN
       );
       expect(publishSpan.attributes[ATTR_RPC_METHOD]).toBe('Publish');
       expect(publishSpan.attributes[ATTR_MESSAGING_SYSTEM]).toBe('aws.sns');
@@ -109,6 +113,9 @@ describe('SNS - v2', () => {
       );
       expect(publishSpans.length).toBe(1);
       const publishSpan = publishSpans[0];
+      expect(publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]).toBe(
+        PhoneNumber
+      );
       expect(publishSpan.attributes[ATTR_MESSAGING_DESTINATION_NAME]).toBe(
         PhoneNumber
       );
@@ -156,6 +163,9 @@ describe('SNS - v2', () => {
         createTopicSpan.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]
       ).toBeUndefined();
       expect(
+        createTopicSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]
+      ).toBeUndefined();
+      expect(
         createTopicSpan.attributes[ATTR_MESSAGING_DESTINATION_NAME]
       ).toBeUndefined();
       expect(createTopicSpan.kind).toBe(SpanKind.CLIENT);
@@ -201,8 +211,11 @@ describe('SNS - v3', () => {
       expect(publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]).toBe(
         MESSAGINGDESTINATIONKINDVALUES_TOPIC
       );
-      expect(publishSpan.attributes[ATTR_MESSAGING_DESTINATION_NAME]).toBe(
+      expect(publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]).toBe(
         topicV3Name
+      );
+      expect(publishSpan.attributes[ATTR_MESSAGING_DESTINATION_NAME]).toBe(
+        topicV3ARN
       );
       expect(publishSpan.attributes[ATTR_RPC_METHOD]).toBe('Publish');
       expect(publishSpan.attributes[ATTR_MESSAGING_SYSTEM]).toBe('aws.sns');
@@ -221,7 +234,7 @@ describe('SNS - v3', () => {
       );
       expect(publishSpans.length).toBe(1);
       const publishSpan = publishSpans[0];
-      expect(publishSpan.attributes[ATTR_MESSAGING_DESTINATION_NAME]).toBe(
+      expect(publishSpan.attributes[SEMATTRS_MESSAGING_DESTINATION]).toBe(
         PhoneNumber
       );
     });

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/sqs.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/sqs.test.ts
@@ -29,6 +29,7 @@ import {
   MESSAGINGDESTINATIONKINDVALUES_QUEUE,
   MESSAGINGOPERATIONVALUES_PROCESS,
   MESSAGINGOPERATIONVALUES_RECEIVE,
+  SEMATTRS_MESSAGING_DESTINATION,
   SEMATTRS_MESSAGING_DESTINATION_KIND,
   SEMATTRS_MESSAGING_URL,
 } from '@opentelemetry/semantic-conventions';
@@ -403,6 +404,9 @@ describe('SQS', () => {
       expect(span.attributes[ATTR_MESSAGING_SYSTEM]).toEqual('aws.sqs');
       expect(span.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]).toEqual(
         MESSAGINGDESTINATIONKINDVALUES_QUEUE
+      );
+      expect(span.attributes[SEMATTRS_MESSAGING_DESTINATION]).toEqual(
+        QueueName
       );
       expect(span.attributes[ATTR_MESSAGING_DESTINATION_NAME]).toEqual(
         QueueName

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/sqs.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/sqs.test.ts
@@ -29,17 +29,19 @@ import {
   MESSAGINGDESTINATIONKINDVALUES_QUEUE,
   MESSAGINGOPERATIONVALUES_PROCESS,
   MESSAGINGOPERATIONVALUES_RECEIVE,
-  SEMATTRS_HTTP_STATUS_CODE,
-  SEMATTRS_MESSAGING_DESTINATION,
   SEMATTRS_MESSAGING_DESTINATION_KIND,
-  SEMATTRS_MESSAGING_MESSAGE_ID,
-  SEMATTRS_MESSAGING_OPERATION,
-  SEMATTRS_MESSAGING_SYSTEM,
   SEMATTRS_MESSAGING_URL,
-  SEMATTRS_RPC_METHOD,
-  SEMATTRS_RPC_SERVICE,
-  SEMATTRS_RPC_SYSTEM,
 } from '@opentelemetry/semantic-conventions';
+import {
+  ATTR_HTTP_STATUS_CODE,
+  ATTR_MESSAGING_DESTINATION_NAME,
+  ATTR_MESSAGING_MESSAGE_ID,
+  ATTR_MESSAGING_OPERATION,
+  ATTR_MESSAGING_SYSTEM,
+  ATTR_RPC_METHOD,
+  ATTR_RPC_SERVICE,
+  ATTR_RPC_SYSTEM,
+} from '@opentelemetry/semantic-conventions/incubating';
 import {
   context,
   SpanKind,
@@ -189,14 +191,14 @@ describe('SQS', () => {
     ) => {
       const awsReceiveSpan = spans.filter(
         s =>
-          s.attributes[SEMATTRS_MESSAGING_OPERATION] ===
+          s.attributes[ATTR_MESSAGING_OPERATION] ===
           MESSAGINGOPERATIONVALUES_RECEIVE
       );
       expect(awsReceiveSpan.length).toBe(1);
 
       const processSpans = spans.filter(
         s =>
-          s.attributes[SEMATTRS_MESSAGING_OPERATION] ===
+          s.attributes[ATTR_MESSAGING_OPERATION] ===
           MESSAGINGOPERATIONVALUES_PROCESS
       );
       expect(processSpans.length).toBe(2);
@@ -392,24 +394,24 @@ describe('SQS', () => {
       const [span] = getTestSpans();
 
       // make sure we have the general aws attributes:
-      expect(span.attributes[SEMATTRS_RPC_SYSTEM]).toEqual('aws-api');
-      expect(span.attributes[SEMATTRS_RPC_METHOD]).toEqual('SendMessage');
-      expect(span.attributes[SEMATTRS_RPC_SERVICE]).toEqual('SQS');
+      expect(span.attributes[ATTR_RPC_SYSTEM]).toEqual('aws-api');
+      expect(span.attributes[ATTR_RPC_METHOD]).toEqual('SendMessage');
+      expect(span.attributes[ATTR_RPC_SERVICE]).toEqual('SQS');
       expect(span.attributes[AttributeNames.AWS_REGION]).toEqual(region);
 
       // custom messaging attributes
-      expect(span.attributes[SEMATTRS_MESSAGING_SYSTEM]).toEqual('aws.sqs');
+      expect(span.attributes[ATTR_MESSAGING_SYSTEM]).toEqual('aws.sqs');
       expect(span.attributes[SEMATTRS_MESSAGING_DESTINATION_KIND]).toEqual(
         MESSAGINGDESTINATIONKINDVALUES_QUEUE
       );
-      expect(span.attributes[SEMATTRS_MESSAGING_DESTINATION]).toEqual(
+      expect(span.attributes[ATTR_MESSAGING_DESTINATION_NAME]).toEqual(
         QueueName
       );
       expect(span.attributes[SEMATTRS_MESSAGING_URL]).toEqual(params.QueueUrl);
-      expect(span.attributes[SEMATTRS_MESSAGING_MESSAGE_ID]).toEqual(
+      expect(span.attributes[ATTR_MESSAGING_MESSAGE_ID]).toEqual(
         response.MessageId
       );
-      expect(span.attributes[SEMATTRS_HTTP_STATUS_CODE]).toEqual(200);
+      expect(span.attributes[ATTR_HTTP_STATUS_CODE]).toEqual(200);
     });
 
     it('sqsProcessHook called and add message attribute to span', async () => {
@@ -439,7 +441,7 @@ describe('SQS', () => {
 
       const processSpans = getTestSpans().filter(
         s =>
-          s.attributes[SEMATTRS_MESSAGING_OPERATION] ===
+          s.attributes[ATTR_MESSAGING_OPERATION] ===
           MESSAGINGOPERATIONVALUES_PROCESS
       );
       expect(processSpans.length).toBe(2);
@@ -463,7 +465,7 @@ describe('SQS', () => {
       );
       const processSpans = getTestSpans().filter(
         s =>
-          s.attributes[SEMATTRS_MESSAGING_OPERATION] ===
+          s.attributes[ATTR_MESSAGING_OPERATION] ===
           MESSAGINGOPERATIONVALUES_PROCESS
       );
       expect(processSpans.length).toBe(2);
@@ -492,7 +494,7 @@ describe('SQS', () => {
 
       const processSpans = getTestSpans().filter(
         s =>
-          s.attributes[SEMATTRS_MESSAGING_OPERATION] ===
+          s.attributes[ATTR_MESSAGING_OPERATION] ===
           MESSAGINGOPERATIONVALUES_PROCESS
       );
       expect(processSpans.length).toBe(2);
@@ -518,9 +520,7 @@ describe('SQS', () => {
       expect(spans.length).toBe(1);
 
       // Spot check a single attribute as a sanity check.
-      expect(spans[0].attributes[SEMATTRS_RPC_METHOD]).toEqual(
-        'SendMessageBatch'
-      );
+      expect(spans[0].attributes[ATTR_RPC_METHOD]).toEqual('SendMessageBatch');
     });
   });
 


### PR DESCRIPTION
## Which problem is this PR solving?

- `SEMATTRS_*` were deprecated in `@opentelemetry/semantic-conventions@1.26.0` https://github.com/open-telemetry/opentelemetry-js/tree/main/semantic-conventions#migrating-from-semattrs_-semresattrs_-

## Short description of the changes

- Migrates `SEMATTRS_*` to `ATTR_*` wherever a replacement is available. The ones without replacement are deprecated, and can be removed in future PRs.
