### PR TITLE
fix(winston-transport, instrumentation-winston): get the correct severityText and severityNumber with winston.format.colorize() is used

### DIFF
--- a/packages/instrumentation-winston/package.json
+++ b/packages/instrumentation-winston/package.json
@@ -10,10 +10,7 @@
     "directory": "packages/instrumentation-winston"
   },
   "scripts": {
-    "test": "npm run test-v1-v2 && npm run test-v3 && nyc merge .nyc_output ./coverage/coverage-final.json",
-    "test-v1-v2": "tav winston 2.4.7 npm run test-run",
-    "test-v3": "npm run test-run",
-    "test-run": "nyc --no-clean mocha 'test/**/*.test.ts'",
+    "test": "nyc mocha 'test/**/*.test.ts'",
     "test-all-versions": "tav",
     "tdd": "npm run test-run -- --watch-extensions ts --watch",
     "clean": "rimraf build/*",

--- a/packages/instrumentation-winston/test/winston.test.ts
+++ b/packages/instrumentation-winston/test/winston.test.ts
@@ -281,13 +281,6 @@ describe('WinstonInstrumentation', () => {
       }
     });
 
-        // XXX
-        // format: winston.format.combine(
-        //   winston.format.timestamp(),
-        //   winston.format.colorize(),
-        //   winston.format.simple()
-        // ),
-
     it('do not emit log record if @opentelemetry/winston-transport load fails', () => {
       const module = require('module');
       const originalRequire = module.prototype.require;

--- a/packages/instrumentation-winston/test/winston.test.ts
+++ b/packages/instrumentation-winston/test/winston.test.ts
@@ -61,7 +61,11 @@ describe('WinstonInstrumentation', () => {
     cli,
   }
 
-  function initLogger(levelsType?: LevelsType) {
+  /**
+   * Set `logger` to a new Winston logger instance with the given
+   * configuration, and setup with `writeSpy` to spy on emitted logs.
+   */
+  function initLogger(levelsType?: LevelsType, formatType?: string) {
     const winston = require('winston');
 
     let levels = winston.config.npm.levels;
@@ -69,6 +73,19 @@ describe('WinstonInstrumentation', () => {
       levels = winston.config.syslog.levels;
     } else if (levelsType === LevelsType.cli) {
       levels = winston.config.cli.levels;
+    }
+
+    let format;
+    switch (formatType) {
+      case 'colorize':
+        format = winston.format.colorize();
+        break;
+      case 'none':
+      case undefined:
+        format = undefined;
+        break;
+      default:
+        throw new Error(`unknown formatType: "${formatType}"`);
     }
 
     const stream = new Writable();
@@ -80,6 +97,7 @@ describe('WinstonInstrumentation', () => {
       logger = winston.createLogger({
         level: 'debug',
         levels: levels,
+        format,
         transports: [
           new winston.transports.Stream({
             stream,
@@ -91,6 +109,7 @@ describe('WinstonInstrumentation', () => {
       isWinston2 = true;
       logger = new winston.Logger({
         levels: levels,
+        format,
         transports: [
           new winston.transports.File({
             stream,
@@ -235,6 +254,39 @@ describe('WinstonInstrumentation', () => {
         );
       }
     });
+
+    it('emit LogRecord with correct severity* when colorize() formatter is used', () => {
+      if (!isWinston2) {
+        instrumentation.setConfig({
+          disableLogSending: false,
+        });
+        initLogger(LevelsType.npm, 'colorize');
+
+        logger.log('debug', kMessage);
+        logger.log('info', kMessage);
+        logger.log('warn', kMessage);
+        const logRecords = memoryLogExporter.getFinishedLogRecords();
+        assert.strictEqual(logRecords.length, 3);
+        assert.strictEqual(logRecords[0].severityText, 'debug');
+        assert.strictEqual(logRecords[0].severityNumber, 5);
+        assert.strictEqual(logRecords[0].body, kMessage);
+        assert.strictEqual(logRecords[1].severityText, 'info');
+        assert.strictEqual(logRecords[1].severityNumber, 9);
+        assert.strictEqual(logRecords[1].body, kMessage);
+        assert.strictEqual(logRecords[2].severityText, 'warn');
+        assert.strictEqual(logRecords[2].severityNumber, 13);
+        assert.strictEqual(logRecords[2].body, kMessage);
+
+        initLogger();
+      }
+    });
+
+        // XXX
+        // format: winston.format.combine(
+        //   winston.format.timestamp(),
+        //   winston.format.colorize(),
+        //   winston.format.simple()
+        // ),
 
     it('do not emit log record if @opentelemetry/winston-transport load fails', () => {
       const module = require('module');

--- a/packages/winston-transport/src/utils.ts
+++ b/packages/winston-transport/src/utils.ts
@@ -60,19 +60,20 @@ function getSeverityNumber(level: string): SeverityNumber | undefined {
 }
 
 export function emitLogRecord(
-  record: Record<string, any>,
+  record: Record<string | symbol, any>,
   logger: Logger
 ): void {
   const { message, level, ...splat } = record;
   const attributes: LogAttributes = {};
+  const levelSym = record[Symbol.for('level')];
   for (const key in splat) {
     if (Object.prototype.hasOwnProperty.call(splat, key)) {
       attributes[key] = splat[key];
     }
   }
   const logRecord: LogRecord = {
-    severityNumber: getSeverityNumber(level),
-    severityText: level,
+    severityNumber: getSeverityNumber(levelSym),
+    severityText: levelSym,
     body: message,
     attributes: attributes,
   };

--- a/packages/winston-transport/src/utils.ts
+++ b/packages/winston-transport/src/utils.ts
@@ -65,6 +65,8 @@ export function emitLogRecord(
 ): void {
   const { message, level, ...splat } = record;
   const attributes: LogAttributes = {};
+  // Ensures the log level is read from a symbol property, avoiding any accidental inclusion 
+  // of ANSI color codes that may be present in the string property
   const levelSym = record[Symbol.for('level')];
   for (const key in splat) {
     if (Object.prototype.hasOwnProperty.call(splat, key)) {

--- a/packages/winston-transport/src/utils.ts
+++ b/packages/winston-transport/src/utils.ts
@@ -65,8 +65,9 @@ export function emitLogRecord(
 ): void {
   const { message, level, ...splat } = record;
   const attributes: LogAttributes = {};
-  // Ensures the log level is read from a symbol property, avoiding any accidental inclusion 
-  // of ANSI color codes that may be present in the string property
+  // Ensures the log level is read from a symbol property, avoiding any
+  // accidental inclusion of ANSI color codes that may be present in the string
+  // property.
   const levelSym = record[Symbol.for('level')];
   for (const key in splat) {
     if (Object.prototype.hasOwnProperty.call(splat, key)) {

--- a/packages/winston-transport/test/openTelemetryTransport.test.ts
+++ b/packages/winston-transport/test/openTelemetryTransport.test.ts
@@ -74,13 +74,18 @@ describe('OpenTelemetryTransportV3', () => {
     it('npm levels', () => {
       const callback = () => {};
       const transport = new OpenTelemetryTransportV3();
-      transport.log({ message: kMessage, level: 'error' }, callback);
-      transport.log({ message: kMessage, level: 'warn' }, callback);
-      transport.log({ message: kMessage, level: 'info' }, callback);
-      transport.log({ message: kMessage, level: 'http' }, callback);
-      transport.log({ message: kMessage, level: 'verbose' }, callback);
-      transport.log({ message: kMessage, level: 'debug' }, callback);
-      transport.log({ message: kMessage, level: 'silly' }, callback);
+      const sym = Symbol.for('level');
+      for (const level of [
+        'error',
+        'warn',
+        'info',
+        'http',
+        'verbose',
+        'debug',
+        'silly',
+      ]) {
+        transport.log({ message: kMessage, level, [sym]: level }, callback);
+      }
       const logRecords = memoryLogExporter.getFinishedLogRecords();
       assert.strictEqual(logRecords.length, 7);
       assert.strictEqual(logRecords[0].severityNumber, SeverityNumber.ERROR);
@@ -95,16 +100,21 @@ describe('OpenTelemetryTransportV3', () => {
     it('cli levels', () => {
       const callback = () => {};
       const transport = new OpenTelemetryTransportV3();
-      transport.log({ message: kMessage, level: 'error' }, callback);
-      transport.log({ message: kMessage, level: 'warn' }, callback);
-      transport.log({ message: kMessage, level: 'help' }, callback);
-      transport.log({ message: kMessage, level: 'data' }, callback);
-      transport.log({ message: kMessage, level: 'info' }, callback);
-      transport.log({ message: kMessage, level: 'debug' }, callback);
-      transport.log({ message: kMessage, level: 'verbose' }, callback);
-      transport.log({ message: kMessage, level: 'prompt' }, callback);
-      transport.log({ message: kMessage, level: 'input' }, callback);
-      transport.log({ message: kMessage, level: 'silly' }, callback);
+      const sym = Symbol.for('level');
+      for (const level of [
+        'error',
+        'warn',
+        'help',
+        'data',
+        'info',
+        'debug',
+        'verbose',
+        'prompt',
+        'input',
+        'silly',
+      ]) {
+        transport.log({ message: kMessage, level, [sym]: level }, callback);
+      }
       const logRecords = memoryLogExporter.getFinishedLogRecords();
       assert.strictEqual(logRecords.length, 10);
       assert.strictEqual(logRecords[0].severityNumber, SeverityNumber.ERROR);
@@ -122,14 +132,19 @@ describe('OpenTelemetryTransportV3', () => {
     it('syslog levels', () => {
       const callback = () => {};
       const transport = new OpenTelemetryTransportV3();
-      transport.log({ message: kMessage, level: 'emerg' }, callback);
-      transport.log({ message: kMessage, level: 'alert' }, callback);
-      transport.log({ message: kMessage, level: 'crit' }, callback);
-      transport.log({ message: kMessage, level: 'error' }, callback);
-      transport.log({ message: kMessage, level: 'warning' }, callback);
-      transport.log({ message: kMessage, level: 'notice' }, callback);
-      transport.log({ message: kMessage, level: 'info' }, callback);
-      transport.log({ message: kMessage, level: 'debug' }, callback);
+      const sym = Symbol.for('level');
+      for (const level of [
+        'emerg',
+        'alert',
+        'crit',
+        'error',
+        'warning',
+        'notice',
+        'info',
+        'debug',
+      ]) {
+        transport.log({ message: kMessage, level, [sym]: level }, callback);
+      }
       const logRecords = memoryLogExporter.getFinishedLogRecords();
       assert.strictEqual(logRecords.length, 8);
       assert.strictEqual(logRecords[0].severityNumber, SeverityNumber.FATAL3);


### PR DESCRIPTION
Before this change the "log sending" feature of instr-winston would
incorrectly include ANSI color codes in the `severityText` for emitted
OTel LogRecords when the winston logger being instrumented was
configured with the `colorize()` formatter, e.g.:

    const logger = winston.createLogger({
      format: winston.format.combine(
        winston.format.timestamp(),
        winston.format.colorize(),
        winston.format.simple()
      ),
      ...

This is because the winston-transport.OpenTelemetryTransportV3 was using
the Winston log info's "level" attribute... which was tweaked by
`colorize()`. Winston log `info` objects have a `Symbol.for("info")`
property which has the unchanged level name:
  https://github.com/winstonjs/winston#streams-objectmode-and-info-objects

This commit *also* changes (fix) what `npm test` runs in the
instrumentation-winston package. Before this, `npm test` was attempting
to test against winston@2 and winston@3 -- presumably for better
coverage. However, it ended up only ever testing with winston@2
(`test-v1-v2` would install winston@2 and test, then `test-v3` would
run the same test again with whatever current version is installed,
which is now winston@2).

The (IMO) correct answer here is:
- `npm test` tests against the latest ver of the target module (winston@3)
- `npm run test-all-versions` handles testing against other versions
- coverage can take a back seat. (Aside: changes coming as part of
  https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2866
  will, IIUC, provide coverage from test-all-versions runs.)

Closes: https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2952
