### PR TITLE
feat(deps): update deps matching '@opentelemetry/*'

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-aws/package.json
+++ b/detectors/node/opentelemetry-resource-detector-aws/package.json
@@ -40,7 +40,7 @@
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/contrib-test-utils": "^0.43.0",
     "@opentelemetry/instrumentation-fs": "^0.17.0",
-    "@opentelemetry/instrumentation-http": "^0.55.0",
+    "@opentelemetry/instrumentation-http": "^0.56.0",
     "@types/mocha": "8.2.3",
     "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",

--- a/detectors/node/opentelemetry-resource-detector-azure/package.json
+++ b/detectors/node/opentelemetry-resource-detector-azure/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/contrib-test-utils": "^0.43.0",
-    "@opentelemetry/instrumentation-http": "^0.55.0",
+    "@opentelemetry/instrumentation-http": "^0.56.0",
     "@types/mocha": "8.2.3",
     "@types/node": "18.18.14",
     "@types/sinon": "10.0.20",

--- a/detectors/node/opentelemetry-resource-detector-gcp/package.json
+++ b/detectors/node/opentelemetry-resource-detector-gcp/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/contrib-test-utils": "^0.43.0",
-    "@opentelemetry/instrumentation-http": "^0.55.0",
+    "@opentelemetry/instrumentation-http": "^0.56.0",
     "@types/mocha": "8.2.3",
     "@types/node": "18.18.14",
     "@types/semver": "7.5.8",

--- a/detectors/node/opentelemetry-resource-detector-instana/package.json
+++ b/detectors/node/opentelemetry-resource-detector-instana/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/contrib-test-utils": "^0.43.0",
-    "@opentelemetry/sdk-node": "^0.55.0",
+    "@opentelemetry/sdk-node": "^0.56.0",
     "@types/mocha": "8.2.3",
     "@types/node": "18.18.14",
     "@types/semver": "7.5.8",

--- a/metapackages/auto-instrumentations-node/package.json
+++ b/metapackages/auto-instrumentations-node/package.json
@@ -46,7 +46,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/instrumentation-amqplib": "^0.44.0",
     "@opentelemetry/instrumentation-aws-lambda": "^0.48.0",
     "@opentelemetry/instrumentation-aws-sdk": "^0.47.0",
@@ -61,9 +61,9 @@
     "@opentelemetry/instrumentation-fs": "^0.17.0",
     "@opentelemetry/instrumentation-generic-pool": "^0.41.0",
     "@opentelemetry/instrumentation-graphql": "^0.45.0",
-    "@opentelemetry/instrumentation-grpc": "^0.55.0",
+    "@opentelemetry/instrumentation-grpc": "^0.56.0",
     "@opentelemetry/instrumentation-hapi": "^0.43.0",
-    "@opentelemetry/instrumentation-http": "^0.55.0",
+    "@opentelemetry/instrumentation-http": "^0.56.0",
     "@opentelemetry/instrumentation-ioredis": "^0.45.0",
     "@opentelemetry/instrumentation-kafkajs": "^0.5.0",
     "@opentelemetry/instrumentation-knex": "^0.42.0",
@@ -92,7 +92,7 @@
     "@opentelemetry/resource-detector-container": "^0.5.1",
     "@opentelemetry/resource-detector-gcp": "^0.30.0",
     "@opentelemetry/resources": "^1.24.0",
-    "@opentelemetry/sdk-node": "^0.55.0"
+    "@opentelemetry/sdk-node": "^0.56.0"
   },
   "files": [
     "build/src/**/*.js",

--- a/metapackages/auto-instrumentations-web/package.json
+++ b/metapackages/auto-instrumentations-web/package.json
@@ -60,11 +60,11 @@
     "webpack-merge": "5.10.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/instrumentation-document-load": "^0.42.0",
-    "@opentelemetry/instrumentation-fetch": "^0.55.0",
+    "@opentelemetry/instrumentation-fetch": "^0.56.0",
     "@opentelemetry/instrumentation-user-interaction": "^0.42.0",
-    "@opentelemetry/instrumentation-xml-http-request": "^0.55.0"
+    "@opentelemetry/instrumentation-xml-http-request": "^0.56.0"
   },
   "files": [
     "build/src/**/*.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
         "@opentelemetry/instrumentation-fs": "^0.17.0",
-        "@opentelemetry/instrumentation-http": "^0.55.0",
+        "@opentelemetry/instrumentation-http": "^0.56.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
@@ -111,6 +111,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "detectors/node/opentelemetry-resource-detector-aws/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "detectors/node/opentelemetry-resource-detector-aws/node_modules/@types/mocha": {
@@ -140,7 +149,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
-        "@opentelemetry/instrumentation-http": "^0.55.0",
+        "@opentelemetry/instrumentation-http": "^0.56.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
@@ -154,6 +163,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "detectors/node/opentelemetry-resource-detector-azure/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "detectors/node/opentelemetry-resource-detector-azure/node_modules/@types/mocha": {
@@ -229,7 +247,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
-        "@opentelemetry/instrumentation-http": "^0.55.0",
+        "@opentelemetry/instrumentation-http": "^0.56.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
@@ -243,6 +261,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "detectors/node/opentelemetry-resource-detector-gcp/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "detectors/node/opentelemetry-resource-detector-gcp/node_modules/@types/mocha": {
@@ -310,7 +337,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
-        "@opentelemetry/sdk-node": "^0.55.0",
+        "@opentelemetry/sdk-node": "^0.56.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
         "@types/semver": "7.5.8",
@@ -324,6 +351,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "detectors/node/opentelemetry-resource-detector-instana/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "detectors/node/opentelemetry-resource-detector-instana/node_modules/@types/mocha": {
@@ -384,7 +420,7 @@
       "version": "0.53.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/instrumentation-amqplib": "^0.44.0",
         "@opentelemetry/instrumentation-aws-lambda": "^0.48.0",
         "@opentelemetry/instrumentation-aws-sdk": "^0.47.0",
@@ -399,9 +435,9 @@
         "@opentelemetry/instrumentation-fs": "^0.17.0",
         "@opentelemetry/instrumentation-generic-pool": "^0.41.0",
         "@opentelemetry/instrumentation-graphql": "^0.45.0",
-        "@opentelemetry/instrumentation-grpc": "^0.55.0",
+        "@opentelemetry/instrumentation-grpc": "^0.56.0",
         "@opentelemetry/instrumentation-hapi": "^0.43.0",
-        "@opentelemetry/instrumentation-http": "^0.55.0",
+        "@opentelemetry/instrumentation-http": "^0.56.0",
         "@opentelemetry/instrumentation-ioredis": "^0.45.0",
         "@opentelemetry/instrumentation-kafkajs": "^0.5.0",
         "@opentelemetry/instrumentation-knex": "^0.42.0",
@@ -430,7 +466,7 @@
         "@opentelemetry/resource-detector-container": "^0.5.1",
         "@opentelemetry/resource-detector-gcp": "^0.30.0",
         "@opentelemetry/resources": "^1.24.0",
-        "@opentelemetry/sdk-node": "^0.55.0"
+        "@opentelemetry/sdk-node": "^0.56.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.4.1",
@@ -463,11 +499,11 @@
       "version": "0.43.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/instrumentation-document-load": "^0.42.0",
-        "@opentelemetry/instrumentation-fetch": "^0.55.0",
+        "@opentelemetry/instrumentation-fetch": "^0.56.0",
         "@opentelemetry/instrumentation-user-interaction": "^0.42.0",
-        "@opentelemetry/instrumentation-xml-http-request": "^0.55.0"
+        "@opentelemetry/instrumentation-xml-http-request": "^0.56.0"
       },
       "devDependencies": {
         "@babel/core": "7.24.6",
@@ -9952,9 +9988,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.55.0.tgz",
-      "integrity": "sha512-3cpa+qI45VHYcA5c0bHM6VHo9gicv3p5mlLHNG3rLyjQU8b7e0st1rWtrUn3JbZ3DwwCfhKop4eQ9UuYlC6Pkg==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.56.0.tgz",
+      "integrity": "sha512-Wr39+94UNNG3Ei9nv3pHd4AJ63gq5nSemMRpCd8fPwDL9rN3vK26lzxfH27mw16XzOSO+TpyQwBAMaLxaPWG0g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -9980,9 +10016,9 @@
       "link": true
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.28.0.tgz",
-      "integrity": "sha512-igcl4Ve+F1N2063PJUkesk/GkYyuGIWinYkSyAFTnIj3gzrOgvOA4k747XNdL47HRRL1w/qh7UW8NDuxOLvKFA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.29.0.tgz",
+      "integrity": "sha512-TKT91jcFXgHyIDF1lgJF3BHGIakn6x0Xp7Tq3zoS3TMPzT9IlP0xEavWP8C1zGjU9UmZP2VR1tJhW9Az1A3w8Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -9992,9 +10028,9 @@
       }
     },
     "node_modules/@opentelemetry/context-zone-peer-dep": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.28.0.tgz",
-      "integrity": "sha512-tGtZ+N/QlMpZmHlSpANJsCBsx04FAF7t1nvyocG+Hr1r9rEJFPbdJ23pRDPYdpHX7D5UislKEz3mP+kfsP9p/A==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.29.0.tgz",
+      "integrity": "sha512-HWmxBAQ0w3QWoJ5wfFzr0pNLXgE7ztKOHUd13Hd4CiG9rSNVS33s0qB57aCGzEk6Y1L4eG8Z19hnb52UirmPdg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -10002,7 +10038,7 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0",
-        "zone.js": "^0.10.2 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0"
+        "zone.js": "^0.10.2 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0"
       }
     },
     "node_modules/@opentelemetry/contrib-test-utils": {
@@ -10010,12 +10046,12 @@
       "link": true
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.28.0.tgz",
-      "integrity": "sha512-ZLwRMV+fNDpVmF2WYUdBHlq0eOWtEaUJSusrzjGnBt7iSRvfjFE3RXYUZJrqou/wIDWV0DwQ5KIfYe9WXg9Xqw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.29.0.tgz",
+      "integrity": "sha512-gmT7vAreXl0DTHD2rVZcw3+l2g84+5XiHIqdBUxXbExymPCvSsGOpiwMmn8nkiJur28STV31wnhIDrzWDPzjfA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.27.0"
+        "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
         "node": ">=14"
@@ -10024,15 +10060,24 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-jaeger": {
+    "node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.28.0.tgz",
-      "integrity": "sha512-w4wHFZjfxxHqUVUyERegruLCI3pGMwkg9t2XhHBVUjmmhuul6RjN1fn22/0ZBhONG76LsIUJpo2W+ejBPnphFA==",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-jaeger": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.29.0.tgz",
+      "integrity": "sha512-GhShia26dMaUOsfemzGs8db+WBxVW6GPHkFEfRugPMiXAsoWxTNiVChUiDRVzOxJ6ZQ2QjbpZ3eHmBZc3SM/1g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/sdk-trace-base": "1.28.0",
-        "@opentelemetry/semantic-conventions": "1.27.0",
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0",
+        "@opentelemetry/semantic-conventions": "1.28.0",
         "jaeger-client": "^3.15.0"
       },
       "engines": {
@@ -10042,17 +10087,26 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-jaeger/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.55.0.tgz",
-      "integrity": "sha512-ykqawCL0ILJWyCJlxCPSAlqQXZ6x2bQsxAVUu8S3z22XNqY5SMx0rl2d93XnvnrOwtcfm+sM9ZhbGh/i5AZ9xw==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.56.0.tgz",
+      "integrity": "sha512-/ef8wcphVKZ0uI7A1oqQI/gEMiBUlkeBkM9AGx6AviQFIbgPVSdNK3+bHBkyq5qMkyWgkeQCSJ0uhc5vJpf0dw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.55.0",
-        "@opentelemetry/otlp-transformer": "0.55.0",
-        "@opentelemetry/sdk-logs": "0.55.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.56.0",
+        "@opentelemetry/otlp-transformer": "0.56.0",
+        "@opentelemetry/sdk-logs": "0.56.0"
       },
       "engines": {
         "node": ">=14"
@@ -10062,16 +10116,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-http": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.55.0.tgz",
-      "integrity": "sha512-fpFObWWq+DoLVrBU2dyMEaVkibByEkmKQZIUIjW/4j7lwIsTgW7aJCoD9RYFVB/tButcqov5Es2C0J2wTjM2tg==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.56.0.tgz",
+      "integrity": "sha512-gN/itg2B30pa+yAqiuIHBCf3E77sSBlyWVzb+U/MDLzEMOwfnexlMvOWULnIO1l2xR2MNLEuPCQAOrL92JHEJg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.55.0",
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/otlp-exporter-base": "0.55.0",
-        "@opentelemetry/otlp-transformer": "0.55.0",
-        "@opentelemetry/sdk-logs": "0.55.0"
+        "@opentelemetry/api-logs": "0.56.0",
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-exporter-base": "0.56.0",
+        "@opentelemetry/otlp-transformer": "0.56.0",
+        "@opentelemetry/sdk-logs": "0.56.0"
       },
       "engines": {
         "node": ">=14"
@@ -10081,18 +10135,18 @@
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.55.0.tgz",
-      "integrity": "sha512-vjE+DxUr+cUpxikdKCPiLZM5Wx7g1bywjCG76TQocvsA7Tmbb9p0t1+8gPlu9AGH7VEzPwDxxpN4p1ajpOurzQ==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.56.0.tgz",
+      "integrity": "sha512-MaO+eGrdksd8MpEbDDLbWegHc3w6ualZV6CENxNOm3wqob0iOx78/YL2NVIKyP/0ktTUIs7xIppUYqfY3ogFLQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.55.0",
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/otlp-exporter-base": "0.55.0",
-        "@opentelemetry/otlp-transformer": "0.55.0",
-        "@opentelemetry/resources": "1.28.0",
-        "@opentelemetry/sdk-logs": "0.55.0",
-        "@opentelemetry/sdk-trace-base": "1.28.0"
+        "@opentelemetry/api-logs": "0.56.0",
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-exporter-base": "0.56.0",
+        "@opentelemetry/otlp-transformer": "0.56.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/sdk-logs": "0.56.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0"
       },
       "engines": {
         "node": ">=14"
@@ -10102,17 +10156,17 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.55.0.tgz",
-      "integrity": "sha512-ohIkCLn2Wc3vhhFuf1bH8kOXHMEdcWiD847x7f3Qfygc+CGiatGLzQYscTcEYsWGMV22gVwB/kVcNcx5a3o8gA==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.56.0.tgz",
+      "integrity": "sha512-9hRHue78CV2XShAt30HadBK8XEtOBiQmnkYquR1RQyf2RYIdJvhiypEZ+Jh3NGW8Qi14icTII/1oPTQlhuyQdQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.55.0",
-        "@opentelemetry/otlp-transformer": "0.55.0",
-        "@opentelemetry/resources": "1.28.0",
-        "@opentelemetry/sdk-trace-base": "1.28.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.56.0",
+        "@opentelemetry/otlp-transformer": "0.56.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0"
       },
       "engines": {
         "node": ">=14"
@@ -10122,16 +10176,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.55.0.tgz",
-      "integrity": "sha512-lMiNic63EVHpW+eChmLD2CieDmwQBFi72+LFbh8+5hY0ShrDGrsGP/zuT5MRh7M/vM/UZYO/2A/FYd7CMQGR7A==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.56.0.tgz",
+      "integrity": "sha512-vqVuJvcwameA0r0cNrRzrZqPLB0otS+95g0XkZdiKOXUo81wYdY6r4kyrwz4nSChqTBEFm0lqi/H2OWGboOa6g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/otlp-exporter-base": "0.55.0",
-        "@opentelemetry/otlp-transformer": "0.55.0",
-        "@opentelemetry/resources": "1.28.0",
-        "@opentelemetry/sdk-trace-base": "1.28.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-exporter-base": "0.56.0",
+        "@opentelemetry/otlp-transformer": "0.56.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0"
       },
       "engines": {
         "node": ">=14"
@@ -10141,16 +10195,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.55.0.tgz",
-      "integrity": "sha512-qxiJFP+bBZW3+goHCGkE1ZdW9gJU0fR7eQ6OP+Rz5oGtEBbq4nkGodhb7C9FJlEFlE2siPtCxoeupV0gtYynag==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.56.0.tgz",
+      "integrity": "sha512-UYVtz8Kp1QZpZFg83ZrnwRIxF2wavNyi1XaIKuQNFjlYuGCh8JH4+GOuHUU4G8cIzOkWdjNR559vv0Q+MCz+1w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/otlp-exporter-base": "0.55.0",
-        "@opentelemetry/otlp-transformer": "0.55.0",
-        "@opentelemetry/resources": "1.28.0",
-        "@opentelemetry/sdk-trace-base": "1.28.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-exporter-base": "0.56.0",
+        "@opentelemetry/otlp-transformer": "0.56.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0"
       },
       "engines": {
         "node": ">=14"
@@ -10160,21 +10214,30 @@
       }
     },
     "node_modules/@opentelemetry/exporter-zipkin": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.28.0.tgz",
-      "integrity": "sha512-AMwr3eGXaPEH7gk8yhcUcen31VXy1yU5VJETu0pCfGpggGCYmhm0FKgYBpL5/vlIgQJWU/sW2vIjCL7aSilpKg==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.29.0.tgz",
+      "integrity": "sha512-9wNUxbl/sju2AvA3UhL2kLF1nfhJ4dVJgvktc3hx80Bg/fWHvF6ik4R3woZ/5gYFqZ97dcuik0dWPQEzLPNBtg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/resources": "1.28.0",
-        "@opentelemetry/sdk-trace-base": "1.28.0",
-        "@opentelemetry/semantic-conventions": "1.27.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0",
+        "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/host-metrics": {
@@ -10186,12 +10249,12 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.55.0.tgz",
-      "integrity": "sha512-YDCMlaQRZkziLL3t6TONRgmmGxDx6MyQDXRD0dknkkgUZtOK5+8MWft1OXzmNu6XfBOdT12MKN5rz+jHUkafKQ==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.56.0.tgz",
+      "integrity": "sha512-2KkGBKE+FPXU1F0zKww+stnlUxUTlBvLCiWdP63Z9sqXYeNI/ziNzsxAp4LAdUcTQmXjw1IWgvm5CAb/BHy99w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.55.0",
+        "@opentelemetry/api-logs": "0.56.0",
         "@types/shimmer": "^1.2.0",
         "import-in-the-middle": "^1.8.1",
         "require-in-the-middle": "^7.1.1",
@@ -10254,21 +10317,30 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-fetch": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.55.0.tgz",
-      "integrity": "sha512-wkybQE85HzInYX2csZ4UuMlCIMCyGGHcNqL9TcoZgAZC2EuXFReTsLytoszknhcaX+P7UT9Ee3915t8KC6XP4w==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.56.0.tgz",
+      "integrity": "sha512-jKlO8hPwId7I9dNyoBQSzSe5+q4j2cDvDHuM2pJUe6MITRKrATe9IqkJRFZ0+vdFG3gO5NMX4yFqNZ/E4zmLYg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/instrumentation": "0.55.0",
-        "@opentelemetry/sdk-trace-web": "1.28.0",
-        "@opentelemetry/semantic-conventions": "1.27.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/instrumentation": "0.56.0",
+        "@opentelemetry/sdk-trace-web": "1.29.0",
+        "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fetch/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/instrumentation-fs": {
@@ -10284,13 +10356,13 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-grpc": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.55.0.tgz",
-      "integrity": "sha512-n2ZH4pRwOy0Vhag/3eKqiyDBwcpUnGgJI9iiIRX7vivE0FMncaLazWphNFezRRaM/LuKwq1TD8pVUvieP68mow==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.56.0.tgz",
+      "integrity": "sha512-cmqCZqyKtyu4oLx3rQmPMeqAo69er7ULnbEBTFCW0++AAimIoAXJptrEvB5X9HYr0NP2TqF8As/vlV3IVmY5OQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "0.55.0",
-        "@opentelemetry/semantic-conventions": "1.27.0"
+        "@opentelemetry/instrumentation": "0.56.0",
+        "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
         "node": ">=14"
@@ -10299,19 +10371,28 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/instrumentation-grpc/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/instrumentation-hapi": {
       "resolved": "plugins/node/opentelemetry-instrumentation-hapi",
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.55.0.tgz",
-      "integrity": "sha512-AO27XSjkgNicfy/YBthskFAwx9VfaO7tChrLaTONTfOWv14GlB3Rs2eTYpywZIHWsW2cR5hvVkcDte4GV0stoA==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.56.0.tgz",
+      "integrity": "sha512-/bWHBUAq8VoATnH9iLk5w8CE9+gj+RgYSUphe7hry472n6fYl7+4PvuScoQMdmSUTprKq/gyr2kOWL6zrC7FkQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/instrumentation": "0.55.0",
-        "@opentelemetry/semantic-conventions": "1.27.0",
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/instrumentation": "0.56.0",
+        "@opentelemetry/semantic-conventions": "1.28.0",
         "forwarded-parse": "2.1.2",
         "semver": "^7.5.2"
       },
@@ -10320,6 +10401,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/instrumentation-ioredis": {
@@ -10423,21 +10513,30 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-xml-http-request": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.55.0.tgz",
-      "integrity": "sha512-Wlz4LzDpBFxHpb24RAM6RoiGspJ7J16ux0Xw5KVLtK3zzpQaxMYEVF0XQNC61WJJa3tRNt3XRjiQ8mrXJZxVQg==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.56.0.tgz",
+      "integrity": "sha512-YQLMuiSIm4yC/gRTwaLBAMXSXqCDL40DzYQ1wZ5cB3U9FcDTDjC4QZ3CTgf2FWcGkPeuGrgUAeithc5S+cUmkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/instrumentation": "0.55.0",
-        "@opentelemetry/sdk-trace-web": "1.28.0",
-        "@opentelemetry/semantic-conventions": "1.27.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/instrumentation": "0.56.0",
+        "@opentelemetry/sdk-trace-web": "1.29.0",
+        "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-xml-http-request/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/instrumentation/node_modules/@types/shimmer": {
@@ -10447,13 +10546,13 @@
       "license": "MIT"
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.55.0.tgz",
-      "integrity": "sha512-iHQI0Zzq3h1T6xUJTVFwmFl5Dt5y1es+fl4kM+k5T/3YvmVyeYkSiF+wHCg6oKrlUAJfk+t55kaAu3sYmt7ZYA==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.56.0.tgz",
+      "integrity": "sha512-eURvv0fcmBE+KE1McUeRo+u0n18ZnUeSc7lDlW/dzlqFYasEbsztTK4v0Qf8C4vEY+aMTjPKUxBG0NX2Te3Pmw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/otlp-transformer": "0.55.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-transformer": "0.56.0"
       },
       "engines": {
         "node": ">=14"
@@ -10463,15 +10562,15 @@
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.55.0.tgz",
-      "integrity": "sha512-gebbjl9FiSp52igWXuGjcWQKfB6IBwFGt5z1VFwTcVZVeEZevB6bJIqoFrhH4A02m7OUlpJ7l4EfRi3UtkNANQ==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.56.0.tgz",
+      "integrity": "sha512-QqM4si8Ew8CW5xVk4mYbfusJzMXyk6tkYA5SI0w/5NBxmiZZaYPwQQ2cu58XUH2IMPAsi71yLJVJQaWBBCta0A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/otlp-exporter-base": "0.55.0",
-        "@opentelemetry/otlp-transformer": "0.55.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-exporter-base": "0.56.0",
+        "@opentelemetry/otlp-transformer": "0.56.0"
       },
       "engines": {
         "node": ">=14"
@@ -10481,17 +10580,17 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.55.0.tgz",
-      "integrity": "sha512-kVqEfxtp6mSN2Dhpy0REo1ghP4PYhC1kMHQJ2qVlO99Pc+aigELjZDfg7/YKmL71gR6wVGIeJfiql/eXL7sQPA==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.56.0.tgz",
+      "integrity": "sha512-kVkH/W2W7EpgWWpyU5VnnjIdSD7Y7FljQYObAQSKdRcejiwMj2glypZtUdfq1LTJcv4ht0jyTrw1D3CCxssNtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.55.0",
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/resources": "1.28.0",
-        "@opentelemetry/sdk-logs": "0.55.0",
-        "@opentelemetry/sdk-metrics": "1.28.0",
-        "@opentelemetry/sdk-trace-base": "1.28.0",
+        "@opentelemetry/api-logs": "0.56.0",
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/sdk-logs": "0.56.0",
+        "@opentelemetry/sdk-metrics": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0",
         "protobufjs": "^7.3.0"
       },
       "engines": {
@@ -10518,12 +10617,12 @@
       "link": true
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.28.0.tgz",
-      "integrity": "sha512-Q7HVDIMwhN5RxL4bECMT4BdbyYSAKkC6U/RGn4NpO/cbqP6ZRg+BS7fPo/pGZi2w8AHfpIGQFXQmE8d2PC5xxQ==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.29.0.tgz",
+      "integrity": "sha512-ktsNDlqhu+/IPGEJRMj81upg2JupUp+SwW3n1ZVZTnrDiYUiMUW41vhaziA7Q6UDhbZvZ58skDpQhe2ZgNIPvg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.28.0"
+        "@opentelemetry/core": "1.29.0"
       },
       "engines": {
         "node": ">=14"
@@ -10537,12 +10636,12 @@
       "link": true
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.28.0.tgz",
-      "integrity": "sha512-wKJ94+s8467CnIRgoSRh0yXm/te0QMOwTq9J01PfG/RzYZvlvN8aRisN2oZ9SznB45dDGnMj3BhUlchSA9cEKA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.29.0.tgz",
+      "integrity": "sha512-EXIEYmFgybnFMijVgqx1mq/diWwSQcd0JWVksytAVQEnAiaDvP45WuncEVQkFIAC0gVxa2+Xr8wL5pF5jCVKbg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.28.0"
+        "@opentelemetry/core": "1.29.0"
       },
       "engines": {
         "node": ">=14"
@@ -10588,13 +10687,13 @@
       "link": true
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.28.0.tgz",
-      "integrity": "sha512-cIyXSVJjGeTICENN40YSvLDAq4Y2502hGK3iN7tfdynQLKWb3XWZQEkPc+eSx47kiy11YeFAlYkEfXwR1w8kfw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.29.0.tgz",
+      "integrity": "sha512-s7mLXuHZE7RQr1wwweGcaRp3Q4UJJ0wazeGlc/N5/XSe6UyXfsh1UQGMADYeg7YwD+cEdMtU1yJAUXdnFzYzyQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/semantic-conventions": "1.27.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
         "node": ">=14"
@@ -10603,15 +10702,24 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.55.0.tgz",
-      "integrity": "sha512-TSx+Yg/d48uWW6HtjS1AD5x6WPfLhDWLl/WxC7I2fMevaiBuKCuraxTB8MDXieCNnBI24bw9ytyXrDCswFfWgA==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.56.0.tgz",
+      "integrity": "sha512-OS0WPBJF++R/cSl+terUjQH5PebloidB1Jbbecgg2rnCmQbTST9xsRes23bLfDQVRvmegmHqDh884h0aRdJyLw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.55.0",
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/resources": "1.28.0"
+        "@opentelemetry/api-logs": "0.56.0",
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/resources": "1.29.0"
       },
       "engines": {
         "node": ">=14"
@@ -10621,13 +10729,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.28.0.tgz",
-      "integrity": "sha512-43tqMK/0BcKTyOvm15/WQ3HLr0Vu/ucAl/D84NO7iSlv6O4eOprxSHa3sUtmYkaZWHqdDJV0AHVz/R6u4JALVQ==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.29.0.tgz",
+      "integrity": "sha512-MkVtuzDjXZaUJSuJlHn6BSXjcQlMvHcsDV7LjY4P6AJeffMa4+kIGDjzsCf6DkAh6Vqlwag5EWEam3KZOX5Drw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/resources": "1.28.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/resources": "1.29.0"
       },
       "engines": {
         "node": ">=14"
@@ -10637,27 +10745,27 @@
       }
     },
     "node_modules/@opentelemetry/sdk-node": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.55.0.tgz",
-      "integrity": "sha512-gSXQWV23+9vhbjsvAIeM0LxY3W8DTKI3MZlzFp61noIb1jSr46ET+qoUjHlfZ1Yymebv9KXWeZsqhft81HBXuQ==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.56.0.tgz",
+      "integrity": "sha512-FOY7tWboBBxqftLNHPJFmDXo9fRoPd2PlzfEvSd6058BJM9gY4pWCg8lbVlu03aBrQjcfCTAhXk/tz1Yqd/m6g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.55.0",
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/exporter-logs-otlp-grpc": "0.55.0",
-        "@opentelemetry/exporter-logs-otlp-http": "0.55.0",
-        "@opentelemetry/exporter-logs-otlp-proto": "0.55.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.55.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.55.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.55.0",
-        "@opentelemetry/exporter-zipkin": "1.28.0",
-        "@opentelemetry/instrumentation": "0.55.0",
-        "@opentelemetry/resources": "1.28.0",
-        "@opentelemetry/sdk-logs": "0.55.0",
-        "@opentelemetry/sdk-metrics": "1.28.0",
-        "@opentelemetry/sdk-trace-base": "1.28.0",
-        "@opentelemetry/sdk-trace-node": "1.28.0",
-        "@opentelemetry/semantic-conventions": "1.27.0"
+        "@opentelemetry/api-logs": "0.56.0",
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.56.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.56.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.56.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.56.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.56.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.56.0",
+        "@opentelemetry/exporter-zipkin": "1.29.0",
+        "@opentelemetry/instrumentation": "0.56.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/sdk-logs": "0.56.0",
+        "@opentelemetry/sdk-metrics": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0",
+        "@opentelemetry/sdk-trace-node": "1.29.0",
+        "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
         "node": ">=14"
@@ -10666,15 +10774,24 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-trace-base": {
+    "node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.28.0.tgz",
-      "integrity": "sha512-ceUVWuCpIao7Y5xE02Xs3nQi0tOGmMea17ecBdwtCvdo9ekmO+ijc9RFDgfifMl7XCBf41zne/1POM3LqSTZDA==",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.29.0.tgz",
+      "integrity": "sha512-hEOpAYLKXF3wGJpXOtWsxEtqBgde0SCv+w+jvr3/UusR4ll3QrENEGnSl1WDCyRrpqOQ5NCNOvZch9UFVa7MnQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/resources": "1.28.0",
-        "@opentelemetry/semantic-conventions": "1.27.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
         "node": ">=14"
@@ -10683,17 +10800,26 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-trace-node": {
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.28.0.tgz",
-      "integrity": "sha512-N0sYfYXvHpP0FNIyc+UfhLnLSTOuZLytV0qQVrDWIlABeD/DWJIGttS7nYeR14gQLXch0M1DW8zm3VeN6Opwtg==",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.29.0.tgz",
+      "integrity": "sha512-ZpGYt+VnMu6O0SRKzhuIivr7qJm3GpWnTCMuJspu4kt3QWIpIenwixo5Vvjuu3R4h2Onl/8dtqAiPIs92xd5ww==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.28.0",
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/propagator-b3": "1.28.0",
-        "@opentelemetry/propagator-jaeger": "1.28.0",
-        "@opentelemetry/sdk-trace-base": "1.28.0",
+        "@opentelemetry/context-async-hooks": "1.29.0",
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/propagator-b3": "1.29.0",
+        "@opentelemetry/propagator-jaeger": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0",
         "semver": "^7.5.2"
       },
       "engines": {
@@ -10704,20 +10830,29 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-web": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.28.0.tgz",
-      "integrity": "sha512-/QOIrJc/A/caKbA9voLua4isf///cjQKB6gomEzX2fL18TBqZhIkm9k2DpjlbtrQoYCJDZ9x7Phrec22aQGpQw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.29.0.tgz",
+      "integrity": "sha512-PQVtJ76dsZ7HYBSlgZGIuxFtnKXxNbyHzMnRUxww7V2/6V/qtQN+cvNkqwPVffrUfbvClOnejo08NezAE1y+6g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/sdk-trace-base": "1.28.0",
-        "@opentelemetry/semantic-conventions": "1.27.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0",
+        "@opentelemetry/semantic-conventions": "1.28.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-web/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
@@ -35604,11 +35739,11 @@
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/exporter-jaeger": "^1.3.1",
-        "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/otlp-transformer": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
+        "@opentelemetry/otlp-transformer": "^0.56.0",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/sdk-metrics": "^1.27.0",
-        "@opentelemetry/sdk-node": "^0.55.0",
+        "@opentelemetry/sdk-node": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
@@ -35625,6 +35760,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "packages/opentelemetry-test-utils/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "packages/opentelemetry-test-utils/node_modules/@types/node": {
       "version": "18.18.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -35639,7 +35783,7 @@
       "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.55.0",
+        "@opentelemetry/api-logs": "^0.56.0",
         "winston-transport": "4.*"
       },
       "devDependencies": {
@@ -35677,7 +35821,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -35723,7 +35867,7 @@
       "version": "0.11.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -35756,7 +35900,7 @@
       "version": "0.14.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0"
+        "@opentelemetry/instrumentation": "^0.56.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -35793,7 +35937,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0"
+        "@opentelemetry/instrumentation": "^0.56.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -35830,7 +35974,7 @@
       "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -35867,7 +36011,7 @@
       "version": "0.42.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0"
+        "@opentelemetry/instrumentation": "^0.56.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -35910,7 +36054,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -35953,7 +36097,7 @@
       "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0"
+        "@opentelemetry/instrumentation": "^0.56.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -36492,7 +36636,7 @@
       "version": "0.44.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -36748,7 +36892,7 @@
       "version": "0.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/tedious": "^4.0.14"
       },
@@ -36903,7 +37047,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0"
+        "@opentelemetry/instrumentation": "^0.56.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.7.0",
@@ -36940,7 +37084,7 @@
       "version": "0.48.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/aws-lambda": "8.10.143"
       },
@@ -36980,7 +37124,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/propagation-utils": "^0.30.13",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
@@ -37036,14 +37180,14 @@
       "version": "0.43.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.55.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/api-logs": "^0.56.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@types/bunyan": "1.8.9"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/resources": "^1.8.0",
-        "@opentelemetry/sdk-logs": "^0.55.0",
+        "@opentelemetry/sdk-logs": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -37062,6 +37206,16 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "plugins/node/opentelemetry-instrumentation-bunyan/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "plugins/node/opentelemetry-instrumentation-bunyan/node_modules/@types/bunyan": {
@@ -37085,7 +37239,7 @@
       "version": "0.43.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37126,7 +37280,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/connect": "3.4.36"
       },
@@ -37170,7 +37324,7 @@
       "version": "0.41.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0"
+        "@opentelemetry/instrumentation": "^0.56.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37209,7 +37363,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37251,7 +37405,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37259,7 +37413,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
-        "@opentelemetry/instrumentation-http": "^0.55.0",
+        "@opentelemetry/instrumentation-http": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/express": "4.17.21",
@@ -37280,6 +37434,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-fastify/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-fastify/node_modules/@types/node": {
       "version": "18.15.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
@@ -37291,7 +37454,7 @@
       "version": "0.41.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0"
+        "@opentelemetry/instrumentation": "^0.56.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37329,7 +37492,7 @@
       "version": "0.45.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0"
+        "@opentelemetry/instrumentation": "^0.56.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37371,7 +37534,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37410,7 +37573,7 @@
       "version": "0.45.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
@@ -37453,7 +37616,7 @@
       "version": "0.42.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37491,7 +37654,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37499,7 +37662,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
-        "@opentelemetry/instrumentation-http": "^0.55.0",
+        "@opentelemetry/instrumentation-http": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/koa": "2.15.0",
@@ -37522,6 +37685,15 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "plugins/node/opentelemetry-instrumentation-koa/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "plugins/node/opentelemetry-instrumentation-koa/node_modules/@types/node": {
       "version": "18.18.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -37536,7 +37708,7 @@
       "version": "0.41.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/memcached": "^2.2.6"
       },
@@ -37575,7 +37747,7 @@
       "version": "0.49.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37802,7 +37974,7 @@
       "version": "0.43.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mysql": "2.15.26"
       },
@@ -37842,7 +38014,7 @@
       "version": "0.43.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@opentelemetry/sql-common": "^0.40.1"
       },
@@ -37882,7 +38054,7 @@
       "version": "0.42.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37926,7 +38098,7 @@
       "version": "0.41.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37964,7 +38136,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.26.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "1.27.0",
         "@opentelemetry/sql-common": "^0.40.1",
         "@types/pg": "8.6.1",
@@ -38010,9 +38182,9 @@
       "version": "0.44.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.55.0",
+        "@opentelemetry/api-logs": "^0.56.0",
         "@opentelemetry/core": "^1.25.0",
-        "@opentelemetry/instrumentation": "^0.55.0"
+        "@opentelemetry/instrumentation": "^0.56.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -38053,7 +38225,7 @@
       "version": "0.44.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
@@ -38085,7 +38257,7 @@
       "version": "0.44.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
@@ -38150,7 +38322,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -38190,7 +38362,7 @@
       "version": "0.42.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -38226,8 +38398,8 @@
       "version": "0.42.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.55.0",
-        "@opentelemetry/instrumentation": "^0.55.0"
+        "@opentelemetry/api-logs": "^0.56.0",
+        "@opentelemetry/instrumentation": "^0.56.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -38269,7 +38441,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-web": "^1.15.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
@@ -38319,7 +38491,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0"
+        "@opentelemetry/instrumentation": "^0.56.0"
       },
       "devDependencies": {
         "@babel/core": "7.24.6",
@@ -38495,7 +38667,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-web": "^1.8.0"
       },
       "devDependencies": {
@@ -38503,7 +38675,7 @@
         "@babel/preset-env": "7.24.6",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-zone-peer-dep": "^1.8.0",
-        "@opentelemetry/instrumentation-xml-http-request": "^0.55.0",
+        "@opentelemetry/instrumentation-xml-http-request": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@types/jquery": "3.5.30",
         "@types/mocha": "10.0.6",
@@ -46785,9 +46957,9 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
     },
     "@opentelemetry/api-logs": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.55.0.tgz",
-      "integrity": "sha512-3cpa+qI45VHYcA5c0bHM6VHo9gicv3p5mlLHNG3rLyjQU8b7e0st1rWtrUn3JbZ3DwwCfhKop4eQ9UuYlC6Pkg==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.56.0.tgz",
+      "integrity": "sha512-Wr39+94UNNG3Ei9nv3pHd4AJ63gq5nSemMRpCd8fPwDL9rN3vK26lzxfH27mw16XzOSO+TpyQwBAMaLxaPWG0g==",
       "requires": {
         "@opentelemetry/api": "^1.3.0"
       }
@@ -46826,7 +46998,7 @@
       "version": "file:metapackages/auto-instrumentations-node",
       "requires": {
         "@opentelemetry/api": "^1.4.1",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/instrumentation-amqplib": "^0.44.0",
         "@opentelemetry/instrumentation-aws-lambda": "^0.48.0",
         "@opentelemetry/instrumentation-aws-sdk": "^0.47.0",
@@ -46841,9 +47013,9 @@
         "@opentelemetry/instrumentation-fs": "^0.17.0",
         "@opentelemetry/instrumentation-generic-pool": "^0.41.0",
         "@opentelemetry/instrumentation-graphql": "^0.45.0",
-        "@opentelemetry/instrumentation-grpc": "^0.55.0",
+        "@opentelemetry/instrumentation-grpc": "^0.56.0",
         "@opentelemetry/instrumentation-hapi": "^0.43.0",
-        "@opentelemetry/instrumentation-http": "^0.55.0",
+        "@opentelemetry/instrumentation-http": "^0.56.0",
         "@opentelemetry/instrumentation-ioredis": "^0.45.0",
         "@opentelemetry/instrumentation-kafkajs": "^0.5.0",
         "@opentelemetry/instrumentation-knex": "^0.42.0",
@@ -46872,7 +47044,7 @@
         "@opentelemetry/resource-detector-container": "^0.5.1",
         "@opentelemetry/resource-detector-gcp": "^0.30.0",
         "@opentelemetry/resources": "^1.24.0",
-        "@opentelemetry/sdk-node": "^0.55.0",
+        "@opentelemetry/sdk-node": "^0.56.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
@@ -46899,11 +47071,11 @@
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/instrumentation-document-load": "^0.42.0",
-        "@opentelemetry/instrumentation-fetch": "^0.55.0",
+        "@opentelemetry/instrumentation-fetch": "^0.56.0",
         "@opentelemetry/instrumentation-user-interaction": "^0.42.0",
-        "@opentelemetry/instrumentation-xml-http-request": "^0.55.0",
+        "@opentelemetry/instrumentation-xml-http-request": "^0.56.0",
         "@types/mocha": "10.0.6",
         "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",
@@ -47067,15 +47239,15 @@
       }
     },
     "@opentelemetry/context-async-hooks": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.28.0.tgz",
-      "integrity": "sha512-igcl4Ve+F1N2063PJUkesk/GkYyuGIWinYkSyAFTnIj3gzrOgvOA4k747XNdL47HRRL1w/qh7UW8NDuxOLvKFA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.29.0.tgz",
+      "integrity": "sha512-TKT91jcFXgHyIDF1lgJF3BHGIakn6x0Xp7Tq3zoS3TMPzT9IlP0xEavWP8C1zGjU9UmZP2VR1tJhW9Az1A3w8Q==",
       "requires": {}
     },
     "@opentelemetry/context-zone-peer-dep": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.28.0.tgz",
-      "integrity": "sha512-tGtZ+N/QlMpZmHlSpANJsCBsx04FAF7t1nvyocG+Hr1r9rEJFPbdJ23pRDPYdpHX7D5UislKEz3mP+kfsP9p/A==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-1.29.0.tgz",
+      "integrity": "sha512-HWmxBAQ0w3QWoJ5wfFzr0pNLXgE7ztKOHUd13Hd4CiG9rSNVS33s0qB57aCGzEk6Y1L4eG8Z19hnb52UirmPdg==",
       "dev": true,
       "requires": {}
     },
@@ -47085,11 +47257,11 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/exporter-jaeger": "^1.3.1",
-        "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/otlp-transformer": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
+        "@opentelemetry/otlp-transformer": "^0.56.0",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/sdk-metrics": "^1.27.0",
-        "@opentelemetry/sdk-node": "^0.55.0",
+        "@opentelemetry/sdk-node": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -47097,6 +47269,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -47109,108 +47286,129 @@
       }
     },
     "@opentelemetry/core": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.28.0.tgz",
-      "integrity": "sha512-ZLwRMV+fNDpVmF2WYUdBHlq0eOWtEaUJSusrzjGnBt7iSRvfjFE3RXYUZJrqou/wIDWV0DwQ5KIfYe9WXg9Xqw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.29.0.tgz",
+      "integrity": "sha512-gmT7vAreXl0DTHD2rVZcw3+l2g84+5XiHIqdBUxXbExymPCvSsGOpiwMmn8nkiJur28STV31wnhIDrzWDPzjfA==",
       "requires": {
-        "@opentelemetry/semantic-conventions": "1.27.0"
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        }
       }
     },
     "@opentelemetry/exporter-jaeger": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.28.0.tgz",
-      "integrity": "sha512-w4wHFZjfxxHqUVUyERegruLCI3pGMwkg9t2XhHBVUjmmhuul6RjN1fn22/0ZBhONG76LsIUJpo2W+ejBPnphFA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-1.29.0.tgz",
+      "integrity": "sha512-GhShia26dMaUOsfemzGs8db+WBxVW6GPHkFEfRugPMiXAsoWxTNiVChUiDRVzOxJ6ZQ2QjbpZ3eHmBZc3SM/1g==",
       "requires": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/sdk-trace-base": "1.28.0",
-        "@opentelemetry/semantic-conventions": "1.27.0",
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0",
+        "@opentelemetry/semantic-conventions": "1.28.0",
         "jaeger-client": "^3.15.0"
+      },
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        }
       }
     },
     "@opentelemetry/exporter-logs-otlp-grpc": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.55.0.tgz",
-      "integrity": "sha512-ykqawCL0ILJWyCJlxCPSAlqQXZ6x2bQsxAVUu8S3z22XNqY5SMx0rl2d93XnvnrOwtcfm+sM9ZhbGh/i5AZ9xw==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.56.0.tgz",
+      "integrity": "sha512-/ef8wcphVKZ0uI7A1oqQI/gEMiBUlkeBkM9AGx6AviQFIbgPVSdNK3+bHBkyq5qMkyWgkeQCSJ0uhc5vJpf0dw==",
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.55.0",
-        "@opentelemetry/otlp-transformer": "0.55.0",
-        "@opentelemetry/sdk-logs": "0.55.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.56.0",
+        "@opentelemetry/otlp-transformer": "0.56.0",
+        "@opentelemetry/sdk-logs": "0.56.0"
       }
     },
     "@opentelemetry/exporter-logs-otlp-http": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.55.0.tgz",
-      "integrity": "sha512-fpFObWWq+DoLVrBU2dyMEaVkibByEkmKQZIUIjW/4j7lwIsTgW7aJCoD9RYFVB/tButcqov5Es2C0J2wTjM2tg==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.56.0.tgz",
+      "integrity": "sha512-gN/itg2B30pa+yAqiuIHBCf3E77sSBlyWVzb+U/MDLzEMOwfnexlMvOWULnIO1l2xR2MNLEuPCQAOrL92JHEJg==",
       "requires": {
-        "@opentelemetry/api-logs": "0.55.0",
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/otlp-exporter-base": "0.55.0",
-        "@opentelemetry/otlp-transformer": "0.55.0",
-        "@opentelemetry/sdk-logs": "0.55.0"
+        "@opentelemetry/api-logs": "0.56.0",
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-exporter-base": "0.56.0",
+        "@opentelemetry/otlp-transformer": "0.56.0",
+        "@opentelemetry/sdk-logs": "0.56.0"
       }
     },
     "@opentelemetry/exporter-logs-otlp-proto": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.55.0.tgz",
-      "integrity": "sha512-vjE+DxUr+cUpxikdKCPiLZM5Wx7g1bywjCG76TQocvsA7Tmbb9p0t1+8gPlu9AGH7VEzPwDxxpN4p1ajpOurzQ==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.56.0.tgz",
+      "integrity": "sha512-MaO+eGrdksd8MpEbDDLbWegHc3w6ualZV6CENxNOm3wqob0iOx78/YL2NVIKyP/0ktTUIs7xIppUYqfY3ogFLQ==",
       "requires": {
-        "@opentelemetry/api-logs": "0.55.0",
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/otlp-exporter-base": "0.55.0",
-        "@opentelemetry/otlp-transformer": "0.55.0",
-        "@opentelemetry/resources": "1.28.0",
-        "@opentelemetry/sdk-logs": "0.55.0",
-        "@opentelemetry/sdk-trace-base": "1.28.0"
+        "@opentelemetry/api-logs": "0.56.0",
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-exporter-base": "0.56.0",
+        "@opentelemetry/otlp-transformer": "0.56.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/sdk-logs": "0.56.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0"
       }
     },
     "@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.55.0.tgz",
-      "integrity": "sha512-ohIkCLn2Wc3vhhFuf1bH8kOXHMEdcWiD847x7f3Qfygc+CGiatGLzQYscTcEYsWGMV22gVwB/kVcNcx5a3o8gA==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.56.0.tgz",
+      "integrity": "sha512-9hRHue78CV2XShAt30HadBK8XEtOBiQmnkYquR1RQyf2RYIdJvhiypEZ+Jh3NGW8Qi14icTII/1oPTQlhuyQdQ==",
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.55.0",
-        "@opentelemetry/otlp-transformer": "0.55.0",
-        "@opentelemetry/resources": "1.28.0",
-        "@opentelemetry/sdk-trace-base": "1.28.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.56.0",
+        "@opentelemetry/otlp-transformer": "0.56.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0"
       }
     },
     "@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.55.0.tgz",
-      "integrity": "sha512-lMiNic63EVHpW+eChmLD2CieDmwQBFi72+LFbh8+5hY0ShrDGrsGP/zuT5MRh7M/vM/UZYO/2A/FYd7CMQGR7A==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.56.0.tgz",
+      "integrity": "sha512-vqVuJvcwameA0r0cNrRzrZqPLB0otS+95g0XkZdiKOXUo81wYdY6r4kyrwz4nSChqTBEFm0lqi/H2OWGboOa6g==",
       "requires": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/otlp-exporter-base": "0.55.0",
-        "@opentelemetry/otlp-transformer": "0.55.0",
-        "@opentelemetry/resources": "1.28.0",
-        "@opentelemetry/sdk-trace-base": "1.28.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-exporter-base": "0.56.0",
+        "@opentelemetry/otlp-transformer": "0.56.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0"
       }
     },
     "@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.55.0.tgz",
-      "integrity": "sha512-qxiJFP+bBZW3+goHCGkE1ZdW9gJU0fR7eQ6OP+Rz5oGtEBbq4nkGodhb7C9FJlEFlE2siPtCxoeupV0gtYynag==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.56.0.tgz",
+      "integrity": "sha512-UYVtz8Kp1QZpZFg83ZrnwRIxF2wavNyi1XaIKuQNFjlYuGCh8JH4+GOuHUU4G8cIzOkWdjNR559vv0Q+MCz+1w==",
       "requires": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/otlp-exporter-base": "0.55.0",
-        "@opentelemetry/otlp-transformer": "0.55.0",
-        "@opentelemetry/resources": "1.28.0",
-        "@opentelemetry/sdk-trace-base": "1.28.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-exporter-base": "0.56.0",
+        "@opentelemetry/otlp-transformer": "0.56.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0"
       }
     },
     "@opentelemetry/exporter-zipkin": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.28.0.tgz",
-      "integrity": "sha512-AMwr3eGXaPEH7gk8yhcUcen31VXy1yU5VJETu0pCfGpggGCYmhm0FKgYBpL5/vlIgQJWU/sW2vIjCL7aSilpKg==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-1.29.0.tgz",
+      "integrity": "sha512-9wNUxbl/sju2AvA3UhL2kLF1nfhJ4dVJgvktc3hx80Bg/fWHvF6ik4R3woZ/5gYFqZ97dcuik0dWPQEzLPNBtg==",
       "requires": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/resources": "1.28.0",
-        "@opentelemetry/sdk-trace-base": "1.28.0",
-        "@opentelemetry/semantic-conventions": "1.27.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        }
       }
     },
     "@opentelemetry/host-metrics": {
@@ -47385,11 +47583,11 @@
       }
     },
     "@opentelemetry/instrumentation": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.55.0.tgz",
-      "integrity": "sha512-YDCMlaQRZkziLL3t6TONRgmmGxDx6MyQDXRD0dknkkgUZtOK5+8MWft1OXzmNu6XfBOdT12MKN5rz+jHUkafKQ==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.56.0.tgz",
+      "integrity": "sha512-2KkGBKE+FPXU1F0zKww+stnlUxUTlBvLCiWdP63Z9sqXYeNI/ziNzsxAp4LAdUcTQmXjw1IWgvm5CAb/BHy99w==",
       "requires": {
-        "@opentelemetry/api-logs": "0.55.0",
+        "@opentelemetry/api-logs": "0.56.0",
         "@types/shimmer": "^1.2.0",
         "import-in-the-middle": "^1.8.1",
         "require-in-the-middle": "^7.1.1",
@@ -47410,7 +47608,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/amqplib": "^0.5.17",
         "@types/lodash": "4.14.199",
@@ -47448,7 +47646,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/propagator-aws-xray": "^1.25.1",
         "@opentelemetry/propagator-aws-xray-lambda": "^0.53.0",
         "@opentelemetry/sdk-metrics": "^1.8.0",
@@ -47487,7 +47685,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/propagation-utils": "^0.30.13",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -47527,10 +47725,10 @@
       "version": "file:plugins/node/opentelemetry-instrumentation-bunyan",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/api-logs": "^0.55.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/api-logs": "^0.56.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/resources": "^1.8.0",
-        "@opentelemetry/sdk-logs": "^0.55.0",
+        "@opentelemetry/sdk-logs": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -47546,6 +47744,12 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+          "dev": true
+        },
         "@types/bunyan": {
           "version": "1.8.9",
           "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.9.tgz",
@@ -47570,7 +47774,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -47602,7 +47806,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -47640,7 +47844,7 @@
         "@cucumber/messages": "^22.0.0",
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/core": "^1.3.1",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.3.1",
         "@opentelemetry/sdk-trace-node": "^1.3.1",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -47661,7 +47865,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
@@ -47689,7 +47893,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/mocha": "7.0.2",
@@ -47721,7 +47925,7 @@
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-web": "^1.15.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -47763,7 +47967,7 @@
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -47798,8 +48002,8 @@
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/instrumentation-http": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
+        "@opentelemetry/instrumentation-http": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -47815,6 +48019,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.15.3",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
@@ -47824,14 +48033,21 @@
       }
     },
     "@opentelemetry/instrumentation-fetch": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.55.0.tgz",
-      "integrity": "sha512-wkybQE85HzInYX2csZ4UuMlCIMCyGGHcNqL9TcoZgAZC2EuXFReTsLytoszknhcaX+P7UT9Ee3915t8KC6XP4w==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.56.0.tgz",
+      "integrity": "sha512-jKlO8hPwId7I9dNyoBQSzSe5+q4j2cDvDHuM2pJUe6MITRKrATe9IqkJRFZ0+vdFG3gO5NMX4yFqNZ/E4zmLYg==",
       "requires": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/instrumentation": "0.55.0",
-        "@opentelemetry/sdk-trace-web": "1.28.0",
-        "@opentelemetry/semantic-conventions": "1.27.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/instrumentation": "0.56.0",
+        "@opentelemetry/sdk-trace-web": "1.29.0",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        }
       }
     },
     "@opentelemetry/instrumentation-fs": {
@@ -47840,7 +48056,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
@@ -47869,7 +48085,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@types/generic-pool": "^3.1.9",
@@ -47898,7 +48114,7 @@
       "version": "file:plugins/node/opentelemetry-instrumentation-graphql",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
@@ -47928,12 +48144,19 @@
       }
     },
     "@opentelemetry/instrumentation-grpc": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.55.0.tgz",
-      "integrity": "sha512-n2ZH4pRwOy0Vhag/3eKqiyDBwcpUnGgJI9iiIRX7vivE0FMncaLazWphNFezRRaM/LuKwq1TD8pVUvieP68mow==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.56.0.tgz",
+      "integrity": "sha512-cmqCZqyKtyu4oLx3rQmPMeqAo69er7ULnbEBTFCW0++AAimIoAXJptrEvB5X9HYr0NP2TqF8As/vlV3IVmY5OQ==",
       "requires": {
-        "@opentelemetry/instrumentation": "0.55.0",
-        "@opentelemetry/semantic-conventions": "1.27.0"
+        "@opentelemetry/instrumentation": "0.56.0",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        }
       }
     },
     "@opentelemetry/instrumentation-hapi": {
@@ -47944,7 +48167,7 @@
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -47969,15 +48192,22 @@
       }
     },
     "@opentelemetry/instrumentation-http": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.55.0.tgz",
-      "integrity": "sha512-AO27XSjkgNicfy/YBthskFAwx9VfaO7tChrLaTONTfOWv14GlB3Rs2eTYpywZIHWsW2cR5hvVkcDte4GV0stoA==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.56.0.tgz",
+      "integrity": "sha512-/bWHBUAq8VoATnH9iLk5w8CE9+gj+RgYSUphe7hry472n6fYl7+4PvuScoQMdmSUTprKq/gyr2kOWL6zrC7FkQ==",
       "requires": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/instrumentation": "0.55.0",
-        "@opentelemetry/semantic-conventions": "1.27.0",
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/instrumentation": "0.56.0",
+        "@opentelemetry/semantic-conventions": "1.28.0",
         "forwarded-parse": "2.1.2",
         "semver": "^7.5.2"
+      },
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        }
       }
     },
     "@opentelemetry/instrumentation-ioredis": {
@@ -47986,7 +48216,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
@@ -48020,7 +48250,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.24.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "7.0.2",
@@ -48049,7 +48279,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -48081,8 +48311,8 @@
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/instrumentation-http": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
+        "@opentelemetry/instrumentation-http": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -48100,6 +48330,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/node": {
           "version": "18.18.14",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
@@ -48118,7 +48353,7 @@
         "@babel/preset-env": "7.24.6",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-web": "^1.8.0",
         "@types/mocha": "10.0.6",
@@ -48259,7 +48494,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@types/lru-cache": "7.10.10",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
@@ -48294,7 +48529,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -48325,7 +48560,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-metrics": "^1.9.1",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
@@ -48480,7 +48715,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
@@ -48516,7 +48751,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-metrics": "^1.8.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -48548,7 +48783,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@opentelemetry/sql-common": "^0.40.1",
@@ -48581,7 +48816,7 @@
         "@nestjs/core": "9.4.3",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -48615,7 +48850,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -48646,7 +48881,7 @@
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
         "@opentelemetry/core": "^1.26.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "1.27.0",
@@ -48682,10 +48917,10 @@
       "version": "file:plugins/node/opentelemetry-instrumentation-pino",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/api-logs": "^0.55.0",
+        "@opentelemetry/api-logs": "^0.56.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
         "@opentelemetry/core": "^1.25.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -48719,7 +48954,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
@@ -48753,7 +48988,7 @@
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/redis-common": "^0.36.2",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
@@ -48799,7 +49034,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -48831,7 +49066,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -48858,7 +49093,7 @@
       "version": "file:plugins/node/instrumentation-runtime-node",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-metrics": "^1.20.0",
         "@types/mocha": "^10.0.6",
         "@types/node": "18.18.14",
@@ -49249,7 +49484,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
@@ -49449,7 +49684,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^1.8.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "7.0.2",
@@ -49554,7 +49789,7 @@
       "requires": {
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-metrics": "^1.8.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
@@ -49587,8 +49822,8 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-zone-peer-dep": "^1.8.0",
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
-        "@opentelemetry/instrumentation-xml-http-request": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
+        "@opentelemetry/instrumentation-xml-http-request": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-web": "^1.8.0",
         "@types/jquery": "3.5.30",
@@ -49729,9 +49964,9 @@
       "version": "file:plugins/node/opentelemetry-instrumentation-winston",
       "requires": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/api-logs": "^0.55.0",
+        "@opentelemetry/api-logs": "^0.56.0",
         "@opentelemetry/context-async-hooks": "^1.21.0",
-        "@opentelemetry/instrumentation": "^0.55.0",
+        "@opentelemetry/instrumentation": "^0.56.0",
         "@opentelemetry/sdk-trace-base": "^1.21.0",
         "@opentelemetry/sdk-trace-node": "^1.21.0",
         "@opentelemetry/winston-transport": "^0.8.0",
@@ -49760,47 +49995,54 @@
       }
     },
     "@opentelemetry/instrumentation-xml-http-request": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.55.0.tgz",
-      "integrity": "sha512-Wlz4LzDpBFxHpb24RAM6RoiGspJ7J16ux0Xw5KVLtK3zzpQaxMYEVF0XQNC61WJJa3tRNt3XRjiQ8mrXJZxVQg==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.56.0.tgz",
+      "integrity": "sha512-YQLMuiSIm4yC/gRTwaLBAMXSXqCDL40DzYQ1wZ5cB3U9FcDTDjC4QZ3CTgf2FWcGkPeuGrgUAeithc5S+cUmkg==",
       "requires": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/instrumentation": "0.55.0",
-        "@opentelemetry/sdk-trace-web": "1.28.0",
-        "@opentelemetry/semantic-conventions": "1.27.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/instrumentation": "0.56.0",
+        "@opentelemetry/sdk-trace-web": "1.29.0",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        }
       }
     },
     "@opentelemetry/otlp-exporter-base": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.55.0.tgz",
-      "integrity": "sha512-iHQI0Zzq3h1T6xUJTVFwmFl5Dt5y1es+fl4kM+k5T/3YvmVyeYkSiF+wHCg6oKrlUAJfk+t55kaAu3sYmt7ZYA==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.56.0.tgz",
+      "integrity": "sha512-eURvv0fcmBE+KE1McUeRo+u0n18ZnUeSc7lDlW/dzlqFYasEbsztTK4v0Qf8C4vEY+aMTjPKUxBG0NX2Te3Pmw==",
       "requires": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/otlp-transformer": "0.55.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-transformer": "0.56.0"
       }
     },
     "@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.55.0.tgz",
-      "integrity": "sha512-gebbjl9FiSp52igWXuGjcWQKfB6IBwFGt5z1VFwTcVZVeEZevB6bJIqoFrhH4A02m7OUlpJ7l4EfRi3UtkNANQ==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.56.0.tgz",
+      "integrity": "sha512-QqM4si8Ew8CW5xVk4mYbfusJzMXyk6tkYA5SI0w/5NBxmiZZaYPwQQ2cu58XUH2IMPAsi71yLJVJQaWBBCta0A==",
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/otlp-exporter-base": "0.55.0",
-        "@opentelemetry/otlp-transformer": "0.55.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/otlp-exporter-base": "0.56.0",
+        "@opentelemetry/otlp-transformer": "0.56.0"
       }
     },
     "@opentelemetry/otlp-transformer": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.55.0.tgz",
-      "integrity": "sha512-kVqEfxtp6mSN2Dhpy0REo1ghP4PYhC1kMHQJ2qVlO99Pc+aigELjZDfg7/YKmL71gR6wVGIeJfiql/eXL7sQPA==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.56.0.tgz",
+      "integrity": "sha512-kVkH/W2W7EpgWWpyU5VnnjIdSD7Y7FljQYObAQSKdRcejiwMj2glypZtUdfq1LTJcv4ht0jyTrw1D3CCxssNtQ==",
       "requires": {
-        "@opentelemetry/api-logs": "0.55.0",
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/resources": "1.28.0",
-        "@opentelemetry/sdk-logs": "0.55.0",
-        "@opentelemetry/sdk-metrics": "1.28.0",
-        "@opentelemetry/sdk-trace-base": "1.28.0",
+        "@opentelemetry/api-logs": "0.56.0",
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/sdk-logs": "0.56.0",
+        "@opentelemetry/sdk-metrics": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0",
         "protobufjs": "^7.3.0"
       }
     },
@@ -50140,11 +50382,11 @@
       }
     },
     "@opentelemetry/propagator-b3": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.28.0.tgz",
-      "integrity": "sha512-Q7HVDIMwhN5RxL4bECMT4BdbyYSAKkC6U/RGn4NpO/cbqP6ZRg+BS7fPo/pGZi2w8AHfpIGQFXQmE8d2PC5xxQ==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.29.0.tgz",
+      "integrity": "sha512-ktsNDlqhu+/IPGEJRMj81upg2JupUp+SwW3n1ZVZTnrDiYUiMUW41vhaziA7Q6UDhbZvZ58skDpQhe2ZgNIPvg==",
       "requires": {
-        "@opentelemetry/core": "1.28.0"
+        "@opentelemetry/core": "1.29.0"
       }
     },
     "@opentelemetry/propagator-instana": {
@@ -50245,11 +50487,11 @@
       }
     },
     "@opentelemetry/propagator-jaeger": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.28.0.tgz",
-      "integrity": "sha512-wKJ94+s8467CnIRgoSRh0yXm/te0QMOwTq9J01PfG/RzYZvlvN8aRisN2oZ9SznB45dDGnMj3BhUlchSA9cEKA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.29.0.tgz",
+      "integrity": "sha512-EXIEYmFgybnFMijVgqx1mq/diWwSQcd0JWVksytAVQEnAiaDvP45WuncEVQkFIAC0gVxa2+Xr8wL5pF5jCVKbg==",
       "requires": {
-        "@opentelemetry/core": "1.28.0"
+        "@opentelemetry/core": "1.29.0"
       }
     },
     "@opentelemetry/propagator-ot-trace": {
@@ -50457,7 +50699,7 @@
         "@opentelemetry/contrib-test-utils": "^0.43.0",
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/instrumentation-fs": "^0.17.0",
-        "@opentelemetry/instrumentation-http": "^0.55.0",
+        "@opentelemetry/instrumentation-http": "^0.56.0",
         "@opentelemetry/resources": "^1.10.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
@@ -50470,6 +50712,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/mocha": {
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
@@ -50493,7 +50740,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
         "@opentelemetry/core": "^1.25.1",
-        "@opentelemetry/instrumentation-http": "^0.55.0",
+        "@opentelemetry/instrumentation-http": "^0.56.0",
         "@opentelemetry/resources": "^1.10.1",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
@@ -50505,6 +50752,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/mocha": {
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
@@ -50565,7 +50817,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
         "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/instrumentation-http": "^0.55.0",
+        "@opentelemetry/instrumentation-http": "^0.56.0",
         "@opentelemetry/resources": "^1.10.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
@@ -50578,6 +50830,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/mocha": {
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
@@ -50632,7 +50889,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.43.0",
         "@opentelemetry/resources": "^1.10.0",
-        "@opentelemetry/sdk-node": "^0.55.0",
+        "@opentelemetry/sdk-node": "^0.56.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/mocha": "8.2.3",
         "@types/node": "18.18.14",
@@ -50643,6 +50900,11 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        },
         "@types/mocha": {
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.3.tgz",
@@ -50661,87 +50923,115 @@
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.28.0.tgz",
-      "integrity": "sha512-cIyXSVJjGeTICENN40YSvLDAq4Y2502hGK3iN7tfdynQLKWb3XWZQEkPc+eSx47kiy11YeFAlYkEfXwR1w8kfw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.29.0.tgz",
+      "integrity": "sha512-s7mLXuHZE7RQr1wwweGcaRp3Q4UJJ0wazeGlc/N5/XSe6UyXfsh1UQGMADYeg7YwD+cEdMtU1yJAUXdnFzYzyQ==",
       "requires": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/semantic-conventions": "1.27.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        }
       }
     },
     "@opentelemetry/sdk-logs": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.55.0.tgz",
-      "integrity": "sha512-TSx+Yg/d48uWW6HtjS1AD5x6WPfLhDWLl/WxC7I2fMevaiBuKCuraxTB8MDXieCNnBI24bw9ytyXrDCswFfWgA==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.56.0.tgz",
+      "integrity": "sha512-OS0WPBJF++R/cSl+terUjQH5PebloidB1Jbbecgg2rnCmQbTST9xsRes23bLfDQVRvmegmHqDh884h0aRdJyLw==",
       "requires": {
-        "@opentelemetry/api-logs": "0.55.0",
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/resources": "1.28.0"
+        "@opentelemetry/api-logs": "0.56.0",
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/resources": "1.29.0"
       }
     },
     "@opentelemetry/sdk-metrics": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.28.0.tgz",
-      "integrity": "sha512-43tqMK/0BcKTyOvm15/WQ3HLr0Vu/ucAl/D84NO7iSlv6O4eOprxSHa3sUtmYkaZWHqdDJV0AHVz/R6u4JALVQ==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.29.0.tgz",
+      "integrity": "sha512-MkVtuzDjXZaUJSuJlHn6BSXjcQlMvHcsDV7LjY4P6AJeffMa4+kIGDjzsCf6DkAh6Vqlwag5EWEam3KZOX5Drw==",
       "requires": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/resources": "1.28.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/resources": "1.29.0"
       }
     },
     "@opentelemetry/sdk-node": {
-      "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.55.0.tgz",
-      "integrity": "sha512-gSXQWV23+9vhbjsvAIeM0LxY3W8DTKI3MZlzFp61noIb1jSr46ET+qoUjHlfZ1Yymebv9KXWeZsqhft81HBXuQ==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.56.0.tgz",
+      "integrity": "sha512-FOY7tWboBBxqftLNHPJFmDXo9fRoPd2PlzfEvSd6058BJM9gY4pWCg8lbVlu03aBrQjcfCTAhXk/tz1Yqd/m6g==",
       "requires": {
-        "@opentelemetry/api-logs": "0.55.0",
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/exporter-logs-otlp-grpc": "0.55.0",
-        "@opentelemetry/exporter-logs-otlp-http": "0.55.0",
-        "@opentelemetry/exporter-logs-otlp-proto": "0.55.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.55.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.55.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.55.0",
-        "@opentelemetry/exporter-zipkin": "1.28.0",
-        "@opentelemetry/instrumentation": "0.55.0",
-        "@opentelemetry/resources": "1.28.0",
-        "@opentelemetry/sdk-logs": "0.55.0",
-        "@opentelemetry/sdk-metrics": "1.28.0",
-        "@opentelemetry/sdk-trace-base": "1.28.0",
-        "@opentelemetry/sdk-trace-node": "1.28.0",
-        "@opentelemetry/semantic-conventions": "1.27.0"
+        "@opentelemetry/api-logs": "0.56.0",
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.56.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.56.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.56.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.56.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.56.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.56.0",
+        "@opentelemetry/exporter-zipkin": "1.29.0",
+        "@opentelemetry/instrumentation": "0.56.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/sdk-logs": "0.56.0",
+        "@opentelemetry/sdk-metrics": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0",
+        "@opentelemetry/sdk-trace-node": "1.29.0",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        }
       }
     },
     "@opentelemetry/sdk-trace-base": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.28.0.tgz",
-      "integrity": "sha512-ceUVWuCpIao7Y5xE02Xs3nQi0tOGmMea17ecBdwtCvdo9ekmO+ijc9RFDgfifMl7XCBf41zne/1POM3LqSTZDA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.29.0.tgz",
+      "integrity": "sha512-hEOpAYLKXF3wGJpXOtWsxEtqBgde0SCv+w+jvr3/UusR4ll3QrENEGnSl1WDCyRrpqOQ5NCNOvZch9UFVa7MnQ==",
       "requires": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/resources": "1.28.0",
-        "@opentelemetry/semantic-conventions": "1.27.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/resources": "1.29.0",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        }
       }
     },
     "@opentelemetry/sdk-trace-node": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.28.0.tgz",
-      "integrity": "sha512-N0sYfYXvHpP0FNIyc+UfhLnLSTOuZLytV0qQVrDWIlABeD/DWJIGttS7nYeR14gQLXch0M1DW8zm3VeN6Opwtg==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.29.0.tgz",
+      "integrity": "sha512-ZpGYt+VnMu6O0SRKzhuIivr7qJm3GpWnTCMuJspu4kt3QWIpIenwixo5Vvjuu3R4h2Onl/8dtqAiPIs92xd5ww==",
       "requires": {
-        "@opentelemetry/context-async-hooks": "1.28.0",
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/propagator-b3": "1.28.0",
-        "@opentelemetry/propagator-jaeger": "1.28.0",
-        "@opentelemetry/sdk-trace-base": "1.28.0",
+        "@opentelemetry/context-async-hooks": "1.29.0",
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/propagator-b3": "1.29.0",
+        "@opentelemetry/propagator-jaeger": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0",
         "semver": "^7.5.2"
       }
     },
     "@opentelemetry/sdk-trace-web": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.28.0.tgz",
-      "integrity": "sha512-/QOIrJc/A/caKbA9voLua4isf///cjQKB6gomEzX2fL18TBqZhIkm9k2DpjlbtrQoYCJDZ9x7Phrec22aQGpQw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-1.29.0.tgz",
+      "integrity": "sha512-PQVtJ76dsZ7HYBSlgZGIuxFtnKXxNbyHzMnRUxww7V2/6V/qtQN+cvNkqwPVffrUfbvClOnejo08NezAE1y+6g==",
       "requires": {
-        "@opentelemetry/core": "1.28.0",
-        "@opentelemetry/sdk-trace-base": "1.28.0",
-        "@opentelemetry/semantic-conventions": "1.27.0"
+        "@opentelemetry/core": "1.29.0",
+        "@opentelemetry/sdk-trace-base": "1.29.0",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.28.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+          "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="
+        }
       }
     },
     "@opentelemetry/semantic-conventions": {
@@ -50774,7 +51064,7 @@
     "@opentelemetry/winston-transport": {
       "version": "file:packages/winston-transport",
       "requires": {
-        "@opentelemetry/api-logs": "^0.55.0",
+        "@opentelemetry/api-logs": "^0.56.0",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
         "@types/sinon": "10.0.20",

--- a/packages/opentelemetry-test-utils/package.json
+++ b/packages/opentelemetry-test-utils/package.json
@@ -45,11 +45,11 @@
   "dependencies": {
     "@opentelemetry/core": "^1.0.0",
     "@opentelemetry/exporter-jaeger": "^1.3.1",
-    "@opentelemetry/instrumentation": "^0.55.0",
-    "@opentelemetry/otlp-transformer": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
+    "@opentelemetry/otlp-transformer": "^0.56.0",
     "@opentelemetry/resources": "^1.8.0",
     "@opentelemetry/sdk-metrics": "^1.27.0",
-    "@opentelemetry/sdk-node": "^0.55.0",
+    "@opentelemetry/sdk-node": "^0.56.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"

--- a/packages/winston-transport/package.json
+++ b/packages/winston-transport/package.json
@@ -47,7 +47,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "^0.55.0",
+    "@opentelemetry/api-logs": "^0.56.0",
     "winston-transport": "4.*"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/winston-transport#readme"

--- a/plugins/node/instrumentation-amqplib/package.json
+++ b/plugins/node/instrumentation-amqplib/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "devDependencies": {

--- a/plugins/node/instrumentation-cucumber/package.json
+++ b/plugins/node/instrumentation-cucumber/package.json
@@ -61,7 +61,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-cucumber#readme"

--- a/plugins/node/instrumentation-dataloader/package.json
+++ b/plugins/node/instrumentation-dataloader/package.json
@@ -55,7 +55,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0"
+    "@opentelemetry/instrumentation": "^0.56.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-dataloader#readme"
 }

--- a/plugins/node/instrumentation-fs/package.json
+++ b/plugins/node/instrumentation-fs/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.55.0"
+    "@opentelemetry/instrumentation": "^0.56.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-fs#readme"
 }

--- a/plugins/node/instrumentation-kafkajs/package.json
+++ b/plugins/node/instrumentation-kafkajs/package.json
@@ -55,7 +55,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-kafkajs#readme"

--- a/plugins/node/instrumentation-lru-memoizer/package.json
+++ b/plugins/node/instrumentation-lru-memoizer/package.json
@@ -55,7 +55,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0"
+    "@opentelemetry/instrumentation": "^0.56.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-lru-memoizer#readme"
 }

--- a/plugins/node/instrumentation-mongoose/package.json
+++ b/plugins/node/instrumentation-mongoose/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-mongoose#readme"

--- a/plugins/node/instrumentation-runtime-node/package.json
+++ b/plugins/node/instrumentation-runtime-node/package.json
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0"
+    "@opentelemetry/instrumentation": "^0.56.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",

--- a/plugins/node/instrumentation-socket.io/package.json
+++ b/plugins/node/instrumentation-socket.io/package.json
@@ -56,7 +56,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-socket.io#readme"

--- a/plugins/node/instrumentation-tedious/package.json
+++ b/plugins/node/instrumentation-tedious/package.json
@@ -60,7 +60,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
     "@types/tedious": "^4.0.14"
   },

--- a/plugins/node/instrumentation-undici/package.json
+++ b/plugins/node/instrumentation-undici/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.55.0"
+    "@opentelemetry/instrumentation": "^0.56.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/instrumentation-undici",
   "sideEffects": false

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/package.json
@@ -56,7 +56,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
     "@types/aws-lambda": "8.10.143"
   },

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/propagation-utils": "^0.30.13",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },

--- a/plugins/node/opentelemetry-instrumentation-bunyan/package.json
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/resources": "^1.8.0",
-    "@opentelemetry/sdk-logs": "^0.55.0",
+    "@opentelemetry/sdk-logs": "^0.56.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -60,8 +60,8 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "^0.55.0",
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/api-logs": "^0.56.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@types/bunyan": "1.8.9"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-bunyan#readme"

--- a/plugins/node/opentelemetry-instrumentation-cassandra/package.json
+++ b/plugins/node/opentelemetry-instrumentation-cassandra/package.json
@@ -59,7 +59,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-cassandra#readme"

--- a/plugins/node/opentelemetry-instrumentation-connect/package.json
+++ b/plugins/node/opentelemetry-instrumentation-connect/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
     "@types/connect": "3.4.36"
   },

--- a/plugins/node/opentelemetry-instrumentation-dns/package.json
+++ b/plugins/node/opentelemetry-instrumentation-dns/package.json
@@ -57,7 +57,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0"
+    "@opentelemetry/instrumentation": "^0.56.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-dns#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-express/package.json
+++ b/plugins/node/opentelemetry-instrumentation-express/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-express#readme"

--- a/plugins/node/opentelemetry-instrumentation-fastify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-fastify/package.json
@@ -47,7 +47,7 @@
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/context-async-hooks": "^1.8.0",
     "@opentelemetry/contrib-test-utils": "^0.43.0",
-    "@opentelemetry/instrumentation-http": "^0.55.0",
+    "@opentelemetry/instrumentation-http": "^0.56.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/express": "4.17.21",
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-fastify#readme"

--- a/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
+++ b/plugins/node/opentelemetry-instrumentation-generic-pool/package.json
@@ -57,7 +57,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0"
+    "@opentelemetry/instrumentation": "^0.56.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-generic-pool#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-graphql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-graphql/package.json
@@ -56,7 +56,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0"
+    "@opentelemetry/instrumentation": "^0.56.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-graphql#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-hapi/package.json
+++ b/plugins/node/opentelemetry-instrumentation-hapi/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-hapi#readme"

--- a/plugins/node/opentelemetry-instrumentation-ioredis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/package.json
@@ -65,7 +65,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/redis-common": "^0.36.2",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },

--- a/plugins/node/opentelemetry-instrumentation-knex/package.json
+++ b/plugins/node/opentelemetry-instrumentation-knex/package.json
@@ -55,7 +55,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-knex#readme"

--- a/plugins/node/opentelemetry-instrumentation-koa/package.json
+++ b/plugins/node/opentelemetry-instrumentation-koa/package.json
@@ -49,7 +49,7 @@
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/context-async-hooks": "^1.8.0",
     "@opentelemetry/contrib-test-utils": "^0.43.0",
-    "@opentelemetry/instrumentation-http": "^0.55.0",
+    "@opentelemetry/instrumentation-http": "^0.56.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@opentelemetry/sdk-trace-node": "^1.8.0",
     "@types/koa": "2.15.0",
@@ -67,7 +67,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-koa#readme"

--- a/plugins/node/opentelemetry-instrumentation-memcached/package.json
+++ b/plugins/node/opentelemetry-instrumentation-memcached/package.json
@@ -57,7 +57,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
     "@types/memcached": "^2.2.6"
   },

--- a/plugins/node/opentelemetry-instrumentation-mongodb/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/package.json
@@ -64,7 +64,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-mongodb#readme"

--- a/plugins/node/opentelemetry-instrumentation-mysql/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql/package.json
@@ -56,7 +56,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
     "@types/mysql": "2.15.26"
   },

--- a/plugins/node/opentelemetry-instrumentation-mysql2/package.json
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/package.json
@@ -58,7 +58,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
     "@opentelemetry/sql-common": "^0.40.1"
   },

--- a/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
+++ b/plugins/node/opentelemetry-instrumentation-nestjs-core/package.json
@@ -64,7 +64,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-nestjs-core#readme"

--- a/plugins/node/opentelemetry-instrumentation-net/package.json
+++ b/plugins/node/opentelemetry-instrumentation-net/package.json
@@ -56,7 +56,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-net#readme"

--- a/plugins/node/opentelemetry-instrumentation-pg/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pg/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.26.0",
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/semantic-conventions": "1.27.0",
     "@opentelemetry/sql-common": "^0.40.1",
     "@types/pg": "8.6.1",

--- a/plugins/node/opentelemetry-instrumentation-pino/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pino/package.json
@@ -62,9 +62,9 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "^0.55.0",
+    "@opentelemetry/api-logs": "^0.56.0",
     "@opentelemetry/core": "^1.25.0",
-    "@opentelemetry/instrumentation": "^0.55.0"
+    "@opentelemetry/instrumentation": "^0.56.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-pino#readme"
 }

--- a/plugins/node/opentelemetry-instrumentation-redis-4/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis-4/package.json
@@ -64,7 +64,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/redis-common": "^0.36.2",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },

--- a/plugins/node/opentelemetry-instrumentation-redis/package.json
+++ b/plugins/node/opentelemetry-instrumentation-redis/package.json
@@ -64,7 +64,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/redis-common": "^0.36.2",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },

--- a/plugins/node/opentelemetry-instrumentation-restify/package.json
+++ b/plugins/node/opentelemetry-instrumentation-restify/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-restify#readme"

--- a/plugins/node/opentelemetry-instrumentation-router/package.json
+++ b/plugins/node/opentelemetry-instrumentation-router/package.json
@@ -54,7 +54,7 @@
     "typescript": "4.4.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-router#readme"

--- a/plugins/node/opentelemetry-instrumentation-winston/package.json
+++ b/plugins/node/opentelemetry-instrumentation-winston/package.json
@@ -62,8 +62,8 @@
     "winston2": "npm:winston@2.4.7"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "^0.55.0",
-    "@opentelemetry/instrumentation": "^0.55.0"
+    "@opentelemetry/api-logs": "^0.56.0",
+    "@opentelemetry/instrumentation": "^0.56.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-winston#readme"
 }

--- a/plugins/web/opentelemetry-instrumentation-document-load/package.json
+++ b/plugins/web/opentelemetry-instrumentation-document-load/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/sdk-trace-web": "^1.15.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },

--- a/plugins/web/opentelemetry-instrumentation-long-task/package.json
+++ b/plugins/web/opentelemetry-instrumentation-long-task/package.json
@@ -78,7 +78,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.55.0"
+    "@opentelemetry/instrumentation": "^0.56.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/package.json
@@ -52,7 +52,7 @@
     "@babel/preset-env": "7.24.6",
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/context-zone-peer-dep": "^1.8.0",
-    "@opentelemetry/instrumentation-xml-http-request": "^0.55.0",
+    "@opentelemetry/instrumentation-xml-http-request": "^0.56.0",
     "@opentelemetry/sdk-trace-base": "^1.8.0",
     "@types/jquery": "3.5.30",
     "@types/mocha": "10.0.6",
@@ -80,7 +80,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^1.8.0",
-    "@opentelemetry/instrumentation": "^0.55.0",
+    "@opentelemetry/instrumentation": "^0.56.0",
     "@opentelemetry/sdk-trace-web": "^1.8.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Description

This PR updates all OpenTelemetry dependencies from the core repo to the latest versions.
Partially created using workflow from #2536 (it failed on PR creation, so it's me not @opentelemetrybot opening the PR 😞 )

## Changes


>     0.55.0 -> 0.56.0 @opentelemetry/api-logs (range-bump)
>     0.55.0 -> 0.56.0 @opentelemetry/instrumentation (range-bump)
>     0.55.0 -> 0.56.0 @opentelemetry/instrumentation-fetch (range-bump)
>     0.55.0 -> 0.56.0 @opentelemetry/instrumentation-grpc (range-bump)
>     0.55.0 -> 0.56.0 @opentelemetry/instrumentation-http (range-bump)
>     0.55.0 -> 0.56.0 @opentelemetry/instrumentation-xml-http-request (range-bump)
>     0.55.0 -> 0.56.0 @opentelemetry/otlp-transformer (range-bump)
>     0.55.0 -> 0.56.0 @opentelemetry/sdk-logs (range-bump)
>     0.55.0 -> 0.56.0 @opentelemetry/sdk-node (range-bump)
>     1.27.0 -> 1.28.0 @opentelemetry/semantic-conventions
>     1.28.0 -> 1.29.0 @opentelemetry/context-async-hooks
>     1.28.0 -> 1.29.0 @opentelemetry/context-zone-peer-dep
>     1.28.0 -> 1.29.0 @opentelemetry/core
>     1.28.0 -> 1.29.0 @opentelemetry/exporter-jaeger
>     1.28.0 -> 1.29.0 @opentelemetry/propagator-b3
>     1.28.0 -> 1.29.0 @opentelemetry/propagator-jaeger
>     1.28.0 -> 1.29.0 @opentelemetry/resources
>     1.28.0 -> 1.29.0 @opentelemetry/sdk-metrics
>     1.28.0 -> 1.29.0 @opentelemetry/sdk-trace-base
>     1.28.0 -> 1.29.0 @opentelemetry/sdk-trace-node
>     1.28.0 -> 1.29.0 @opentelemetry/sdk-trace-web