### PR TITLE
refactor(auto-instrumentations-node): migrate away from getEnv()

### DIFF
--- a/metapackages/auto-instrumentations-node/src/register.ts
+++ b/metapackages/auto-instrumentations-node/src/register.ts
@@ -16,14 +16,12 @@
 import * as opentelemetry from '@opentelemetry/sdk-node';
 import { diag, DiagConsoleLogger } from '@opentelemetry/api';
 import {
+  getLogLevelFromEnv,
   getNodeAutoInstrumentations,
   getResourceDetectorsFromEnv,
 } from './utils';
 
-diag.setLogger(
-  new DiagConsoleLogger(),
-  opentelemetry.core.getEnv().OTEL_LOG_LEVEL
-);
+diag.setLogger(new DiagConsoleLogger(), getLogLevelFromEnv());
 
 const sdk = new opentelemetry.NodeSDK({
   instrumentations: getNodeAutoInstrumentations(),

--- a/metapackages/auto-instrumentations-node/src/utils.ts
+++ b/metapackages/auto-instrumentations-node/src/utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { diag } from '@opentelemetry/api';
+import { diag, DiagLogLevel } from '@opentelemetry/api';
 import { Instrumentation } from '@opentelemetry/instrumentation';
 
 import { AmqplibInstrumentation } from '@opentelemetry/instrumentation-amqplib';
@@ -134,6 +134,17 @@ const InstrumentationMap = {
   '@opentelemetry/instrumentation-tedious': TediousInstrumentation,
   '@opentelemetry/instrumentation-undici': UndiciInstrumentation,
   '@opentelemetry/instrumentation-winston': WinstonInstrumentation,
+};
+
+// The support string -> DiagLogLevel mappings
+const logLevelMap: { [key: string]: DiagLogLevel } = {
+  ALL: DiagLogLevel.ALL,
+  VERBOSE: DiagLogLevel.VERBOSE,
+  DEBUG: DiagLogLevel.DEBUG,
+  INFO: DiagLogLevel.INFO,
+  WARN: DiagLogLevel.WARN,
+  ERROR: DiagLogLevel.ERROR,
+  NONE: DiagLogLevel.NONE,
 };
 
 const defaultExcludedInstrumentations = [
@@ -292,4 +303,17 @@ export function getResourceDetectorsFromEnv(): Array<Detector | DetectorSync> {
     }
     return resourceDetector || [];
   });
+}
+
+export function getLogLevelFromEnv(): DiagLogLevel {
+  const rawLogLevel = process.env.OTEL_LOG_LEVEL;
+
+  // NOTE: as per specification we should actually only register if something is set, but our previous implementation
+  // always registered a logger, even when nothing was set. Falling back to 'INFO' here to keep the same behavior as
+  // with previous implementations.
+  // Also: no point in warning - no logger is registered yet
+  return (
+    logLevelMap[rawLogLevel?.trim().toUpperCase() ?? 'INFO'] ??
+    DiagLogLevel.INFO
+  );
 }

--- a/metapackages/auto-instrumentations-node/test/utils.test.ts
+++ b/metapackages/auto-instrumentations-node/test/utils.test.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { diag } from '@opentelemetry/api';
+import { diag, DiagLogLevel } from '@opentelemetry/api';
 import { HttpInstrumentationConfig } from '@opentelemetry/instrumentation-http';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { getNodeAutoInstrumentations } from '../src';
-import { getResourceDetectorsFromEnv } from '../src/utils';
+import { getLogLevelFromEnv, getResourceDetectorsFromEnv } from '../src/utils';
 
 describe('utils', () => {
   describe('getNodeAutoInstrumentations', () => {
@@ -221,6 +221,46 @@ describe('utils', () => {
 
       spy.restore();
       delete process.env.OTEL_NODE_RESOURCE_DETECTORS;
+    });
+  });
+
+  describe('getLogLevelFromEnv', function () {
+    afterEach(function () {
+      delete process.env.OTEL_LOG_LEVEL;
+    });
+
+    it('should select log level based on env var', function () {
+      process.env.OTEL_LOG_LEVEL = 'NONE';
+      assert.strictEqual(getLogLevelFromEnv(), DiagLogLevel.NONE);
+      process.env.OTEL_LOG_LEVEL = 'VERBOSE';
+      assert.strictEqual(getLogLevelFromEnv(), DiagLogLevel.VERBOSE);
+      process.env.OTEL_LOG_LEVEL = 'DEBUG';
+      assert.strictEqual(getLogLevelFromEnv(), DiagLogLevel.DEBUG);
+      process.env.OTEL_LOG_LEVEL = 'INFO';
+      assert.strictEqual(getLogLevelFromEnv(), DiagLogLevel.INFO);
+      process.env.OTEL_LOG_LEVEL = 'WARN';
+      assert.strictEqual(getLogLevelFromEnv(), DiagLogLevel.WARN);
+      process.env.OTEL_LOG_LEVEL = 'ERROR';
+      assert.strictEqual(getLogLevelFromEnv(), DiagLogLevel.ERROR);
+      process.env.OTEL_LOG_LEVEL = 'ALL';
+      assert.strictEqual(getLogLevelFromEnv(), DiagLogLevel.ALL);
+    });
+
+    it('should ignore casing', function () {
+      process.env.OTEL_LOG_LEVEL = 'warn';
+      assert.strictEqual(getLogLevelFromEnv(), DiagLogLevel.WARN);
+      process.env.OTEL_LOG_LEVEL = 'WaRN';
+      assert.strictEqual(getLogLevelFromEnv(), DiagLogLevel.WARN);
+    });
+
+    it('should fall back to INFO on bogus input', function () {
+      process.env.OTEL_LOG_LEVEL = 'bogus';
+      assert.strictEqual(getLogLevelFromEnv(), DiagLogLevel.INFO);
+    });
+
+    it('should use INFO when unset', function () {
+      delete process.env.OTEL_LOG_LEVEL;
+      assert.strictEqual(getLogLevelFromEnv(), DiagLogLevel.INFO);
     });
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?

We're planning to remove `getEnv()` as it does not scale well when everyone has to update `@opentelemetry/core` to get their env vars. For `OTEL_*` there will be a replacement utility function, but until this one is available, we can use `process.env` directly.

Refs https://github.com/open-telemetry/opentelemetry-js/pull/5443

## Short description of the changes

Moves code for parsing `OTEL_LOG_LEVEL` to `@opentelemetry/auto-instrumentations-node` here. It may be changed later as we add similar code to `@opentelemetry/sdk-node`.