### PR TITLE
refactor: use isWrapped from instrumentation package

### DIFF
--- a/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.nozone.test.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.nozone.test.ts
@@ -16,7 +16,10 @@
 const originalSetTimeout = window.setTimeout;
 
 import { trace } from '@opentelemetry/api';
-import { registerInstrumentations, isWrapped } from '@opentelemetry/instrumentation';
+import {
+  registerInstrumentations,
+  isWrapped,
+} from '@opentelemetry/instrumentation';
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
 import * as tracing from '@opentelemetry/sdk-trace-base';
 import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.nozone.test.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/test/userInteraction.nozone.test.ts
@@ -16,8 +16,7 @@
 const originalSetTimeout = window.setTimeout;
 
 import { trace } from '@opentelemetry/api';
-import { isWrapped } from '@opentelemetry/core';
-import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { registerInstrumentations, isWrapped } from '@opentelemetry/instrumentation';
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
 import * as tracing from '@opentelemetry/sdk-trace-base';
 import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';

--- a/plugins/web/opentelemetry-plugin-react-load/src/BaseOpenTelemetryComponent.ts
+++ b/plugins/web/opentelemetry-plugin-react-load/src/BaseOpenTelemetryComponent.ts
@@ -15,7 +15,7 @@
  */
 
 import * as api from '@opentelemetry/api';
-import { isWrapped } from '@opentelemetry/core';
+import { isWrapped } from '@opentelemetry/instrumentation';
 import * as shimmer from 'shimmer';
 import { AttributeNames } from './enums/AttributeNames';
 import * as React from 'react';

--- a/plugins/web/opentelemetry-plugin-react-load/test/BaseOpenTelemetryComponent.test.ts
+++ b/plugins/web/opentelemetry-plugin-react-load/test/BaseOpenTelemetryComponent.test.ts
@@ -20,7 +20,7 @@ import {
   propagation,
   trace,
 } from '@opentelemetry/api';
-import { isWrapped } from '@opentelemetry/core';
+import { isWrapped } from '@opentelemetry/instrumentation';
 import { B3Propagator } from '@opentelemetry/propagator-b3';
 import {
   BasicTracerProvider,


### PR DESCRIPTION
## Which problem is this PR solving?

For `@opentelemetry/core@2.0.0` we'll remove `isWrapped()` since it's duplicated in `@opentelemetry/instrumentation`. It makes more sense to have it in `@opentelemetry/instrumentation` since that's actually an instrumentation-related utility function.

Refs https://github.com/open-telemetry/opentelemetry-js/pull/5444

## Short description of the changes

Uses `isWrapped()` from `@opentelemetry/instrumentation` instead. It is a drop-in replacement as the implementations are identical:
- from core: https://github.com/open-telemetry/opentelemetry-js/blob/4553b29d4a04b5b7e4bf87cad64dc2fc8c740d8e/packages/opentelemetry-core/src/utils/wrap.ts#L19-L30
- from instrumentation: https://github.com/open-telemetry/opentelemetry-js/blob/fdab6422ae238b04beb2e92ac38153e35e5800ac/experimental/packages/opentelemetry-instrumentation/src/utils.ts#L72-L83

`ShimWrapped` is also fully compatible:
- from core: https://github.com/open-telemetry/opentelemetry-js/blob/4a6021af7a8fd8a912d221cab3d96b40a0b0433c/packages/opentelemetry-core/src/common/types.ts#L30-L40
- from instrumentation: https://github.com/open-telemetry/opentelemetry-js/blob/d2812d2810a812f069f7d40fb9c6c870e30fb8e0/experimental/packages/opentelemetry-instrumentation/src/types.ts#L66-L76
