### PR TITLE
chore(host-metrics): do not diag.warn if using default options

### DIFF
--- a/packages/opentelemetry-host-metrics/src/BaseMetrics.ts
+++ b/packages/opentelemetry-host-metrics/src/BaseMetrics.ts
@@ -43,9 +43,6 @@ export abstract class BaseMetrics {
     // Do not use `??` operator to allow falling back to default when the
     // specified name is an empty string.
     this._name = config?.name || DEFAULT_NAME;
-    if (config?.meterProvider == null) {
-      this._logger.warn('No meter provider, using default');
-    }
     const meterProvider = config?.meterProvider ?? metrics.getMeterProvider();
     this._meter = meterProvider.getMeter(this._name, PACKAGE_VERSION);
   }


### PR DESCRIPTION
Currently 'new HostMetrics();' will diag.warn 'No meter provider, using default'.
This shouldn't be a warning. It is fine to use the default meter provider.

/cc @legendecas as code owner