### PR TITLE
chore(instr-koa): update instrumentation-koa tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37509,6 +37509,7 @@
         "koa": "2.13.1",
         "nyc": "15.1.0",
         "rimraf": "5.0.10",
+        "semver": "7.6.3",
         "sinon": "15.2.0",
         "test-all-versions": "6.1.0",
         "typescript": "4.4.4"
@@ -48092,6 +48093,7 @@
         "koa": "2.13.1",
         "nyc": "15.1.0",
         "rimraf": "5.0.10",
+        "semver": "7.6.3",
         "sinon": "15.2.0",
         "test-all-versions": "6.1.0",
         "typescript": "4.4.4"

--- a/plugins/node/opentelemetry-instrumentation-koa/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-koa/.tav.yml
@@ -1,8 +1,14 @@
 "@koa/router":
-  versions:
-    include: ">=8.0.0"
-    mode: latest-minors
-  commands: npm run test
+  jobs:
+    - versions:
+        include: ">=8.0.0 <13"
+        mode: latest-minors
+      commands: npm run test
+    - versions:
+        include: ">=13 <14"
+        mode: latest-minors
+      node: '>=18'
+      commands: npm run test
 
 koa:
   # Testing ^2.7.0 covers at least 97% of the downloaded koa versions

--- a/plugins/node/opentelemetry-instrumentation-koa/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/package.json
@@ -60,6 +60,7 @@
     "koa": "2.13.1",
     "nyc": "15.1.0",
     "rimraf": "5.0.10",
+    "semver": "7.6.3",
     "sinon": "15.2.0",
     "test-all-versions": "6.1.0",
     "typescript": "4.4.4"


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes: #2564 

## Short description of the changes

- skip `@koa/router` tests if version is not compatible with nodejs version
