### PR TITLE
fix: export KoaLayerType enum correctly

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-koa/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/src/index.ts
@@ -16,9 +16,9 @@
 
 export { KoaInstrumentation } from './instrumentation';
 export { AttributeNames } from './enums/AttributeNames';
+export { KoaLayerType } from './types';
 export type {
-  KoaInstrumentationConfig,
-  KoaLayerType,
+  KoaInstrumentationConfig,  
   KoaRequestCustomAttributeFunction,
   KoaRequestInfo,
 } from './types';

--- a/plugins/node/opentelemetry-instrumentation-koa/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-koa/src/index.ts
@@ -18,7 +18,7 @@ export { KoaInstrumentation } from './instrumentation';
 export { AttributeNames } from './enums/AttributeNames';
 export { KoaLayerType } from './types';
 export type {
-  KoaInstrumentationConfig,  
+  KoaInstrumentationConfig,
   KoaRequestCustomAttributeFunction,
   KoaRequestInfo,
 } from './types';


### PR DESCRIPTION
## Short description of the changes

KoaLayerType is an enum. It was erroneously exported as a type causing errors on in Koa setups. This breaks the configuration setup for ignoring certain Koa Layers when publishing spans. 

This was working in @opentelemetry/instrumentation-koa v0.46.0, now broken in v0.50.0.

Typescript linter error: 

![image](https://github.com/user-attachments/assets/c50418ef-2290-4e07-a1b9-bd73683e270d)


