### PR TITLE
fix(instrumentation-runtime-node): fix .isEnabled()

### DIFF
--- a/packages/instrumentation-runtime-node/src/instrumentation.ts
+++ b/packages/instrumentation-runtime-node/src/instrumentation.ts
@@ -73,6 +73,7 @@ export class RuntimeNodeInstrumentation extends InstrumentationBase<RuntimeNodeI
   }
 
   override enable() {
+    super.enable();
     if (!this._collectors) return;
 
     for (const collector of this._collectors) {
@@ -81,6 +82,7 @@ export class RuntimeNodeInstrumentation extends InstrumentationBase<RuntimeNodeI
   }
 
   override disable() {
+    super.disable();
     for (const collector of this._collectors) {
       collector.disable();
     }

--- a/packages/instrumentation-runtime-node/test/instrumentation.test.ts
+++ b/packages/instrumentation-runtime-node/test/instrumentation.test.ts
@@ -67,7 +67,9 @@ describe('instrumentation', function () {
     const scopeMetrics = firstCollections.resourceMetrics.scopeMetrics;
     assert.strictEqual(scopeMetrics.length, 0);
 
+    assert.equal(instrumentation.isEnabled(), false);
     instrumentation.enable();
+    assert.equal(instrumentation.isEnabled(), true);
     await new Promise(resolve => setTimeout(resolve, MEASUREMENT_INTERVAL * 5));
 
     const secondCollection = await metricReader.collect();


### PR DESCRIPTION
This instrumentation overrides the enable() and disable() methods. However,
it was not calling super for those, so the private '_enabled' state on
the super class was not getting updated, which broke 'instr.isEnable()'.
It would always return false.


# example showing isEnabled() not working

```js
> var mod = require('@opentelemetry/instrumentation-runtime-node')
undefined
> var instr = new mod.RuntimeNodeInstrumentation()
undefined
> instr.isEnabled()
false
> instr.enable()
undefined
> instr.isEnabled()
false
```

That last `.isEnabled()` result should be `true`.