### PR TITLE
chore(deps): update collector images in examples

### DIFF
--- a/examples/connect/docker/collector-config.yaml
+++ b/examples/connect/docker/collector-config.yaml
@@ -3,9 +3,10 @@ receivers:
     protocols:
       grpc:
       http:
-        cors_allowed_origins:
-        - http://*
-        - https://*
+        cors:
+          allowed_origins:
+          - http://*
+          - https://*
 
 exporters:
   zipkin:
@@ -17,6 +18,9 @@ processors:
   batch:
 
 service:
+  telemetry:
+    logs:
+      level: debug
   pipelines:
     traces:
       receivers: [otlp]

--- a/examples/connect/docker/docker-compose.yaml
+++ b/examples/connect/docker/docker-compose.yaml
@@ -2,9 +2,9 @@ version: "3"
 services:
   # Collector
   collector:
-    image: otel/opentelemetry-collector:0.38.0
+    image: otel/opentelemetry-collector:0.118.0
 #    image: otel/opentelemetry-collector:latest
-    command: ["--config=/conf/collector-config.yaml", "--log-level=DEBUG"]
+    command: ["--config=/conf/collector-config.yaml"]
     volumes:
       - ./collector-config.yaml:/conf/collector-config.yaml
     ports:

--- a/examples/fastify/docker/docker-compose.yaml
+++ b/examples/fastify/docker/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   collector:
-    image: otel/opentelemetry-collector:0.92.0
+    image: otel/opentelemetry-collector:0.118.0
     command: ["--config=/conf/collector-config.yaml"]
     volumes:
       - ./collector-config.yaml:/conf/collector-config.yaml

--- a/examples/graphql/docker/collector-config.yaml
+++ b/examples/graphql/docker/collector-config.yaml
@@ -3,9 +3,10 @@ receivers:
     protocols:
       grpc:
       http:
-        cors_allowed_origins:
-          - http://*
-          - https://*
+        cors:
+          allowed_origins:
+            - http://*
+            - https://*
 
 exporters:
   zipkin:

--- a/examples/graphql/docker/docker-compose.yaml
+++ b/examples/graphql/docker/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
   # Collector
   collector:
     #    image: otel/opentelemetry-collector:latest
-    image: otel/opentelemetry-collector:0.38.0
+    image: otel/opentelemetry-collector:0.118.0
     command: ["--config=/conf/collector-config.yaml"]
     volumes:
       - ./collector-config.yaml:/conf/collector-config.yaml

--- a/examples/mysql/docker/docker-compose.yaml
+++ b/examples/mysql/docker/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
 # Collector
 
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.111.0
+    image: otel/opentelemetry-collector-contrib:0.118.0
     command: ["--config=/etc/otel-collector-config.yaml", ""]
     volumes:
       - ./collector/otel-collector-config.yaml:/etc/otel-collector-config.yaml

--- a/examples/react-load/preact/docker/docker-compose.yaml
+++ b/examples/react-load/preact/docker/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
 
   # Collector
   collector:
-    image: otel/opentelemetry-collector-contrib:0.75.0
+    image: otel/opentelemetry-collector-contrib:0.118.0
     command: ["--config=/conf/collector-config.yaml"]
     volumes:
       - ./collector-config.yaml:/conf/collector-config.yaml

--- a/examples/react-load/react/docker/collector-config.yaml
+++ b/examples/react-load/react/docker/collector-config.yaml
@@ -3,7 +3,9 @@ receivers:
     protocols:
       http:
         endpoint: 0.0.0.0:55678
-        cors_allowed_origins: http://localhost:3000
+        cors:
+          allowed_origins:
+          - http://localhost:3000
 
 exporters:
   zipkin:

--- a/examples/react-load/react/docker/docker-compose.yaml
+++ b/examples/react-load/react/docker/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
 
   # Collector
   collector:
-    image: otel/opentelemetry-collector-contrib:0.40.0
+    image: otel/opentelemetry-collector-contrib:0.118.0
     command: ["--config=/conf/collector-config.yaml"]
     volumes:
       - ./collector-config.yaml:/conf/collector-config.yaml

--- a/examples/web/docker/docker-compose.yaml
+++ b/examples/web/docker/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   collector:
-    image: otel/opentelemetry-collector:0.99.0
+    image: otel/opentelemetry-collector:0.118.0
     command: ["--config=/conf/collector-config.yaml"]
     volumes:
       - ./collector-config.yaml:/conf/collector-config.yaml


### PR DESCRIPTION
## Which problem is this PR solving?

- This was needed because I was trying to run the graphql example and ran into a problem where the image of the collector was so old that an arm release of the container wasn't available.

## Short description of the changes

- updated all the collectors in various examples to the latest current release of the collector.
- updated the collector config and ran docker compose up to ensure they all worked
