### PR TITLE
chore(instrumentation-amqp): bump @types/amqplib and remove unnecessary casts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9754,12 +9754,12 @@
       }
     },
     "node_modules/@types/amqplib": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.5.17.tgz",
-      "integrity": "sha512-RImqiLP1swDqWBW8UX9iBXVEOw6MYzNmxdXqfemDfdwtUvdTM/W0s2RlSuMVIGkRhaWvpkC9O/N81VzzQwfAbw==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.10.7.tgz",
+      "integrity": "sha512-IVj3avf9AQd2nXCx0PGk/OYq7VmHiyNxWFSb5HhU9ATh+i+gHWvVcljFTcTWQ/dyHJCTrzCixde+r/asL2ErDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/bluebird": "*",
         "@types/node": "*"
       }
     },
@@ -9772,12 +9772,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/babel__code-frame/-/babel__code-frame-7.0.6.tgz",
       "integrity": "sha512-Anitqkl3+KrzcW2k77lRlg/GfLZLWXBuNgbEcIOU6M92yw42vsd3xV/Z/yAHEj8m+KUjL6bWOVOFqX8PFPJ4LA==",
-      "dev": true
-    },
-    "node_modules/@types/bluebird": {
-      "version": "3.5.42",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.42.tgz",
-      "integrity": "sha512-Jhy+MWRlro6UjVi578V/4ZGNfeCOcNCp0YaFNIUGFKlImowqwb1O/22wDVk3FDGMLqxdpOV3qQHD5fPEH4hK6A==",
       "dev": true
     },
     "node_modules/@types/body-parser": {
@@ -31948,7 +31942,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.49.0",
-        "@types/amqplib": "^0.5.17",
+        "@types/amqplib": "^0.10.7",
         "@types/lodash": "4.14.199",
         "@types/mocha": "10.0.10",
         "@types/node": "18.18.14",
@@ -42210,7 +42204,7 @@
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/instrumentation": "^0.203.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
-        "@types/amqplib": "^0.5.17",
+        "@types/amqplib": "^0.10.7",
         "@types/lodash": "4.14.199",
         "@types/mocha": "10.0.10",
         "@types/node": "18.18.14",
@@ -46736,12 +46730,11 @@
       }
     },
     "@types/amqplib": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.5.17.tgz",
-      "integrity": "sha512-RImqiLP1swDqWBW8UX9iBXVEOw6MYzNmxdXqfemDfdwtUvdTM/W0s2RlSuMVIGkRhaWvpkC9O/N81VzzQwfAbw==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.10.7.tgz",
+      "integrity": "sha512-IVj3avf9AQd2nXCx0PGk/OYq7VmHiyNxWFSb5HhU9ATh+i+gHWvVcljFTcTWQ/dyHJCTrzCixde+r/asL2ErDA==",
       "dev": true,
       "requires": {
-        "@types/bluebird": "*",
         "@types/node": "*"
       }
     },
@@ -46754,12 +46747,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/babel__code-frame/-/babel__code-frame-7.0.6.tgz",
       "integrity": "sha512-Anitqkl3+KrzcW2k77lRlg/GfLZLWXBuNgbEcIOU6M92yw42vsd3xV/Z/yAHEj8m+KUjL6bWOVOFqX8PFPJ4LA==",
-      "dev": true
-    },
-    "@types/bluebird": {
-      "version": "3.5.42",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.42.tgz",
-      "integrity": "sha512-Jhy+MWRlro6UjVi578V/4ZGNfeCOcNCp0YaFNIUGFKlImowqwb1O/22wDVk3FDGMLqxdpOV3qQHD5fPEH4hK6A==",
       "dev": true
     },
     "@types/body-parser": {

--- a/packages/instrumentation-amqplib/package.json
+++ b/packages/instrumentation-amqplib/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/contrib-test-utils": "^0.49.0",
-    "@types/amqplib": "^0.5.17",
+    "@types/amqplib": "^0.10.7",
     "@types/lodash": "4.14.199",
     "@types/mocha": "10.0.10",
     "@types/node": "18.18.14",

--- a/packages/instrumentation-amqplib/src/utils.ts
+++ b/packages/instrumentation-amqplib/src/utils.ts
@@ -60,6 +60,9 @@ export type InstrumentationConsumeChannel = amqp.Channel & {
 export type InstrumentationMessage = amqp.Message & {
   [MESSAGE_STORED_SPAN]?: Span;
 };
+export type InstrumentationConsumeMessage = amqp.ConsumeMessage & {
+  [MESSAGE_STORED_SPAN]?: Span;
+};
 
 const IS_CONFIRM_CHANNEL_CONTEXT_KEY: symbol = createContextKey(
   'opentelemetry.amqplib.channel.is-confirm-channel'
@@ -117,7 +120,7 @@ const extractConnectionAttributeOrLog = (
 };
 
 export const getConnectionAttributesFromServer = (
-  conn: amqp.Connection['connection']
+  conn: amqp.Connection
 ): Attributes => {
   const product = conn.serverProperties.product?.toLowerCase?.();
   if (product) {

--- a/packages/instrumentation-amqplib/test/amqplib-promise.test.ts
+++ b/packages/instrumentation-amqplib/test/amqplib-promise.test.ts
@@ -68,7 +68,7 @@ const CHANNEL_CLOSED_IN_TEST = Symbol(
 );
 
 describe('amqplib instrumentation promise model', () => {
-  let conn: amqp.Connection;
+  let conn: amqp.ChannelModel;
   before(async function () {
     if (!shouldTest) {
       this.skip();

--- a/packages/instrumentation-amqplib/test/utils.test.ts
+++ b/packages/instrumentation-amqplib/test/utils.test.ts
@@ -33,7 +33,7 @@ import { rabbitMqUrl } from './config';
 
 describe('utils', () => {
   describe('getConnectionAttributesFromServer', () => {
-    let conn: amqp.Connection;
+    let conn: amqp.ChannelModel;
     before(async function () {
       if (!shouldTest) {
         this.skip();


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Updates amqplib types to the latest released version, addressing type inconsistencies and improving type safety.

## Short description of the changes

- Removed unnecessary `as any` casts that were required due to limitations in the previous amqplib types version.
- Introduced a new `InstrumentationConsumeMessage` type to more accurately represent a `ConsumeMessage` along with its associated span.
- **No behavior changes**: this PR only involves typing improvements and does not alter the runtime behavior of the code.