### PR TITLE
fix(instrumentation-hapi): fix this binding for plugin register method

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-hapi/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-hapi/src/instrumentation.ts
@@ -267,10 +267,10 @@ export class HapiInstrumentation extends InstrumentationBase {
   private _wrapRegisterHandler<T>(plugin: Hapi.Plugin<T>): void {
     const instrumentation: HapiInstrumentation = this;
     const pluginName = getPluginName(plugin);
-    const oldHandler = plugin.register;
+    const oldRegister = plugin.register;
     const self = this;
     const newRegisterHandler = function (
-      this: unknown,
+      this: typeof plugin,
       server: Hapi.Server,
       options: T
     ) {
@@ -291,7 +291,7 @@ export class HapiInstrumentation extends InstrumentationBase {
           pluginName
         );
       });
-      return oldHandler(server, options);
+      return oldRegister.call(this, server, options);
     };
     plugin.register = newRegisterHandler;
   }

--- a/plugins/node/opentelemetry-instrumentation-hapi/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-hapi/src/instrumentation.ts
@@ -269,7 +269,11 @@ export class HapiInstrumentation extends InstrumentationBase {
     const pluginName = getPluginName(plugin);
     const oldHandler = plugin.register;
     const self = this;
-    const newRegisterHandler = function (server: Hapi.Server, options: T) {
+    const newRegisterHandler = function (
+      this: unknown,
+      server: Hapi.Server,
+      options: T
+    ) {
       self._wrap(server, 'route', original => {
         return instrumentation._getServerRoutePatch.bind(instrumentation)(
           original,

--- a/plugins/node/opentelemetry-instrumentation-hapi/test/hapi-plugin.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-hapi/test/hapi-plugin.test.ts
@@ -81,12 +81,13 @@ describe('Hapi Instrumentation - Hapi.Plugin Tests', () => {
     name: 'simplePlugin',
     version: '1.0.0',
     multiple: true,
+    value: 42,
     register: async function (server: hapi.Server, options: any) {
       server.route({
         method: 'GET',
         path: '/hello',
-        handler: function (request, h) {
-          return `hello, world, ${options.name}`;
+        handler: (request, h) => {
+          return `hello, world, ${this.value} ${options.name}`;
         },
       });
     },


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2624

## Short description of the changes

Correctly bind `this` to plugin's `register` method.
