### PR TITLE
fix(instrumentation-aws-lambda): Change endSpan error-logs for forceflush into debug-logs

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -382,14 +382,14 @@ export class AwsLambdaInstrumentation extends InstrumentationBase<AwsLambdaInstr
     if (this._traceForceFlusher) {
       flushers.push(this._traceForceFlusher());
     } else {
-      diag.error(
+      diag.debug(
         'Spans may not be exported for the lambda function because we are not force flushing before callback.'
       );
     }
     if (this._metricForceFlusher) {
       flushers.push(this._metricForceFlusher());
     } else {
-      diag.error(
+      diag.debug(
         'Metrics may not be exported for the lambda function because we are not force flushing before callback.'
       );
     }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2747

## Short description of the changes

- This log is not an actual error, because it is really just a warning. Thus, change it to `debug` log.
  - It could be argued that this could be `warn` log instead, but given the default `info` log level, these logs appear in each Lambda invocation when TracerProvider and/or MeterProvider are not configured, which is a bit noisy for logs.