### PR TITLE
fix(instrumentation-dataloader): support ESM imports of dataloader module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31938,6 +31938,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^2.0.0",
+        "@opentelemetry/contrib-test-utils": "^0.49.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0",
         "@opentelemetry/sdk-trace-node": "^2.0.0",
         "@types/mocha": "10.0.10",
@@ -41825,6 +41826,7 @@
       "requires": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^2.0.0",
+        "@opentelemetry/contrib-test-utils": "^0.49.0",
         "@opentelemetry/instrumentation": "^0.203.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0",
         "@opentelemetry/sdk-trace-node": "^2.0.0",

--- a/packages/instrumentation-dataloader/package.json
+++ b/packages/instrumentation-dataloader/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/context-async-hooks": "^2.0.0",
+    "@opentelemetry/contrib-test-utils": "^0.49.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "@opentelemetry/sdk-trace-node": "^2.0.0",
     "@types/mocha": "10.0.10",

--- a/packages/instrumentation-dataloader/src/instrumentation.ts
+++ b/packages/instrumentation-dataloader/src/instrumentation.ts
@@ -44,6 +44,13 @@ type PrimeFn = (typeof Dataloader.prototype)['prime'];
 type ClearFn = (typeof Dataloader.prototype)['clear'];
 type ClearAllFn = (typeof Dataloader.prototype)['clearAll'];
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function extractModuleExports(module: any) {
+  return module[Symbol.toStringTag] === 'Module'
+    ? module.default // ESM
+    : module; // CommonJS
+}
+
 export class DataloaderInstrumentation extends InstrumentationBase<DataloaderInstrumentationConfig> {
   constructor(config: DataloaderInstrumentationConfig = {}) {
     super(PACKAGE_NAME, PACKAGE_VERSION, config);
@@ -54,7 +61,8 @@ export class DataloaderInstrumentation extends InstrumentationBase<DataloaderIns
       new InstrumentationNodeModuleDefinition(
         MODULE_NAME,
         ['>=2.0.0 <3'],
-        dataloader => {
+        dataloaderPkg => {
+          const dataloader = extractModuleExports(dataloaderPkg);
           this._patchLoad(dataloader.prototype);
           this._patchLoadMany(dataloader.prototype);
           this._patchPrime(dataloader.prototype);
@@ -63,14 +71,15 @@ export class DataloaderInstrumentation extends InstrumentationBase<DataloaderIns
 
           return this._getPatchedConstructor(dataloader);
         },
-        dataloader => {
+        dataloaderPkg => {
+          const dataloader = extractModuleExports(dataloaderPkg);
           ['load', 'loadMany', 'prime', 'clear', 'clearAll'].forEach(method => {
             if (isWrapped(dataloader.prototype[method])) {
               this._unwrap(dataloader.prototype, method);
             }
           });
         }
-      ) as InstrumentationNodeModuleDefinition,
+      ),
     ];
   }
 

--- a/packages/instrumentation-dataloader/test/fixtures/use-dataloader-default-import.mjs
+++ b/packages/instrumentation-dataloader/test/fixtures/use-dataloader-default-import.mjs
@@ -1,0 +1,53 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Use dataloader from an ES module:
+//    node --experimental-loader=@opentelemetry/instrumentation/hook.mjs use-dataloader-default-import.mjs
+
+import { trace } from '@opentelemetry/api';
+import { createTestNodeSdk } from '@opentelemetry/contrib-test-utils';
+import * as crypto from 'crypto';
+
+import { DataloaderInstrumentation } from '../../build/src/index.js';
+
+const sdk = createTestNodeSdk({
+  serviceName: 'use-dataloader',
+  instrumentations: [
+    new DataloaderInstrumentation()
+  ]
+})
+sdk.start();
+
+import Dataloader from 'dataloader';
+
+function getMd5HashFromIdx(idx ) {
+  return crypto.createHash('md5').update(String(idx)).digest('hex');
+}
+const dataloader = new Dataloader(
+  async keys =>
+    keys.map((_, idx) => {
+      return getMd5HashFromIdx(idx);
+    }),
+  { cache: true }
+);
+
+const tracer = trace.getTracer();
+await tracer.startActiveSpan('manual', async (span) => {
+  await dataloader.load(1);
+  span.end();
+});
+
+await sdk.shutdown();


### PR DESCRIPTION
**NB:** code change primarily comes from #2813 and relates to #1942.

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- This allows ESM applications to successfully import (vs. require) the dataloader package while instrumenting via otel

## Short description of the changes

- Allows for `default` export to be nested inside the imported object instead of assuming its at the root level
