### PR TITLE
chore(eslint): lint examples/bunyan and prepare for linting .js and .mjs files

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,10 +5,10 @@ module.exports = {
     "node",
     "prettier"
   ],
-  extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended", "plugin:prettier/recommended"],
+  extends: ["eslint:recommended", "plugin:prettier/recommended"],
   parser: "@typescript-eslint/parser",
   parserOptions: {
-    "project": "./tsconfig.json"
+    "project": null
   },
   rules: {
     "quotes": ["error", "single", { "avoidEscape": true }],
@@ -28,6 +28,11 @@ module.exports = {
   overrides: [
     {
       files: ['*.ts'],
+      // Enable typescript-eslint for ts files.
+      extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended", "plugin:prettier/recommended"],
+      parserOptions: {
+        "project": "./tsconfig.json"
+      },
       rules: {
         "@typescript-eslint/no-floating-promises": "error",
         "@typescript-eslint/no-this-alias": "off",
@@ -49,13 +54,24 @@ module.exports = {
           }
         }],
         "@typescript-eslint/no-shadow": ["warn"],
+        "prefer-rest-params": "off",
       }
     },
     {
       files: ["test/**/*.ts"],
+      // Enable typescript-eslint for ts files.
+      extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended", "plugin:prettier/recommended"],
+      parserOptions: {
+        "project": "./tsconfig.json"
+      },
       rules: {
         "no-empty": "off",
         "@typescript-eslint/ban-ts-ignore": "off",
+        "@typescript-eslint/ban-types": ["warn", {
+          "types": {
+            "Function": null,
+          }
+        }],
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-unused-vars": "off",
@@ -63,7 +79,14 @@ module.exports = {
         "@typescript-eslint/no-shadow": ["off"],
         "@typescript-eslint/no-floating-promises": ["off"],
         "@typescript-eslint/no-non-null-assertion": ["off"],
-        "@typescript-eslint/explicit-module-boundary-types": ["off"]
+        "@typescript-eslint/explicit-module-boundary-types": ["off"],
+        "prefer-rest-params": "off",
+      }
+    },
+    {
+      files: ["*.mjs"],
+      parserOptions: {
+        sourceType: 'module',
       }
     }
   ]

--- a/examples/bunyan/.eslintrc.js
+++ b/examples/bunyan/.eslintrc.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const baseConfig = require('../../eslint.config');
+
+module.exports = {
+  ...baseConfig,
+  env: {
+    node: true,
+  },
+};

--- a/examples/bunyan/app.js
+++ b/examples/bunyan/app.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+'use strict';
+
 // A small example that shows using OpenTelemetry's instrumentation of
 // Bunyan loggers. Usage:
 //    node --require ./telemetry.js app.js
@@ -21,9 +23,9 @@
 const otel = require('@opentelemetry/api');
 const bunyan = require('bunyan');
 
-const log = bunyan.createLogger({name: 'myapp', level: 'debug'});
+const log = bunyan.createLogger({ name: 'myapp', level: 'debug' });
 
-log.debug({foo: 'bar'}, 'hi');
+log.debug({ foo: 'bar' }, 'hi');
 
 const tracer = otel.trace.getTracer('example');
 tracer.startActiveSpan('manual-span', span => {

--- a/examples/bunyan/app.mjs
+++ b/examples/bunyan/app.mjs
@@ -21,13 +21,12 @@
 import { trace } from '@opentelemetry/api';
 import bunyan from 'bunyan';
 
-const log = bunyan.createLogger({name: 'myapp', level: 'debug'});
+const log = bunyan.createLogger({ name: 'myapp', level: 'debug' });
 
-log.debug({foo: 'bar'}, 'hi');
+log.debug({ foo: 'bar' }, 'hi');
 
 const tracer = trace.getTracer('example');
 tracer.startActiveSpan('manual-span', span => {
   log.info('this record will have trace_id et al fields for the current span');
   span.end();
 });
-

--- a/examples/bunyan/package.json
+++ b/examples/bunyan/package.json
@@ -4,6 +4,8 @@
   "version": "0.1.0",
   "description": "Example of Bunyan integration with OpenTelemetry",
   "scripts": {
+    "lint": "eslint . --ext=ts,js,mjs",
+    "lint:fix": "eslint . --ext=ts,js,mjs --fix",
     "start": "node -r ./telemetry.js app.js"
   },
   "repository": {

--- a/examples/bunyan/telemetry.js
+++ b/examples/bunyan/telemetry.js
@@ -14,17 +14,25 @@
  * limitations under the License.
  */
 
+'use strict';
+
 // Setup telemetry for tracing and Bunyan logging.
 //
 // This writes OTel spans and log records to the console for simplicity. In a
 // real setup you would configure exporters to send to remote observability apps
 // for viewing and analysis.
 
-const { NodeSDK, tracing, logs, api } = require('@opentelemetry/sdk-node');
-const { envDetectorSync, hostDetectorSync, processDetectorSync } = require('@opentelemetry/resources');
+const { NodeSDK, tracing, logs } = require('@opentelemetry/sdk-node');
+const {
+  envDetectorSync,
+  hostDetectorSync,
+  processDetectorSync,
+} = require('@opentelemetry/resources');
 // api.diag.setLogger(new api.DiagConsoleLogger(), api.DiagLogLevel.DEBUG);
 
-const { BunyanInstrumentation } = require('@opentelemetry/instrumentation-bunyan');
+const {
+  BunyanInstrumentation,
+} = require('@opentelemetry/instrumentation-bunyan');
 
 const sdk = new NodeSDK({
   serviceName: 'bunyan-example',
@@ -36,20 +44,22 @@ const sdk = new NodeSDK({
     // The HostDetector adds `host.name` and `host.arch` fields. `host.name`
     // replaces the usual Bunyan `hostname` field. HostDetector is *not* a
     // default detector of the `NodeSDK`.
-    hostDetectorSync
+    hostDetectorSync,
   ],
-  spanProcessor: new tracing.SimpleSpanProcessor(new tracing.ConsoleSpanExporter()),
-  logRecordProcessor: new logs.SimpleLogRecordProcessor(new logs.ConsoleLogRecordExporter()),
-  instrumentations: [
-    new BunyanInstrumentation(),
-  ]
-})
-process.on("SIGTERM", () => {
+  spanProcessor: new tracing.SimpleSpanProcessor(
+    new tracing.ConsoleSpanExporter()
+  ),
+  logRecordProcessor: new logs.SimpleLogRecordProcessor(
+    new logs.ConsoleLogRecordExporter()
+  ),
+  instrumentations: [new BunyanInstrumentation()],
+});
+process.on('SIGTERM', () => {
   sdk
     .shutdown()
     .then(
       () => {},
-      (err) => console.log("warning: error shutting down OTel SDK", err)
+      err => console.log('warning: error shutting down OTel SDK', err)
     )
     .finally(() => process.exit(0));
 });


### PR DESCRIPTION
This adds support for 'npm run lint' in examples/bunyan, using the same
base eslint.config.js used by most of the repo.

There are ulterior motives:
- This is a first step to linting all the examples using the same
  base config (rather than the spotty linting of examples using the
  separate "examples/.eslintrc".
- The eslint.config.js changes support being used to lint .ts,
  .js, and .mjs files reasonably. I'll follow-up with a separate PR
  adding linting of .mjs files used for some ESM testing
  (e.g. "instrumentation-ioredis/test/fixtures/use-ioredis.mjs")
- I'll follow-up separately to get 'npm run lint' working for
  other examples and get the top-level `npm run lint:examples`
  using those.

Hattip to the following for some of the eslint config changes:
  https://github.com/open-telemetry/opentelemetry-js/pull/4446/files#diff-1a88e8e72db982c999acf146817a416a02d93547458e6525610cf69b24751af9

---

If it helps review:
- the first commit is just the config changes
- the second commit is the changes to examples/bunyan to get 'npm run lint' passing