### PR TITLE
chore: restore lint:deps checking; fix some deps issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36048,7 +36048,6 @@
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/exporter-jaeger": "^1.3.1",
         "@opentelemetry/instrumentation": "^0.57.0",
-        "@opentelemetry/otlp-transformer": "^0.57.0",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/sdk-metrics": "^1.27.0",
         "@opentelemetry/sdk-node": "^0.57.0",
@@ -39682,7 +39681,7 @@
       "version": "0.31.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "^1.0.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
         "shimmer": "^1.2.1"
       },
       "devDependencies": {
@@ -47401,7 +47400,6 @@
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/exporter-jaeger": "^1.3.1",
         "@opentelemetry/instrumentation": "^0.57.0",
-        "@opentelemetry/otlp-transformer": "^0.57.0",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/sdk-metrics": "^1.27.0",
         "@opentelemetry/sdk-node": "^0.57.0",
@@ -50416,7 +50414,7 @@
         "@babel/core": "7.24.6",
         "@babel/preset-env": "7.24.6",
         "@opentelemetry/api": "^1.0.0",
-        "@opentelemetry/core": "^1.0.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
         "@opentelemetry/propagator-b3": "^1.26.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@opentelemetry/sdk-trace-web": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:ci:changed": "nx affected -t test --base=origin/main --head=HEAD",
     "test-all-versions": "nx run-many -t test-all-versions",
     "changelog": "lerna-changelog",
-    "lint": "nx run-many -t lint && npm run lint:readme && npm run lint:markdown && npm run lint:semconv-deps",
+    "lint": "nx run-many -t lint && npm run lint:deps && npm run lint:readme && npm run lint:markdown && npm run lint:semconv-deps",
     "lint:fix": "nx run-many -t lint:fix && npm run lint:markdown:fix",
     "lint:deps": "npx --yes knip@5.33.3 --dependencies --production --tags=-knipignore",
     "lint:examples": "eslint ./examples/**/*.js",

--- a/packages/opentelemetry-test-utils/package.json
+++ b/packages/opentelemetry-test-utils/package.json
@@ -46,7 +46,6 @@
     "@opentelemetry/core": "^1.0.0",
     "@opentelemetry/exporter-jaeger": "^1.3.1",
     "@opentelemetry/instrumentation": "^0.57.0",
-    "@opentelemetry/otlp-transformer": "^0.57.0",
     "@opentelemetry/resources": "^1.8.0",
     "@opentelemetry/sdk-metrics": "^1.27.0",
     "@opentelemetry/sdk-node": "^0.57.0",

--- a/plugins/web/opentelemetry-plugin-react-load/package.json
+++ b/plugins/web/opentelemetry-plugin-react-load/package.json
@@ -87,7 +87,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "dependencies": {
-    "@opentelemetry/core": "^1.0.0",
+    "@opentelemetry/instrumentation": "^0.57.1",
     "shimmer": "^1.2.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/web/opentelemetry-plugin-react-load#readme"


### PR DESCRIPTION
Fixes these 'lint:deps' hits:

```
Unused dependencies (2)
@opentelemetry/otlp-transformer  packages/opentelemetry-test-utils/package.json
@opentelemetry/core              plugins/web/opentelemetry-plugin-react-load/package.json
Unlisted dependencies (1)
@opentelemetry/instrumentation  plugins/web/opentelemetry-plugin-react-load/src/BaseOpenTelemetryComponent.ts
```

`lint:deps` was accidentally removed in a merge-from-main in https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2493.