### PR TITLE
fix(instr-mysql2): Fix mysql2 instrumentation connection prototype

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26284,11 +26284,10 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.11.3",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.11.3.tgz",
-      "integrity": "sha512-Qpu2ADfbKzyLdwC/5d4W7+5Yz7yBzCU05YWt5npWzACST37wJsB23wgOSo00qi043urkiRwXtEvJc9UnuLX/MQ==",
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.11.5.tgz",
+      "integrity": "sha512-0XFu8rUmFN9vC0ME36iBvCUObftiMHItrYFhlCRvFWbLgpNqtC4Br/NmZX1HNCszxT0GGy5QtP+k3Q3eCJPaYA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "aws-ssl-profiles": "^1.1.1",
         "denque": "^2.1.0",
@@ -37853,7 +37852,7 @@
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
-        "mysql2": "3.11.3",
+        "mysql2": "3.11.5",
         "nyc": "15.1.0",
         "rimraf": "5.0.10",
         "semver": "7.6.3",
@@ -48554,7 +48553,7 @@
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
-        "mysql2": "3.11.3",
+        "mysql2": "3.11.5",
         "nyc": "15.1.0",
         "rimraf": "5.0.10",
         "semver": "7.6.3",
@@ -63019,9 +63018,9 @@
       }
     },
     "mysql2": {
-      "version": "3.11.3",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.11.3.tgz",
-      "integrity": "sha512-Qpu2ADfbKzyLdwC/5d4W7+5Yz7yBzCU05YWt5npWzACST37wJsB23wgOSo00qi043urkiRwXtEvJc9UnuLX/MQ==",
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.11.5.tgz",
+      "integrity": "sha512-0XFu8rUmFN9vC0ME36iBvCUObftiMHItrYFhlCRvFWbLgpNqtC4Br/NmZX1HNCszxT0GGy5QtP+k3Q3eCJPaYA==",
       "dev": true,
       "requires": {
         "aws-ssl-profiles": "^1.1.1",

--- a/plugins/node/opentelemetry-instrumentation-mysql2/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/package.json
@@ -50,7 +50,7 @@
     "@types/mocha": "7.0.2",
     "@types/node": "18.18.14",
     "@types/semver": "7.5.8",
-    "mysql2": "3.11.3",
+    "mysql2": "3.11.5",
     "nyc": "15.1.0",
     "rimraf": "5.0.10",
     "semver": "7.6.3",

--- a/plugins/node/opentelemetry-instrumentation-mysql2/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/src/instrumentation.ts
@@ -215,13 +215,12 @@ export class MySQL2Instrumentation extends InstrumentationBase<MySQL2Instrumenta
   private _getConnectionPrototype(moduleExports: any): mysqlTypes.Connection {
     const baseClass = Object.getPrototypeOf(moduleExports.Connection);
 
-    // if `baseClass` has no prototype means connection is not extending
-    // another class so the functions we need to patch are already there
-    if (typeof baseClass.prototype === 'undefined') {
-      return moduleExports.Connection.prototype;
+    // return the base class prototype if it has the method
+    // we need to patch (mysql2@3.11.5+)
+    if (typeof baseClass.prototype?.query === 'function') {
+      return baseClass.prototype;
     }
 
-    // return the BaseConnection prototype (mysql2@3.11.5+)
-    return baseClass.prototype;
+    return moduleExports.Connection.prototype;
   }
 }

--- a/plugins/node/opentelemetry-instrumentation-mysql2/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/src/instrumentation.ts
@@ -79,8 +79,7 @@ export class MySQL2Instrumentation extends InstrumentationBase<MySQL2Instrumenta
         },
         (moduleExports: any) => {
           if (moduleExports === undefined) return;
-          const ConnectionPrototype: mysqlTypes.Connection =
-            moduleExports.Connection.prototype;
+          const ConnectionPrototype = this._getConnectionPrototype(moduleExports);
           this._unwrap(ConnectionPrototype, 'query');
           this._unwrap(ConnectionPrototype, 'execute');
         }

--- a/plugins/node/opentelemetry-instrumentation-mysql2/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/src/instrumentation.ts
@@ -55,7 +55,8 @@ export class MySQL2Instrumentation extends InstrumentationBase<MySQL2Instrumenta
         'mysql2',
         ['>=1.4.2 <4'],
         (moduleExports: any) => {
-          const ConnectionPrototype = this._getConnectionPrototype(moduleExports);
+          const ConnectionPrototype =
+            this._getConnectionPrototype(moduleExports);
 
           if (isWrapped(ConnectionPrototype.query)) {
             this._unwrap(ConnectionPrototype, 'query');
@@ -79,7 +80,8 @@ export class MySQL2Instrumentation extends InstrumentationBase<MySQL2Instrumenta
         },
         (moduleExports: any) => {
           if (moduleExports === undefined) return;
-          const ConnectionPrototype = this._getConnectionPrototype(moduleExports);
+          const ConnectionPrototype =
+            this._getConnectionPrototype(moduleExports);
           this._unwrap(ConnectionPrototype, 'query');
           this._unwrap(ConnectionPrototype, 'execute');
         }


### PR DESCRIPTION
## Which problem is this PR solving?

`mysql2@3.11.5` introduced a internal refactoring to solve circular dependencies within the package.
ref: https://github.com/sidorares/node-mysql2/pull/3081

The changes include a new `BaseConnection` class which contains the methods we need to patch (query, execute). The `Connection` class is extending it therefore the instrumentation gets the wrong prototype when patching.

Fixes: #2572 

## Short description of the changes

- bump `mysql2` to v3.11.5
- added a function to extract the proper prototype when patching/unpatching
