### PR TITLE
chore(instrumentation-pg): have `@opentelemetry/semantic-conventions` package dependency with caret (`^`) version to sync with other instrumentation packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38732,7 +38732,7 @@
       "dependencies": {
         "@opentelemetry/core": "^1.26.0",
         "@opentelemetry/instrumentation": "^0.57.0",
-        "@opentelemetry/semantic-conventions": "1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
         "@opentelemetry/sql-common": "^0.40.1",
         "@types/pg": "8.6.1",
         "@types/pg-pool": "2.0.6"
@@ -38761,14 +38761,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "plugins/node/opentelemetry-instrumentation-pg/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
-      "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "plugins/node/opentelemetry-instrumentation-pg/node_modules/@types/mocha": {
@@ -48807,7 +48799,7 @@
         "@opentelemetry/instrumentation": "^0.57.0",
         "@opentelemetry/sdk-trace-base": "^1.8.0",
         "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "1.27.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
         "@opentelemetry/sql-common": "^0.40.1",
         "@types/mocha": "7.0.2",
         "@types/node": "18.18.14",
@@ -48825,11 +48817,6 @@
         "typescript": "4.4.4"
       },
       "dependencies": {
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.27.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.27.0.tgz",
-          "integrity": "sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg=="
-        },
         "@types/mocha": {
           "version": "7.0.2",
           "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",

--- a/plugins/node/opentelemetry-instrumentation-pg/package.json
+++ b/plugins/node/opentelemetry-instrumentation-pg/package.json
@@ -71,7 +71,7 @@
   "dependencies": {
     "@opentelemetry/core": "^1.26.0",
     "@opentelemetry/instrumentation": "^0.57.0",
-    "@opentelemetry/semantic-conventions": "1.27.0",
+    "@opentelemetry/semantic-conventions": "^1.27.0",
     "@opentelemetry/sql-common": "^0.40.1",
     "@types/pg": "8.6.1",
     "@types/pg-pool": "2.0.6"

--- a/plugins/node/opentelemetry-instrumentation-pg/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/instrumentation.ts
@@ -65,7 +65,7 @@ import {
   METRIC_DB_CLIENT_OPERATION_DURATION,
   ATTR_DB_NAMESPACE,
   ATTR_DB_OPERATION_NAME,
-} from '@opentelemetry/semantic-conventions/incubating';
+} from './semconv';
 
 export class PgInstrumentation extends InstrumentationBase<PgInstrumentationConfig> {
   private _operationDuration!: Histogram;

--- a/plugins/node/opentelemetry-instrumentation-pg/src/semconv.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/semconv.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const ATTR_DB_CLIENT_CONNECTION_POOL_NAME =
+  'db.client.connection.pool.name';
+export const ATTR_DB_CLIENT_CONNECTION_STATE = 'db.client.connection.state';
+export const ATTR_DB_NAMESPACE = 'db.namespace';
+export const ATTR_DB_OPERATION_NAME = 'db.operation.name';
+export const DB_CLIENT_CONNECTION_STATE_VALUE_USED = 'used';
+export const DB_CLIENT_CONNECTION_STATE_VALUE_IDLE = 'idle';
+export const METRIC_DB_CLIENT_CONNECTION_COUNT = 'db.client.connection.count';
+export const METRIC_DB_CLIENT_CONNECTION_PENDING_REQUESTS =
+  'db.client.connection.pending_requests';
+export const METRIC_DB_CLIENT_OPERATION_DURATION =
+  'db.client.operation.duration';

--- a/plugins/node/opentelemetry-instrumentation-pg/src/semconv.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/semconv.ts
@@ -14,15 +14,87 @@
  * limitations under the License.
  */
 
+/**
+ * The name of the connection pool; unique within the instrumented application. In case the connection pool implementation doesn't provide a name, instrumentation **SHOULD** use a combination of parameters that would make the name unique, for example, combining attributes `server.address`, `server.port`, and `db.namespace`, formatted as `server.address:server.port/db.namespace`. Instrumentations that generate connection pool name following different patterns **SHOULD** document it.
+ *
+ * @example myDataSource
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
 export const ATTR_DB_CLIENT_CONNECTION_POOL_NAME =
   'db.client.connection.pool.name';
+
+/**
+ * The state of a connection in the pool
+ *
+ * @example idle
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
 export const ATTR_DB_CLIENT_CONNECTION_STATE = 'db.client.connection.state';
+
+/**
+ * The name of the database, fully qualified within the server address and port.
+ *
+ * @example customers
+ * @example test.users
+ *
+ * @note If a database system has multiple namespace components, they **SHOULD** be concatenated (potentially using database system specific conventions) from most general to most specific namespace component, and more specific namespaces **SHOULD NOT** be captured without the more general namespaces, to ensure that "startswith" queries for the more general namespaces will be valid.
+ * Semantic conventions for individual database systems **SHOULD** document what `db.namespace` means in the context of that system.
+ * It is **RECOMMENDED** to capture the value as provided by the application without attempting to do any case normalization.
+ * This attribute has stability level RELEASE CANDIDATE.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
 export const ATTR_DB_NAMESPACE = 'db.namespace';
+
+/**
+ * The name of the operation or command being executed.
+ *
+ * @example findAndModify
+ * @example HMSET
+ * @example SELECT
+ *
+ * @note It is **RECOMMENDED** to capture the value as provided by the application without attempting to do any case normalization.
+ * If the operation name is parsed from the query text, it **SHOULD** be the first operation name found in the query.
+ * For batch operations, if the individual operations are known to have the same operation name then that operation name **SHOULD** be used prepended by `BATCH `, otherwise `db.operation.name` **SHOULD** be `BATCH` or some other database system specific term if more applicable.
+ * This attribute has stability level RELEASE CANDIDATE.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
 export const ATTR_DB_OPERATION_NAME = 'db.operation.name';
+
+/**
+ * Enum value "used" for attribute {@link ATTR_DB_CLIENT_CONNECTION_STATE}.
+ */
 export const DB_CLIENT_CONNECTION_STATE_VALUE_USED = 'used';
+
+/**
+ * Enum value "idle" for attribute {@link ATTR_DB_CLIENT_CONNECTION_STATE}.
+ */
 export const DB_CLIENT_CONNECTION_STATE_VALUE_IDLE = 'idle';
+
+/**
+ * The number of connections that are currently in state described by the `state` attribute
+ *
+ * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
 export const METRIC_DB_CLIENT_CONNECTION_COUNT = 'db.client.connection.count';
+
+/**
+ * The number of current pending requests for an open connection
+ *
+ * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
 export const METRIC_DB_CLIENT_CONNECTION_PENDING_REQUESTS =
   'db.client.connection.pending_requests';
+
+/**
+ * Duration of database client operations.
+ *
+ * @note Batch operations **SHOULD** be recorded as a single operation.
+ *
+ * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
 export const METRIC_DB_CLIENT_OPERATION_DURATION =
   'db.client.operation.duration';

--- a/plugins/node/opentelemetry-instrumentation-pg/src/utils.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/utils.ts
@@ -42,7 +42,7 @@ import {
   ATTR_DB_CLIENT_CONNECTION_STATE,
   DB_CLIENT_CONNECTION_STATE_VALUE_USED,
   DB_CLIENT_CONNECTION_STATE_VALUE_IDLE,
-} from '@opentelemetry/semantic-conventions/incubating';
+} from './semconv';
 import {
   PgClientExtended,
   PostgresCallback,

--- a/plugins/node/opentelemetry-instrumentation-pg/test/pg-pool.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/test/pg-pool.test.ts
@@ -55,7 +55,7 @@ import {
   METRIC_DB_CLIENT_CONNECTION_COUNT,
   METRIC_DB_CLIENT_CONNECTION_PENDING_REQUESTS,
   METRIC_DB_CLIENT_OPERATION_DURATION,
-} from '@opentelemetry/semantic-conventions/incubating';
+} from '../src/semconv';
 
 const memoryExporter = new InMemorySpanExporter();
 

--- a/plugins/node/opentelemetry-instrumentation-pg/test/pg.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/test/pg.test.ts
@@ -56,7 +56,7 @@ import {
 import {
   METRIC_DB_CLIENT_OPERATION_DURATION,
   ATTR_DB_OPERATION_NAME,
-} from '@opentelemetry/semantic-conventions/incubating';
+} from '../src/semconv';
 import { addSqlCommenterComment } from '@opentelemetry/sql-common';
 
 const memoryExporter = new InMemorySpanExporter();


### PR DESCRIPTION
… so latest minor versions will be able to used

## Which problem is this PR solving?

Currently, `@opentelemetry/instrumentation-pg` package has `@opentelemetry/semantic-conventions` dependency with direct version (`1.27.0`), but other instrumentation packages have that with caret version (`^1.27.0`) of it. And this leads to having multiple copies of the `@opentelemetry/semantic-conventions` package with different versions in the AWS Lambda Node.js layer.  

## Short description of the changes

Change `@opentelemetry/semantic-conventions` package version to `^1.27.0` to be sync with the other instrumentation packages.
