### PR TITLE
chore(examples): lint examples/hapi using shared top-level eslint config

### DIFF
--- a/examples/hapi/.eslintrc.js
+++ b/examples/hapi/.eslintrc.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const baseConfig = require('../../eslint.config');
+
+module.exports = {
+  ...baseConfig,
+  env: {
+    node: true,
+  },
+};

--- a/examples/hapi/.npmrc
+++ b/examples/hapi/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/examples/hapi/client.js
+++ b/examples/hapi/client.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 'use strict';
 
 // eslint-disable-next-line import/order
@@ -20,8 +36,12 @@ function makeRequest() {
       span.setStatus({ code: api.SpanStatusCode.ERROR, message: e.message });
     }
     span.end();
-    console.log('Sleeping 5 seconds before shutdown to ensure all records are flushed.');
-    setTimeout(() => { console.log('Completed.'); }, 5000);
+    console.log(
+      'Sleeping 5 seconds before shutdown to ensure all records are flushed.'
+    );
+    setTimeout(() => {
+      console.log('Completed.');
+    }, 5000);
   });
 }
 

--- a/examples/hapi/package.json
+++ b/examples/hapi/package.json
@@ -9,8 +9,8 @@
     "zipkin:client": "cross-env EXPORTER=zipkin node ./client.js",
     "jaeger:server": "cross-env EXPORTER=jaeger node ./server.js",
     "jaeger:client": "cross-env EXPORTER=jaeger node ./client.js",
-    "lint": "eslint . --ext .js",
-    "lint:fix": "eslint . --ext .js --fix"
+    "lint": "eslint . --ext=ts,js,mjs",
+    "lint:fix": "eslint . --ext=ts,js,mjs --fix"
   },
   "repository": {
     "type": "git",
@@ -44,7 +44,6 @@
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib#readme",
   "devDependencies": {
-    "cross-env": "^6.0.0",
-    "eslint": "^7.4.0"
+    "cross-env": "^6.0.0"
   }
 }

--- a/examples/hapi/server.js
+++ b/examples/hapi/server.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 'use strict';
 
 const api = require('@opentelemetry/api');
@@ -28,27 +44,26 @@ const BlogPostPlugin = {
         method: 'GET',
         path: '/post/{id}',
         handler: showNewPost,
-      }]);
+      },
+    ]);
   },
 };
 
 async function setUp() {
-  await server.register(
-    { plugin: BlogPostPlugin },
-  );
+  await server.register({ plugin: BlogPostPlugin });
 
-  server.route(
-    {
-      method: 'GET',
-      path: '/run_test',
-      handler: runTest,
-    },
-  );
+  server.route({
+    method: 'GET',
+    path: '/run_test',
+    handler: runTest,
+  });
 
   server.ext('onRequest', async (request, h) => {
     console.log('No-op Hapi lifecycle extension method');
     const syntheticDelay = 50;
-    await new Promise((r) => setTimeout(r, syntheticDelay));
+    await new Promise(r => {
+      setTimeout(r, syntheticDelay);
+    });
     return h.continue;
   });
 
@@ -59,7 +74,7 @@ async function setUp() {
 
 /**
  *  Blog Post functions: list, add, or show posts
-*/
+ */
 const posts = ['post 0', 'post 1', 'post 2'];
 
 function addPost(_, h) {
@@ -77,7 +92,9 @@ async function showNewPost(request) {
   const post = posts[id];
   if (!post) throw new Error('Invalid post id');
   const syntheticDelay = 200;
-  await new Promise((r) => setTimeout(r, syntheticDelay));
+  await new Promise(r => {
+    setTimeout(r, syntheticDelay);
+  });
   return post;
 }
 
@@ -91,7 +108,7 @@ function runTest(_, h) {
 }
 
 setUp();
-process.on('unhandledRejection', (err) => {
+process.on('unhandledRejection', err => {
   console.log(err);
   process.exit(1);
 });

--- a/examples/hapi/tracer.js
+++ b/examples/hapi/tracer.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 'use strict';
 
 const api = require('@opentelemetry/api');
@@ -11,7 +27,7 @@ const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 
 const EXPORTER = process.env.EXPORTER || '';
 
-module.exports = (serviceName) => {
+module.exports = serviceName => {
   let exporter;
   if (EXPORTER === 'jaeger') {
     exporter = new JaegerExporter({ serviceName });
@@ -20,9 +36,7 @@ module.exports = (serviceName) => {
   }
 
   const provider = new NodeTracerProvider({
-    spanProcessors: [
-      new SimpleSpanProcessor(exporter),
-    ],
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
   });
 
   // Initialize the OpenTelemetry APIs to use the NodeTracerProvider bindings


### PR DESCRIPTION
Refs: https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2891
