### PR TITLE
test(instrumentation-aws-sdk): update client in bedrock-runtime tests to use NodeHttpHandler instead of the new default NodeHttp2Handler

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/bedrock-runtime.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/bedrock-runtime.test.ts
@@ -43,6 +43,7 @@ import {
 import { AwsCredentialIdentity } from '@aws-sdk/types';
 import * as path from 'path';
 import { Definition, back as nockBack } from 'nock';
+import { NodeHttpHandler } from '@smithy/node-http-handler';
 
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import {
@@ -88,7 +89,11 @@ describe('Bedrock', () => {
     };
   }
 
-  const client = new BedrockRuntimeClient({ region, credentials });
+  const client = new BedrockRuntimeClient({
+    region,
+    credentials,
+    requestHandler: new NodeHttpHandler(),
+  });
 
   let nockDone: () => void;
   beforeEach(async function () {

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/test/bedrock-runtime.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/test/bedrock-runtime.test.ts
@@ -89,6 +89,7 @@ describe('Bedrock', () => {
     };
   }
 
+  // Use NodeHttpHandler to use HTTP instead of HTTP2 because nock does not support HTTP2
   const client = new BedrockRuntimeClient({
     region,
     credentials,


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2806

## Short description of the changes

- manually configure the Bedrock Runtime client to use NodeHttpHandler (instead of the new default NodeHttp2Handler) in tests so Nock will work, similarly to what is done for [Kinesis client test](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/instrumentation-aws-sdk-v0.51.0/plugins/node/opentelemetry-instrumentation-aws-sdk/test/kinesis.test.ts#L55-L59).

## Testing

Locally changed the `devDependencies` for aws sdk instrumentation to use `"@aws-sdk/client-bedrock-runtime": "3.798.0"`, then ran the tests which succeeded.