### PR TITLE
fix(test-utils): extend assertCloudResource with cloud.platform

### DIFF
--- a/packages/opentelemetry-test-utils/src/resource-assertions.ts
+++ b/packages/opentelemetry-test-utils/src/resource-assertions.ts
@@ -22,6 +22,7 @@ import {
   SEMRESATTRS_CLOUD_AVAILABILITY_ZONE,
   SEMRESATTRS_CLOUD_PROVIDER,
   SEMRESATTRS_CLOUD_REGION,
+  SEMRESATTRS_CLOUD_PLATFORM,
   SEMRESATTRS_CONTAINER_ID,
   SEMRESATTRS_CONTAINER_IMAGE_NAME,
   SEMRESATTRS_CONTAINER_IMAGE_TAG,
@@ -63,6 +64,7 @@ export const assertCloudResource = (
     accountId?: string;
     region?: string;
     zone?: string;
+    platform?: string;
   }
 ) => {
   assertHasOneLabel('cloud', resource);
@@ -85,6 +87,11 @@ export const assertCloudResource = (
     assert.strictEqual(
       resource.attributes[SEMRESATTRS_CLOUD_AVAILABILITY_ZONE],
       validations.zone
+    );
+  if (validations.platform)
+    assert.strictEqual(
+      resource.attributes[SEMRESATTRS_CLOUD_PLATFORM],
+      validations.platform
     );
 };
 


### PR DESCRIPTION
## Which problem is this PR solving?
I'm currently trying to expand the gcp resource detector (https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2818) and for that I will also be adding support for detecting `cloud.platform`. Currently the helper does not support this.

## Short description of the changes
Semantic conventions for `cloud` also includes `cloud.platform`. However, currently the assertion helper for `cloud` does not support `cloud.platform`. This PR adds support for `cloud.platform` in the `assertCloudResource` test-util.
