### PR TITLE
fix(instrumentation-mysql2)!:Missing masking of sql queries

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-mysql2/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/src/instrumentation.ts
@@ -137,13 +137,20 @@ export class MySQL2Instrumentation extends InstrumentationBase<MySQL2Instrumenta
         } else if (arguments[2]) {
           values = [_valuesOrCallback];
         }
-
+        const { maskStatement, maskStatementHook, responseHook } =
+          thisPlugin.getConfig();
         const span = thisPlugin.tracer.startSpan(getSpanName(query), {
           kind: api.SpanKind.CLIENT,
           attributes: {
             ...MySQL2Instrumentation.COMMON_ATTRIBUTES,
             ...getConnectionAttributes(this.config),
-            [SEMATTRS_DB_STATEMENT]: getDbStatement(query, format, values),
+            [SEMATTRS_DB_STATEMENT]: getDbStatement(
+              query,
+              format,
+              values,
+              maskStatement,
+              maskStatementHook
+            ),
           },
         });
 
@@ -166,7 +173,6 @@ export class MySQL2Instrumentation extends InstrumentationBase<MySQL2Instrumenta
               message: err.message,
             });
           } else {
-            const { responseHook } = thisPlugin.getConfig();
             if (typeof responseHook === 'function') {
               safeExecuteInTheMiddle(
                 () => {

--- a/plugins/node/opentelemetry-instrumentation-mysql2/src/types.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/src/types.ts
@@ -25,7 +25,26 @@ export interface MySQL2InstrumentationExecutionResponseHook {
   (span: Span, responseHookInfo: MySQL2ResponseHookInformation): void;
 }
 
+export interface MySQL2InstrumentationQueryMaskingHook {
+  (query: string): string;
+}
+
 export interface MySQL2InstrumentationConfig extends InstrumentationConfig {
+  /**
+   * If true, the query will be masked before setting it as a span attribute, using the {@link maskStatementHook}.
+   *
+   * @default true
+   * @see maskStatementHook
+   */
+  maskStatement?: boolean;
+
+  /**
+   * Hook that allows masking the query string before setting it as span attribute.
+   *
+   * @default (query: string) => query.replace(/\b\d+\b/g, '?').replace(/(["'])(?:(?=(\\?))\2.)*?\1/g, '?')
+   */
+  maskStatementHook?: MySQL2InstrumentationQueryMaskingHook;
+
   /**
    * Hook that allows adding custom span attributes based on the data
    * returned MySQL2 queries.


### PR DESCRIPTION

## Which problem is this PR solving?
Based on Issue #1758  and my [comment](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1857#issuecomment-2668028719) in the PR #1857 this PR is a quickfix for missing masking from sql queries. 

Since OpenTelemetry instrumentation should remain as lightweight as possible, introducing a full SQL parser would be too heavy. As a result, the default masking approach is intentionally simplistic. However, users can define their own `maskStatementHook`, allowing them to leverage a SQL parser or other custom logic for more advanced masking if needed.

Additionally, some use cases may require no masking at all. To accommodate this, the `maskStatement` setting allows users to disable masking entirely, preserving the original behavior of the MySQL2Instrumentation as it was before.

## Short description of the changes
This PR extends MySQL2InstrumentationConfig with two new options:

* `maskStatementHook` → A customizable hook for masking SQL statements (optional). Default:
 ```ts
  return query.replace(/\b\d+\b/g, '?').replace(/(["'])(?:(?=(\\?))\2.)*?\1/g, '?')
 ```
* `maskStatement` → A boolean flag (default: true) that determines whether maskStatementHook is applied at all.

