### PR TITLE
refactor(examples/express): small refactor of imports

### DIFF
--- a/examples/express/src/tracer.ts
+++ b/examples/express/src/tracer.ts
@@ -1,22 +1,14 @@
 'use strict';
 
-import { SpanKind, Attributes } from "@opentelemetry/api";
-
-import opentelemetry = require('@opentelemetry/api');
-
-// Not functionally required but gives some insight what happens behind the scenes
-const { diag, DiagConsoleLogger, DiagLogLevel } = opentelemetry;
-diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
-
+import { trace, SamplingDecision, SpanKind, Attributes } from '@opentelemetry/api';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { Sampler, AlwaysOnSampler, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
 import { Resource } from '@opentelemetry/resources';
 import { ATTR_SERVICE_NAME, ATTR_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
-
 import { ExpressInstrumentation } from '@opentelemetry/instrumentation-express';
-import {HttpInstrumentation} from '@opentelemetry/instrumentation-http';
+import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 
 export const setupTracing = (serviceName: string) => {
   const provider = new NodeTracerProvider({
@@ -41,7 +33,7 @@ export const setupTracing = (serviceName: string) => {
   // Initialize the OpenTelemetry APIs to use the NodeTracerProvider bindings
   provider.register();
 
-  return opentelemetry.trace.getTracer(serviceName);
+  return trace.getTracer(serviceName);
 };
 
 type FilterFunction = (spanName: string, spanKind: SpanKind, attributes: Attributes) => boolean;
@@ -50,7 +42,7 @@ function filterSampler(filterFn: FilterFunction, parent: Sampler): Sampler {
   return {
     shouldSample(ctx, tid, spanName, spanKind, attr, links) {
       if (!filterFn(spanName, spanKind, attr)) {
-        return { decision: opentelemetry.SamplingDecision.NOT_RECORD };
+        return { decision: SamplingDecision.NOT_RECORD };
       }
       return parent.shouldSample(ctx, tid, spanName, spanKind, attr, links);
     },
@@ -61,5 +53,5 @@ function filterSampler(filterFn: FilterFunction, parent: Sampler): Sampler {
 }
 
 function ignoreHealthCheck(spanName: string, spanKind: SpanKind, attributes: Attributes) {
-  return spanKind !== opentelemetry.SpanKind.SERVER || attributes[ATTR_HTTP_ROUTE] !== "/health";
+  return spanKind !== SpanKind.SERVER || attributes[ATTR_HTTP_ROUTE] !== "/health";
 }


### PR DESCRIPTION
Minor refactor to clean up imports from the api pkg.
Remove the DiagConsoleLogger for now. There isn't any useful diag log output
for this example, and configuring it just adds some noise.
