### PR TITLE
fix(test-utils): Don't swallow assertion errors from `checkResult` and `checkCollector`

### DIFF
--- a/packages/opentelemetry-test-utils/src/test-fixtures.ts
+++ b/packages/opentelemetry-test-utils/src/test-fixtures.ts
@@ -236,7 +236,7 @@ export async function runTestFixture(
   const collector = new TestCollector();
   await collector.start();
 
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
     execFile(
       process.execPath,
       opts.argv,
@@ -261,6 +261,8 @@ export async function runTestFixture(
           if (opts.checkCollector) {
             await opts.checkCollector(collector);
           }
+        } catch(err) {
+          reject(err);
         } finally {
           collector.close();
           resolve();

--- a/packages/opentelemetry-test-utils/src/test-fixtures.ts
+++ b/packages/opentelemetry-test-utils/src/test-fixtures.ts
@@ -261,7 +261,7 @@ export async function runTestFixture(
           if (opts.checkCollector) {
             await opts.checkCollector(collector);
           }
-        } catch(err) {
+        } catch (err) {
           reject(err);
         } finally {
           collector.close();

--- a/plugins/node/opentelemetry-instrumentation-hapi/test/hapi.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-hapi/test/hapi.test.ts
@@ -557,15 +557,24 @@ describe('Hapi Instrumentation - Core Tests', () => {
         },
         checkCollector: (collector: TestCollector) => {
           const spans = collector.sortedSpans;
-          assert.strictEqual(spans.length, 2);
-          assert.strictEqual(spans[0].name, 'GET /route/{param}');
+
+          assert.strictEqual(spans.length, 3);
+
+          assert.strictEqual(spans[0].name, 'GET');
           assert.strictEqual(
             spans[0].instrumentationScope.name,
             '@opentelemetry/instrumentation-http'
           );
-          assert.strictEqual(spans[1].name, 'route - /route/{param}');
+
+          assert.strictEqual(spans[1].name, 'GET /route/{param}');
           assert.strictEqual(
             spans[1].instrumentationScope.name,
+            '@opentelemetry/instrumentation-http'
+          );
+
+          assert.strictEqual(spans[2].name, 'route - /route/{param}');
+          assert.strictEqual(
+            spans[2].instrumentationScope.name,
             '@opentelemetry/instrumentation-hapi'
           );
         },


### PR DESCRIPTION
## Which problem is this PR solving?

- Assertion errors thrown inside `runTextFixture` are swallowed and not reported.

## Short description of the changes

- Reject the `runTestFixture` promise with the thrown error, if there is one.
- Updated Hapi tests that seem to be silently failing before this update.
