### PR TITLE
feat(detectors): mark as side effect free

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-alibaba-cloud/package.json
+++ b/detectors/node/opentelemetry-resource-detector-alibaba-cloud/package.json
@@ -61,5 +61,6 @@
     "@opentelemetry/resources": "^1.10.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-alibaba-cloud#readme"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-alibaba-cloud#readme",
+  "sideEffects": false
 }

--- a/detectors/node/opentelemetry-resource-detector-aws/package.json
+++ b/detectors/node/opentelemetry-resource-detector-aws/package.json
@@ -62,5 +62,6 @@
     "@opentelemetry/resources": "^1.10.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-aws#readme"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-aws#readme",
+  "sideEffects": false
 }

--- a/detectors/node/opentelemetry-resource-detector-azure/package.json
+++ b/detectors/node/opentelemetry-resource-detector-azure/package.json
@@ -53,5 +53,6 @@
     "@opentelemetry/resources": "^1.10.1",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-azure#readme"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-azure#readme",
+  "sideEffects": false
 }

--- a/detectors/node/opentelemetry-resource-detector-container/package.json
+++ b/detectors/node/opentelemetry-resource-detector-container/package.json
@@ -56,5 +56,6 @@
     "@opentelemetry/resources": "^1.10.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-container#readme"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-container#readme",
+  "sideEffects": false
 }

--- a/detectors/node/opentelemetry-resource-detector-gcp/package.json
+++ b/detectors/node/opentelemetry-resource-detector-gcp/package.json
@@ -61,5 +61,6 @@
     "@opentelemetry/semantic-conventions": "^1.27.0",
     "gcp-metadata": "^6.0.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-gcp#readme"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-gcp#readme",
+  "sideEffects": false
 }

--- a/detectors/node/opentelemetry-resource-detector-github/package.json
+++ b/detectors/node/opentelemetry-resource-detector-github/package.json
@@ -57,5 +57,6 @@
   "dependencies": {
     "@opentelemetry/resources": "^1.10.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-github#readme"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-github#readme",
+  "sideEffects": false
 }

--- a/detectors/node/opentelemetry-resource-detector-instana/package.json
+++ b/detectors/node/opentelemetry-resource-detector-instana/package.json
@@ -58,5 +58,6 @@
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"
   },
-  "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-instana#readme"
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/detectors/node/opentelemetry-resource-detector-instana#readme",
+  "sideEffects": false
 }


### PR DESCRIPTION
## Which problem is this PR solving?

In my previous [PR](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2636), I have forgotten to mark resource detector modules as side effect free. So, during my internal tests with custom built resource detector packages, I have noticed that they are not tree-shaked by webpack even though they are not referenced.

## Short description of the changes

Add `sideEffects` property as `false` to the `package.json` files of all the resource detector modules.
