### PR TITLE
feat(instrumentation-mongoose)!: add instrumentation of static methods

### DIFF
--- a/plugins/node/instrumentation-mongoose/.tav.yml
+++ b/plugins/node/instrumentation-mongoose/.tav.yml
@@ -1,6 +1,10 @@
 mongoose:
   - versions:
-      include: ">=5.9.7 <7"
+      include: ">=5.10.19 <6"
+      mode: latest-minors
+    commands: npm run test-v5-v6
+  - versions:
+      include: ">=6.7.5 <7"
       mode: latest-minors
     commands: npm run test-v5-v6
   - versions:

--- a/plugins/node/instrumentation-mongoose/src/mongoose.ts
+++ b/plugins/node/instrumentation-mongoose/src/mongoose.ts
@@ -151,6 +151,17 @@ export class MongooseInstrumentation extends InstrumentationBase<MongooseInstrum
     });
     this._wrap(moduleExports.Model, 'aggregate', this.patchModelAggregate());
 
+    this._wrap(
+      moduleExports.Model,
+      'insertMany',
+      this.patchModelStatic('insertMany', moduleVersion)
+    );
+    this._wrap(
+      moduleExports.Model,
+      'bulkWrite',
+      this.patchModelStatic('bulkWrite', moduleVersion)
+    );
+
     return moduleExports;
   }
 
@@ -175,6 +186,9 @@ export class MongooseInstrumentation extends InstrumentationBase<MongooseInstrum
       this._unwrap(moduleExports.Query.prototype, funcName as any);
     });
     this._unwrap(moduleExports.Model, 'aggregate');
+
+    this._unwrap(moduleExports.Model, 'insertMany');
+    this._unwrap(moduleExports.Model, 'bulkWrite');
   }
 
   private patchAggregateExec(moduleVersion: string | undefined) {
@@ -301,6 +315,71 @@ export class MongooseInstrumentation extends InstrumentationBase<MongooseInstrum
         return self._handleResponse(
           span,
           originalOnModelFunction,
+          this,
+          arguments,
+          callback,
+          moduleVersion
+        );
+      };
+    };
+  }
+
+  private patchModelStatic(op: string, moduleVersion: string | undefined) {
+    const self = this;
+    return (original: Function) => {
+      return function patchedStatic(
+        this: any,
+        docsOrOps: any,
+        options?: any,
+        callback?: Function
+      ) {
+        if (
+          self.getConfig().requireParentSpan &&
+          trace.getSpan(context.active()) === undefined
+        ) {
+          return original.apply(this, arguments);
+        }
+
+        if (options instanceof Function) {
+          callback = options;
+          options = undefined;
+        }
+
+        const serializePayload: SerializerPayload = {};
+        switch (op) {
+          case 'insertMany':
+            serializePayload.documents = docsOrOps;
+            break;
+          case 'bulkWrite':
+            serializePayload.operations = docsOrOps;
+            break;
+          default:
+            serializePayload.document = docsOrOps;
+            break;
+        }
+        if (options !== undefined) {
+          serializePayload.options = options;
+        }
+
+        const attributes: Attributes = {};
+        const { dbStatementSerializer } = self.getConfig();
+        if (dbStatementSerializer) {
+          attributes[SEMATTRS_DB_STATEMENT] = dbStatementSerializer(
+            op,
+            serializePayload
+          );
+        }
+
+        const span = self._startSpan(
+          this.collection,
+          this.modelName,
+          op,
+          attributes
+        );
+
+        return self._handleResponse(
+          span,
+          original,
           this,
           arguments,
           callback,

--- a/plugins/node/instrumentation-mongoose/src/types.ts
+++ b/plugins/node/instrumentation-mongoose/src/types.ts
@@ -23,6 +23,8 @@ export interface SerializerPayload {
   document?: any;
   aggregatePipeline?: any;
   fields?: any;
+  documents?: any;
+  operations?: any;
 }
 
 export type DbStatementSerializer = (

--- a/plugins/node/instrumentation-mongoose/test/mongoose-common.test.ts
+++ b/plugins/node/instrumentation-mongoose/test/mongoose-common.test.ts
@@ -319,6 +319,107 @@ describe('mongoose instrumentation [common]', () => {
     expect(statement.document).toEqual(expect.objectContaining(document));
   });
 
+  it('instrumenting insertMany operation', async () => {
+    const documents = [
+      {
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'john.doe+1@example.com',
+      },
+      {
+        firstName: 'Jane',
+        lastName: 'Doe',
+        email: 'jane.doe+1@example.com',
+      },
+    ];
+    await User.insertMany(documents);
+
+    const spans = getTestSpans();
+    expect(spans.length).toBe(1);
+    assertSpan(spans[0] as ReadableSpan);
+    expect(spans[0].attributes[SEMATTRS_DB_OPERATION]).toBe('insertMany');
+    const statement = getStatement(spans[0] as ReadableSpan);
+    expect(statement.documents).toEqual(documents);
+  });
+
+  it('instrumenting bulkWrite operation', async () => {
+    const operations = [
+      {
+        insertOne: {
+          document: {
+            firstName: 'Jane',
+            lastName: 'Doe',
+            email: 'jane.doe+2@example.com',
+            age: 25,
+          },
+        },
+      },
+      {
+        updateMany: {
+          filter: { age: { $lte: 20 } },
+          update: { $set: { age: 20 } },
+        },
+      },
+      {
+        updateOne: {
+          filter: { firstName: 'Jane' },
+          update: { $inc: { age: 1 } },
+        },
+      },
+      { deleteOne: { filter: { firstName: 'Michael' } } },
+      {
+        updateOne: {
+          filter: { firstName: 'Zara' },
+          update: {
+            $set: { lastName: 'Doe', age: 40, email: 'zara@example.com' },
+          },
+          upsert: true,
+        },
+      },
+    ];
+    await User.bulkWrite(operations);
+
+    const spans = getTestSpans();
+    expect(spans.length).toBe(1);
+    assertSpan(spans[0] as ReadableSpan);
+    expect(spans[0].attributes[SEMATTRS_DB_OPERATION]).toBe('bulkWrite');
+    const statement = getStatement(spans[0] as ReadableSpan);
+    expect(statement.operations).toEqual([
+      {
+        insertOne: {
+          document: {
+            firstName: 'Jane',
+            lastName: 'Doe',
+            email: 'jane.doe+2@example.com',
+            age: 25,
+          },
+        },
+      },
+      {
+        updateMany: {
+          filter: { age: { $lte: 20 } },
+          update: { $set: { age: 20 } },
+        },
+      },
+      {
+        updateOne: {
+          filter: { firstName: 'Jane' },
+          update: { $inc: { age: 1 } },
+        },
+      },
+      { deleteOne: { filter: { firstName: 'Michael' } } },
+      {
+        updateOne: {
+          filter: { firstName: 'Zara' },
+          update: {
+            $set: { lastName: 'Doe', age: 40, email: 'zara@example.com' },
+          },
+          upsert: true,
+        },
+      },
+    ]);
+  });
+
   it('instrumenting aggregate operation', async () => {
     await User.aggregate([
       { $match: { firstName: 'John' } },

--- a/plugins/node/instrumentation-mongoose/test/user.ts
+++ b/plugins/node/instrumentation-mongoose/test/user.ts
@@ -15,6 +15,8 @@
  */
 import { Schema, Document } from 'mongoose';
 import * as mongoose from 'mongoose';
+import { context } from '@opentelemetry/api';
+import { suppressTracing } from '@opentelemetry/core';
 
 export interface IUser extends Document {
   email: string;
@@ -35,25 +37,27 @@ const User = mongoose.model<IUser>('User', UserSchema);
 export default User;
 
 export const loadUsers = async () => {
-  await User.insertMany([
-    new User({
-      firstName: 'John',
-      lastName: 'Doe',
-      email: 'john.doe@example.com',
-      age: 18,
-    }),
-    new User({
-      firstName: 'Jane',
-      lastName: 'Doe',
-      email: 'jane.doe@example.com',
-      age: 19,
-    }),
-    new User({
-      firstName: 'Michael',
-      lastName: 'Fox',
-      email: 'michael.fox@example.com',
-      age: 16,
-    }),
-  ]);
+  await context.with(suppressTracing(context.active()), async () => {
+    await User.insertMany([
+      new User({
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'john.doe@example.com',
+        age: 18,
+      }),
+      new User({
+        firstName: 'Jane',
+        lastName: 'Doe',
+        email: 'jane.doe@example.com',
+        age: 19,
+      }),
+      new User({
+        firstName: 'Michael',
+        lastName: 'Fox',
+        email: 'michael.fox@example.com',
+        age: 16,
+      }),
+    ]);
+  });
   await User.createIndexes();
 };


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Currently Mongoose instrumentation does not track static methods like `insertMany` and `bulkWrite`

## Short description of the changes

Added `patchModelStatic` to allow instrumentation of static model methods.  
Changed tested versions of `mongoose` because some older versions have weird timeouts with callbacks `suppressTracing` in tests.

## Related issues

Fixes #2488