### PR TITLE
fix(auto-instrumentations-node): make SIGTERM shutdown test more reliable

### DIFF
--- a/metapackages/auto-instrumentations-node/test/test-app/app-server.js
+++ b/metapackages/auto-instrumentations-node/test/test-app/app-server.js
@@ -17,22 +17,34 @@
 //Used in register.test.ts to mimic a JS app that stays alive like a server.
 const http = require('http');
 
-const options = {
-  hostname: 'example.com',
-  port: 80,
-  path: '/',
-  method: 'GET',
-};
+// Create a local server that responds immediately
+const server = http.createServer((req, res) => {
+  res.end('ok');
+});
 
-const req = http.request(options);
-req.end();
-req.on('close', () => {
-  console.log('Finished request');
+server.listen(0, () => {
+  const port = server.address().port;
+  const req = http.request({
+    hostname: 'localhost',
+    port: port,
+    path: '/',
+    method: 'GET',
+  });
+
+  req.end();
+  req.on('response', res => {
+    res.on('end', () => {
+      console.log('Finished request');
+    });
+    res.resume();
+  });
 });
 
 // Make sure there is work on the event loop
 const handle = setInterval(() => {}, 1);
+
 // Gracefully shut down
 process.on('SIGTERM', () => {
   clearInterval(handle);
+  server.close();
 });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

The test `shuts down the NodeSDK when SIGTERM is received` is flaky due to making HTTP requests to `example.com`:

![image](https://github.com/user-attachments/assets/6f233ad0-b135-4983-89fc-0e084e7ca399)

## Short description of the changes

The key improvements are:

1. **Controlled Environment**: Instead of depending on `example.com` (which could be slow/unreachable), we use a local server that responds immediately.

2. **Better Event Handling**: Changed from using `req.on('close')` to `res.on('end')` which is more reliable for confirming the request completed.

3. **Proper Cleanup**: Added `server.close()` to the SIGTERM handler to ensure clean shutdown.

4. **Fixed Timing**: The local server responds immediately, reducing the chance of hitting the test's 1500ms timeout.

The main issue was likely that requests to `example.com` were taking too long or failing, causing the test to hit its timeout before seeing the `Finished request` message. By using a local server, we make the test much more deterministic and faster.

