### PR TITLE
chore: set `isolatedModules` compilation option

### DIFF
--- a/detectors/node/opentelemetry-resource-detector-github/src/detectors/index.ts
+++ b/detectors/node/opentelemetry-resource-detector-github/src/detectors/index.ts
@@ -13,4 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './GitHubDetector';
+export { gitHubDetector } from './GitHubDetector';

--- a/detectors/node/opentelemetry-resource-detector-github/src/index.ts
+++ b/detectors/node/opentelemetry-resource-detector-github/src/index.ts
@@ -13,4 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './detectors';
+export { gitHubDetector } from './detectors';

--- a/incubator/opentelemetry-sampler-aws-xray/src/index.ts
+++ b/incubator/opentelemetry-sampler-aws-xray/src/index.ts
@@ -13,5 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './remote-sampler';
-export { AWSXRayRemoteSamplerConfig } from './types';
+export { AWSXRayRemoteSampler, _AWSXRayRemoteSampler } from './remote-sampler';
+export type { AWSXRayRemoteSamplerConfig } from './types';

--- a/metapackages/auto-instrumentations-node/src/index.ts
+++ b/metapackages/auto-instrumentations-node/src/index.ts
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 export {
   getNodeAutoInstrumentations,
   getResourceDetectorsFromEnv as getResourceDetectors,
-  InstrumentationConfigMap,
 } from './utils';
+export type { InstrumentationConfigMap } from './utils';

--- a/metapackages/auto-instrumentations-web/src/index.ts
+++ b/metapackages/auto-instrumentations-web/src/index.ts
@@ -13,5 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-export { getWebAutoInstrumentations, InstrumentationConfigMap } from './utils';
+export { getWebAutoInstrumentations } from './utils';
+export type { InstrumentationConfigMap } from './utils';

--- a/packages/baggage-log-record-processor/src/index.ts
+++ b/packages/baggage-log-record-processor/src/index.ts
@@ -15,4 +15,5 @@
  */
 
 export { BaggageLogRecordProcessor } from './baggage-log-record-processor';
-export { ALLOW_ALL_BAGGAGE_KEYS, BaggageKeyPredicate } from './types';
+export { ALLOW_ALL_BAGGAGE_KEYS } from './types';
+export type { BaggageKeyPredicate } from './types';

--- a/packages/baggage-span-processor/src/index.ts
+++ b/packages/baggage-span-processor/src/index.ts
@@ -15,4 +15,5 @@
  */
 
 export { BaggageSpanProcessor } from './baggage-span-processor';
-export { ALLOW_ALL_BAGGAGE_KEYS, BaggageKeyPredicate } from './types';
+export { ALLOW_ALL_BAGGAGE_KEYS } from './types';
+export type { BaggageKeyPredicate } from './types';

--- a/packages/opentelemetry-host-metrics/src/index.ts
+++ b/packages/opentelemetry-host-metrics/src/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
-export * from './BaseMetrics';
-export * from './metric';
-export * from './types';
+export { BaseMetrics } from './BaseMetrics';
+export type { MetricsCollectorConfig } from './BaseMetrics';
+export { HostMetrics } from './metric';
+export type { CpuUsageData, MemoryData, ProcessCpuUsageData } from './types';

--- a/packages/opentelemetry-id-generator-aws-xray/src/index.ts
+++ b/packages/opentelemetry-id-generator-aws-xray/src/index.ts
@@ -13,4 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './platform';
+export { AWSXRayIdGenerator } from './platform';

--- a/packages/opentelemetry-id-generator-aws-xray/src/platform/browser/index.ts
+++ b/packages/opentelemetry-id-generator-aws-xray/src/platform/browser/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export * from './AWSXRayIdGenerator';
+export { AWSXRayIdGenerator } from './AWSXRayIdGenerator';

--- a/packages/opentelemetry-id-generator-aws-xray/src/platform/index.ts
+++ b/packages/opentelemetry-id-generator-aws-xray/src/platform/index.ts
@@ -13,4 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './node';
+export { AWSXRayIdGenerator } from './node';

--- a/packages/opentelemetry-id-generator-aws-xray/src/platform/node/index.ts
+++ b/packages/opentelemetry-id-generator-aws-xray/src/platform/node/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export * from './AWSXRayIdGenerator';
+export { AWSXRayIdGenerator } from './AWSXRayIdGenerator';

--- a/packages/opentelemetry-test-utils/src/index.ts
+++ b/packages/opentelemetry-test-utils/src/index.ts
@@ -28,20 +28,19 @@ export { OtlpSpanKind } from './otlp-types';
 export {
   createTestNodeSdk,
   runTestFixture,
-  TestSpan,
-  RunTestFixtureOptions,
   TestCollector,
 } from './test-fixtures';
+export type { TestSpan, RunTestFixtureOptions } from './test-fixtures';
 export {
   assertPropagation,
   assertSpan,
   cleanUpDocker,
   getPackageVersion,
   initMeterProvider,
-  TimedEvent,
   startDocker,
   TestMetricReader,
 } from './test-utils';
+export type { TimedEvent } from './test-utils';
 export {
   getInstrumentation,
   getTestMemoryExporter,

--- a/packages/opentelemetry-test-utils/src/instrumentations/index.ts
+++ b/packages/opentelemetry-test-utils/src/instrumentations/index.ts
@@ -20,9 +20,17 @@ import { getInstrumentation } from './instrumentation-singleton';
 import { registerInstrumentationTestingProvider } from './otel-default-provider';
 import { resetMemoryExporter } from './otel-provider-api';
 
-export * from './instrumentation-singleton';
-export * from './otel-provider-api';
-export * from './otel-default-provider';
+export {
+  getInstrumentation,
+  registerInstrumentationTesting,
+} from './instrumentation-singleton';
+export {
+  getTestMemoryExporter,
+  getTestSpans,
+  resetMemoryExporter,
+  setTestMemoryExporter,
+} from './otel-provider-api';
+export { registerInstrumentationTestingProvider } from './otel-default-provider';
 
 export const mochaHooks = {
   beforeAll(done: Function) {

--- a/plugins/node/instrumentation-amqplib/src/index.ts
+++ b/plugins/node/instrumentation-amqplib/src/index.ts
@@ -13,5 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './amqplib';
-export * from './types';
+export { AmqplibInstrumentation } from './amqplib';
+export { DEFAULT_CONFIG, EndOperation } from './types';
+export type {
+  AmqplibConsumeCustomAttributeFunction,
+  AmqplibConsumeEndCustomAttributeFunction,
+  AmqplibInstrumentationConfig,
+  AmqplibPublishConfirmCustomAttributeFunction,
+  AmqplibPublishCustomAttributeFunction,
+  AmqplibPublishOptions,
+  CommonMessageFields,
+  ConsumeEndInfo,
+  ConsumeInfo,
+  ConsumeMessage,
+  ConsumeMessageFields,
+  Message,
+  MessageFields,
+  MessageProperties,
+  PublishConfirmedInfo,
+  PublishInfo,
+} from './types';

--- a/plugins/node/instrumentation-cucumber/src/index.ts
+++ b/plugins/node/instrumentation-cucumber/src/index.ts
@@ -14,5 +14,6 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
+export { CucumberInstrumentation } from './instrumentation';
+export { AttributeNames } from './types';
+export type { CucumberInstrumentationConfig } from './types';

--- a/plugins/node/instrumentation-dataloader/src/index.ts
+++ b/plugins/node/instrumentation-dataloader/src/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export * from './types';
-export * from './instrumentation';
+export { DataloaderInstrumentation } from './instrumentation';
+export type { DataloaderInstrumentationConfig } from './types';

--- a/plugins/node/instrumentation-fs/src/index.ts
+++ b/plugins/node/instrumentation-fs/src/index.ts
@@ -14,5 +14,15 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
+export { FsInstrumentation } from './instrumentation';
+export type {
+  CreateHook,
+  EndHook,
+  FMember,
+  FPMember,
+  FsInstrumentationConfig,
+  FunctionProperties,
+  FunctionPropertyNames,
+  FunctionPropertyNamesTwoLevels,
+  Member,
+} from './types';

--- a/plugins/node/instrumentation-kafkajs/src/index.ts
+++ b/plugins/node/instrumentation-kafkajs/src/index.ts
@@ -14,5 +14,11 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
+export { KafkaJsInstrumentation } from './instrumentation';
+export type {
+  KafkaConsumerCustomAttributeFunction,
+  KafkaJsInstrumentationConfig,
+  KafkaProducerCustomAttributeFunction,
+  KafkajsMessage,
+  MessageInfo,
+} from './types';

--- a/plugins/node/instrumentation-lru-memoizer/src/index.ts
+++ b/plugins/node/instrumentation-lru-memoizer/src/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
+export { LruMemoizerInstrumentation } from './instrumentation';

--- a/plugins/node/instrumentation-mongoose/src/index.ts
+++ b/plugins/node/instrumentation-mongoose/src/index.ts
@@ -13,5 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './mongoose';
-export * from './types';
+export { MongooseInstrumentation } from './mongoose';
+export type {
+  DbStatementSerializer,
+  MongooseInstrumentationConfig,
+  MongooseResponseCustomAttributesFunction,
+  ResponseInfo,
+  SerializerPayload,
+} from './types';

--- a/plugins/node/instrumentation-runtime-node/src/index.ts
+++ b/plugins/node/instrumentation-runtime-node/src/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
+export { RuntimeNodeInstrumentation } from './instrumentation';
+export type { RuntimeNodeInstrumentationConfig } from './types';

--- a/plugins/node/instrumentation-socket.io/src/index.ts
+++ b/plugins/node/instrumentation-socket.io/src/index.ts
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './socket.io';
-export * from './types';
-export * from './AttributeNames';
+export { SocketIoInstrumentation } from './socket.io';
+export { SocketIoInstrumentationAttributes } from './AttributeNames';
+export { defaultSocketIoPath } from './types';
+export type {
+  SocketIoHookFunction,
+  SocketIoHookInfo,
+  SocketIoInstrumentationConfig,
+} from './types';

--- a/plugins/node/instrumentation-tedious/src/index.ts
+++ b/plugins/node/instrumentation-tedious/src/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
+export { TediousInstrumentation } from './instrumentation';
+export type { TediousInstrumentationConfig } from './types';

--- a/plugins/node/instrumentation-typeorm/src/index.ts
+++ b/plugins/node/instrumentation-typeorm/src/index.ts
@@ -13,5 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './typeorm';
-export * from './types';
+export { TypeormInstrumentation } from './typeorm';
+export { ExtendedDatabaseAttribute } from './types';
+export type {
+  HookInfo,
+  TypeormInstrumentationConfig,
+  TypeormResponseCustomAttributesFunction,
+} from './types';

--- a/plugins/node/instrumentation-typeorm/src/utils/index.ts
+++ b/plugins/node/instrumentation-typeorm/src/utils/index.ts
@@ -13,5 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './get-func-param-names';
-export * from './suppressTracing';
+export { getParamNames } from './get-func-param-names';
+export {
+  isTypeormInternalTracingSuppressed,
+  suppressTypeormInternalTracing,
+} from './suppressTracing';

--- a/plugins/node/instrumentation-undici/src/index.ts
+++ b/plugins/node/instrumentation-undici/src/index.ts
@@ -14,5 +14,13 @@
  * limitations under the License.
  */
 
-export * from './undici';
-export * from './types';
+export { UndiciInstrumentation } from './undici';
+export type {
+  IgnoreRequestFunction,
+  RequestHookFunction,
+  ResponseHookFunction,
+  StartSpanHookFunction,
+  UndiciInstrumentationConfig,
+  UndiciRequest,
+  UndiciResponse,
+} from './types';

--- a/plugins/node/opentelemetry-instrumentation-aws-lambda/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-lambda/src/index.ts
@@ -14,5 +14,13 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
+export {
+  AwsLambdaInstrumentation,
+  lambdaMaxInitInMilliseconds,
+} from './instrumentation';
+export type {
+  AwsLambdaInstrumentationConfig,
+  EventContextExtractor,
+  RequestHook,
+  ResponseHook,
+} from './types';

--- a/plugins/node/opentelemetry-instrumentation-aws-sdk/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-aws-sdk/src/index.ts
@@ -13,5 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './aws-sdk';
-export * from './types';
+export { AwsInstrumentation } from './aws-sdk';
+export type {
+  AwsSdkDynamoDBStatementSerializer,
+  AwsSdkInstrumentationConfig,
+  AwsSdkRequestCustomAttributeFunction,
+  AwsSdkRequestHookInformation,
+  AwsSdkResponseCustomAttributeFunction,
+  AwsSdkResponseHookInformation,
+  AwsSdkSqsProcessCustomAttributeFunction,
+  AwsSdkSqsProcessHookInformation,
+  CommandInput,
+  NormalizedRequest,
+  NormalizedResponse,
+} from './types';

--- a/plugins/node/opentelemetry-instrumentation-bunyan/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-bunyan/src/index.ts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
-export * from './OpenTelemetryBunyanStream';
+export { BunyanInstrumentation } from './instrumentation';
+export { OpenTelemetryBunyanStream } from './OpenTelemetryBunyanStream';
+export type { BunyanInstrumentationConfig, LogHookFunction } from './types';

--- a/plugins/node/opentelemetry-instrumentation-cassandra/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-cassandra/src/index.ts
@@ -14,5 +14,11 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
+export { CassandraDriverInstrumentation } from './instrumentation';
+export type {
+  CassandraDriverInstrumentationConfig,
+  CassandraDriverResponseCustomAttributeFunction,
+  ResponseHookInfo,
+  ResultSet,
+  Row,
+} from './types';

--- a/plugins/node/opentelemetry-instrumentation-connect/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-connect/src/index.ts
@@ -14,5 +14,9 @@
  * limitations under the License.
  */
 
-export * from './enums/AttributeNames';
-export * from './instrumentation';
+export { ConnectInstrumentation, ANONYMOUS_NAME } from './instrumentation';
+export {
+  AttributeNames,
+  ConnectNames,
+  ConnectTypes,
+} from './enums/AttributeNames';

--- a/plugins/node/opentelemetry-instrumentation-dns/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-dns/src/index.ts
@@ -15,4 +15,4 @@
  */
 
 export { DnsInstrumentation } from './instrumentation';
-export { DnsInstrumentationConfig, IgnoreMatcher } from './types';
+export type { DnsInstrumentationConfig, IgnoreMatcher } from './types';

--- a/plugins/node/opentelemetry-instrumentation-express/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-express/src/index.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './enums/ExpressLayerType';
-export * from './enums/AttributeNames';
-export * from './types';
+export { ExpressInstrumentation } from './instrumentation';
+export { ExpressLayerType } from './enums/ExpressLayerType';
+export { AttributeNames } from './enums/AttributeNames';
+export type {
+  ExpressInstrumentationConfig,
+  ExpressRequestCustomAttributeFunction,
+  ExpressRequestInfo,
+  IgnoreMatcher,
+  LayerPathSegment,
+  SpanNameHook,
+} from './types';

--- a/plugins/node/opentelemetry-instrumentation-fastify/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-fastify/src/index.ts
@@ -14,6 +14,14 @@
  * limitations under the License.
  */
 
-export * from './enums/AttributeNames';
-export * from './types';
-export * from './instrumentation';
+export { FastifyInstrumentation } from './instrumentation';
+export {
+  AttributeNames,
+  FastifyNames,
+  FastifyTypes,
+} from './enums/AttributeNames';
+export type {
+  FastifyCustomAttributeFunction,
+  FastifyInstrumentationConfig,
+  FastifyRequestInfo,
+} from './types';

--- a/plugins/node/opentelemetry-instrumentation-generic-pool/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-generic-pool/src/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
+export { GenericPoolInstrumentation } from './instrumentation';

--- a/plugins/node/opentelemetry-instrumentation-graphql/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/src/index.ts
@@ -14,5 +14,9 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
+export { GraphQLInstrumentation } from './instrumentation';
+export type {
+  GraphQLInstrumentationConfig,
+  GraphQLInstrumentationExecutionResponseHook,
+  GraphQLInstrumentationParsedConfig,
+} from './types';

--- a/plugins/node/opentelemetry-instrumentation-hapi/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-hapi/src/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './enums/AttributeNames';
+export { HapiInstrumentation } from './instrumentation';
+export { AttributeNames } from './enums/AttributeNames';

--- a/plugins/node/opentelemetry-instrumentation-ioredis/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/src/index.ts
@@ -14,5 +14,12 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
+export { IORedisInstrumentation } from './instrumentation';
+export type {
+  CommandArgs,
+  DbStatementSerializer,
+  IORedisInstrumentationConfig,
+  IORedisRequestHookInformation,
+  RedisRequestCustomAttributeFunction,
+  RedisResponseCustomAttributeFunction,
+} from './types';

--- a/plugins/node/opentelemetry-instrumentation-knex/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-knex/src/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
+export { KnexInstrumentation } from './instrumentation';
+export type { KnexInstrumentationConfig } from './types';

--- a/plugins/node/opentelemetry-instrumentation-koa/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/src/index.ts
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
-export * from './enums/AttributeNames';
+export { KoaInstrumentation } from './instrumentation';
+export { AttributeNames } from './enums/AttributeNames';
+export type {
+  KoaInstrumentationConfig,
+  KoaLayerType,
+  KoaRequestCustomAttributeFunction,
+  KoaRequestInfo,
+} from './types';

--- a/plugins/node/opentelemetry-instrumentation-memcached/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-memcached/src/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
+export { MemcachedInstrumentation } from './instrumentation';
+export type { InstrumentationConfig } from './types';

--- a/plugins/node/opentelemetry-instrumentation-mongodb/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/src/index.ts
@@ -14,5 +14,12 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
+export { MongoDBInstrumentation } from './instrumentation';
+export type {
+  CommandResult,
+  DbStatementSerializer,
+  MongoDBInstrumentationConfig,
+  MongoDBInstrumentationExecutionResponseHook,
+  MongoResponseHookInformation,
+  MongodbCommandType,
+} from './types';

--- a/plugins/node/opentelemetry-instrumentation-mysql/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql/src/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
+export { MySQLInstrumentation } from './instrumentation';
+export type { MySQLInstrumentationConfig } from './types';

--- a/plugins/node/opentelemetry-instrumentation-mysql2/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/src/index.ts
@@ -14,5 +14,9 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
+export { MySQL2Instrumentation } from './instrumentation';
+export type {
+  MySQL2InstrumentationConfig,
+  MySQL2InstrumentationExecutionResponseHook,
+  MySQL2ResponseHookInformation,
+} from './types';

--- a/plugins/node/opentelemetry-instrumentation-nestjs-core/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-nestjs-core/src/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './enums/AttributeNames';
+export { NestInstrumentation } from './instrumentation';
+export { AttributeNames } from './enums/AttributeNames';

--- a/plugins/node/opentelemetry-instrumentation-net/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-net/src/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
+export { NetInstrumentation } from './instrumentation';
+export type { TLSAttributes } from './types';

--- a/plugins/node/opentelemetry-instrumentation-oracledb/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-oracledb/src/index.ts
@@ -16,5 +16,12 @@
  * Copyright (c) 2025, Oracle and/or its affiliates.
  * */
 
-export * from './instrumentation';
-export * from './types';
+export { OracleInstrumentation } from './instrumentation';
+export type {
+  OracleInstrumentationConfig,
+  OracleInstrumentationExecutionRequestHook,
+  OracleInstrumentationExecutionResponseHook,
+  OracleRequestHookInformation,
+  OracleResponseHookInformation,
+  SpanConnectionConfig,
+} from './types';

--- a/plugins/node/opentelemetry-instrumentation-pg/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/src/index.ts
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
-export * from './enums/AttributeNames';
+export { PgInstrumentation } from './instrumentation';
+export { AttributeNames } from './enums/AttributeNames';
+export type {
+  PgInstrumentationConfig,
+  PgInstrumentationExecutionRequestHook,
+  PgInstrumentationExecutionResponseHook,
+  PgRequestHookInformation,
+  PgResponseHookInformation,
+} from './types';

--- a/plugins/node/opentelemetry-instrumentation-pino/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-pino/src/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
+export { PinoInstrumentation } from './instrumentation';
+export type { LogHookFunction, PinoInstrumentationConfig } from './types';

--- a/plugins/node/opentelemetry-instrumentation-redis-4/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-redis-4/src/index.ts
@@ -14,5 +14,9 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
+export { RedisInstrumentation } from './instrumentation';
+export type {
+  DbStatementSerializer,
+  RedisInstrumentationConfig,
+  RedisResponseCustomAttributeFunction,
+} from './types';

--- a/plugins/node/opentelemetry-instrumentation-redis/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-redis/src/index.ts
@@ -14,5 +14,10 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
+export { RedisInstrumentation } from './instrumentation';
+export type {
+  DbStatementSerializer,
+  RedisCommand,
+  RedisInstrumentationConfig,
+  RedisResponseCustomAttributeFunction,
+} from './types';

--- a/plugins/node/opentelemetry-instrumentation-restify/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/src/index.ts
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './enums/AttributeNames';
-export * from './types';
+export { RestifyInstrumentation } from './instrumentation';
+export { AttributeNames } from './enums/AttributeNames';
+export type {
+  LayerType,
+  RestifyCustomAttributeFunction,
+  RestifyInstrumentationConfig,
+  RestifyRequestInfo,
+} from './types';

--- a/plugins/node/opentelemetry-instrumentation-router/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-router/src/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './enums/AttributeNames';
+export { RouterInstrumentation } from './instrumentation';
+export { AttributeNames } from './enums/AttributeNames';

--- a/plugins/node/opentelemetry-instrumentation-winston/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-winston/src/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
+export { WinstonInstrumentation } from './instrumentation';
+export type { LogHookFunction, WinstonInstrumentationConfig } from './types';

--- a/plugins/web/opentelemetry-instrumentation-document-load/src/index.ts
+++ b/plugins/web/opentelemetry-instrumentation-document-load/src/index.ts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './enums/AttributeNames';
-export * from './types';
+export { DocumentLoadInstrumentation } from './instrumentation';
+export { AttributeNames } from './enums/AttributeNames';
+export type {
+  DocumentLoadCustomAttributeFunction,
+  DocumentLoadInstrumentationConfig,
+  ResourceFetchCustomAttributeFunction,
+} from './types';

--- a/plugins/web/opentelemetry-instrumentation-long-task/src/index.ts
+++ b/plugins/web/opentelemetry-instrumentation-long-task/src/index.ts
@@ -14,5 +14,11 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
+export { LongTaskInstrumentation } from './instrumentation';
+export type {
+  LongtaskInstrumentationConfig,
+  ObserverCallback,
+  ObserverCallbackInformation,
+  PerformanceLongTaskTiming,
+  TaskAttributionTiming,
+} from './types';

--- a/plugins/web/opentelemetry-instrumentation-user-interaction/src/index.ts
+++ b/plugins/web/opentelemetry-instrumentation-user-interaction/src/index.ts
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
-export * from './instrumentation';
-export * from './types';
-export * from './enums/AttributeNames';
+export { UserInteractionInstrumentation } from './instrumentation';
+export { AttributeNames } from './enums/AttributeNames';
+export type {
+  EventName,
+  ShouldPreventSpanCreation,
+  UserInteractionInstrumentationConfig,
+} from './types';

--- a/plugins/web/opentelemetry-plugin-react-load/src/index.ts
+++ b/plugins/web/opentelemetry-plugin-react-load/src/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export * from './BaseOpenTelemetryComponent';
-export * from './enums/AttributeNames';
+export { BaseOpenTelemetryComponent } from './BaseOpenTelemetryComponent';
+export { AttributeNames } from './enums/AttributeNames';

--- a/propagators/opentelemetry-propagator-ot-trace/src/index.ts
+++ b/propagators/opentelemetry-propagator-ot-trace/src/index.ts
@@ -14,4 +14,10 @@
  * limitations under the License.
  */
 
-export * from './OTTracePropagator';
+export {
+  OTTracePropagator,
+  OT_BAGGAGE_PREFIX,
+  OT_SAMPLED_HEADER,
+  OT_SPAN_ID_HEADER,
+  OT_TRACE_ID_HEADER,
+} from './OTTracePropagator';

--- a/scripts/pr-labels-to-npm-workspace-args.mjs
+++ b/scripts/pr-labels-to-npm-workspace-args.mjs
@@ -8,7 +8,6 @@
 
 const labels = JSON.parse(process.argv[2]);
 
-console.error('process.argv', process.argv)
 console.error('Labels:', labels);
 
 const workspaces = labels

--- a/scripts/pr-labels-to-npm-workspace-args.mjs
+++ b/scripts/pr-labels-to-npm-workspace-args.mjs
@@ -8,6 +8,7 @@
 
 const labels = JSON.parse(process.argv[2]);
 
+console.error('process.argv', process.argv)
 console.error('Labels:', labels);
 
 const workspaces = labels

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,6 +8,7 @@
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
     "inlineSources": true,
+    "isolatedModules": true,
     "module": "node16",
     "moduleResolution": "node16",
     "newLine": "LF",


### PR DESCRIPTION
## Which problem is this PR solving?

This is a follow up PR on https://github.com/open-telemetry/opentelemetry-js/pull/5697

IMHO the compilation options should be in sync if possible. Also TypeScript [docs](https://www.typescriptlang.org/tsconfig/#isolatedModules) recommend to enable it to give better support for bundlers. It may benefit instrumentations targeting browser runtime.

## Short description of the changes

- set `isolatedModules` to true in `tsconfig.base.json`
- make all exports explicit
- mark all exported types as `export type`
