### PR TITLE
fix: incorrect export of enums

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-mongodb/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-mongodb/src/index.ts
@@ -15,11 +15,11 @@
  */
 
 export { MongoDBInstrumentation } from './instrumentation';
+export { MongodbCommandType } from './types';
 export type {
   CommandResult,
   DbStatementSerializer,
   MongoDBInstrumentationConfig,
   MongoDBInstrumentationExecutionResponseHook,
   MongoResponseHookInformation,
-  MongodbCommandType,
 } from './types';

--- a/plugins/node/opentelemetry-instrumentation-net/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-net/src/index.ts
@@ -15,4 +15,4 @@
  */
 
 export { NetInstrumentation } from './instrumentation';
-export type { TLSAttributes } from './types';
+export { TLSAttributes } from './types';

--- a/plugins/node/opentelemetry-instrumentation-restify/src/index.ts
+++ b/plugins/node/opentelemetry-instrumentation-restify/src/index.ts
@@ -16,8 +16,8 @@
 
 export { RestifyInstrumentation } from './instrumentation';
 export { AttributeNames } from './enums/AttributeNames';
+export { LayerType } from './types';
 export type {
-  LayerType,
   RestifyCustomAttributeFunction,
   RestifyInstrumentationConfig,
   RestifyRequestInfo,


### PR DESCRIPTION
## Which problem is this PR solving?
- Some enums are incorrectly exported as a type as a result of commit https://github.com/open-telemetry/opentelemetry-js-contrib/commit/60612f26582f470663512c0cb2aabae9d00d2651 (PR: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2839)

## Short description of the changes
- Follow up from https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2873
- Fixed the exports
