### PR TITLE
feat: Clarify the duplicate logging workaround

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-winston/README.md
+++ b/plugins/node/opentelemetry-instrumentation-winston/README.md
@@ -139,7 +139,22 @@ const logger = winston.createLogger({
 ```
 
 > [!IMPORTANT]
-> Logs will be duplicated if `@opentelemetry/winston-transport` is added as a transport in `winston` and `@opentelemetry/instrumentation-winston` is configured with `disableLogSending: false`.
+> Logs will be duplicated if `@opentelemetry/winston-transport` is added as a transport in `winston` and `@opentelemetry/instrumentation-winston` is configured with `disableLogSending: false`. You must import `winston` after you have called `registerInstrumentations`. 
+> ```js
+>const { WinstonInstrumentation } = require('@opentelemetry/instrumentation-winston');
+>const { registerInstrumentations } = require('@opentelemetry/instrumentation');
+>registerInstrumentations({
+>    instrumentations: [
+>        new WinstonInstrumentation({
+>          // Disable the duplicate logging from the auto instrumentation
+>          disableLogSending: true
+>        }),
+>    ],
+>});
+>// Winston import must be after the WinstonInstrumentation creation
+>const { OpenTelemetryTransportV3 } = require('@opentelemetry/winston-transport');
+>const winston = require('winston');
+> ```
 
 ## Semantic Conventions
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- I spent a few days trying to figure out how to stop duplicate logs from happening while needing to use the `OpenTelemetryTransportV3` to format my payload correctly.

## Short description of the changes

- This adds some clarity and an example how to correctly disable the default logger in the auto instrumentation. 
