### PR TITLE
feat(instrumentation-express): propagate context and measure full handler spans

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-express/test/express.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-express/test/express.test.ts
@@ -96,7 +96,7 @@ describe('ExpressInstrumentation', () => {
           );
           assert.strictEqual(response, 'tata');
           rootSpan.end();
-          assert.strictEqual(finishListenerCount, 2);
+          assert.strictEqual(finishListenerCount, 3);
           assert.notStrictEqual(
             memoryExporter
               .getFinishedSpans()
@@ -201,7 +201,7 @@ describe('ExpressInstrumentation', () => {
           );
           assert.strictEqual(response, 'tata');
           rootSpan.end();
-          assert.strictEqual(finishListenerCount, 2);
+          assert.strictEqual(finishListenerCount, 3);
           assert.notStrictEqual(
             memoryExporter
               .getFinishedSpans()


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Currently the Express instrumentation does not propagate context and does not properly instrument request handlers.

## Short description of the changes

Context is propagated for middleware and request handler spans, while their `next` callback is reset to the parent context to avoid extreme nesting as suggested in #2022. Request handler spans are also no longer ended prematurely.

Router spans are kept as-is since they are broken and propagating context for them would make things even more confusing than they already are.

## Example traces

### Before
![example trace before the changes](https://github.com/user-attachments/assets/834b21a6-147b-4261-89b8-378458d5a794)

### After
![example trace after the changes](https://github.com/user-attachments/assets/b100b596-1f7f-4467-8ade-7a864f586727)

## Related issues

- Fixes #2022
- Fixes #2023
- Fixes #2146
- Fixes #2442
- Fixes #2469
- Fixes #2617 
- Supersedes #2603