### PR TITLE
refactor(instrumentation-restify): update semconv usage to ATTR_ exports

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-restify/src/instrumentation.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/src/instrumentation.ts
@@ -31,7 +31,7 @@ import {
   isWrapped,
   safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
-import { SEMATTRS_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
+import { ATTR_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
 import { isPromise, isAsyncFunction } from './utils';
 import { getRPCMetadata, RPCType } from '@opentelemetry/core';
 import type { RestifyInstrumentationConfig } from './types';
@@ -172,7 +172,7 @@ export class RestifyInstrumentation extends InstrumentationBase<RestifyInstrumen
           [AttributeNames.VERSION]: this._moduleVersion || 'n/a',
           [AttributeNames.TYPE]: metadata.type,
           [AttributeNames.METHOD]: metadata.methodName,
-          [SEMATTRS_HTTP_ROUTE]: route,
+          [ATTR_HTTP_ROUTE]: route,
         };
         const span = this.tracer.startSpan(
           spanName,

--- a/plugins/node/opentelemetry-instrumentation-restify/test/restify.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/test/restify.test.ts
@@ -15,7 +15,6 @@
  */
 
 import { context, trace, Span } from '@opentelemetry/api';
-import { SEMATTRS_HTTP_METHOD } from '@opentelemetry/semantic-conventions';
 import { RPCMetadata, RPCType, setRPCMetadata } from '@opentelemetry/core';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
@@ -495,7 +494,7 @@ describe('Restify Instrumentation', () => {
     describe('using requestHook in config', () => {
       it('calls requestHook provided function when set in config', async () => {
         const requestHook = (span: Span, info: RestifyRequestInfo) => {
-          span.setAttribute(SEMATTRS_HTTP_METHOD, info.request.method);
+          span.setAttribute('my.http.method', info.request.method);
           span.setAttribute('restify.layer', info.layerType);
         };
 
@@ -517,7 +516,7 @@ describe('Restify Instrumentation', () => {
               // span from get
               const span = memoryExporter.getFinishedSpans()[2];
               assert.notStrictEqual(span, undefined);
-              assert.strictEqual(span.attributes[SEMATTRS_HTTP_METHOD], 'GET');
+              assert.strictEqual(span.attributes['my.http.method'], 'GET');
               assert.strictEqual(
                 span.attributes['restify.layer'],
                 'request_handler'
@@ -529,7 +528,7 @@ describe('Restify Instrumentation', () => {
 
       it('does not propagate an error from a requestHook that throws exception', async () => {
         const requestHook = (span: Span, info: RestifyRequestInfo) => {
-          span.setAttribute(SEMATTRS_HTTP_METHOD, info.request.method);
+          span.setAttribute('my.http.method', info.request.method);
 
           throw Error('error thrown in requestHook');
         };
@@ -552,7 +551,7 @@ describe('Restify Instrumentation', () => {
               // span from get
               const span = memoryExporter.getFinishedSpans()[2];
               assert.notStrictEqual(span, undefined);
-              assert.strictEqual(span.attributes[SEMATTRS_HTTP_METHOD], 'GET');
+              assert.strictEqual(span.attributes['my.http.method'], 'GET');
             }
           }
         );


### PR DESCRIPTION
Refs: https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2377
