### PR TITLE
test(aws-sdk): drop support for Node.js 14.x [DO NOT MERGE]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37371,7 +37371,7 @@
         "typescript": "4.4.4"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/.tav.yml
@@ -11,7 +11,6 @@
 # - https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1828#issuecomment-1834276719
 
 # node version support in JS SDK v3:
-# - 14.x dropped in v3.567.0 https://github.com/aws/aws-sdk-js-v3/pull/6034
 # - 16.x dropped in v3.723.0 https://github.com/aws/aws-sdk-js-v3/pull/6775
 
 "@aws-sdk/client-s3":
@@ -29,12 +28,6 @@
         exclude: "3.529.0 || >=3.363.0 <=3.377.0"
         mode: "max-7"
       commands: npm run test
-    - node: "14"
-      versions:
-        include: "^3.6.1 && <3.567.0"
-        exclude: "3.529.0 || >=3.363.0 <=3.377.0"
-        mode: "max-7"
-      commands: npm run test
 
 "@aws-sdk/client-sqs":
   jobs:
@@ -47,12 +40,6 @@
     - node: "16"
       versions:
         include: "^3.24.0 && <3.723.0"
-        exclude: ">=3.363.0 <=3.377.0"
-        mode: "max-7"
-      commands: npm run test
-    - node: "14"
-      versions:
-        include: "^3.24.0 && <3.567.0"
         exclude: ">=3.363.0 <=3.377.0"
         mode: "max-7"
       commands: npm run test

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json
@@ -75,6 +75,6 @@
     "typescript": "4.4.4"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   }
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- DO NOT MERGE
- Refs: https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2629#issuecomment-2577993128

## Short description of the changes

- This PR is just to check if CI fails, if we try to drop support for Node.js 14.x in one of the `@opentelemetry/auto-instrumentations-node` dependencies
