### PR TITLE
feat(test-utils): add assertion helper for faas resources

### DIFF
--- a/packages/opentelemetry-test-utils/src/resource-assertions.ts
+++ b/packages/opentelemetry-test-utils/src/resource-assertions.ts
@@ -26,6 +26,9 @@ import {
   SEMRESATTRS_CONTAINER_IMAGE_NAME,
   SEMRESATTRS_CONTAINER_IMAGE_TAG,
   SEMRESATTRS_CONTAINER_NAME,
+  SEMRESATTRS_FAAS_INSTANCE,
+  SEMRESATTRS_FAAS_NAME,
+  SEMRESATTRS_FAAS_VERSION,
   SEMRESATTRS_HOST_ID,
   SEMRESATTRS_HOST_IMAGE_ID,
   SEMRESATTRS_HOST_IMAGE_NAME,
@@ -322,6 +325,40 @@ export const assertProcessResource = (
     assert.strictEqual(
       resource.attributes[SEMRESATTRS_PROCESS_COMMAND_LINE],
       validations.commandLine
+    );
+  }
+};
+
+/**
+ * Test utility method to validate a faas resource
+ *
+ * @param resource the Resource to validate
+ * @param validations validations for the resource attributes
+ */
+export const assertFaasResource = (
+  resource: Resource,
+  validations: {
+    name?: string;
+    instance?: string;
+    version?: string;
+  }
+) => {
+  if (validations.name) {
+    assert.strictEqual(
+      resource.attributes[SEMRESATTRS_FAAS_NAME],
+      validations.name
+    );
+  }
+  if (validations.instance) {
+    assert.strictEqual(
+      resource.attributes[SEMRESATTRS_FAAS_INSTANCE],
+      validations.instance
+    );
+  }
+  if (validations.version) {
+    assert.strictEqual(
+      resource.attributes[SEMRESATTRS_FAAS_VERSION],
+      validations.version
     );
   }
 };


### PR DESCRIPTION
## Which problem is this PR solving?
I'm currently trying to expand the resource detector for gcp and aligning it with the rest of the gcp resource detectors in other languages, that currently sets `faas.name`, `faas.version`, and `faas.instance` for Cloud Run services. 

I have another PR open on this topic: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2818 where I will be using this helper. 

## Short description of the changes  

This PR adds an assertion helper to the `opentelemtry-test-utils` package. Similarly to the rest of the assertion helpers it uses the semantic conventions and validates the inputs. 
