### PR TITLE
test(redis-4): fix tests with redis@4.4.0 and earlier

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-redis-4/test/redis.test.ts
+++ b/plugins/node/opentelemetry-instrumentation-redis-4/test/redis.test.ts
@@ -314,7 +314,12 @@ describe('redis@^4.0.0', () => {
         // Ignore. If the test Redis is not at the default port we expect this
         // to error.
       }
-      await newClient.disconnect();
+      try {
+        await newClient.disconnect();
+      } catch (_disconnectErr) {
+        // Ignore. In redis@4.4.0 and earlier this disconnect throws
+        // "The client is closed" if the connect failed.
+      }
 
       const [span] = getTestSpans();
       assert.strictEqual(span.name, 'redis-connect');


### PR DESCRIPTION
In redis@4.4.0 and earlier versions of redis v4, client.disconnect()
will throw if the connect failed. That broke the "with empty string for
client URL, ..." test case, at least on macOS:

    npm run test:docker:run
    RUN_REDIS_TESTS=1 npm t

I cannot explain why this is not failing in CI. Perhaps something
platform specific? This is related to socket handling in the redis
client. I believe the relevant change in node-redis was:
https://github.com/redis/node-redis/pull/2295
which was part of `@redis/client@1.3.1` which was included in
`redis@4.4.0`.
