### PR TITLE
test(aws-sdk): set v3 versions based on Node.js support

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/.tav.yml
@@ -10,19 +10,49 @@
 # - https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2464#issuecomment-2403652552
 # - https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1828#issuecomment-1834276719
 
+# node version support in JS SDK v3:
+# - 14.x dropped in v3.567.0 https://github.com/aws/aws-sdk-js-v3/pull/6034
+# - 16.x dropped in v3.723.0 https://github.com/aws/aws-sdk-js-v3/pull/6775
+
 "@aws-sdk/client-s3":
   # - 3.529.0 was missing the fast-xml-parser dependency (https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.529.1)
-  versions:
-    include: "^3.6.1"
-    exclude: "3.529.0 || >=3.363.0 <=3.377.0"
-    mode: "max-7"
-  commands:
-    - npm run test
+  jobs:
+    - node: ">=18"
+      versions:
+        include: "^3.6.1"
+        exclude: "3.529.0 || >=3.363.0 <=3.377.0"
+        mode: "max-7"
+      commands: npm run test
+    - node: "16"
+      versions:
+        include: "^3.6.1 && <3.723.0"
+        exclude: "3.529.0 || >=3.363.0 <=3.377.0"
+        mode: "max-7"
+      commands: npm run test
+    - node: "14"
+      versions:
+        include: "^3.6.1 && <3.567.0"
+        exclude: "3.529.0 || >=3.363.0 <=3.377.0"
+        mode: "max-7"
+      commands: npm run test
 
 "@aws-sdk/client-sqs":
-  versions:
-    include: "^3.24.0"
-    exclude: ">=3.363.0 <=3.377.0"
-    mode: "max-7"
-  commands:
-    - npm run test
+  jobs:
+    - node: ">=18"
+      versions:
+        include: "^3.24.0"
+        exclude: ">=3.363.0 <=3.377.0"
+        mode: "max-7"
+      commands: npm run test
+    - node: "16"
+      versions:
+        include: "^3.24.0 && <3.723.0"
+        exclude: ">=3.363.0 <=3.377.0"
+        mode: "max-7"
+      commands: npm run test
+    - node: "14"
+      versions:
+        include: "^3.24.0 && <3.567.0"
+        exclude: ">=3.363.0 <=3.377.0"
+        mode: "max-7"
+      commands: npm run test


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes: https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2627

## Short description of the changes

- Sets AWS SDK for JavaScript v3 versions based on Node.js version they support.
