### PR TITLE
fix(instrumentation-undici): fix several header handling handling bugs

### DIFF
--- a/plugins/node/instrumentation-undici/src/types.ts
+++ b/plugins/node/instrumentation-undici/src/types.ts
@@ -22,9 +22,10 @@ export interface UndiciRequest {
   path: string;
   /**
    * Serialized string of headers in the form `name: value\r\n` for v5
-   * Array of strings v6
+   * Array of strings `[key1, value1, key2, value2]`, where values are
+   * `string | string[]` for v6
    */
-  headers: string | string[];
+  headers: string | (string | string[])[];
   /**
    * Helper method to add headers (from v6)
    */

--- a/plugins/node/instrumentation-undici/test/undici.test.ts
+++ b/plugins/node/instrumentation-undici/test/undici.test.ts
@@ -795,43 +795,87 @@ describe('UndiciInstrumentation `undici` tests', function () {
       });
     });
 
-    it('should not report an user-agent if it was not defined', async function () {
-      let spans = memoryExporter.getFinishedSpans();
-      assert.strictEqual(spans.length, 0);
+    const userAgentRequests: Array<{
+      name: string;
+      headers: Record<string, string | string[] | undefined>;
+      expectedUserAgent: string | undefined;
+    }> = [
+      {
+        name: 'no user-agent',
+        headers: { 'foo-client': 'bar' },
+        expectedUserAgent: undefined,
+      },
+      {
+        name: 'a user-agent',
+        headers: { 'foo-client': 'bar', 'user-agent': 'custom' },
+        expectedUserAgent: 'custom',
+      },
+      {
+        name: 'explicitly-undefined user-agent',
+        headers: { 'foo-client': 'bar', 'user-agent': undefined },
+        expectedUserAgent: undefined,
+      },
+      // contra the spec, but we shouldn't crash
+      {
+        name: 'multiple user-agents',
+        headers: {
+          'foo-client': 'bar',
+          'user-agent': ['agent', 'other-agent'],
+        },
+        expectedUserAgent: 'agent',
+      },
+      {
+        name: 'another header with value user-agent',
+        headers: { 'foo-client': 'user-agent', 'user-agent': 'custom' },
+        expectedUserAgent: 'custom',
+      },
+      {
+        name: 'another header with multiple values',
+        headers: { 'foo-client': ['one', 'two'], 'user-agent': 'custom' },
+        expectedUserAgent: 'custom',
+      },
+      {
+        name: 'another header with explicitly-undefined value',
+        headers: { 'foo-client': undefined, 'user-agent': 'custom' },
+        expectedUserAgent: 'custom',
+      },
+    ];
 
-      // Do some requests
-      const headers = {
-        'foo-client': 'bar',
-      };
+    for (const testCase of userAgentRequests) {
+      it(`should report the correct user-agent when the request has ${testCase.name}`, async function () {
+        let spans = memoryExporter.getFinishedSpans();
+        assert.strictEqual(spans.length, 0);
 
-      const queryRequestUrl = `${protocol}://${hostname}:${mockServer.port}/?query=test`;
-      const queryResponse = await undici.request(queryRequestUrl, { headers });
-      await consumeResponseBody(queryResponse.body);
+        const queryRequestUrl = `${protocol}://${hostname}:${mockServer.port}/?query=test`;
+        const queryResponse = await undici.request(queryRequestUrl, {
+          headers: testCase.headers,
+        });
+        await consumeResponseBody(queryResponse.body);
 
-      assert.ok(
-        queryResponse.headers['propagation-error'] == null,
-        'propagation is set for instrumented requests'
-      );
+        assert.ok(
+          queryResponse.headers['propagation-error'] == null,
+          'propagation is set for instrumented requests'
+        );
 
-      spans = memoryExporter.getFinishedSpans();
-      const span = spans[0];
-      assert.ok(span, 'a span is present');
-      assert.strictEqual(spans.length, 1);
-      assertSpan(span, {
-        hostname: 'localhost',
-        httpStatusCode: queryResponse.statusCode,
-        httpMethod: 'GET',
-        path: '/',
-        query: '?query=test',
-        reqHeaders: headers,
-        resHeaders: queryResponse.headers,
+        spans = memoryExporter.getFinishedSpans();
+        const span = spans[0];
+        assert.ok(span, 'a span is present');
+        assert.strictEqual(spans.length, 1);
+        assertSpan(span, {
+          hostname: 'localhost',
+          httpStatusCode: queryResponse.statusCode,
+          httpMethod: 'GET',
+          path: '/',
+          query: '?query=test',
+          reqHeaders: testCase.headers,
+          resHeaders: queryResponse.headers,
+        });
+        assert.strictEqual(
+          span.attributes['user_agent.original'],
+          testCase.expectedUserAgent
+        );
       });
-      assert.strictEqual(
-        span.attributes['user_agent.original'],
-        undefined,
-        'user-agent is undefined'
-      );
-    });
+    }
 
     it('should create valid span if request.path is a full URL', async function () {
       let spans = memoryExporter.getFinishedSpans();

--- a/plugins/node/instrumentation-undici/test/utils/assertSpan.ts
+++ b/plugins/node/instrumentation-undici/test/utils/assertSpan.ts
@@ -171,7 +171,7 @@ export const assertSpan = (
     if (userAgent) {
       assert.strictEqual(
         span.attributes[SemanticAttributes.USER_AGENT_ORIGINAL],
-        userAgent
+        Array.isArray(userAgent) ? userAgent[0] : userAgent
       );
     }
   }


### PR DESCRIPTION
## Which problem is this PR solving?

The handling for User-Agent had a bunch of bugs, most notably with the handling of multiple-valued headers, which are rare but legal.

Code similar to the added test "another header with multiple values" caused us errors in production from the user-agent code, and is where I started. Reading the code, writing tests, and improving the types revealed several more bugs in the same code as well as the span-to-attributes handling; the added tests "multiple user-agents", "another header with value user-agent" also fail before this PR (the others are just to actually cover the ordinary cases.

Similarly, I also fixed an incorrect case in undici v5 where it would treat a `user-agent-bogus` header as a user agent, but I couldn't write a test case since the tests run with the newer version.

## Short description of the changes

The relevant code is rewritten to handle multiple headers consistently, and refactored so we don't have to write it all twice.