### PR TITLE
refactor(auto-instrumentations-node): use env var utility functions to setup diagnostics logging

### DIFF
--- a/metapackages/auto-instrumentations-node/package.json
+++ b/metapackages/auto-instrumentations-node/package.json
@@ -33,10 +33,12 @@
     "url": "https://github.com/open-telemetry/opentelemetry-js-contrib/issues"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.4.1"
+    "@opentelemetry/api": "^1.4.1",
+    "@opentelemetry/core": "^2.0.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.4.1",
+    "@opentelemetry/core": "^2.0.0",
     "@types/mocha": "10.0.10",
     "@types/node": "18.18.14",
     "@types/sinon": "17.0.4",

--- a/metapackages/auto-instrumentations-node/src/register.ts
+++ b/metapackages/auto-instrumentations-node/src/register.ts
@@ -15,10 +15,7 @@
  */
 import * as opentelemetry from '@opentelemetry/sdk-node';
 import { diag, DiagConsoleLogger } from '@opentelemetry/api';
-import {
-  getStringFromEnv,
-  diagLogLevelFromString,
-} from '@opentelemetry/core';
+import { getStringFromEnv, diagLogLevelFromString } from '@opentelemetry/core';
 import {
   getNodeAutoInstrumentations,
   getResourceDetectorsFromEnv,

--- a/metapackages/auto-instrumentations-node/src/register.ts
+++ b/metapackages/auto-instrumentations-node/src/register.ts
@@ -16,12 +16,20 @@
 import * as opentelemetry from '@opentelemetry/sdk-node';
 import { diag, DiagConsoleLogger } from '@opentelemetry/api';
 import {
-  getLogLevelFromEnv,
+  getStringFromEnv,
+  diagLogLevelFromString,
+} from '@opentelemetry/core';
+import {
   getNodeAutoInstrumentations,
   getResourceDetectorsFromEnv,
 } from './utils';
 
-diag.setLogger(new DiagConsoleLogger(), getLogLevelFromEnv());
+const logLevel = getStringFromEnv('OTEL_LOG_LEVEL');
+if (logLevel != null) {
+  diag.setLogger(new DiagConsoleLogger(), {
+    logLevel: diagLogLevelFromString(logLevel),
+  });
+}
 
 const sdk = new opentelemetry.NodeSDK({
   instrumentations: getNodeAutoInstrumentations(),

--- a/metapackages/auto-instrumentations-node/src/utils.ts
+++ b/metapackages/auto-instrumentations-node/src/utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { diag, DiagLogLevel } from '@opentelemetry/api';
+import { diag } from '@opentelemetry/api';
 import { Instrumentation } from '@opentelemetry/instrumentation';
 
 import { AmqplibInstrumentation } from '@opentelemetry/instrumentation-amqplib';
@@ -133,17 +133,6 @@ const InstrumentationMap = {
   '@opentelemetry/instrumentation-tedious': TediousInstrumentation,
   '@opentelemetry/instrumentation-undici': UndiciInstrumentation,
   '@opentelemetry/instrumentation-winston': WinstonInstrumentation,
-};
-
-// The support string -> DiagLogLevel mappings
-const logLevelMap: { [key: string]: DiagLogLevel } = {
-  ALL: DiagLogLevel.ALL,
-  VERBOSE: DiagLogLevel.VERBOSE,
-  DEBUG: DiagLogLevel.DEBUG,
-  INFO: DiagLogLevel.INFO,
-  WARN: DiagLogLevel.WARN,
-  ERROR: DiagLogLevel.ERROR,
-  NONE: DiagLogLevel.NONE,
 };
 
 const defaultExcludedInstrumentations = [
@@ -302,17 +291,4 @@ export function getResourceDetectorsFromEnv(): Array<ResourceDetector> {
     }
     return resourceDetector || [];
   });
-}
-
-export function getLogLevelFromEnv(): DiagLogLevel {
-  const rawLogLevel = process.env.OTEL_LOG_LEVEL;
-
-  // NOTE: as per specification we should actually only register if something is set, but our previous implementation
-  // always registered a logger, even when nothing was set. Falling back to 'INFO' here to keep the same behavior as
-  // with previous implementations.
-  // Also: no point in warning - no logger is registered yet
-  return (
-    logLevelMap[rawLogLevel?.trim().toUpperCase() ?? 'INFO'] ??
-    DiagLogLevel.INFO
-  );
 }

--- a/metapackages/auto-instrumentations-node/test/utils.test.ts
+++ b/metapackages/auto-instrumentations-node/test/utils.test.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { diag, DiagLogLevel } from '@opentelemetry/api';
+import { diag } from '@opentelemetry/api';
 import { HttpInstrumentationConfig } from '@opentelemetry/instrumentation-http';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { getNodeAutoInstrumentations } from '../src';
-import { getLogLevelFromEnv, getResourceDetectorsFromEnv } from '../src/utils';
+import { getResourceDetectorsFromEnv } from '../src/utils';
 
 describe('utils', () => {
   describe('getNodeAutoInstrumentations', () => {
@@ -221,46 +221,6 @@ describe('utils', () => {
 
       spy.restore();
       delete process.env.OTEL_NODE_RESOURCE_DETECTORS;
-    });
-  });
-
-  describe('getLogLevelFromEnv', function () {
-    afterEach(function () {
-      delete process.env.OTEL_LOG_LEVEL;
-    });
-
-    it('should select log level based on env var', function () {
-      process.env.OTEL_LOG_LEVEL = 'NONE';
-      assert.strictEqual(getLogLevelFromEnv(), DiagLogLevel.NONE);
-      process.env.OTEL_LOG_LEVEL = 'VERBOSE';
-      assert.strictEqual(getLogLevelFromEnv(), DiagLogLevel.VERBOSE);
-      process.env.OTEL_LOG_LEVEL = 'DEBUG';
-      assert.strictEqual(getLogLevelFromEnv(), DiagLogLevel.DEBUG);
-      process.env.OTEL_LOG_LEVEL = 'INFO';
-      assert.strictEqual(getLogLevelFromEnv(), DiagLogLevel.INFO);
-      process.env.OTEL_LOG_LEVEL = 'WARN';
-      assert.strictEqual(getLogLevelFromEnv(), DiagLogLevel.WARN);
-      process.env.OTEL_LOG_LEVEL = 'ERROR';
-      assert.strictEqual(getLogLevelFromEnv(), DiagLogLevel.ERROR);
-      process.env.OTEL_LOG_LEVEL = 'ALL';
-      assert.strictEqual(getLogLevelFromEnv(), DiagLogLevel.ALL);
-    });
-
-    it('should ignore casing', function () {
-      process.env.OTEL_LOG_LEVEL = 'warn';
-      assert.strictEqual(getLogLevelFromEnv(), DiagLogLevel.WARN);
-      process.env.OTEL_LOG_LEVEL = 'WaRN';
-      assert.strictEqual(getLogLevelFromEnv(), DiagLogLevel.WARN);
-    });
-
-    it('should fall back to INFO on bogus input', function () {
-      process.env.OTEL_LOG_LEVEL = 'bogus';
-      assert.strictEqual(getLogLevelFromEnv(), DiagLogLevel.INFO);
-    });
-
-    it('should use INFO when unset', function () {
-      delete process.env.OTEL_LOG_LEVEL;
-      assert.strictEqual(getLogLevelFromEnv(), DiagLogLevel.INFO);
     });
   });
 });


### PR DESCRIPTION
## Which problem is this PR solving?

With https://github.com/open-telemetry/opentelemetry-js/pull/5443 we've introduced new utility functions for getting getting environment variables in an OTel Spec compliant manner, and we've migrated from using the old getEnv() utility function (https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2708).

However, to provide an easier upgrade-path, for users of getEnv() we've also introduced a [utility function to get a log level from a string](https://github.com/open-telemetry/opentelemetry-js/blob/b322a24b4a3296577fb908c0bc9b33efc57c501e/packages/opentelemetry-core/src/utils/configuration.ts#L28-L50), so the mapping we now do is now obsolete and we should align it with the core repo.

Refs https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2774

## Short description of the changes

Removed unnecessary utility function, map and tests. Replaced with new core utility functions.