### PR TITLE
chore: update auto-instrumentations README.md

### DIFF
--- a/metapackages/auto-instrumentations-node/README.md
+++ b/metapackages/auto-instrumentations-node/README.md
@@ -11,7 +11,7 @@ The net result is the ability to gather telemetry data from a Node application w
 
 This module also provides a simple way to manually initialize multiple Node instrumentations for use with the OpenTelemetry SDK.
 
-Compatible with OpenTelemetry JS API and SDK `1.0+`.
+Compatible with OpenTelemetry JS API and SDK `2.0+`.
 
 ## Installation
 


### PR DESCRIPTION
The latest version of the auto-instrumentation package is only compatible with 2.x/0.2xx versions. Update the README accordingly.