### PR TITLE
chore(instrumentation-nestjs): update nestjs supported versions

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-nestjs-core/README.md
+++ b/plugins/node/opentelemetry-instrumentation-nestjs-core/README.md
@@ -17,7 +17,7 @@ npm install --save @opentelemetry/instrumentation-nestjs-core
 
 ### Supported Versions
 
-- [`@nestjs/core`](https://www.npmjs.com/package/@nestjs/core) versions `>=4.0.0 <11`
+- [`@nestjs/core`](https://www.npmjs.com/package/@nestjs/core) versions `>=4.0.0 <12`
 
 ## Usage
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- README is not up-to-date with code

## Short description of the changes

- Updates supported versions in nestjs README

#2685 added support for NestJS 11 and I can confirm the latest released artifact works fine with it, so this updates the README to reflect it. I wasn't sure if it's better to remove `<YY` for `YY` that don't exist yet or keep it to not "pre-support" new major versions, let me know which is better.
