### PR TITLE
chore(aws): replace deprecated substr with substring

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -90,7 +90,10 @@ export class AwsLambdaInstrumentation extends InstrumentationBase<AwsLambdaInstr
     }
 
     const handler = path.basename(handlerDef);
-    const moduleRoot = handlerDef.substr(0, handlerDef.length - handler.length);
+    const moduleRoot = handlerDef.substring(
+      0,
+      handlerDef.length - handler.length
+    );
 
     const [module, functionName] = handler.split('.', 2);
 

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sns.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sns.ts
@@ -93,7 +93,7 @@ export class SnsServiceExtension implements ServiceExtension {
     if (topicArn || targetArn) {
       const arn = topicArn ?? targetArn;
       try {
-        return arn.substr(arn.lastIndexOf(':') + 1);
+        return arn.substring(arn.lastIndexOf(':') + 1);
       } catch (err) {
         return arn;
       }


### PR DESCRIPTION
## Which problem is this PR solving?

- The [String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated.

## Short description of the changes

- This PR replaces `String.prototype.substr()` with [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring)
