### PR TITLE
fix(instrumentation-fastify): add missing module export

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-fastify/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-fastify/src/instrumentation.ts
@@ -27,6 +27,7 @@ import type {
   FastifyInstance,
   FastifyRequest,
   FastifyReply,
+  FastifyErrorCodes,
 } from 'fastify';
 import { hooksNamesToWrap } from './constants';
 import {
@@ -185,6 +186,7 @@ export class FastifyInstrumentation extends InstrumentationBase<FastifyInstrumen
 
   private _patchConstructor(moduleExports: {
     fastify: () => FastifyInstance;
+    errorCodes: FastifyErrorCodes | undefined;
   }): () => FastifyInstance {
     const instrumentation = this;
 
@@ -198,6 +200,9 @@ export class FastifyInstrumentation extends InstrumentationBase<FastifyInstrumen
       return app;
     }
 
+    if (moduleExports.errorCodes !== undefined) {
+      fastify.errorCodes = moduleExports.errorCodes;
+    }
     fastify.fastify = fastify;
     fastify.default = fastify;
     return fastify;

--- a/plugins/node/opentelemetry-instrumentation-fastify/test/instrumentation.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-fastify/test/instrumentation.test.ts
@@ -560,4 +560,15 @@ describe('fastify', () => {
       },
     });
   });
+
+  it('should expose errorCodes', async function () {
+    // errorCodes was added in v4.8.0
+    // ref: https://github.com/fastify/fastify/compare/v4.7.0...v4.8.0
+    if (semver.lt(fastifyVersion, '4.8.0')) {
+      this.skip();
+    }
+    assert.ok(Fastify.errorCodes);
+    assert.strictEqual(typeof Fastify.errorCodes, 'object');
+    assert.ok('FST_ERR_NOT_FOUND' in Fastify.errorCodes);
+  });
 });


### PR DESCRIPTION
## Which problem is this PR solving?

This PR adds an additional export that is part of the fastify public API to the `InstrumentationNodeModuleDefinition` patch function. Without this patch, 

## Short description of the changes

fastify v4.8+ exports an object named `errorCodes` as both a property of the default export and as a named export.

The export is documented at https://github.com/fastify/fastify/blob/4.x/docs/Reference/Errors.md?plain=1#L236.

This closes #2027.