### PR TITLE
chore(instr-kafkajs): add missing dev-dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35194,6 +35194,7 @@
         "nyc": "15.1.0",
         "rimraf": "5.0.10",
         "sinon": "15.2.0",
+        "test-all-versions": "6.1.0",
         "typescript": "5.0.4"
       },
       "engines": {
@@ -44909,6 +44910,7 @@
         "nyc": "15.1.0",
         "rimraf": "5.0.10",
         "sinon": "15.2.0",
+        "test-all-versions": "6.1.0",
         "typescript": "5.0.4"
       },
       "dependencies": {


### PR DESCRIPTION
## Which problem is this PR solving?

https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2758 added `test-all-versions` dependency in the `package.json` file of `kafkajs` instrumentation.

However the `package-lock.json` file in root was not updated. So now PRs make a change whenever `npm install` is ran. The 1st problem is that since the change is in root `nx affected` considerd that all packages are affected the unit tests run for all packages instead of only the modified ones.

## Short description of the changes

- checkout main
- run `npm intstall`
- push `package-lock.json`

NOTE: I wonder if it's possible to add a guard in CI for this case.
