### PR TITLE
refactor(examples): update semconv usage to ATTR_ exports

### DIFF
--- a/examples/connect/tracing.js
+++ b/examples/connect/tracing.js
@@ -6,7 +6,7 @@ const { diag, DiagConsoleLogger, DiagLogLevel } = opentelemetry;
 diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
 
 const { Resource } = require('@opentelemetry/resources');
-const { SEMRESATTRS_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
+const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
 const { SimpleSpanProcessor } = require('@opentelemetry/sdk-trace-base');
@@ -25,7 +25,7 @@ module.exports = (serviceName) => {
   const exporter = new CollectorTraceExporter();
   const provider = new NodeTracerProvider({
     resource: new Resource({
-      [SEMRESATTRS_SERVICE_NAME]: serviceName,
+      [ATTR_SERVICE_NAME]: serviceName,
     }),
     spanProcessors: [
       new SimpleSpanProcessor(exporter),

--- a/examples/graphql/tracer.js
+++ b/examples/graphql/tracer.js
@@ -8,11 +8,11 @@ const { OTLPTraceExporter } = require('@opentelemetry/exporter-otlp-http');
 const { HttpInstrumentation } = require('@opentelemetry/instrumentation-http');
 const { ExpressInstrumentation } = require('@opentelemetry/instrumentation-express');
 const { Resource } = require('@opentelemetry/resources');
-const { SEMRESATTRS_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
+const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 
 const provider = new NodeTracerProvider({
   resource: new Resource({
-    [SEMRESATTRS_SERVICE_NAME]: 'graphql-service',
+    [ATTR_SERVICE_NAME]: 'graphql-service',
   }),
   spanProcessors: [
     new SimpleSpanProcessor(new OTLPTraceExporter()),

--- a/examples/koa/src/tracer.ts
+++ b/examples/koa/src/tracer.ts
@@ -10,7 +10,7 @@ import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { JaegerExporter } from '@opentelemetry/exporter-jaeger';
 import { ZipkinExporter } from '@opentelemetry/exporter-zipkin';
 import { Resource } from '@opentelemetry/resources';
-import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
 
 const EXPORTER = process.env.EXPORTER || '';
 
@@ -24,7 +24,7 @@ export const setupTracing = (serviceName: string) => {
 
   const provider = new NodeTracerProvider({
     resource: new Resource({
-      [SEMRESATTRS_SERVICE_NAME]: serviceName
+      [ATTR_SERVICE_NAME]: serviceName
     }),
     spanProcessors: [
       new SimpleSpanProcessor(exporter),

--- a/examples/memcached/tracer.js
+++ b/examples/memcached/tracer.js
@@ -9,7 +9,7 @@ const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
 const { SimpleSpanProcessor, ConsoleSpanExporter } = require('@opentelemetry/sdk-trace-base');
 const { Resource } = require('@opentelemetry/resources');
-const { SEMRESATTRS_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
+const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 
 const { MemcachedInstrumentation } = require('@opentelemetry/instrumentation-memcached');
 
@@ -17,7 +17,7 @@ module.exports = (serviceName) => {
   const exporter = new ConsoleSpanExporter();
   const provider = new NodeTracerProvider({
     resource: new Resource({
-      [SEMRESATTRS_SERVICE_NAME]: serviceName,
+      [ATTR_SERVICE_NAME]: serviceName,
     }),
     spanProcessors: [
       new SimpleSpanProcessor(exporter),

--- a/examples/mysql/src/tracer.ts
+++ b/examples/mysql/src/tracer.ts
@@ -8,7 +8,7 @@ import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { MySQLInstrumentation } from '@opentelemetry/instrumentation-mysql';
 import { Resource } from '@opentelemetry/resources';
-import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import {
   MeterProvider,
   PeriodicExportingMetricReader,
@@ -39,7 +39,7 @@ export const setupTracing = (serviceName: string) => {
 
   const tracerProvider = new NodeTracerProvider({
     resource: new Resource({
-      [SEMRESATTRS_SERVICE_NAME]: serviceName,
+      [ATTR_SERVICE_NAME]: serviceName,
     }),
     spanProcessors,
   });

--- a/examples/react-load/react/src/web-tracer.js
+++ b/examples/react-load/react/src/web-tracer.js
@@ -5,7 +5,7 @@ import { ZoneContextManager } from '@opentelemetry/context-zone';
 import { CollectorTraceExporter } from '@opentelemetry/exporter-collector';
 import { diag, DiagConsoleLogger } from '@opentelemetry/api';
 import { Resource } from '@opentelemetry/resources';
-import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
 
 export default (serviceName) => {
   const exporter = new CollectorTraceExporter({
@@ -14,7 +14,7 @@ export default (serviceName) => {
 
   const provider = new WebTracerProvider({
     resource: new Resource({
-        [SEMRESATTRS_SERVICE_NAME]: "react-load-example"
+        [ATTR_SERVICE_NAME]: "react-load-example"
     }),
     spanProcessors: [
       new SimpleSpanProcessor(new ConsoleSpanExporter()),

--- a/examples/redis/src/tracer.ts
+++ b/examples/redis/src/tracer.ts
@@ -9,7 +9,7 @@ import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { RedisInstrumentation } from '@opentelemetry/instrumentation-redis';
 import { Resource } from '@opentelemetry/resources';
-import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 
 const EXPORTER = process.env.EXPORTER || '';
 
@@ -23,7 +23,7 @@ export const setupTracing = (serviceName: string) => {
 
   const provider = new NodeTracerProvider({
     resource: new Resource({
-      [SEMRESATTRS_SERVICE_NAME]: serviceName,
+      [ATTR_SERVICE_NAME]: serviceName,
     }),
     spanProcessors: [
       new SimpleSpanProcessor(exporter),

--- a/examples/web/examples/document-load/index.js
+++ b/examples/web/examples/document-load/index.js
@@ -9,11 +9,11 @@ import { B3Propagator } from '@opentelemetry/propagator-b3';
 import { CompositePropagator, W3CTraceContextPropagator } from '@opentelemetry/core';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { Resource } from '@opentelemetry/resources';
-import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 
 const provider = new WebTracerProvider({
   resource: new Resource({
-    [SEMRESATTRS_SERVICE_NAME]: 'web-service-dl',
+    [ATTR_SERVICE_NAME]: 'web-service-dl',
   }),
   spanProcessors: [
     new SimpleSpanProcessor(new ConsoleSpanExporter()),

--- a/examples/web/examples/meta/index.js
+++ b/examples/web/examples/meta/index.js
@@ -6,11 +6,11 @@ import { B3Propagator } from '@opentelemetry/propagator-b3';
 import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { Resource } from '@opentelemetry/resources';
-import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 
 const providerWithZone = new WebTracerProvider({
   resource: new Resource({
-    [SEMRESATTRS_SERVICE_NAME]: 'web-service-meta',
+    [ATTR_SERVICE_NAME]: 'web-service-meta',
   }),
   spanProcessors: [
     new SimpleSpanProcessor(new ConsoleSpanExporter()),

--- a/examples/web/examples/user-interaction/index.js
+++ b/examples/web/examples/user-interaction/index.js
@@ -7,11 +7,11 @@ import { B3Propagator } from '@opentelemetry/propagator-b3';
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { Resource } from '@opentelemetry/resources';
-import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 
 const providerWithZone = new WebTracerProvider({
   resource: new Resource({
-    [SEMRESATTRS_SERVICE_NAME]: 'web-service-ui',
+    [ATTR_SERVICE_NAME]: 'web-service-ui',
   }),
   spanProcessors: [
     new SimpleSpanProcessor(new ConsoleSpanExporter()),


### PR DESCRIPTION
Refs: #2377

Note: I did *not* work through the steps for each example. Clearly many of these examples are out of date and need work. However, there is no way this change will add *more* breakage, examples/**/package.json include `"@opentelemetry/semantic-conventions": "^1.27.0",` and version 1.27.0 has the `ATTR_SERVICE_NAME` export being used.