### PR TITLE
refactor(resource-detector-aws): migrate away from getEnv()

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsEcsDetectorSync.ts
+++ b/detectors/node/opentelemetry-resource-detector-aws/src/detectors/AwsEcsDetectorSync.ts
@@ -48,7 +48,6 @@ import * as http from 'http';
 import * as util from 'util';
 import * as fs from 'fs';
 import * as os from 'os';
-import { getEnv } from '@opentelemetry/core';
 
 const HTTP_TIMEOUT_IN_MS = 1000;
 
@@ -77,8 +76,7 @@ export class AwsEcsDetectorSync implements DetectorSync {
   }
 
   private async _getAttributes(): Promise<ResourceAttributes> {
-    const env = getEnv();
-    if (!env.ECS_CONTAINER_METADATA_URI_V4 && !env.ECS_CONTAINER_METADATA_URI) {
+    if (!process.env.ECS_CONTAINER_METADATA_URI_V4 && !process.env.ECS_CONTAINER_METADATA_URI) {
       diag.debug('AwsEcsDetector failed: Process is not on ECS');
       return {};
     }
@@ -89,7 +87,7 @@ export class AwsEcsDetectorSync implements DetectorSync {
         [ATTR_CLOUD_PLATFORM]: CLOUD_PLATFORM_VALUE_AWS_ECS,
       }).merge(await AwsEcsDetectorSync._getContainerIdAndHostnameResource());
 
-      const metadataUrl = getEnv().ECS_CONTAINER_METADATA_URI_V4;
+      const metadataUrl = process.env.ECS_CONTAINER_METADATA_URI_V4;
       if (metadataUrl) {
         const [containerMetadata, taskMetadata] = await Promise.all([
           AwsEcsDetectorSync._getUrlAsJson(metadataUrl),


### PR DESCRIPTION
## Which problem is this PR solving?

We're planning to remove `getEnv()` as it does not scale well when everyone has to update `@opentelemetry/core` to get their env vars. For `OTEL_*` there will be a replacement utility function. For all others, when the package does not need to be browser-compatible (which seems to be the case here) using `process.env` directly should be fine.

Refs https://github.com/open-telemetry/opentelemetry-js/pull/5443

## Short description of the changes

This PR removes `getEnv()` with `process.env`, it does not inline defaults as leaving them out was semantically equivalent. (they used to be empty strings)