### PR TITLE
ci(update-otel-deps): use --set-upstream when pushing

### DIFF
--- a/.github/workflows/update-otel-deps.yaml
+++ b/.github/workflows/update-otel-deps.yaml
@@ -42,7 +42,7 @@ jobs:
           git checkout -b feat/update-otel-deps
           node ./scripts/update-otel-deps.js
           git commit -am "feat(deps): update deps matching '@opentelemetry/*'"
-          git push origin feat/update-otel-deps --force
+          git push --set-upstream origin feat/update-otel-deps --force
           gh pr create --repo open-telemetry/opentelemetry-js-contrib --title 'chore: prepare next release' --body 'Updates all `@opentelemetry/*` dependencies to latest'
         env:
           GITHUB_TOKEN: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

The workflow [is currently failing](https://github.com/open-telemetry/opentelemetry-js-contrib/actions/runs/12164311207/job/33926373050) as I was missing `--set-upstream` before running `gh pr create`. 

Not doing so makes it attempt to look for the current branch on the https://github.com/open-telemetry/opentelemetry-js-contrib repo, where it does not exist.