### PR TITLE
test(instrumentation-graphql): update semconv usage to ATTR_ exports

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-graphql/test/graphql.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-graphql/test/graphql.test.ts
@@ -21,7 +21,7 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 import { Span, SpanStatusCode } from '@opentelemetry/api';
-import { SEMATTRS_EXCEPTION_MESSAGE } from '@opentelemetry/semantic-conventions';
+import { ATTR_EXCEPTION_MESSAGE } from '@opentelemetry/semantic-conventions';
 import * as assert from 'assert';
 import type * as graphqlTypes from 'graphql';
 import { GraphQLInstrumentation } from '../src';
@@ -1448,7 +1448,7 @@ describe('graphql', () => {
       const resolveEvent = resolveSpan.events[0];
       assert.deepStrictEqual(resolveEvent.name, 'exception');
       assert.deepStrictEqual(
-        resolveEvent.attributes?.[SEMATTRS_EXCEPTION_MESSAGE],
+        resolveEvent.attributes?.[ATTR_EXCEPTION_MESSAGE],
         'sync resolver error from tests'
       );
 


### PR DESCRIPTION
Refs: https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2377
