### PR TITLE
test: stop using the obsolete AsyncHooksContextManager in tests

### DIFF
--- a/plugins/node/instrumentation-cucumber/test/cucumber.test.ts
+++ b/plugins/node/instrumentation-cucumber/test/cucumber.test.ts
@@ -16,7 +16,7 @@
 
 import { context, SpanStatusCode } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -61,7 +61,7 @@ describe('CucumberInstrumentation', () => {
     }),
     spanProcessors: [spanProcessor],
   });
-  const contextManager = new AsyncHooksContextManager().enable();
+  const contextManager = new AsyncLocalStorageContextManager().enable();
 
   before(() => {
     instrumentation.setTracerProvider(provider);

--- a/plugins/node/instrumentation-dataloader/test/dataloader.test.ts
+++ b/plugins/node/instrumentation-dataloader/test/dataloader.test.ts
@@ -20,7 +20,7 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 import { context, SpanKind, SpanStatusCode, trace } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 
 import { DataloaderInstrumentation } from '../src';
 const instrumentation = new DataloaderInstrumentation();
@@ -34,7 +34,7 @@ import * as Dataloader from 'dataloader';
 
 describe('DataloaderInstrumentation', () => {
   let dataloader: Dataloader<string, number>;
-  let contextManager: AsyncHooksContextManager;
+  let contextManager: AsyncLocalStorageContextManager;
 
   const memoryExporter = new InMemorySpanExporter();
   const provider = new NodeTracerProvider({
@@ -47,7 +47,7 @@ describe('DataloaderInstrumentation', () => {
 
   beforeEach(async () => {
     instrumentation.enable();
-    contextManager = new AsyncHooksContextManager();
+    contextManager = new AsyncLocalStorageContextManager();
     context.setGlobalContextManager(contextManager.enable());
     dataloader = new Dataloader(async keys => keys.map((_, idx) => idx), {
       cache: false,

--- a/plugins/node/instrumentation-fs/test/fs.test.ts
+++ b/plugins/node/instrumentation-fs/test/fs.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { context, trace } from '@opentelemetry/api';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
   BasicTracerProvider,
   InMemorySpanExporter,
@@ -65,12 +65,12 @@ const provider = new BasicTracerProvider({
 const tracer = provider.getTracer('default');
 
 describe('fs instrumentation', () => {
-  let contextManager: AsyncHooksContextManager;
+  let contextManager: AsyncLocalStorageContextManager;
   let fs: typeof FSType;
   let plugin: FsInstrumentation;
 
   beforeEach(async () => {
-    contextManager = new AsyncHooksContextManager();
+    contextManager = new AsyncLocalStorageContextManager();
     context.setGlobalContextManager(contextManager.enable());
     plugin = new FsInstrumentation(pluginConfig);
     plugin.setTracerProvider(provider);

--- a/plugins/node/instrumentation-fs/test/fsPromises.test.ts
+++ b/plugins/node/instrumentation-fs/test/fsPromises.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { context, trace } from '@opentelemetry/api';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
   BasicTracerProvider,
   InMemorySpanExporter,
@@ -44,12 +44,12 @@ const provider = new BasicTracerProvider({
 const tracer = provider.getTracer('default');
 
 describe('fs/promises instrumentation', () => {
-  let contextManager: AsyncHooksContextManager;
+  let contextManager: AsyncLocalStorageContextManager;
   let fsPromises: typeof FSPromisesType;
   let plugin: FsInstrumentation;
 
   beforeEach(async () => {
-    contextManager = new AsyncHooksContextManager();
+    contextManager = new AsyncLocalStorageContextManager();
     context.setGlobalContextManager(contextManager.enable());
     plugin = new FsInstrumentation(pluginConfig);
     plugin.setTracerProvider(provider);

--- a/plugins/node/instrumentation-fs/test/parent.test.ts
+++ b/plugins/node/instrumentation-fs/test/parent.test.ts
@@ -23,7 +23,7 @@ import * as assert from 'assert';
 import type * as FSType from 'fs';
 import type { FsInstrumentationConfig } from '../src/types';
 import * as api from '@opentelemetry/api';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 
 const memoryExporter = new InMemorySpanExporter();
 const provider = new BasicTracerProvider({
@@ -49,7 +49,7 @@ describe('fs instrumentation: requireParentSpan', () => {
   };
 
   beforeEach(() => {
-    const contextManager = new AsyncHooksContextManager();
+    const contextManager = new AsyncLocalStorageContextManager();
     api.context.setGlobalContextManager(contextManager.enable());
   });
 

--- a/plugins/node/instrumentation-tedious/test/instrumentation.test.ts
+++ b/plugins/node/instrumentation-tedious/test/instrumentation.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { context, trace, SpanStatusCode, SpanKind } from '@opentelemetry/api';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
   DBSYSTEMVALUES_MSSQL,
   SEMATTRS_DB_NAME,
@@ -87,7 +87,7 @@ const incompatVersions =
 
 describe('tedious', () => {
   let tedious: any;
-  let contextManager: AsyncHooksContextManager;
+  let contextManager: AsyncLocalStorageContextManager;
   let connection: Connection;
   const memoryExporter = new InMemorySpanExporter();
   const provider = new BasicTracerProvider({
@@ -124,7 +124,7 @@ describe('tedious', () => {
     // connecting often takes more time even if the DB is running locally
     this.timeout(10000);
     instrumentation.disable();
-    contextManager = new AsyncHooksContextManager().enable();
+    contextManager = new AsyncLocalStorageContextManager().enable();
     context.setGlobalContextManager(contextManager);
     instrumentation.setTracerProvider(provider);
     instrumentation.enable();

--- a/plugins/node/instrumentation-undici/test/fetch.test.ts
+++ b/plugins/node/instrumentation-undici/test/fetch.test.ts
@@ -22,7 +22,7 @@ import {
   propagation,
   trace,
 } from '@opentelemetry/api';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -59,7 +59,7 @@ describe('UndiciInstrumentation `fetch` tests', function () {
     instrumentation.setTracerProvider(provider);
 
     propagation.setGlobalPropagator(new MockPropagation());
-    context.setGlobalContextManager(new AsyncHooksContextManager().enable());
+    context.setGlobalContextManager(new AsyncLocalStorageContextManager().enable());
     mockServer.start(done);
     mockServer.mockListener((req, res) => {
       // There are some situations where there is no way to access headers

--- a/plugins/node/instrumentation-undici/test/fetch.test.ts
+++ b/plugins/node/instrumentation-undici/test/fetch.test.ts
@@ -59,7 +59,9 @@ describe('UndiciInstrumentation `fetch` tests', function () {
     instrumentation.setTracerProvider(provider);
 
     propagation.setGlobalPropagator(new MockPropagation());
-    context.setGlobalContextManager(new AsyncLocalStorageContextManager().enable());
+    context.setGlobalContextManager(
+      new AsyncLocalStorageContextManager().enable()
+    );
     mockServer.start(done);
     mockServer.mockListener((req, res) => {
       // There are some situations where there is no way to access headers

--- a/plugins/node/instrumentation-undici/test/metrics.test.ts
+++ b/plugins/node/instrumentation-undici/test/metrics.test.ts
@@ -16,7 +16,7 @@
 import * as assert from 'assert';
 
 import { context, propagation } from '@opentelemetry/api';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import {
   AggregationTemporality,
@@ -58,7 +58,7 @@ describe('UndiciInstrumentation metrics tests', function () {
     instrumentation.setTracerProvider(provider);
     instrumentation.setMeterProvider(meterProvider);
 
-    context.setGlobalContextManager(new AsyncHooksContextManager().enable());
+    context.setGlobalContextManager(new AsyncLocalStorageContextManager().enable());
     mockServer.start(done);
     mockServer.mockListener((req, res) => {
       // Return a valid response always

--- a/plugins/node/instrumentation-undici/test/metrics.test.ts
+++ b/plugins/node/instrumentation-undici/test/metrics.test.ts
@@ -58,7 +58,9 @@ describe('UndiciInstrumentation metrics tests', function () {
     instrumentation.setTracerProvider(provider);
     instrumentation.setMeterProvider(meterProvider);
 
-    context.setGlobalContextManager(new AsyncLocalStorageContextManager().enable());
+    context.setGlobalContextManager(
+      new AsyncLocalStorageContextManager().enable()
+    );
     mockServer.start(done);
     mockServer.mockListener((req, res) => {
       // Return a valid response always

--- a/plugins/node/instrumentation-undici/test/undici.test.ts
+++ b/plugins/node/instrumentation-undici/test/undici.test.ts
@@ -24,7 +24,7 @@ import {
   propagation,
   trace,
 } from '@opentelemetry/api';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -85,7 +85,7 @@ describe('UndiciInstrumentation `undici` tests', function () {
     instrumentation.setTracerProvider(provider);
 
     propagation.setGlobalPropagator(new MockPropagation());
-    context.setGlobalContextManager(new AsyncHooksContextManager().enable());
+    context.setGlobalContextManager(new AsyncLocalStorageContextManager().enable());
     mockServer.start(done);
     mockServer.mockListener((req, res) => {
       // There are some situations where there is no way to access headers

--- a/plugins/node/instrumentation-undici/test/undici.test.ts
+++ b/plugins/node/instrumentation-undici/test/undici.test.ts
@@ -85,7 +85,9 @@ describe('UndiciInstrumentation `undici` tests', function () {
     instrumentation.setTracerProvider(provider);
 
     propagation.setGlobalPropagator(new MockPropagation());
-    context.setGlobalContextManager(new AsyncLocalStorageContextManager().enable());
+    context.setGlobalContextManager(
+      new AsyncLocalStorageContextManager().enable()
+    );
     mockServer.start(done);
     mockServer.mockListener((req, res) => {
       // There are some situations where there is no way to access headers

--- a/plugins/node/opentelemetry-instrumentation-cassandra/test/cassandra-driver.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-cassandra/test/cassandra-driver.test.ts
@@ -37,6 +37,8 @@ import {
   SEMATTRS_EXCEPTION_MESSAGE,
   SEMATTRS_EXCEPTION_STACKTRACE,
   SEMATTRS_EXCEPTION_TYPE,
+  SEMATTRS_NET_PEER_NAME,
+  SEMATTRS_NET_PEER_PORT,
 } from '@opentelemetry/semantic-conventions';
 import * as assert from 'assert';
 import * as testUtils from '@opentelemetry/contrib-test-utils';
@@ -57,6 +59,10 @@ const testCassandra = process.env.RUN_CASSANDRA_TESTS;
 const testCassandraLocally = process.env.RUN_CASSANDRA_TESTS_LOCAL;
 const shouldTest = testCassandra || testCassandraLocally;
 const cassandraTimeoutMs = 60000;
+const cassandraContactPoint =
+  process.env.CASSANDRA_HOST ?? testCassandraLocally
+    ? '127.0.0.1'
+    : 'cassandra';
 
 function assertSpan(
   span: ReadableSpan,
@@ -80,11 +86,16 @@ function assertSpan(
   testUtils.assertSpan(span, SpanKind.CLIENT, attributes, [], spanStatus);
 }
 
-function assertSingleSpan(name: string, query?: string, status?: SpanStatus) {
+function assertSingleSpan(
+  name: string,
+  query?: string,
+  status?: SpanStatus,
+  customAttributes?: Attributes
+) {
   const spans = memoryExporter.getFinishedSpans();
   assert.strictEqual(spans.length, 1);
   const [span] = spans;
-  assertSpan(span, name, query, status);
+  assertSpan(span, name, query, status, customAttributes);
 }
 
 function assertAttributeInSingleSpan(name: string, attributes?: Attributes) {
@@ -97,7 +108,8 @@ function assertAttributeInSingleSpan(name: string, attributes?: Attributes) {
 function assertErrorSpan(
   name: string,
   error: Error & { code?: number },
-  query?: string
+  query?: string,
+  customAttributes?: Attributes
 ) {
   const spans = memoryExporter.getFinishedSpans();
   assert.strictEqual(spans.length, 1);
@@ -106,6 +118,7 @@ function assertErrorSpan(
   const attributes: Attributes = {
     [SEMATTRS_DB_SYSTEM]: DBSYSTEMVALUES_CASSANDRA,
     [SEMATTRS_DB_USER]: 'cassandra',
+    ...customAttributes,
   };
 
   if (query !== undefined) {
@@ -154,12 +167,8 @@ describe('CassandraDriverInstrumentation', () => {
     instrumentation.setTracerProvider(provider);
 
     const cassandra = require('cassandra-driver');
-    const endpoint =
-      process.env.CASSANDRA_HOST ?? testCassandraLocally
-        ? '127.0.0.1'
-        : 'cassandra';
     client = new cassandra.Client({
-      contactPoints: [endpoint],
+      contactPoints: [cassandraContactPoint],
       localDataCenter: 'datacenter1',
       credentials: {
         username: 'cassandra',
@@ -198,12 +207,18 @@ describe('CassandraDriverInstrumentation', () => {
 
     it('creates a span for promise based execute', async () => {
       await client.execute('select * from ot.test');
-      assertSingleSpan('cassandra-driver.execute');
+      assertSingleSpan('cassandra-driver.execute', undefined, undefined, {
+        [SEMATTRS_NET_PEER_NAME]: cassandraContactPoint,
+        [SEMATTRS_NET_PEER_PORT]: 9042,
+      });
     });
 
     it('creates a span for callback based execute', done => {
       client.execute('select * from ot.test', () => {
-        assertSingleSpan('cassandra-driver.execute');
+        assertSingleSpan('cassandra-driver.execute', undefined, undefined, {
+          [SEMATTRS_NET_PEER_NAME]: cassandraContactPoint,
+          [SEMATTRS_NET_PEER_PORT]: 9042,
+        });
         done();
       });
     });
@@ -212,7 +227,10 @@ describe('CassandraDriverInstrumentation', () => {
       try {
         await client.execute('selec * from');
       } catch (e: any) {
-        assertErrorSpan('cassandra-driver.execute', e);
+        assertErrorSpan('cassandra-driver.execute', e, undefined, {
+          [SEMATTRS_NET_PEER_NAME]: cassandraContactPoint,
+          [SEMATTRS_NET_PEER_PORT]: 9042,
+        });
         return;
       }
 
@@ -239,13 +257,31 @@ describe('CassandraDriverInstrumentation', () => {
       it('retains statements', async () => {
         const query = 'select * from ot.test';
         await client.execute(query);
-        assertSingleSpan('cassandra-driver.execute', query);
+        assertSingleSpan('cassandra-driver.execute', query, undefined, {
+          [SEMATTRS_NET_PEER_NAME]: cassandraContactPoint,
+          [SEMATTRS_NET_PEER_PORT]: 9042,
+        });
       });
 
       it('truncates long queries', async () => {
         const query = 'select userid, count from ot.test';
         await client.execute(query);
-        assertSingleSpan('cassandra-driver.execute', query.substring(0, 25));
+        const customAttributes = {
+          [SEMATTRS_NET_PEER_NAME]: cassandraContactPoint,
+          [SEMATTRS_NET_PEER_PORT]: 9042,
+        };
+        assertSingleSpan(
+          'cassandra-driver.execute',
+          query.substring(0, 25),
+          undefined,
+          customAttributes
+        );
+        assertSingleSpan(
+          'cassandra-driver.execute',
+          query.substring(0, 25),
+          undefined,
+          customAttributes
+        );
       });
     });
 
@@ -278,6 +314,8 @@ describe('CassandraDriverInstrumentation', () => {
         assertAttributeInSingleSpan('cassandra-driver.execute', {
           [customAttributeName]: customAttributeValue,
           [responseAttributeName]: 2,
+          [SEMATTRS_NET_PEER_NAME]: cassandraContactPoint,
+          [SEMATTRS_NET_PEER_PORT]: 9042,
         });
       });
 
@@ -299,6 +337,8 @@ describe('CassandraDriverInstrumentation', () => {
 
         assertAttributeInSingleSpan('cassandra-driver.execute', {
           [hookAttributeName]: hookAttributeValue,
+          [SEMATTRS_NET_PEER_NAME]: cassandraContactPoint,
+          [SEMATTRS_NET_PEER_PORT]: 9042,
         });
       });
     });
@@ -320,7 +360,10 @@ describe('CassandraDriverInstrumentation', () => {
 
     it('creates a span for callback based batch', done => {
       client.batch([q1, q2], () => {
-        assertSingleSpan('cassandra-driver.batch');
+        assertSingleSpan('cassandra-driver.batch', undefined, undefined, {
+          [SEMATTRS_NET_PEER_NAME]: cassandraContactPoint,
+          [SEMATTRS_NET_PEER_PORT]: 9042,
+        });
         done();
       });
     });
@@ -370,7 +413,10 @@ describe('CassandraDriverInstrumentation', () => {
       const spans = memoryExporter.getFinishedSpans();
       // stream internally uses execute
       assert.strictEqual(spans.length, 2);
-      assertSpan(spans[0], 'cassandra-driver.execute');
+      assertSpan(spans[0], 'cassandra-driver.execute', undefined, undefined, {
+        [SEMATTRS_NET_PEER_NAME]: cassandraContactPoint,
+        [SEMATTRS_NET_PEER_PORT]: 9042,
+      });
       assertSpan(spans[1], 'cassandra-driver.stream');
     }
 

--- a/plugins/node/opentelemetry-instrumentation-cassandra/test/cassandra-driver.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-cassandra/test/cassandra-driver.test.ts
@@ -28,7 +28,7 @@ import {
   SpanStatusCode,
 } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
   DBSYSTEMVALUES_CASSANDRA,
   SEMATTRS_DB_STATEMENT,
@@ -51,7 +51,7 @@ const memoryExporter = new InMemorySpanExporter();
 const provider = new NodeTracerProvider({
   spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
 });
-context.setGlobalContextManager(new AsyncHooksContextManager());
+context.setGlobalContextManager(new AsyncLocalStorageContextManager());
 
 const testCassandra = process.env.RUN_CASSANDRA_TESTS;
 const testCassandraLocally = process.env.RUN_CASSANDRA_TESTS_LOCAL;

--- a/plugins/node/opentelemetry-instrumentation-connect/test/instrumentation.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-connect/test/instrumentation.test.ts
@@ -18,7 +18,7 @@ import * as assert from 'assert';
 import { context, trace } from '@opentelemetry/api';
 import { RPCType, setRPCMetadata, RPCMetadata } from '@opentelemetry/core';
 import { ATTR_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import {
   InMemorySpanExporter,
@@ -48,7 +48,7 @@ const httpRequest = {
 };
 
 const instrumentation = new ConnectInstrumentation();
-const contextManager = new AsyncHooksContextManager().enable();
+const contextManager = new AsyncLocalStorageContextManager().enable();
 const memoryExporter = new InMemorySpanExporter();
 const spanProcessor = new SimpleSpanProcessor(memoryExporter);
 const provider = new NodeTracerProvider({

--- a/plugins/node/opentelemetry-instrumentation-express/test/custom-config.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-express/test/custom-config.test.ts
@@ -16,7 +16,7 @@
 
 import { context, trace } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -44,7 +44,7 @@ describe('ExpressInstrumentation', () => {
     spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
   });
   const tracer = provider.getTracer('default');
-  const contextManager = new AsyncHooksContextManager().enable();
+  const contextManager = new AsyncLocalStorageContextManager().enable();
 
   before(() => {
     instrumentation.setTracerProvider(provider);

--- a/plugins/node/opentelemetry-instrumentation-express/test/express.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-express/test/express.test.ts
@@ -16,7 +16,7 @@
 
 import { SpanStatusCode, context, trace } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -47,7 +47,7 @@ describe('ExpressInstrumentation', () => {
     spanProcessors: [spanProcessor],
   });
   const tracer = provider.getTracer('default');
-  const contextManager = new AsyncHooksContextManager().enable();
+  const contextManager = new AsyncLocalStorageContextManager().enable();
 
   before(() => {
     instrumentation.setTracerProvider(provider);

--- a/plugins/node/opentelemetry-instrumentation-express/test/hooks.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-express/test/hooks.test.ts
@@ -16,7 +16,7 @@
 
 import { context, trace, Span } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -43,7 +43,7 @@ describe('ExpressInstrumentation hooks', () => {
     spanProcessors: [spanProcessor],
   });
   const tracer = provider.getTracer('default');
-  const contextManager = new AsyncHooksContextManager().enable();
+  const contextManager = new AsyncLocalStorageContextManager().enable();
 
   before(() => {
     instrumentation.setTracerProvider(provider);

--- a/plugins/node/opentelemetry-instrumentation-express/test/ignore-all.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-express/test/ignore-all.test.ts
@@ -16,7 +16,7 @@
 
 import { context, trace, Span } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -47,7 +47,7 @@ describe('ExpressInstrumentation', () => {
     spanProcessors: [spanProcessor],
   });
   const tracer = provider.getTracer('default');
-  const contextManager = new AsyncHooksContextManager().enable();
+  const contextManager = new AsyncLocalStorageContextManager().enable();
 
   before(() => {
     instrumentation.setTracerProvider(provider);

--- a/plugins/node/opentelemetry-instrumentation-fastify/test/instrumentation.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-fastify/test/instrumentation.test.ts
@@ -17,7 +17,7 @@
 import * as assert from 'assert';
 import { context, SpanStatusCode } from '@opentelemetry/api';
 import { ATTR_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import {
   InMemorySpanExporter,
@@ -61,7 +61,7 @@ const httpRequest = {
 
 const httpInstrumentation = new HttpInstrumentation();
 const instrumentation = new FastifyInstrumentation();
-const contextManager = new AsyncHooksContextManager().enable();
+const contextManager = new AsyncLocalStorageContextManager().enable();
 const memoryExporter = new InMemorySpanExporter();
 const spanProcessor = new SimpleSpanProcessor(memoryExporter);
 const provider = new NodeTracerProvider({

--- a/plugins/node/opentelemetry-instrumentation-generic-pool/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-generic-pool/test/index.test.ts
@@ -16,7 +16,7 @@
 
 import { context, trace } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -74,13 +74,13 @@ describe('GenericPool instrumentation', () => {
   });
   plugin.setTracerProvider(provider);
   const tracer = provider.getTracer('default');
-  let contextManager: AsyncHooksContextManager;
+  let contextManager: AsyncLocalStorageContextManager;
   let acquire: Function;
 
   beforeEach(async () => {
     plugin.enable();
     acquire = createPool();
-    contextManager = new AsyncHooksContextManager();
+    contextManager = new AsyncLocalStorageContextManager();
     context.setGlobalContextManager(contextManager.enable());
     assert.strictEqual(memoryExporter.getFinishedSpans().length, 0);
   });

--- a/plugins/node/opentelemetry-instrumentation-hapi/test/hapi-plugin.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-hapi/test/hapi-plugin.test.ts
@@ -16,7 +16,7 @@
 
 import { context, trace } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -35,7 +35,7 @@ describe('Hapi Instrumentation - Hapi.Plugin Tests', () => {
     spanProcessors: [spanProcessor],
   });
   const tracer = provider.getTracer('default');
-  let contextManager: AsyncHooksContextManager;
+  let contextManager: AsyncLocalStorageContextManager;
   let server: hapi.Server;
 
   before(() => {
@@ -44,7 +44,7 @@ describe('Hapi Instrumentation - Hapi.Plugin Tests', () => {
   });
 
   beforeEach(async () => {
-    contextManager = new AsyncHooksContextManager();
+    contextManager = new AsyncLocalStorageContextManager();
     context.setGlobalContextManager(contextManager.enable());
     server = hapi.server({
       port: 3000,

--- a/plugins/node/opentelemetry-instrumentation-hapi/test/hapi-server-ext.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-hapi/test/hapi-server-ext.test.ts
@@ -16,7 +16,7 @@
 
 import { context, SpanStatusCode, trace } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -36,7 +36,7 @@ describe('Hapi Instrumentation - Server.Ext Tests', () => {
     spanProcessors: [spanProcessor],
   });
   const tracer = provider.getTracer('default');
-  let contextManager: AsyncHooksContextManager;
+  let contextManager: AsyncLocalStorageContextManager;
   let server: hapi.Server;
 
   before(() => {
@@ -45,7 +45,7 @@ describe('Hapi Instrumentation - Server.Ext Tests', () => {
   });
 
   beforeEach(async () => {
-    contextManager = new AsyncHooksContextManager();
+    contextManager = new AsyncLocalStorageContextManager();
     context.setGlobalContextManager(contextManager.enable());
     server = hapi.server({
       port: 5000,

--- a/plugins/node/opentelemetry-instrumentation-hapi/test/hapi.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-hapi/test/hapi.test.ts
@@ -17,7 +17,7 @@
 import { context, trace, SpanStatusCode } from '@opentelemetry/api';
 import { RPCMetadata, RPCType, setRPCMetadata } from '@opentelemetry/core';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -41,7 +41,7 @@ describe('Hapi Instrumentation - Core Tests', () => {
     spanProcessors: [spanProcessor],
   });
   const tracer = provider.getTracer('default');
-  let contextManager: AsyncHooksContextManager;
+  let contextManager: AsyncLocalStorageContextManager;
   let server: hapi.Server;
 
   before(() => {
@@ -50,7 +50,7 @@ describe('Hapi Instrumentation - Core Tests', () => {
   });
 
   beforeEach(async () => {
-    contextManager = new AsyncHooksContextManager();
+    contextManager = new AsyncLocalStorageContextManager();
     context.setGlobalContextManager(contextManager.enable());
     server = hapi.server({
       port: 3000,

--- a/plugins/node/opentelemetry-instrumentation-ioredis/test/ioredis.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-ioredis/test/ioredis.test.ts
@@ -23,7 +23,7 @@ import {
   Span,
 } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import * as testUtils from '@opentelemetry/contrib-test-utils';
 import {
   InMemorySpanExporter,
@@ -94,9 +94,9 @@ describe('ioredis', () => {
   const shouldTestLocal = process.env.RUN_REDIS_TESTS_LOCAL;
   const shouldTest = process.env.RUN_REDIS_TESTS || shouldTestLocal;
 
-  let contextManager: AsyncHooksContextManager;
+  let contextManager: AsyncLocalStorageContextManager;
   beforeEach(() => {
-    contextManager = new AsyncHooksContextManager().enable();
+    contextManager = new AsyncLocalStorageContextManager().enable();
     context.setGlobalContextManager(contextManager);
   });
 

--- a/plugins/node/opentelemetry-instrumentation-knex/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-knex/test/index.test.ts
@@ -21,7 +21,7 @@ import {
   trace,
 } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -43,7 +43,7 @@ describe('Knex instrumentation', () => {
   });
   plugin.setTracerProvider(provider);
   const tracer = provider.getTracer('default');
-  let contextManager: AsyncHooksContextManager;
+  let contextManager: AsyncLocalStorageContextManager;
   let client: any;
 
   before(() => {
@@ -55,7 +55,7 @@ describe('Knex instrumentation', () => {
   });
 
   beforeEach(async () => {
-    contextManager = new AsyncHooksContextManager();
+    contextManager = new AsyncLocalStorageContextManager();
     context.setGlobalContextManager(contextManager.enable());
 
     client = knex({

--- a/plugins/node/opentelemetry-instrumentation-koa/test/koa.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/test/koa.test.ts
@@ -19,7 +19,7 @@ import type { RouterParamContext } from '@koa/router';
 import * as KoaRouter from '@koa/router';
 import { context, trace, Span } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import * as testUtils from '@opentelemetry/contrib-test-utils';
 import {
   InMemorySpanExporter,
@@ -80,7 +80,7 @@ describe('Koa Instrumentation', function () {
   });
   plugin.setTracerProvider(provider);
   const tracer = provider.getTracer('default');
-  let contextManager: AsyncHooksContextManager;
+  let contextManager: AsyncLocalStorageContextManager;
   let app: koa;
   let server: http.Server;
   let port: number;
@@ -94,7 +94,7 @@ describe('Koa Instrumentation', function () {
   });
 
   beforeEach(async () => {
-    contextManager = new AsyncHooksContextManager();
+    contextManager = new AsyncLocalStorageContextManager();
     context.setGlobalContextManager(contextManager.enable());
 
     app = new koa();

--- a/plugins/node/opentelemetry-instrumentation-memcached/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-memcached/test/index.test.ts
@@ -22,7 +22,7 @@ import {
   trace,
 } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import * as testUtils from '@opentelemetry/contrib-test-utils';
 import {
   InMemorySpanExporter,
@@ -80,10 +80,10 @@ describe('memcached@2.x', () => {
   });
   const tracer = provider.getTracer('default');
   instrumentation.setTracerProvider(provider);
-  let contextManager: AsyncHooksContextManager;
+  let contextManager: AsyncLocalStorageContextManager;
 
   beforeEach(() => {
-    contextManager = new AsyncHooksContextManager();
+    contextManager = new AsyncLocalStorageContextManager();
     context.setGlobalContextManager(contextManager.enable());
     instrumentation.setConfig({});
     instrumentation.enable();

--- a/plugins/node/opentelemetry-instrumentation-mysql/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql/test/index.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { context, Context, trace, SpanStatusCode } from '@opentelemetry/api';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
   DBSYSTEMVALUES_MYSQL,
   SEMATTRS_DB_NAME,
@@ -50,7 +50,7 @@ import * as mysqlTypes from 'mysql';
 import { AttributeNames } from '../src/AttributeNames';
 
 describe('mysql@2.x-Tracing', () => {
-  let contextManager: AsyncHooksContextManager;
+  let contextManager: AsyncLocalStorageContextManager;
   let connection: mysqlTypes.Connection;
   let pool: mysqlTypes.Pool;
   let poolCluster: mysqlTypes.PoolCluster;
@@ -89,7 +89,7 @@ describe('mysql@2.x-Tracing', () => {
 
   beforeEach(() => {
     instrumentation.disable();
-    contextManager = new AsyncHooksContextManager().enable();
+    contextManager = new AsyncLocalStorageContextManager().enable();
     context.setGlobalContextManager(contextManager);
     instrumentation.setTracerProvider(provider);
     instrumentation.enable();

--- a/plugins/node/opentelemetry-instrumentation-mysql2/test/mysql.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-mysql2/test/mysql.test.ts
@@ -16,7 +16,7 @@
 
 import * as semver from 'semver';
 import { context, trace, SpanStatusCode } from '@opentelemetry/api';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
   DBSYSTEMVALUES_MYSQL,
   SEMATTRS_DB_NAME,
@@ -89,7 +89,7 @@ describe('mysql2', () => {
   });
 
   describe('callback API', () => {
-    let contextManager: AsyncHooksContextManager;
+    let contextManager: AsyncLocalStorageContextManager;
     const memoryExporter = new InMemorySpanExporter();
     const provider = new BasicTracerProvider({
       spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
@@ -143,7 +143,7 @@ describe('mysql2', () => {
 
     beforeEach(() => {
       instrumentation.disable();
-      contextManager = new AsyncHooksContextManager().enable();
+      contextManager = new AsyncLocalStorageContextManager().enable();
       context.setGlobalContextManager(contextManager);
       instrumentation.setTracerProvider(provider);
       instrumentation.enable();
@@ -1219,7 +1219,7 @@ describe('mysql2', () => {
   describe('promise API', () => {
     let instrumentation: MySQL2Instrumentation;
 
-    let contextManager: AsyncHooksContextManager;
+    let contextManager: AsyncLocalStorageContextManager;
     const memoryExporter = new InMemorySpanExporter();
     const provider = new BasicTracerProvider({
       spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
@@ -1284,7 +1284,7 @@ describe('mysql2', () => {
 
     beforeEach(async () => {
       instrumentation.disable();
-      contextManager = new AsyncHooksContextManager().enable();
+      contextManager = new AsyncLocalStorageContextManager().enable();
       context.setGlobalContextManager(contextManager);
       instrumentation.setTracerProvider(provider);
       instrumentation.enable();

--- a/plugins/node/opentelemetry-instrumentation-nestjs-core/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-nestjs-core/test/index.test.ts
@@ -18,7 +18,7 @@ import * as semver from 'semver';
 
 import { context, SpanStatusCode } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -42,14 +42,14 @@ describe('nestjs-core', () => {
     spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
   });
   instrumentation.setTracerProvider(provider);
-  let contextManager: AsyncHooksContextManager;
+  let contextManager: AsyncLocalStorageContextManager;
   let app: App;
   let request = async (path: string): Promise<unknown> => {
     throw new Error('Not yet initialized.');
   };
 
   beforeEach(async () => {
-    contextManager = new AsyncHooksContextManager();
+    contextManager = new AsyncLocalStorageContextManager();
     context.setGlobalContextManager(contextManager.enable());
     instrumentation.setConfig({});
     instrumentation.enable();

--- a/plugins/node/opentelemetry-instrumentation-net/test/tls.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-net/test/tls.test.ts
@@ -20,7 +20,7 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import * as assert from 'assert';
 import * as tls from 'tls';
 import { NetInstrumentation } from '../src';
@@ -50,7 +50,7 @@ function getTLSSpans() {
 
 describe('NetInstrumentation', () => {
   let instrumentation: NetInstrumentation;
-  let contextManager: AsyncHooksContextManager;
+  let contextManager: AsyncLocalStorageContextManager;
 
   let tlsServer: tls.Server;
   let tlsSocket: tls.TLSSocket;
@@ -58,7 +58,7 @@ describe('NetInstrumentation', () => {
   before(() => {
     instrumentation = new NetInstrumentation();
     instrumentation.setTracerProvider(provider);
-    contextManager = new AsyncHooksContextManager().enable();
+    contextManager = new AsyncLocalStorageContextManager().enable();
     context.setGlobalContextManager(contextManager.enable());
     require('net');
   });

--- a/plugins/node/opentelemetry-instrumentation-oracledb/test/oracle.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-oracledb/test/oracle.test.ts
@@ -24,7 +24,7 @@ import {
   SpanStatus,
   trace,
 } from '@opentelemetry/api';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import * as testUtils from '@opentelemetry/contrib-test-utils';
 import {
   BasicTracerProvider,
@@ -56,7 +56,7 @@ import {
 } from '../src/semconv';
 
 const memoryExporter = new InMemorySpanExporter();
-let contextManager: AsyncHooksContextManager;
+let contextManager: AsyncLocalStorageContextManager;
 const provider = new BasicTracerProvider({
   spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
 });
@@ -508,7 +508,7 @@ describe('oracledb', () => {
     }
     await doSetup();
     updateAttrSpanList(connection);
-    contextManager = new AsyncHooksContextManager().enable();
+    contextManager = new AsyncLocalStorageContextManager().enable();
     context.setGlobalContextManager(contextManager);
     instrumentation.setTracerProvider(provider);
     instrumentation.enable();
@@ -527,7 +527,7 @@ describe('oracledb', () => {
   });
 
   beforeEach(() => {
-    contextManager = new AsyncHooksContextManager().enable();
+    contextManager = new AsyncLocalStorageContextManager().enable();
     context.setGlobalContextManager(contextManager);
   });
 

--- a/plugins/node/opentelemetry-instrumentation-pg/test/pg-pool.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/test/pg-pool.test.ts
@@ -29,7 +29,7 @@ import {
   PgInstrumentationConfig,
   PgResponseHookInformation,
 } from '../src';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import * as testUtils from '@opentelemetry/contrib-test-utils';
 import {
   InMemorySpanExporter,
@@ -121,7 +121,7 @@ describe('pg-pool', () => {
   }
 
   let pool: pgPool<pg.Client>;
-  let contextManager: AsyncHooksContextManager;
+  let contextManager: AsyncLocalStorageContextManager;
   let instrumentation: PgInstrumentation;
   const provider = new BasicTracerProvider({
     spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
@@ -149,7 +149,7 @@ describe('pg-pool', () => {
 
     instrumentation = new PgInstrumentation();
 
-    contextManager = new AsyncHooksContextManager().enable();
+    contextManager = new AsyncLocalStorageContextManager().enable();
     context.setGlobalContextManager(contextManager);
     instrumentation.setTracerProvider(provider);
 
@@ -168,7 +168,7 @@ describe('pg-pool', () => {
   });
 
   beforeEach(() => {
-    contextManager = new AsyncHooksContextManager().enable();
+    contextManager = new AsyncLocalStorageContextManager().enable();
     context.setGlobalContextManager(contextManager);
   });
 

--- a/plugins/node/opentelemetry-instrumentation-pg/test/pg.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/test/pg.test.ts
@@ -23,7 +23,7 @@ import {
   SpanStatus,
   trace,
 } from '@opentelemetry/api';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import * as testUtils from '@opentelemetry/contrib-test-utils';
 import {
   BasicTracerProvider,
@@ -117,7 +117,7 @@ describe('pg', () => {
   let postgres: typeof pg;
   let client: pg.Client;
   let instrumentation: PgInstrumentation;
-  let contextManager: AsyncHooksContextManager;
+  let contextManager: AsyncLocalStorageContextManager;
   const provider = new BasicTracerProvider({
     spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
   });
@@ -151,7 +151,7 @@ describe('pg', () => {
 
     instrumentation = new PgInstrumentation();
 
-    contextManager = new AsyncHooksContextManager().enable();
+    contextManager = new AsyncLocalStorageContextManager().enable();
     context.setGlobalContextManager(contextManager);
     instrumentation.setTracerProvider(provider);
 
@@ -170,7 +170,7 @@ describe('pg', () => {
   });
 
   beforeEach(() => {
-    contextManager = new AsyncHooksContextManager().enable();
+    contextManager = new AsyncLocalStorageContextManager().enable();
     context.setGlobalContextManager(contextManager);
 
     // Add a spy on the underlying client's internal query queue so that

--- a/plugins/node/opentelemetry-instrumentation-pg/test/utils.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-pg/test/utils.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { context, trace } from '@opentelemetry/api';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import {
   BasicTracerProvider,
@@ -48,7 +48,7 @@ const getLatestSpan = () => {
 
 describe('utils.ts', () => {
   const client = new pg.Client(CONFIG) as PgClientExtended;
-  let contextManager: AsyncHooksContextManager;
+  let contextManager: AsyncLocalStorageContextManager;
   const provider = new BasicTracerProvider({
     spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
   });
@@ -58,7 +58,7 @@ describe('utils.ts', () => {
     {};
 
   beforeEach(() => {
-    contextManager = new AsyncHooksContextManager().enable();
+    contextManager = new AsyncLocalStorageContextManager().enable();
     context.setGlobalContextManager(contextManager);
   });
 

--- a/plugins/node/opentelemetry-instrumentation-redis/test/redis.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-redis/test/redis.test.ts
@@ -23,7 +23,7 @@ import {
   Span,
 } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import * as testUtils from '@opentelemetry/contrib-test-utils';
 import {
   InMemorySpanExporter,
@@ -76,9 +76,9 @@ describe('redis@2.x', () => {
   const shouldTestLocal = process.env.RUN_REDIS_TESTS_LOCAL;
   const shouldTest = process.env.RUN_REDIS_TESTS || shouldTestLocal;
 
-  let contextManager: AsyncHooksContextManager;
+  let contextManager: AsyncLocalStorageContextManager;
   beforeEach(() => {
-    contextManager = new AsyncHooksContextManager().enable();
+    contextManager = new AsyncLocalStorageContextManager().enable();
     context.setGlobalContextManager(contextManager);
   });
 

--- a/plugins/node/opentelemetry-instrumentation-restify/test/restify.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/test/restify.test.ts
@@ -17,7 +17,7 @@
 import { context, trace, Span } from '@opentelemetry/api';
 import { RPCMetadata, RPCType, setRPCMetadata } from '@opentelemetry/core';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -124,7 +124,7 @@ describe('Restify Instrumentation', () => {
   });
   plugin.setTracerProvider(provider);
   const tracer = provider.getTracer('default');
-  let contextManager: AsyncHooksContextManager;
+  let contextManager: AsyncLocalStorageContextManager;
   let server: restify.Server;
   let port: number;
 
@@ -137,7 +137,7 @@ describe('Restify Instrumentation', () => {
   });
 
   beforeEach(async () => {
-    contextManager = new AsyncHooksContextManager();
+    contextManager = new AsyncLocalStorageContextManager();
     context.setGlobalContextManager(contextManager.enable());
 
     server = await createServer();

--- a/plugins/node/opentelemetry-instrumentation-router/test/index.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-router/test/index.test.ts
@@ -16,7 +16,7 @@
 
 import { context, trace } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -159,7 +159,7 @@ describe('Router instrumentation', () => {
   });
   plugin.setTracerProvider(provider);
   const tracer = provider.getTracer('default');
-  let contextManager: AsyncHooksContextManager;
+  let contextManager: AsyncLocalStorageContextManager;
   let server: http.Server;
 
   const request = (path: string, serverOverwrite?: http.Server) => {
@@ -185,7 +185,7 @@ describe('Router instrumentation', () => {
     // To force `require-in-the-middle` to definitely reload and patch the layer
     require('router/lib/layer.js');
     server = await createServer();
-    contextManager = new AsyncHooksContextManager();
+    contextManager = new AsyncLocalStorageContextManager();
     context.setGlobalContextManager(contextManager.enable());
     assert.strictEqual(memoryExporter.getFinishedSpans().length, 0);
   });

--- a/plugins/node/opentelemetry-instrumentation-winston/test/winston.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-winston/test/winston.test.ts
@@ -27,7 +27,7 @@ import {
 import { context, trace, Span, INVALID_SPAN_CONTEXT } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { isWrapped } from '@opentelemetry/instrumentation';
-import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { Writable } from 'stream';
@@ -39,7 +39,7 @@ const provider = new NodeTracerProvider({
   spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
 });
 const tracer = provider.getTracer('default');
-context.setGlobalContextManager(new AsyncHooksContextManager());
+context.setGlobalContextManager(new AsyncLocalStorageContextManager());
 
 const loggerProvider = new LoggerProvider();
 const memoryLogExporter = new InMemoryLogRecordExporter();


### PR DESCRIPTION
Since support for Node.js <14.8.0 was dropped, the modern
AsyncLocalStorageContextManager can always be used. This was done
for runtime code in https://github.com/open-telemetry/opentelemetry-js/pull/4341
This PR does this for tests that were explicitly setting a
context manager.
