### PR TITLE
chore(instrumentation-tedious): remove special case config in tsconfig now that target is es2022

### DIFF
--- a/plugins/node/instrumentation-tedious/tsconfig.json
+++ b/plugins/node/instrumentation-tedious/tsconfig.json
@@ -2,12 +2,7 @@
   "extends": "../../../tsconfig.base",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "build",
-    // When testing with tedious@18, skipLibCheck:true is needed to avoid
-    // checking its types. They require AggregateError that is only available
-    // with `"target": "es2022"`, which, IIUC we don't want with our regular TS
-    // v4 build for release.
-    "skipLibCheck": true
+    "outDir": "build"
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
As of #2738 the tsconfig target is es2022 now, so this special case is
no longer necessary.
