### PR TITLE
feat(instrumentation-mysql2): Add hook for setting span name

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-mysql2/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/src/types.ts
@@ -16,6 +16,7 @@
 
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import type { Span } from '@opentelemetry/api';
+import type { Query, QueryOptions } from 'mysql2';
 
 export interface MySQL2ResponseHookInformation {
   queryResults: any;
@@ -25,6 +26,22 @@ export interface MySQL2InstrumentationExecutionResponseHook {
   (span: Span, responseHookInfo: MySQL2ResponseHookInformation): void;
 }
 
+export interface MySQL2RequestInfo {
+  host?: string;
+  database?: string;
+  query: string | Query | QueryOptions;
+  values?: unknown[];
+}
+
+export type SpanNameHook = (
+  info: MySQL2RequestInfo,
+  /**
+   * If no decision is taken based on RequestInfo, the default name
+   * supplied by the instrumentation can be used instead.
+   */
+  defaultName: string
+) => string;
+
 export interface MySQL2InstrumentationConfig extends InstrumentationConfig {
   /**
    * Hook that allows adding custom span attributes based on the data
@@ -33,6 +50,11 @@ export interface MySQL2InstrumentationConfig extends InstrumentationConfig {
    * @default undefined
    */
   responseHook?: MySQL2InstrumentationExecutionResponseHook;
+
+  /**
+   * Hook to override the name for an SQL span
+   */
+  spanNameHook?: SpanNameHook;
 
   /**
    * If true, queries are modified to also include a comment with


### PR DESCRIPTION
## Which problem is this PR solving?

My company runs a set clause to set a connection SQL variables to the user triggering the action before all our SQL clauses. This means the span name for requests always ends up being set which is not useful. Plus now that WITH statements are a more common SQL feature I am sure plenty of users could benefit from a way to customize the span name.

## Short description of the changes

This adds a new config option the the mysql2 instrumentation which allows people to provide custom behavior for span name. I modeled the API after the similar API that already exists in the express instrumentation.

