### PR TITLE
fix(docs): broken link for community contribution lifecycle and processes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@ Before creating a pull request, please make sure:
 - You have read the guide for contributing
   - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
 - You signed all your commits (otherwise we won't be able to merge the PR)
-  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
+  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
 - You added unit tests for the new functionality
 - You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
   the issue that your PR fixes (if such)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ git merge upstream/main
 
 Remember to always work in a branch of your local copy, as you might otherwise have to contend with conflicts in main.
 
-Please also see [GitHub workflow](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#github-workflow) section of general project contributing guide.
+Please also see [GitHub workflow](https://github.com/open-telemetry/community/blob/main/guides/contributor/processes.md#github-workflow) section of general project contributing guide.
 
 ## Development
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes broken links missed in https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2542

## Short description of the changes

- Fixes the broken link for contribution processes which were moved in https://github.com/open-telemetry/community/pull/2051
- Verified that there are no more occurrences

### Before

```console
$ grep -rnI 'community/blob/[^/]*/CONTRIBUTING.md' .
./CONTRIBUTING.md:91:Please also see [GitHub workflow](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#github-workflow) section of general project contributing guide.
./.github/PULL_REQUEST_TEMPLATE.md:10:  - See https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md#sign-the-cla
```

### After

```console
$ grep -rnI 'community/blob/[^/]*/CONTRIBUTING.md' .
```
