### PR TITLE
fix: http.response_content_length does not get populated when ignoreNetworkEvents is set to true

### DIFF
--- a/plugins/web/opentelemetry-instrumentation-document-load/src/instrumentation.ts
+++ b/plugins/web/opentelemetry-instrumentation-document-load/src/instrumentation.ts
@@ -117,9 +117,7 @@ export class DocumentLoadInstrumentation extends InstrumentationBase<DocumentLoa
         if (fetchSpan) {
           fetchSpan.setAttribute(SEMATTRS_HTTP_URL, location.href);
           context.with(trace.setSpan(context.active(), fetchSpan), () => {
-            if (!this.getConfig().ignoreNetworkEvents) {
-              addSpanNetworkEvents(fetchSpan, entries);
-            }
+            addSpanNetworkEvents(fetchSpan, entries, this.getConfig().ignoreNetworkEvents);
             this._addCustomAttributesOnSpan(
               fetchSpan,
               this.getConfig().applyCustomAttributesOnSpan?.documentFetch
@@ -205,9 +203,7 @@ export class DocumentLoadInstrumentation extends InstrumentationBase<DocumentLoa
     );
     if (span) {
       span.setAttribute(SEMATTRS_HTTP_URL, resource.name);
-      if (!this.getConfig().ignoreNetworkEvents) {
-        addSpanNetworkEvents(span, resource);
-      }
+      addSpanNetworkEvents(span, resource, this.getConfig().ignoreNetworkEvents);
       this._addCustomAttributesOnResourceSpan(
         span,
         resource,


### PR DESCRIPTION
fix: http.response_content_length does not get populated when ignoreNetworkEvents is set to true

This PR fixes the issue #2879 where when the instrumentation is configured with `ignoreNetworkEvents` set as true, the two attributes: http.response_content_length and http.response_content_length_compressed are also getting omitted, due to a logic flaw that did not call the `addSpanNetworkEvents` when the ignoreNetworkEvents were set to true.

Regardless of whether ignoreNetworkEvents are set to true or false, the response content length should be returned to the resource fetch span, as it is not a part of network span events.

Fixes: #2879
