### PR TITLE
test(instrumentation-aws-sdk): adapt tav versions include rule for v14 and v16

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/.tav.yml
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/.tav.yml
@@ -25,13 +25,13 @@
       commands: npm run test
     - node: "16"
       versions:
-        include: "^3.6.1 && <3.723.0"
+        include: ">=3.6.1 <3.723.0"
         exclude: "3.529.0 || >=3.363.0 <=3.377.0"
         mode: "max-7"
       commands: npm run test
     - node: "14"
       versions:
-        include: "^3.6.1 && <3.567.0"
+        include: ">=3.6.1 <3.567.0"
         exclude: "3.529.0 || >=3.363.0 <=3.377.0"
         mode: "max-7"
       commands: npm run test
@@ -46,13 +46,13 @@
       commands: npm run test
     - node: "16"
       versions:
-        include: "^3.24.0 && <3.723.0"
+        include: ">=3.24.0 <3.723.0"
         exclude: ">=3.363.0 <=3.377.0"
         mode: "max-7"
       commands: npm run test
     - node: "14"
       versions:
-        include: "^3.24.0 && <3.567.0"
+        include: ">=3.24.0 <3.567.0"
         exclude: ">=3.363.0 <=3.377.0"
         mode: "max-7"
       commands: npm run test


### PR DESCRIPTION
## Which problem is this PR solving?

Tests are failing on `main` - it seems that the rules for Node.js v14/v16 don't work as intended. This changes the `^` to `>=`. Should be equivalent since there's also an upper limit specified for each rule.