### PR TITLE
chore: update `nx.json` for better caching

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -18,8 +18,8 @@
         "^compile"
       ],
       "inputs": [
-        "{projectRoot}/src",
-        "{projectRoot}/test"
+        "{projectRoot}/src/**/*.ts",
+        "{projectRoot}/test/**/*.ts"
       ],
       "outputs": [
         "{projectRoot}/build"
@@ -27,8 +27,8 @@
     },
     "lint": {
       "inputs": [
-        "{projectRoot}/src",
-        "{projectRoot}/test"
+        "{projectRoot}/src/**/*.ts",
+        "{projectRoot}/test/**/*.ts"
       ]
     },
     "version:update": {


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes `nx.json` configuration for caching. The `input` globs need to have the recursive lookup for typescript files `**/*.ts` otherwise it will compile only once from the root folder even if you do changes in a package later.

The issue impacts only locally and not in the CI.

## Short description of the changes

- modify the glob patter in `nx.json` inputs
