### PR TITLE
fix(*): Migrate away from deprecated `addSpanProcessor` in tests

### DIFF
--- a/plugins/node/instrumentation-cucumber/test/cucumber.test.ts
+++ b/plugins/node/instrumentation-cucumber/test/cucumber.test.ts
@@ -53,14 +53,14 @@ import {
 import { PassThrough } from 'stream';
 
 describe('CucumberInstrumentation', () => {
+  const memoryExporter = new InMemorySpanExporter();
+  const spanProcessor = new SimpleSpanProcessor(memoryExporter);
   const provider = new NodeTracerProvider({
     resource: new Resource({
       [SEMRESATTRS_SERVICE_NAME]: 'CucumberInstrumentation',
     }),
+    spanProcessors: [spanProcessor],
   });
-  const memoryExporter = new InMemorySpanExporter();
-  const spanProcessor = new SimpleSpanProcessor(memoryExporter);
-  provider.addSpanProcessor(spanProcessor);
   const contextManager = new AsyncHooksContextManager().enable();
 
   before(() => {

--- a/plugins/node/instrumentation-dataloader/test/dataloader.test.ts
+++ b/plugins/node/instrumentation-dataloader/test/dataloader.test.ts
@@ -37,12 +37,13 @@ describe('DataloaderInstrumentation', () => {
   let contextManager: AsyncHooksContextManager;
 
   const memoryExporter = new InMemorySpanExporter();
-  const provider = new NodeTracerProvider();
+  const provider = new NodeTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+  });
   const tracer = provider.getTracer('default');
 
   instrumentation.setTracerProvider(provider);
   extraInstrumentation.setTracerProvider(provider);
-  provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
 
   beforeEach(async () => {
     instrumentation.enable();

--- a/plugins/node/instrumentation-fs/test/fs.test.ts
+++ b/plugins/node/instrumentation-fs/test/fs.test.ts
@@ -58,10 +58,11 @@ const pluginConfig = {
   createHook,
   endHook,
 };
-const provider = new BasicTracerProvider();
-const tracer = provider.getTracer('default');
 const memoryExporter = new InMemorySpanExporter();
-provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+const provider = new BasicTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+});
+const tracer = provider.getTracer('default');
 
 describe('fs instrumentation', () => {
   let contextManager: AsyncHooksContextManager;

--- a/plugins/node/instrumentation-fs/test/fsHooks.test.ts
+++ b/plugins/node/instrumentation-fs/test/fsHooks.test.ts
@@ -37,9 +37,10 @@ const pluginConfig = {
   endHook,
 };
 
-const provider = new BasicTracerProvider();
 const memoryExporter = new InMemorySpanExporter();
-provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+const provider = new BasicTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+});
 
 const assertNotHookError = (err?: Error | null) => {
   assert.ok(

--- a/plugins/node/instrumentation-fs/test/fsPromises.test.ts
+++ b/plugins/node/instrumentation-fs/test/fsPromises.test.ts
@@ -37,10 +37,11 @@ const endHook = <EndHook>sinon.spy((fnName, { args, span }) => {
 const pluginConfig = {
   endHook,
 };
-const provider = new BasicTracerProvider();
-const tracer = provider.getTracer('default');
 const memoryExporter = new InMemorySpanExporter();
-provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+const provider = new BasicTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+});
+const tracer = provider.getTracer('default');
 
 describe('fs/promises instrumentation', () => {
   let contextManager: AsyncHooksContextManager;

--- a/plugins/node/instrumentation-fs/test/fsPromisesHooks.test.ts
+++ b/plugins/node/instrumentation-fs/test/fsPromisesHooks.test.ts
@@ -37,9 +37,10 @@ const pluginConfig = {
   endHook,
 };
 
-const provider = new BasicTracerProvider();
 const memoryExporter = new InMemorySpanExporter();
-provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+const provider = new BasicTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+});
 
 const assertNotHookError = (err?: Error | null) => {
   assert.ok(

--- a/plugins/node/instrumentation-fs/test/parent.test.ts
+++ b/plugins/node/instrumentation-fs/test/parent.test.ts
@@ -25,9 +25,10 @@ import type { FsInstrumentationConfig } from '../src/types';
 import * as api from '@opentelemetry/api';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 
-const provider = new BasicTracerProvider();
 const memoryExporter = new InMemorySpanExporter();
-provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+const provider = new BasicTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+});
 
 const tracer = provider.getTracer('default');
 

--- a/plugins/node/instrumentation-tedious/test/instrumentation.test.ts
+++ b/plugins/node/instrumentation-tedious/test/instrumentation.test.ts
@@ -89,10 +89,12 @@ describe('tedious', () => {
   let tedious: any;
   let contextManager: AsyncHooksContextManager;
   let connection: Connection;
-  const provider = new BasicTracerProvider();
+  const memoryExporter = new InMemorySpanExporter();
+  const provider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+  });
   const shouldTest = process.env.RUN_MSSQL_TESTS; // For CI: assumes local db is already available
   const shouldTestLocally = process.env.RUN_MSSQL_TESTS_LOCAL; // For local: spins up local db via docker
-  const memoryExporter = new InMemorySpanExporter();
 
   before(function (done) {
     if (!(shouldTest || shouldTestLocally) || incompatVersions) {
@@ -101,7 +103,6 @@ describe('tedious', () => {
       this.test!.parent!.pending = true;
       this.skip();
     }
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
     if (shouldTestLocally) {
       testUtils.startDocker('mssql');
       // wait 15 seconds for docker container to start

--- a/plugins/node/instrumentation-undici/test/fetch.test.ts
+++ b/plugins/node/instrumentation-undici/test/fetch.test.ts
@@ -42,8 +42,9 @@ describe('UndiciInstrumentation `fetch` tests', function () {
   const hostname = 'localhost';
   const mockServer = new MockServer();
   const memoryExporter = new InMemorySpanExporter();
-  const provider = new NodeTracerProvider();
-  provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+  const provider = new NodeTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+  });
 
   before(function (done) {
     // Do not test if the `fetch` global API is not available

--- a/plugins/node/instrumentation-undici/test/undici.test.ts
+++ b/plugins/node/instrumentation-undici/test/undici.test.ts
@@ -68,8 +68,9 @@ describe('UndiciInstrumentation `undici` tests', function () {
   const hostname = 'localhost';
   const mockServer = new MockServer();
   const memoryExporter = new InMemorySpanExporter();
-  const provider = new NodeTracerProvider();
-  provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+  const provider = new NodeTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+  });
 
   before(function (done) {
     // Load `undici`. It may fail if nodejs version is <18 because the module uses

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler.force-flush.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler.force-flush.test.ts
@@ -88,8 +88,9 @@ describe('force flush', () => {
   });
 
   it('should force flush NodeTracerProvider', async () => {
-    const provider = new NodeTracerProvider();
-    provider.addSpanProcessor(new BatchSpanProcessor(traceMemoryExporter));
+    const provider = new NodeTracerProvider({
+      spanProcessors: [new BatchSpanProcessor(traceMemoryExporter)],
+    });
     provider.register();
     let forceFlushed = false;
     const forceFlush = () =>
@@ -118,10 +119,9 @@ describe('force flush', () => {
   });
 
   it('should force flush ProxyTracerProvider with NodeTracerProvider', async () => {
-    const nodeTracerProvider = new NodeTracerProvider();
-    nodeTracerProvider.addSpanProcessor(
-      new BatchSpanProcessor(traceMemoryExporter)
-    );
+    const nodeTracerProvider = new NodeTracerProvider({
+      spanProcessors: [new BatchSpanProcessor(traceMemoryExporter)],
+    });
     nodeTracerProvider.register();
     const provider = new ProxyTracerProvider();
     provider.setDelegate(nodeTracerProvider);
@@ -183,10 +183,9 @@ describe('force flush', () => {
   });
 
   it('should callback once after force flush providers', async () => {
-    const nodeTracerProvider = new NodeTracerProvider();
-    nodeTracerProvider.addSpanProcessor(
-      new BatchSpanProcessor(traceMemoryExporter)
-    );
+    const nodeTracerProvider = new NodeTracerProvider({
+      spanProcessors: [new BatchSpanProcessor(traceMemoryExporter)],
+    });
     nodeTracerProvider.register();
     const tracerProvider = new ProxyTracerProvider();
     tracerProvider.setDelegate(nodeTracerProvider);

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler.test.ts
@@ -120,8 +120,9 @@ describe('lambda handler', () => {
   ) => {
     process.env._HANDLER = handler;
 
-    const provider = new NodeTracerProvider();
-    provider.addSpanProcessor(new BatchSpanProcessor(memoryExporter));
+    const provider = new NodeTracerProvider({
+      spanProcessors: [new BatchSpanProcessor(memoryExporter)],
+    });
     provider.register();
 
     instrumentation = new AwsLambdaInstrumentation(config);

--- a/plugins/node/opentelemetry-instrumentation-bunyan/test/bunyan.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/test/bunyan.test.ts
@@ -40,11 +40,10 @@ import type * as BunyanLogger from 'bunyan';
 // import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
 // diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
 
-const tracerProvider = new NodeTracerProvider();
+const tracerProvider = new NodeTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(new InMemorySpanExporter())],
+});
 tracerProvider.register();
-tracerProvider.addSpanProcessor(
-  new SimpleSpanProcessor(new InMemorySpanExporter())
-);
 const tracer = tracerProvider.getTracer('default');
 
 const resource = new Resource({

--- a/plugins/node/opentelemetry-instrumentation-cassandra/test/cassandra-driver.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-cassandra/test/cassandra-driver.test.ts
@@ -48,8 +48,9 @@ import {
 import { ResponseHookInfo } from '../src/types';
 
 const memoryExporter = new InMemorySpanExporter();
-const provider = new NodeTracerProvider();
-provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+const provider = new NodeTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+});
 context.setGlobalContextManager(new AsyncHooksContextManager());
 
 const testCassandra = process.env.RUN_CASSANDRA_TESTS;

--- a/plugins/node/opentelemetry-instrumentation-connect/test/instrumentation.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-connect/test/instrumentation.test.ts
@@ -50,14 +50,15 @@ const httpRequest = {
 const instrumentation = new ConnectInstrumentation();
 const contextManager = new AsyncHooksContextManager().enable();
 const memoryExporter = new InMemorySpanExporter();
-const provider = new NodeTracerProvider();
 const spanProcessor = new SimpleSpanProcessor(memoryExporter);
+const provider = new NodeTracerProvider({
+  spanProcessors: [spanProcessor],
+});
 instrumentation.setTracerProvider(provider);
 context.setGlobalContextManager(contextManager);
 
 const tracer = provider.getTracer('default');
 
-provider.addSpanProcessor(spanProcessor);
 instrumentation.enable();
 
 import * as connect from 'connect';

--- a/plugins/node/opentelemetry-instrumentation-dns/test/functionals/dns-disable.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/test/functionals/dns-disable.test.ts
@@ -26,9 +26,10 @@ import * as Sinon from 'sinon';
 import * as dns from 'dns';
 
 const memoryExporter = new InMemorySpanExporter();
-const provider = new NodeTracerProvider();
+const provider = new NodeTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+});
 const tracer = provider.getTracer('default');
-provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
 
 describe('DnsInstrumentation', () => {
   let instrumentation: DnsInstrumentation;

--- a/plugins/node/opentelemetry-instrumentation-dns/test/integrations/dns-lookup.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/test/integrations/dns-lookup.test.ts
@@ -27,8 +27,9 @@ import { assertSpan } from '../utils/assertSpan';
 import { SpanStatusCode } from '@opentelemetry/api';
 
 const memoryExporter = new InMemorySpanExporter();
-const provider = new NodeTracerProvider();
-provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+const provider = new NodeTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+});
 
 describe('dns.lookup()', () => {
   let instrumentation: DnsInstrumentation;

--- a/plugins/node/opentelemetry-instrumentation-dns/test/integrations/dns-slash-promises-lookup.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/test/integrations/dns-slash-promises-lookup.test.ts
@@ -27,8 +27,9 @@ import { assertSpan } from '../utils/assertSpan';
 import { SpanStatusCode } from '@opentelemetry/api';
 
 const memoryExporter = new InMemorySpanExporter();
-const provider = new NodeTracerProvider();
-provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+const provider = new NodeTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+});
 
 const supportsPromises =
   parseInt(process.versions.node.split('.')[0], 10) >= 15;

--- a/plugins/node/opentelemetry-instrumentation-dns/test/integrations/dnspromise-lookup.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/test/integrations/dnspromise-lookup.test.ts
@@ -27,8 +27,9 @@ import { assertSpan } from '../utils/assertSpan';
 import { SpanStatusCode } from '@opentelemetry/api';
 
 const memoryExporter = new InMemorySpanExporter();
-const provider = new NodeTracerProvider();
-provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+const provider = new NodeTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+});
 
 describe('dns.promises.lookup()', () => {
   let instrumentation: DnsInstrumentation;

--- a/plugins/node/opentelemetry-instrumentation-express/test/custom-config.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-express/test/custom-config.test.ts
@@ -39,10 +39,10 @@ import * as express from 'express';
 import * as http from 'http';
 
 describe('ExpressInstrumentation', () => {
-  const provider = new NodeTracerProvider();
   const memoryExporter = new InMemorySpanExporter();
-  const spanProcessor = new SimpleSpanProcessor(memoryExporter);
-  provider.addSpanProcessor(spanProcessor);
+  const provider = new NodeTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+  });
   const tracer = provider.getTracer('default');
   const contextManager = new AsyncHooksContextManager().enable();
 

--- a/plugins/node/opentelemetry-instrumentation-express/test/express.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-express/test/express.test.ts
@@ -37,10 +37,11 @@ import { RPCMetadata, getRPCMetadata } from '@opentelemetry/core';
 import { Server } from 'http';
 
 describe('ExpressInstrumentation', () => {
-  const provider = new NodeTracerProvider();
   const memoryExporter = new InMemorySpanExporter();
   const spanProcessor = new SimpleSpanProcessor(memoryExporter);
-  provider.addSpanProcessor(spanProcessor);
+  const provider = new NodeTracerProvider({
+    spanProcessors: [spanProcessor],
+  });
   const tracer = provider.getTracer('default');
   const contextManager = new AsyncHooksContextManager().enable();
 

--- a/plugins/node/opentelemetry-instrumentation-express/test/hooks.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-express/test/hooks.test.ts
@@ -37,10 +37,11 @@ import { httpRequest, serverWithMiddleware } from './utils';
 import { RPCMetadata, getRPCMetadata } from '@opentelemetry/core';
 
 describe('ExpressInstrumentation hooks', () => {
-  const provider = new NodeTracerProvider();
   const memoryExporter = new InMemorySpanExporter();
   const spanProcessor = new SimpleSpanProcessor(memoryExporter);
-  provider.addSpanProcessor(spanProcessor);
+  const provider = new NodeTracerProvider({
+    spanProcessors: [spanProcessor],
+  });
   const tracer = provider.getTracer('default');
   const contextManager = new AsyncHooksContextManager().enable();
 

--- a/plugins/node/opentelemetry-instrumentation-express/test/ignore-all.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-express/test/ignore-all.test.ts
@@ -41,10 +41,11 @@ import * as express from 'express';
 import * as http from 'http';
 
 describe('ExpressInstrumentation', () => {
-  const provider = new NodeTracerProvider();
   const memoryExporter = new InMemorySpanExporter();
   const spanProcessor = new SimpleSpanProcessor(memoryExporter);
-  provider.addSpanProcessor(spanProcessor);
+  const provider = new NodeTracerProvider({
+    spanProcessors: [spanProcessor],
+  });
   const tracer = provider.getTracer('default');
   const contextManager = new AsyncHooksContextManager().enable();
 

--- a/plugins/node/opentelemetry-instrumentation-fastify/test/instrumentation.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-fastify/test/instrumentation.test.ts
@@ -66,13 +66,14 @@ const httpInstrumentation = new HttpInstrumentation();
 const instrumentation = new FastifyInstrumentation();
 const contextManager = new AsyncHooksContextManager().enable();
 const memoryExporter = new InMemorySpanExporter();
-const provider = new NodeTracerProvider();
 const spanProcessor = new SimpleSpanProcessor(memoryExporter);
+const provider = new NodeTracerProvider({
+  spanProcessors: [spanProcessor],
+});
 instrumentation.setTracerProvider(provider);
 httpInstrumentation.setTracerProvider(provider);
 context.setGlobalContextManager(contextManager);
 
-provider.addSpanProcessor(spanProcessor);
 instrumentation.enable();
 httpInstrumentation.enable();
 

--- a/plugins/node/opentelemetry-instrumentation-generic-pool/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-generic-pool/test/index.test.ts
@@ -67,10 +67,11 @@ const createPool = {
 }[isOldVersion ? 'v2' : 'v3'];
 
 describe('GenericPool instrumentation', () => {
-  const provider = new NodeTracerProvider();
   const memoryExporter = new InMemorySpanExporter();
   const spanProcessor = new SimpleSpanProcessor(memoryExporter);
-  provider.addSpanProcessor(spanProcessor);
+  const provider = new NodeTracerProvider({
+    spanProcessors: [spanProcessor],
+  });
   plugin.setTracerProvider(provider);
   const tracer = provider.getTracer('default');
   let contextManager: AsyncHooksContextManager;

--- a/plugins/node/opentelemetry-instrumentation-graphql/test/graphql.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/test/graphql.test.ts
@@ -99,8 +99,9 @@ const queryInvalid = `
 `;
 
 const exporter = new InMemorySpanExporter();
-const provider = new BasicTracerProvider();
-provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+const provider = new BasicTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(exporter)],
+});
 graphQLInstrumentation.setTracerProvider(provider);
 
 describe('graphql', () => {

--- a/plugins/node/opentelemetry-instrumentation-hapi/test/hapi-plugin.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-hapi/test/hapi-plugin.test.ts
@@ -29,10 +29,11 @@ import { HapiLayerType } from '../src/internal-types';
 import { AttributeNames } from '../src/enums/AttributeNames';
 
 describe('Hapi Instrumentation - Hapi.Plugin Tests', () => {
-  const provider = new NodeTracerProvider();
   const memoryExporter = new InMemorySpanExporter();
   const spanProcessor = new SimpleSpanProcessor(memoryExporter);
-  provider.addSpanProcessor(spanProcessor);
+  const provider = new NodeTracerProvider({
+    spanProcessors: [spanProcessor],
+  });
   const tracer = provider.getTracer('default');
   let contextManager: AsyncHooksContextManager;
   let server: hapi.Server;

--- a/plugins/node/opentelemetry-instrumentation-hapi/test/hapi-server-ext.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-hapi/test/hapi-server-ext.test.ts
@@ -30,10 +30,11 @@ import { HapiLayerType } from '../src/internal-types';
 import { AttributeNames } from '../src/enums/AttributeNames';
 
 describe('Hapi Instrumentation - Server.Ext Tests', () => {
-  const provider = new NodeTracerProvider();
   const memoryExporter = new InMemorySpanExporter();
   const spanProcessor = new SimpleSpanProcessor(memoryExporter);
-  provider.addSpanProcessor(spanProcessor);
+  const provider = new NodeTracerProvider({
+    spanProcessors: [spanProcessor],
+  });
   const tracer = provider.getTracer('default');
   let contextManager: AsyncHooksContextManager;
   let server: hapi.Server;

--- a/plugins/node/opentelemetry-instrumentation-hapi/test/hapi.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-hapi/test/hapi.test.ts
@@ -35,10 +35,11 @@ import { HapiLayerType } from '../src/internal-types';
 import { AttributeNames } from '../src/enums/AttributeNames';
 
 describe('Hapi Instrumentation - Core Tests', () => {
-  const provider = new NodeTracerProvider();
   const memoryExporter = new InMemorySpanExporter();
   const spanProcessor = new SimpleSpanProcessor(memoryExporter);
-  provider.addSpanProcessor(spanProcessor);
+  const provider = new NodeTracerProvider({
+    spanProcessors: [spanProcessor],
+  });
   const tracer = provider.getTracer('default');
   let contextManager: AsyncHooksContextManager;
   let server: hapi.Server;

--- a/plugins/node/opentelemetry-instrumentation-ioredis/test/ioredis.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/test/ioredis.test.ts
@@ -86,7 +86,9 @@ const sanitizeEventForAssertion = (span: ReadableSpan) => {
 };
 
 describe('ioredis', () => {
-  const provider = new NodeTracerProvider();
+  const provider = new NodeTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+  });
   let ioredis: typeof ioredisTypes.default;
   let instrumentation: IORedisInstrumentation;
   const shouldTestLocal = process.env.RUN_REDIS_TESTS_LOCAL;
@@ -115,7 +117,6 @@ describe('ioredis', () => {
       testUtils.startDocker('redis');
     }
 
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
     instrumentation = new IORedisInstrumentation();
     instrumentation.setTracerProvider(provider);
     ioredis = require('ioredis');

--- a/plugins/node/opentelemetry-instrumentation-knex/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-knex/test/index.test.ts
@@ -36,10 +36,11 @@ const plugin = new KnexInstrumentation({
 import knex from 'knex';
 
 describe('Knex instrumentation', () => {
-  const provider = new NodeTracerProvider();
   const memoryExporter = new InMemorySpanExporter();
   const spanProcessor = new SimpleSpanProcessor(memoryExporter);
-  provider.addSpanProcessor(spanProcessor);
+  const provider = new NodeTracerProvider({
+    spanProcessors: [spanProcessor],
+  });
   plugin.setTracerProvider(provider);
   const tracer = provider.getTracer('default');
   let contextManager: AsyncHooksContextManager;

--- a/plugins/node/opentelemetry-instrumentation-koa/test/koa.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/test/koa.test.ts
@@ -73,10 +73,11 @@ const isrouterCompat =
   (semver.gte(LIB_VERSION, '13.0.0') && semver.gte(NODE_VERSION, '18.0.0'));
 
 describe('Koa Instrumentation', function () {
-  const provider = new NodeTracerProvider();
   const memoryExporter = new InMemorySpanExporter();
   const spanProcessor = new SimpleSpanProcessor(memoryExporter);
-  provider.addSpanProcessor(spanProcessor);
+  const provider = new NodeTracerProvider({
+    spanProcessors: [spanProcessor],
+  });
   plugin.setTracerProvider(provider);
   const tracer = provider.getTracer('default');
   let contextManager: AsyncHooksContextManager;

--- a/plugins/node/opentelemetry-instrumentation-memcached/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-memcached/test/index.test.ts
@@ -75,9 +75,10 @@ const shouldTestLocal = process.env.RUN_MEMCACHED_TESTS_LOCAL;
 const shouldTest = process.env.RUN_MEMCACHED_TESTS || shouldTestLocal;
 
 describe('memcached@2.x', () => {
-  const provider = new NodeTracerProvider();
+  const provider = new NodeTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+  });
   const tracer = provider.getTracer('default');
-  provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
   instrumentation.setTracerProvider(provider);
   let contextManager: AsyncHooksContextManager;
 

--- a/plugins/node/opentelemetry-instrumentation-mysql/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql/test/index.test.ts
@@ -54,11 +54,13 @@ describe('mysql@2.x-Tracing', () => {
   let connection: mysqlTypes.Connection;
   let pool: mysqlTypes.Pool;
   let poolCluster: mysqlTypes.PoolCluster;
-  const provider = new BasicTracerProvider();
   const testMysql = process.env.RUN_MYSQL_TESTS; // For CI: assumes local mysql db is already available
   const testMysqlLocally = process.env.RUN_MYSQL_TESTS_LOCAL; // For local: spins up local mysql db via docker
   const shouldTest = testMysql || testMysqlLocally; // Skips these tests if false (default)
   const memoryExporter = new InMemorySpanExporter();
+  const provider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+  });
 
   before(function (done) {
     if (!shouldTest) {
@@ -67,7 +69,7 @@ describe('mysql@2.x-Tracing', () => {
       this.test!.parent!.pending = true;
       this.skip();
     }
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+
     if (testMysqlLocally) {
       testUtils.startDocker('mysql');
       // wait 15 seconds for docker container to start

--- a/plugins/node/opentelemetry-instrumentation-mysql2/test/mysql.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/test/mysql.test.ts
@@ -90,8 +90,10 @@ describe('mysql2', () => {
 
   describe('callback API', () => {
     let contextManager: AsyncHooksContextManager;
-    const provider = new BasicTracerProvider();
     const memoryExporter = new InMemorySpanExporter();
+    const provider = new BasicTracerProvider({
+      spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+    });
 
     let connection: Connection;
     let rootConnection: Connection;
@@ -123,7 +125,6 @@ describe('mysql2', () => {
         this.test!.parent!.pending = true;
         this.skip();
       }
-      provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
       rootConnection = createConnection({
         port,
         user: 'root',

--- a/plugins/node/opentelemetry-instrumentation-nestjs-core/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-nestjs-core/test/index.test.ts
@@ -38,8 +38,9 @@ util.inspect.defaultOptions.depth = 3;
 util.inspect.defaultOptions.breakLength = 200;
 
 describe('nestjs-core', () => {
-  const provider = new NodeTracerProvider();
-  provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+  const provider = new NodeTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+  });
   instrumentation.setTracerProvider(provider);
   let contextManager: AsyncHooksContextManager;
   let app: App;

--- a/plugins/node/opentelemetry-instrumentation-net/test/connect.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-net/test/connect.test.ts
@@ -28,8 +28,9 @@ import { SocketEvent } from '../src/internal-types';
 import { assertIpcSpan, assertTcpSpan, IPC_PATH, HOST, PORT } from './utils';
 
 const memoryExporter = new InMemorySpanExporter();
-const provider = new NodeTracerProvider();
-provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+const provider = new NodeTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+});
 
 function getSpan() {
   const spans = memoryExporter.getFinishedSpans();

--- a/plugins/node/opentelemetry-instrumentation-net/test/instrument.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-net/test/instrument.test.ts
@@ -27,9 +27,10 @@ import * as net from 'net';
 import { HOST, PORT } from './utils';
 
 const memoryExporter = new InMemorySpanExporter();
-const provider = new NodeTracerProvider();
+const provider = new NodeTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+});
 const tracer = provider.getTracer('default');
-provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
 
 describe('NetInstrumentation', () => {
   let instrumentation: NetInstrumentation;

--- a/plugins/node/opentelemetry-instrumentation-net/test/tls.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-net/test/tls.test.ts
@@ -34,8 +34,9 @@ import {
 } from './utils';
 
 const memoryExporter = new InMemorySpanExporter();
-const provider = new NodeTracerProvider();
-provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
+const provider = new NodeTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+});
 
 function getTLSSpans() {
   const spans = memoryExporter.getFinishedSpans();

--- a/plugins/node/opentelemetry-instrumentation-pg/test/pg-pool.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/test/pg-pool.test.ts
@@ -123,7 +123,9 @@ describe('pg-pool', () => {
   let pool: pgPool<pg.Client>;
   let contextManager: AsyncHooksContextManager;
   let instrumentation: PgInstrumentation;
-  const provider = new BasicTracerProvider();
+  const provider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+  });
 
   const testPostgres = process.env.RUN_POSTGRES_TESTS; // For CI: assumes local postgres db is already available
   const testPostgresLocally = process.env.RUN_POSTGRES_TESTS_LOCAL; // For local: spins up local postgres db via docker
@@ -141,7 +143,6 @@ describe('pg-pool', () => {
       skip();
     }
 
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
     if (testPostgresLocally) {
       testUtils.startDocker('postgres');
     }

--- a/plugins/node/opentelemetry-instrumentation-pg/test/pg.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/test/pg.test.ts
@@ -118,7 +118,9 @@ describe('pg', () => {
   let client: pg.Client;
   let instrumentation: PgInstrumentation;
   let contextManager: AsyncHooksContextManager;
-  const provider = new BasicTracerProvider();
+  const provider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+  });
   const tracer = provider.getTracer('external');
 
   const testPostgres = process.env.RUN_POSTGRES_TESTS; // For CI: assumes local postgres db is already available
@@ -143,7 +145,6 @@ describe('pg', () => {
       skip();
     }
 
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
     if (testPostgresLocally) {
       testUtils.startDocker('postgres');
     }

--- a/plugins/node/opentelemetry-instrumentation-pg/test/utils.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/test/utils.test.ts
@@ -49,15 +49,13 @@ const getLatestSpan = () => {
 describe('utils.ts', () => {
   const client = new pg.Client(CONFIG) as PgClientExtended;
   let contextManager: AsyncHooksContextManager;
-  const provider = new BasicTracerProvider();
+  const provider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+  });
   const tracer = provider.getTracer('external');
 
   const instrumentationConfig: PgInstrumentationConfig & InstrumentationConfig =
     {};
-
-  before(() => {
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
-  });
 
   beforeEach(() => {
     contextManager = new AsyncHooksContextManager().enable();

--- a/plugins/node/opentelemetry-instrumentation-pino/test/pino.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pino/test/pino.test.ts
@@ -45,11 +45,10 @@ import { PACKAGE_NAME, PACKAGE_VERSION } from '../src/version';
 
 import type { pino as Pino } from 'pino';
 
-const tracerProvider = new NodeTracerProvider();
+const tracerProvider = new NodeTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(new InMemorySpanExporter())],
+});
 tracerProvider.register();
-tracerProvider.addSpanProcessor(
-  new SimpleSpanProcessor(new InMemorySpanExporter())
-);
 const tracer = tracerProvider.getTracer('default');
 
 // Setup LoggerProvider for "log sending" tests.

--- a/plugins/node/opentelemetry-instrumentation-redis/test/redis.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-redis/test/redis.test.ts
@@ -68,7 +68,9 @@ const unsetStatus: SpanStatus = {
 };
 
 describe('redis@2.x', () => {
-  const provider = new NodeTracerProvider();
+  const provider = new NodeTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+  });
   const tracer = provider.getTracer('external');
   let redis: typeof redisTypes;
   const shouldTestLocal = process.env.RUN_REDIS_TESTS_LOCAL;
@@ -98,7 +100,6 @@ describe('redis@2.x', () => {
     }
 
     redis = require('redis');
-    provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
     instrumentation.setTracerProvider(provider);
     instrumentation.enable();
   });

--- a/plugins/node/opentelemetry-instrumentation-restify/test/restify.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/test/restify.test.ts
@@ -118,10 +118,11 @@ const createServer = async (setupRoutes?: Function) => {
 };
 
 describe('Restify Instrumentation', () => {
-  const provider = new NodeTracerProvider();
   const memoryExporter = new InMemorySpanExporter();
   const spanProcessor = new SimpleSpanProcessor(memoryExporter);
-  provider.addSpanProcessor(spanProcessor);
+  const provider = new NodeTracerProvider({
+    spanProcessors: [spanProcessor],
+  });
   plugin.setTracerProvider(provider);
   const tracer = provider.getTracer('default');
   let contextManager: AsyncHooksContextManager;

--- a/plugins/node/opentelemetry-instrumentation-router/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-router/test/index.test.ts
@@ -152,10 +152,11 @@ const spans = {
 };
 
 describe('Router instrumentation', () => {
-  const provider = new NodeTracerProvider();
   const memoryExporter = new InMemorySpanExporter();
   const spanProcessor = new SimpleSpanProcessor(memoryExporter);
-  provider.addSpanProcessor(spanProcessor);
+  const provider = new NodeTracerProvider({
+    spanProcessors: [spanProcessor],
+  });
   plugin.setTracerProvider(provider);
   const tracer = provider.getTracer('default');
   let contextManager: AsyncHooksContextManager;

--- a/plugins/node/opentelemetry-instrumentation-winston/test/winston.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-winston/test/winston.test.ts
@@ -35,9 +35,10 @@ import type { Winston2Logger, Winston3Logger } from '../src/internal-types';
 import { WinstonInstrumentation } from '../src';
 
 const memoryExporter = new InMemorySpanExporter();
-const provider = new NodeTracerProvider();
+const provider = new NodeTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+});
 const tracer = provider.getTracer('default');
-provider.addSpanProcessor(new SimpleSpanProcessor(memoryExporter));
 context.setGlobalContextManager(new AsyncHooksContextManager());
 
 const loggerProvider = new LoggerProvider();

--- a/plugins/web/opentelemetry-instrumentation-document-load/test/documentLoad.test.ts
+++ b/plugins/web/opentelemetry-instrumentation-document-load/test/documentLoad.test.ts
@@ -48,10 +48,11 @@ import { EventNames } from '../src/enums/EventNames';
 const assert = chai.assert;
 
 const exporter = new InMemorySpanExporter();
-const provider = new BasicTracerProvider();
 const spanProcessor = new SimpleSpanProcessor(exporter);
+const provider = new BasicTracerProvider({
+  spanProcessors: [spanProcessor],
+});
 
-provider.addSpanProcessor(spanProcessor);
 provider.register();
 
 const resources = [

--- a/plugins/web/opentelemetry-instrumentation-long-task/test/compatibility.test.ts
+++ b/plugins/web/opentelemetry-instrumentation-long-task/test/compatibility.test.ts
@@ -38,11 +38,10 @@ describe("LongTaskInstrumentation doesn't throw in unsupported environments", ()
   let dummySpanExporter: DummySpanExporter;
 
   before(() => {
-    webTracerProvider = new WebTracerProvider();
     dummySpanExporter = new DummySpanExporter();
-    webTracerProvider.addSpanProcessor(
-      new tracing.SimpleSpanProcessor(dummySpanExporter)
-    );
+    webTracerProvider = new WebTracerProvider({
+      spanProcessors: [new tracing.SimpleSpanProcessor(dummySpanExporter)],
+    });
     webTracerProvider.register();
   });
 

--- a/plugins/web/opentelemetry-instrumentation-long-task/test/longTask.test.ts
+++ b/plugins/web/opentelemetry-instrumentation-long-task/test/longTask.test.ts
@@ -60,12 +60,11 @@ describe('LongTaskInstrumentation', () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    webTracerProvider = new WebTracerProvider();
     dummySpanExporter = new DummySpanExporter();
     exportSpy = sandbox.stub(dummySpanExporter, 'export');
-    webTracerProvider.addSpanProcessor(
-      new tracing.SimpleSpanProcessor(dummySpanExporter)
-    );
+    webTracerProvider = new WebTracerProvider({
+      spanProcessors: [new tracing.SimpleSpanProcessor(dummySpanExporter)],
+    });
     webTracerProvider.register();
 
     longTaskInstrumentation = new LongTaskInstrumentation({

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.nozone.test.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.nozone.test.ts
@@ -90,13 +90,11 @@ describe('UserInteractionInstrumentation', () => {
 
       sandbox.useFakeTimers();
 
-      webTracerProvider = new WebTracerProvider();
-
       dummySpanExporter = new DummySpanExporter();
       exportSpy = sandbox.stub(dummySpanExporter, 'export');
-      webTracerProvider.addSpanProcessor(
-        new tracing.SimpleSpanProcessor(dummySpanExporter)
-      );
+      webTracerProvider = new WebTracerProvider({
+        spanProcessors: [new tracing.SimpleSpanProcessor(dummySpanExporter)],
+      });
       webTracerProvider.register();
 
       registerTestInstrumentations();

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.test.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.test.ts
@@ -95,13 +95,11 @@ describe('UserInteractionInstrumentation', () => {
 
       sandbox.useFakeTimers();
 
-      webTracerProvider = new WebTracerProvider();
       dummySpanExporter = new DummySpanExporter();
       exportSpy = sandbox.stub(dummySpanExporter, 'export');
-      webTracerProvider.addSpanProcessor(
-        new tracing.SimpleSpanProcessor(dummySpanExporter)
-      );
-
+      webTracerProvider = new WebTracerProvider({
+        spanProcessors: [new tracing.SimpleSpanProcessor(dummySpanExporter)],
+      });
       webTracerProvider.register({
         contextManager,
       });

--- a/plugins/web/opentelemetry-plugin-react-load/test/BaseOpenTelemetryComponent.test.ts
+++ b/plugins/web/opentelemetry-plugin-react-load/test/BaseOpenTelemetryComponent.test.ts
@@ -68,11 +68,11 @@ describe('ReactLoad Instrumentation', () => {
     contextManager = new StackContextManager().enable();
     context.setGlobalContextManager(contextManager);
 
-    provider = new BasicTracerProvider();
-
     dummyExporter = new DummyExporter();
     spanProcessor = new SimpleSpanProcessor(dummyExporter);
-    provider.addSpanProcessor(spanProcessor);
+    provider = new BasicTracerProvider({
+      spanProcessors: [spanProcessor],
+    });
     sandbox = sinon.createSandbox();
 
     trace.setGlobalTracerProvider(provider);


### PR DESCRIPTION
This migrates from the deprecated `addSpanProcessor` method to the constructor option in preparation for the upcoming SDK 2.0 release.

This commit migrates all usages **in tests** for each package, and there are no changes to the runtime code. It's a lot of changes, but since it's all in tests, as long as the tests pass, I don't think there is anything risky in here. It probably doesn't need a CHANGELOG entry either.

Ref #2645 (cc @pichlermarc)