### PR TITLE
fix(aws-lambda-instrumentation): errors while instrumenting cause instrumented lambda to fail 

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts
@@ -157,11 +157,16 @@ export class AwsLambdaInstrumentation extends InstrumentationBase<AwsLambdaInstr
               if (isWrapped(moduleExports[functionName])) {
                 this._unwrap(moduleExports, functionName);
               }
+              // try {
               this._wrap(
                 moduleExports,
                 functionName,
                 this._getHandler(lambdaStartTime)
               );
+              // } catch (error) {
+              //   // _wrap is not error safe. We do not want the instrumented lambda to fail if wrapping fails.
+              //   diag.error('patching handler function failed', error);
+              // }
               return moduleExports;
             },
             (moduleExports?: LambdaModule) => {

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler.instrumentationError.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler.instrumentationError.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// We access through node_modules to allow it to be patched.
+/* eslint-disable node/no-extraneous-require */
+
+import * as path from 'path';
+
+import {
+  AwsLambdaInstrumentation,
+  AwsLambdaInstrumentationConfig,
+} from '../../src';
+import {
+  BatchSpanProcessor,
+  InMemorySpanExporter,
+} from '@opentelemetry/sdk-trace-base';
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { Context } from 'aws-lambda';
+import * as assert from 'assert';
+
+const memoryExporter = new InMemorySpanExporter();
+
+describe('lambda handler', () => {
+  let instrumentation: AwsLambdaInstrumentation;
+
+  let oldEnv: NodeJS.ProcessEnv;
+
+  const ctx = {
+    functionName: 'my_function',
+    invokedFunctionArn: 'my_arn',
+    awsRequestId: 'aws_request_id',
+  } as Context;
+
+  const initializeHandler = (
+    handler: string,
+    config: AwsLambdaInstrumentationConfig = {}
+  ) => {
+    process.env._HANDLER = handler;
+
+    const provider = new NodeTracerProvider({
+      spanProcessors: [new BatchSpanProcessor(memoryExporter)],
+    });
+    provider.register();
+
+    instrumentation = new AwsLambdaInstrumentation(config);
+    instrumentation.setTracerProvider(provider);
+
+    return provider;
+  };
+
+  const lambdaRequire = (module: string) =>
+    require(path.resolve(__dirname, '..', module));
+
+  beforeEach(() => {
+    oldEnv = { ...process.env };
+    process.env.LAMBDA_TASK_ROOT = path.resolve(__dirname, '..');
+  });
+
+  afterEach(() => {
+    process.env = oldEnv;
+    instrumentation.disable();
+
+    memoryExporter.reset();
+  });
+
+  describe('handler with module.exports syntax', () => {
+    it('should not fail', async () => {
+      initializeHandler('lambda-test/instrumentationError.handler');
+
+      const result = await new Promise((resolve, reject) => {
+        lambdaRequire('lambda-test/instrumentationError').handler(
+          'arg',
+          ctx,
+          (err: Error, res: any) => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve(res);
+            }
+          }
+        );
+      });
+      assert.strictEqual(result, 'ok');
+    });
+  });
+});

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/test/lambda-test/instrumentationError.js
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/test/lambda-test/instrumentationError.js
@@ -1,0 +1,12 @@
+const obj = {};
+Object.defineProperty(obj, 'handler', {
+  get: () => handler,
+  enumerable: true,
+  configurable: false, // ❗️Nicht konfigurierbar = Problem für Shimmer
+});
+
+module.exports = obj;
+
+async function handler(event) {
+  return 'ok';
+}


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Errors thrown by shimmer cause the instrumented lambda to fail.

Fixes https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1287

## Short description of the changes

Since the instrumentation should never cause the instrumented lambdas to fail, errors thrown by shimmer should be caught and logged.

I can reproduce the error but I don't really have an idea on how to fix this. @anuraaga could you help?

Output of the test with try-catch enabled:
> npx mocha test/integrations/lambda-handler.moduleError.test.ts
>  lambda handler
    handler with module.exports syntax
      1) should not fail
no original to unwrap to -- has handler already been unwrapped?
>  0 passing (2s)
  1 failing
>  1) lambda handler
       handler with module.exports syntax
         should not fail:
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/ms/Repos/opentelemetry-js-contrib/plugins/node/opentelemetry-instrumentation-aws-lambda/test/integrations/lambda-handler.moduleError.test.ts)
      at listOnTimeout (node:internal/timers:581:17)
      at processTimers (node:internal/timers:519:7)

Without try-catch:
>npx mocha test/integrations/lambda-handler.instrumentationError.test.ts
  lambda handler
    handler with module.exports syntax
      1) should not fail
no original to unwrap to -- has handler already been unwrapped?
  0 passing (9ms)
  1 failing
>  1) lambda handler
       handler with module.exports syntax
         should not fail:
     TypeError: Cannot redefine property: handler