### PR TITLE
chore(aws-sdk): remove dependency on SQS type from JS SDK v2

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sqs.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/services/sqs.ts
@@ -25,7 +25,7 @@ import {
 } from '@opentelemetry/api';
 import { pubsubPropagation } from '@opentelemetry/propagation-utils';
 import { RequestMetadata, ServiceExtension } from './ServiceExtension';
-import type { SQS } from 'aws-sdk';
+import type { SQS } from '../aws-sdk.types';
 import {
   AwsSdkInstrumentationConfig,
   NormalizedRequest,
@@ -119,7 +119,9 @@ export class SqsServiceExtension implements ServiceExtension {
           const entries = request.commandInput?.Entries;
           if (Array.isArray(entries)) {
             entries.forEach(
-              (messageParams: SQS.SendMessageBatchRequestEntry) => {
+              (messageParams: {
+                MessageAttributes: SQS.MessageBodyAttributeMap;
+              }) => {
                 messageParams.MessageAttributes = injectPropagationContext(
                   messageParams.MessageAttributes ?? {}
                 );


### PR DESCRIPTION
## Which problem is this PR solving?

- Noticed in https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2623

## Short description of the changes

- Removes dependency on type from JS SDK v2 devDependency.
