### PR TITLE
feat(instrumentation-amqp): adds latest semantic conventions

### DIFF
--- a/packages/instrumentation-amqplib/src/amqplib.ts
+++ b/packages/instrumentation-amqplib/src/amqplib.ts
@@ -68,6 +68,7 @@ import {
   getConnectionAttributesFromServer,
   getConnectionAttributesFromUrl,
   getPublishAttributes,
+  getPublishSpanName,
   InstrumentationConnection,
   InstrumentationConsumeChannel,
   InstrumentationConsumeMessage,
@@ -76,7 +77,6 @@ import {
   isConfirmChannelTracing,
   markConfirmChannelTracing,
   MESSAGE_STORED_SPAN,
-  normalizeExchange,
   unmarkConfirmChannelTracing,
 } from './utils';
 /** @knipignore */
@@ -675,21 +675,22 @@ export class AmqplibInstrumentation extends InstrumentationBase<AmqplibInstrumen
     channel: InstrumentationPublishChannel,
     options?: Options.Publish
   ) {
-    const normalizedExchange = normalizeExchange(exchange);
-
-    const span = self.tracer.startSpan(`publish ${normalizedExchange}`, {
-      kind: SpanKind.PRODUCER,
-      attributes: {
-        ...channel.connection[CONNECTION_ATTRIBUTES],
-        ...getPublishAttributes(
-          exchange,
-          routingKey,
-          contentLength,
-          options,
-          self._messagingSemconvStability
-        ),
-      },
-    });
+    const span = self.tracer.startSpan(
+      getPublishSpanName(exchange, routingKey, self._messagingSemconvStability),
+      {
+        kind: SpanKind.PRODUCER,
+        attributes: {
+          ...channel.connection[CONNECTION_ATTRIBUTES],
+          ...getPublishAttributes(
+            exchange,
+            routingKey,
+            contentLength,
+            options,
+            self._messagingSemconvStability
+          ),
+        },
+      }
+    );
     const modifiedOptions = options ?? {};
     modifiedOptions.headers = modifiedOptions.headers ?? {};
 

--- a/packages/instrumentation-amqplib/src/amqplib.ts
+++ b/packages/instrumentation-amqplib/src/amqplib.ts
@@ -58,6 +58,7 @@ import {
   getConnectionAttributesFromServer,
   getConnectionAttributesFromUrl,
   getConsumeAttributes,
+  getConsumeSpanName,
   getPublishAttributes,
   getPublishSpanName,
   InstrumentationConnection,
@@ -442,7 +443,7 @@ export class AmqplibInstrumentation extends InstrumentationBase<AmqplibInstrumen
           }
         }
         const span = self.tracer.startSpan(
-          `${queue} process`,
+          getConsumeSpanName(queue, msg, self._messagingSemconvStability),
           {
             kind: SpanKind.CONSUMER,
             attributes: {

--- a/packages/instrumentation-amqplib/src/amqplib.ts
+++ b/packages/instrumentation-amqplib/src/amqplib.ts
@@ -85,6 +85,7 @@ const supportedVersions = ['>=0.5.5 <1'];
 
 export class AmqplibInstrumentation extends InstrumentationBase<AmqplibInstrumentationConfig> {
   private _netSemconvStability!: SemconvStability;
+  private _messagingSemconvStability!: SemconvStability;
 
   constructor(config: AmqplibInstrumentationConfig = {}) {
     super(PACKAGE_NAME, PACKAGE_VERSION, { ...DEFAULT_CONFIG, ...config });
@@ -95,6 +96,10 @@ export class AmqplibInstrumentation extends InstrumentationBase<AmqplibInstrumen
   private _setSemconvStabilityFromEnv() {
     this._netSemconvStability = semconvStabilityFromStr(
       'http',
+      process.env.OTEL_SEMCONV_STABILITY_OPT_IN
+    );
+    this._messagingSemconvStability = semconvStabilityFromStr(
+      'messaging',
       process.env.OTEL_SEMCONV_STABILITY_OPT_IN
     );
   }
@@ -273,7 +278,8 @@ export class AmqplibInstrumentation extends InstrumentationBase<AmqplibInstrumen
           if (err == null) {
             const urlAttributes = getConnectionAttributesFromUrl(
               url,
-              self._netSemconvStability
+              self._netSemconvStability,
+              self._messagingSemconvStability
             );
             const serverAttributes = getConnectionAttributesFromServer(conn);
             conn[CONNECTION_ATTRIBUTES] = {

--- a/packages/instrumentation-amqplib/src/amqplib.ts
+++ b/packages/instrumentation-amqplib/src/amqplib.ts
@@ -67,6 +67,7 @@ import {
   CONNECTION_ATTRIBUTES,
   getConnectionAttributesFromServer,
   getConnectionAttributesFromUrl,
+  getPublishAttributes,
   InstrumentationConnection,
   InstrumentationConsumeChannel,
   InstrumentationConsumeMessage,
@@ -526,6 +527,7 @@ export class AmqplibInstrumentation extends InstrumentationBase<AmqplibInstrumen
         self,
         exchange,
         routingKey,
+        content.length,
         channel,
         options
       );
@@ -628,6 +630,7 @@ export class AmqplibInstrumentation extends InstrumentationBase<AmqplibInstrumen
           self,
           exchange,
           routingKey,
+        content.length,
           channel,
           options
         );
@@ -668,6 +671,7 @@ export class AmqplibInstrumentation extends InstrumentationBase<AmqplibInstrumen
     self: this,
     exchange: string,
     routingKey: string,
+    contentLength: number,
     channel: InstrumentationPublishChannel,
     options?: Options.Publish
   ) {
@@ -677,13 +681,13 @@ export class AmqplibInstrumentation extends InstrumentationBase<AmqplibInstrumen
       kind: SpanKind.PRODUCER,
       attributes: {
         ...channel.connection[CONNECTION_ATTRIBUTES],
-        [ATTR_MESSAGING_DESTINATION]: exchange,
-        [ATTR_MESSAGING_DESTINATION_KIND]:
-          MESSAGING_DESTINATION_KIND_VALUE_TOPIC,
-
-        [ATTR_MESSAGING_RABBITMQ_ROUTING_KEY]: routingKey,
-        [OLD_ATTR_MESSAGING_MESSAGE_ID]: options?.messageId,
-        [ATTR_MESSAGING_CONVERSATION_ID]: options?.correlationId,
+        ...getPublishAttributes(
+          exchange,
+          routingKey,
+          contentLength,
+          options,
+          self._messagingSemconvStability
+        ),
       },
     });
     const modifiedOptions = options ?? {};

--- a/packages/instrumentation-amqplib/src/utils.ts
+++ b/packages/instrumentation-amqplib/src/utils.ts
@@ -95,9 +95,6 @@ const IS_CONFIRM_CHANNEL_CONTEXT_KEY: symbol = createContextKey(
   'opentelemetry.amqplib.channel.is-confirm-channel'
 );
 
-export const normalizeExchange = (exchangeName: string) =>
-  exchangeName !== '' ? exchangeName : '<default>';
-
 const censorPassword = (url: string): string => {
   return url.replace(/:[^:@/]*@/, ':***@');
 };
@@ -224,6 +221,20 @@ export const getConnectionAttributesFromUrl = (
   }
   return attributes;
 };
+
+export const getPublishSpanName = (
+  exchange: string,
+  routingKey: string,
+  messagingSemconvStability: SemconvStability
+): string => {
+  if (messagingSemconvStability & SemconvStability.STABLE) {
+    return `publish ${getPublishDestinationName(exchange, routingKey)}`;
+  }
+  return `publish ${normalizeExchange(exchange)}`;
+};
+
+const normalizeExchange = (exchangeName: string) =>
+  exchangeName !== '' ? exchangeName : '<default>';
 
 export const getPublishAttributes = (
   exchange: string,

--- a/packages/instrumentation-amqplib/test/amqplib-callbacks-stable.test.ts
+++ b/packages/instrumentation-amqplib/test/amqplib-callbacks-stable.test.ts
@@ -1,0 +1,587 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import 'mocha';
+import { expect } from 'expect';
+import { AmqplibInstrumentation } from '../src';
+import {
+  getTestSpans,
+  registerInstrumentationTesting,
+} from '@opentelemetry/contrib-test-utils';
+
+const instrumentation = registerInstrumentationTesting(
+  new AmqplibInstrumentation()
+);
+
+import * as amqpCallback from 'amqplib/callback_api';
+import {
+  ATTR_NETWORK_PEER_ADDRESS,
+  ATTR_NETWORK_PEER_PORT,
+  ATTR_NETWORK_PROTOCOL_NAME,
+  ATTR_NETWORK_PROTOCOL_VERSION,
+  ATTR_SERVER_ADDRESS,
+  ATTR_SERVER_PORT,
+} from '@opentelemetry/semantic-conventions';
+import { Baggage, context, propagation, SpanKind } from '@opentelemetry/api';
+import { asyncConfirmSend, asyncConsume, shouldTest } from './utils';
+import { rabbitMqUrl, TEST_RABBITMQ_HOST, TEST_RABBITMQ_PORT } from './config';
+import {
+  CompositePropagator,
+  W3CBaggagePropagator,
+  W3CTraceContextPropagator,
+} from '@opentelemetry/core';
+import { SemconvStability } from '@opentelemetry/instrumentation';
+import {
+  ATTR_MESSAGING_SYSTEM,
+  ATTR_MESSAGING_MESSAGE_BODY_SIZE,
+  ATTR_MESSAGING_OPERATION_TYPE,
+  MESSAGING_OPERATION_TYPE_VALUE_SEND,
+  ATTR_MESSAGING_OPERATION_NAME,
+  ATTR_MESSAGING_DESTINATION_NAME,
+  ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY,
+  MESSAGING_OPERATION_TYPE_VALUE_PROCESS,
+  ATTR_MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG,
+} from '@opentelemetry/semantic-conventions/incubating';
+
+const msgPayload = 'payload from test';
+const queueName = 'queue-name-from-unittest';
+
+describe('amqplib instrumentation callback model - stable semconv', () => {
+  let conn: amqpCallback.Connection;
+  before(() => {
+    propagation.setGlobalPropagator(
+      new CompositePropagator({
+        propagators: [
+          new W3CBaggagePropagator(),
+          new W3CTraceContextPropagator(),
+        ],
+      })
+    );
+  });
+  before(function (done) {
+    instrumentation['_semconvStability'] = SemconvStability.STABLE;
+    if (!shouldTest) {
+      this.skip();
+    } else {
+      amqpCallback.connect(rabbitMqUrl, (err, connection) => {
+        conn = connection;
+        done(err);
+      });
+    }
+  });
+  after(done => {
+    instrumentation['_semconvStability'] = SemconvStability.OLD;
+    if (!shouldTest) {
+      done();
+    } else {
+      conn.close(() => done());
+    }
+  });
+
+  describe('channel', () => {
+    let channel: amqpCallback.Channel;
+    beforeEach(done => {
+      conn.createChannel(
+        context.bind(context.active(), (err, c) => {
+          channel = c;
+          // install an error handler, otherwise when we have tests that create error on the channel,
+          // it throws and crash process
+          channel.on('error', () => {});
+          channel.assertQueue(
+            queueName,
+            { durable: false },
+            context.bind(context.active(), (err, ok) => {
+              channel.purgeQueue(
+                queueName,
+                context.bind(context.active(), (err, ok) => {
+                  done();
+                })
+              );
+            })
+          );
+        })
+      );
+    });
+
+    afterEach(done => {
+      try {
+        channel.close(err => {
+          done();
+        });
+      } catch {}
+    });
+
+    it('simple publish and consume from queue callback', done => {
+      const hadSpaceInBuffer = channel.sendToQueue(
+        queueName,
+        Buffer.from(msgPayload)
+      );
+      expect(hadSpaceInBuffer).toBeTruthy();
+
+      asyncConsume(
+        channel,
+        queueName,
+        [msg => expect(msg.content.toString()).toEqual(msgPayload)],
+        {
+          noAck: true,
+        }
+      ).then(() => {
+        const [publishSpan, consumeSpan] = getTestSpans();
+
+        // assert publish span
+        expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
+        expect(publishSpan.name).toMatch(`publish ${queueName}`);
+        expect(publishSpan.attributes).toEqual({
+          [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+          [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+          [ATTR_MESSAGING_OPERATION_TYPE]: MESSAGING_OPERATION_TYPE_VALUE_SEND,
+          [ATTR_MESSAGING_OPERATION_NAME]: 'publish',
+          [ATTR_MESSAGING_DESTINATION_NAME]: queueName,
+          [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: queueName,
+          [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+          [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+          [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+          [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+        });
+
+        // assert consume span
+        expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
+        expect(consumeSpan.name).toMatch(`consume ${queueName}`);
+        expect(consumeSpan.attributes).toEqual({
+          [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+          [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+          [ATTR_MESSAGING_OPERATION_TYPE]:
+            MESSAGING_OPERATION_TYPE_VALUE_PROCESS,
+          [ATTR_MESSAGING_OPERATION_NAME]: 'consume',
+          [ATTR_MESSAGING_DESTINATION_NAME]: queueName,
+          [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: queueName,
+          [ATTR_MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG]: 1,
+          [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+          [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+          [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+          [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+        });
+
+        // assert context propagation
+        expect(consumeSpan.spanContext().traceId).toEqual(
+          publishSpan.spanContext().traceId
+        );
+        expect(consumeSpan.parentSpanContext?.spanId).toEqual(
+          publishSpan.spanContext().spanId
+        );
+
+        done();
+      });
+    });
+
+    it('baggage is available while consuming', done => {
+      const baggageContext = propagation.setBaggage(
+        context.active(),
+        propagation.createBaggage({
+          key1: { value: 'value1' },
+        })
+      );
+      context.with(baggageContext, () => {
+        channel.sendToQueue(queueName, Buffer.from(msgPayload));
+        let extractedBaggage: Baggage | undefined;
+        asyncConsume(
+          channel,
+          queueName,
+          [
+            msg => {
+              extractedBaggage = propagation.getActiveBaggage();
+            },
+          ],
+          {
+            noAck: true,
+          }
+        ).then(() => {
+          expect(extractedBaggage).toBeDefined();
+          expect(extractedBaggage!.getEntry('key1')).toBeDefined();
+          done();
+        });
+      });
+    });
+
+    it('end span with ack sync', done => {
+      channel.sendToQueue(queueName, Buffer.from(msgPayload));
+
+      asyncConsume(channel, queueName, [msg => channel.ack(msg)]).then(() => {
+        // assert consumed message span has ended
+        expect(getTestSpans().length).toBe(2);
+        done();
+      });
+    });
+
+    it('end span with ack async', done => {
+      channel.sendToQueue(queueName, Buffer.from(msgPayload));
+
+      asyncConsume(channel, queueName, [
+        msg =>
+          setTimeout(() => {
+            channel.ack(msg);
+            expect(getTestSpans().length).toBe(2);
+            done();
+          }, 1),
+      ]);
+    });
+  });
+
+  describe('confirm channel', () => {
+    let confirmChannel: amqpCallback.ConfirmChannel;
+    beforeEach(done => {
+      conn.createConfirmChannel(
+        context.bind(context.active(), (err, c) => {
+          confirmChannel = c;
+          // install an error handler, otherwise when we have tests that create error on the channel,
+          // it throws and crash process
+          confirmChannel.on('error', () => {});
+          confirmChannel.assertQueue(
+            queueName,
+            { durable: false },
+            context.bind(context.active(), (err, ok) => {
+              confirmChannel.purgeQueue(
+                queueName,
+                context.bind(context.active(), (err, ok) => {
+                  done();
+                })
+              );
+            })
+          );
+        })
+      );
+    });
+
+    afterEach(done => {
+      try {
+        confirmChannel.close(err => {
+          done();
+        });
+      } catch {}
+    });
+
+    it('simple publish and consume from queue callback', done => {
+      asyncConfirmSend(confirmChannel, queueName, msgPayload).then(() => {
+        asyncConsume(
+          confirmChannel,
+          queueName,
+          [msg => expect(msg.content.toString()).toEqual(msgPayload)],
+          {
+            noAck: true,
+          }
+        ).then(() => {
+          const [publishSpan, consumeSpan] = getTestSpans();
+
+          // assert publish span
+          expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
+          expect(publishSpan.name).toEqual(`publish ${queueName}`);
+          expect(publishSpan.attributes).toEqual({
+            [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+            [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+            [ATTR_MESSAGING_OPERATION_TYPE]:
+              MESSAGING_OPERATION_TYPE_VALUE_SEND,
+            [ATTR_MESSAGING_OPERATION_NAME]: 'publish',
+            [ATTR_MESSAGING_DESTINATION_NAME]: queueName,
+            [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: queueName,
+            [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+            [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+            [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+            [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+            [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+            [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+          });
+
+          // assert consume span
+          expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
+          expect(consumeSpan.name).toEqual(`consume ${queueName}`);
+          expect(consumeSpan.attributes).toEqual({
+            [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+            [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+            [ATTR_MESSAGING_OPERATION_TYPE]:
+              MESSAGING_OPERATION_TYPE_VALUE_PROCESS,
+            [ATTR_MESSAGING_OPERATION_NAME]: 'consume',
+            [ATTR_MESSAGING_DESTINATION_NAME]: queueName,
+            [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: queueName,
+            [ATTR_MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG]: 1,
+            [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+            [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+            [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+            [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+            [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+            [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+          });
+
+          // assert context propagation
+          expect(consumeSpan.spanContext().traceId).toEqual(
+            publishSpan.spanContext().traceId
+          );
+          expect(consumeSpan.parentSpanContext?.spanId).toEqual(
+            publishSpan.spanContext().spanId
+          );
+
+          done();
+        });
+      });
+    });
+
+    it('end span with ack sync', done => {
+      asyncConfirmSend(confirmChannel, queueName, msgPayload).then(() => {
+        asyncConsume(confirmChannel, queueName, [
+          msg => confirmChannel.ack(msg),
+        ]).then(() => {
+          // assert consumed message span has ended
+          expect(getTestSpans().length).toBe(2);
+          done();
+        });
+      });
+    });
+
+    it('end span with ack async', done => {
+      asyncConfirmSend(confirmChannel, queueName, msgPayload).then(() => {
+        asyncConsume(confirmChannel, queueName, [
+          msg =>
+            setTimeout(() => {
+              confirmChannel.ack(msg);
+              expect(getTestSpans().length).toBe(2);
+              done();
+            }, 1),
+        ]);
+      });
+    });
+  });
+
+  describe('channel with links config', () => {
+    let channel: amqpCallback.Channel;
+    beforeEach(done => {
+      instrumentation.setConfig({
+        useLinksForConsume: true,
+      });
+      conn.createChannel(
+        context.bind(context.active(), (err, c) => {
+          channel = c;
+          // install an error handler, otherwise when we have tests that create error on the channel,
+          // it throws and crash process
+          channel.on('error', () => {});
+          channel.assertQueue(
+            queueName,
+            { durable: false },
+            context.bind(context.active(), (err, ok) => {
+              channel.purgeQueue(
+                queueName,
+                context.bind(context.active(), (err, ok) => {
+                  done();
+                })
+              );
+            })
+          );
+        })
+      );
+    });
+
+    afterEach(done => {
+      try {
+        channel.close(err => {
+          done();
+        });
+      } catch {}
+    });
+
+    it('simple publish and consume from queue callback', done => {
+      const hadSpaceInBuffer = channel.sendToQueue(
+        queueName,
+        Buffer.from(msgPayload)
+      );
+      expect(hadSpaceInBuffer).toBeTruthy();
+
+      asyncConsume(
+        channel,
+        queueName,
+        [msg => expect(msg.content.toString()).toEqual(msgPayload)],
+        {
+          noAck: true,
+        }
+      ).then(() => {
+        const [publishSpan, consumeSpan] = getTestSpans();
+
+        // assert publish span
+        expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
+        expect(publishSpan.name).toEqual(`publish ${queueName}`);
+        expect(publishSpan.attributes).toEqual({
+          [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+          [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+          [ATTR_MESSAGING_OPERATION_TYPE]: MESSAGING_OPERATION_TYPE_VALUE_SEND,
+          [ATTR_MESSAGING_OPERATION_NAME]: 'publish',
+          [ATTR_MESSAGING_DESTINATION_NAME]: queueName,
+          [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: queueName,
+          [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+          [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+          [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+          [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+        });
+
+        // assert consume span
+        expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
+        expect(consumeSpan.name).toEqual(`consume ${queueName}`);
+        expect(consumeSpan.attributes).toEqual({
+          [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+          [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+          [ATTR_MESSAGING_OPERATION_TYPE]:
+            MESSAGING_OPERATION_TYPE_VALUE_PROCESS,
+          [ATTR_MESSAGING_OPERATION_NAME]: 'consume',
+          [ATTR_MESSAGING_DESTINATION_NAME]: queueName,
+          [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: queueName,
+          [ATTR_MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG]: 1,
+          [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+          [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+          [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+          [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+        });
+
+        // new trace should be created
+        expect(consumeSpan.spanContext().traceId).not.toEqual(
+          publishSpan.spanContext().traceId
+        );
+        expect(consumeSpan.parentSpanContext?.spanId).toBeUndefined();
+
+        // link back to publish span
+        expect(consumeSpan.links.length).toBe(1);
+        expect(consumeSpan.links[0].context.traceId).toEqual(
+          publishSpan.spanContext().traceId
+        );
+        expect(consumeSpan.links[0].context.spanId).toEqual(
+          publishSpan.spanContext().spanId
+        );
+
+        done();
+      });
+    });
+  });
+
+  describe('confirm channel with links config', () => {
+    let confirmChannel: amqpCallback.ConfirmChannel;
+    beforeEach(done => {
+      instrumentation.setConfig({
+        useLinksForConsume: true,
+      });
+      conn.createConfirmChannel(
+        context.bind(context.active(), (err, c) => {
+          confirmChannel = c;
+          // install an error handler, otherwise when we have tests that create error on the channel,
+          // it throws and crash process
+          confirmChannel.on('error', () => {});
+          confirmChannel.assertQueue(
+            queueName,
+            { durable: false },
+            context.bind(context.active(), (err, ok) => {
+              confirmChannel.purgeQueue(
+                queueName,
+                context.bind(context.active(), (err, ok) => {
+                  done();
+                })
+              );
+            })
+          );
+        })
+      );
+    });
+
+    afterEach(done => {
+      try {
+        confirmChannel.close(err => {
+          done();
+        });
+      } catch {}
+    });
+
+    it('simple publish and consume from queue callback', done => {
+      asyncConfirmSend(confirmChannel, queueName, msgPayload).then(() => {
+        asyncConsume(
+          confirmChannel,
+          queueName,
+          [msg => expect(msg.content.toString()).toEqual(msgPayload)],
+          {
+            noAck: true,
+          }
+        ).then(() => {
+          const [publishSpan, consumeSpan] = getTestSpans();
+
+          // assert publish span
+          expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
+          expect(publishSpan.name).toEqual(`publish ${queueName}`);
+          expect(publishSpan.attributes).toEqual({
+            [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+            [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+            [ATTR_MESSAGING_OPERATION_TYPE]:
+              MESSAGING_OPERATION_TYPE_VALUE_SEND,
+            [ATTR_MESSAGING_OPERATION_NAME]: 'publish',
+            [ATTR_MESSAGING_DESTINATION_NAME]: queueName,
+            [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: queueName,
+            [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+            [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+            [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+            [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+            [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+            [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+          });
+
+          // assert consume span
+          expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
+          expect(consumeSpan.name).toEqual(`consume ${queueName}`);
+          expect(consumeSpan.attributes).toEqual({
+            [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+            [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+            [ATTR_MESSAGING_OPERATION_TYPE]:
+              MESSAGING_OPERATION_TYPE_VALUE_PROCESS,
+            [ATTR_MESSAGING_OPERATION_NAME]: 'consume',
+            [ATTR_MESSAGING_DESTINATION_NAME]: queueName,
+            [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: queueName,
+            [ATTR_MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG]: 1,
+            [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+            [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+            [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+            [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+            [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+            [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+          });
+
+          // new trace should be created
+          expect(consumeSpan.spanContext().traceId).not.toEqual(
+            publishSpan.spanContext().traceId
+          );
+          expect(consumeSpan.parentSpanContext?.spanId).toBeUndefined();
+
+          // link back to publish span
+          expect(consumeSpan.links.length).toBe(1);
+          expect(consumeSpan.links[0].context.traceId).toEqual(
+            publishSpan.spanContext().traceId
+          );
+          expect(consumeSpan.links[0].context.spanId).toEqual(
+            publishSpan.spanContext().spanId
+          );
+
+          done();
+        });
+      });
+    });
+  });
+});

--- a/packages/instrumentation-amqplib/test/amqplib-callbacks-stable.test.ts
+++ b/packages/instrumentation-amqplib/test/amqplib-callbacks-stable.test.ts
@@ -71,7 +71,7 @@ describe('amqplib instrumentation callback model - stable semconv', () => {
     );
   });
   before(function (done) {
-    instrumentation['_semconvStability'] = SemconvStability.STABLE;
+    instrumentation['_messagingSemconvStability'] = SemconvStability.STABLE;
     if (!shouldTest) {
       this.skip();
     } else {
@@ -82,7 +82,7 @@ describe('amqplib instrumentation callback model - stable semconv', () => {
     }
   });
   after(done => {
-    instrumentation['_semconvStability'] = SemconvStability.OLD;
+    instrumentation['_messagingSemconvStability'] = SemconvStability.OLD;
     if (!shouldTest) {
       done();
     } else {

--- a/packages/instrumentation-amqplib/test/amqplib-connection-stable.test.ts
+++ b/packages/instrumentation-amqplib/test/amqplib-connection-stable.test.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import 'mocha';
+import { expect } from 'expect';
+import { shouldTest } from './utils';
+import {
+  rabbitMqUrl,
+  TEST_RABBITMQ_HOST,
+  TEST_RABBITMQ_PASS,
+  TEST_RABBITMQ_PORT,
+  TEST_RABBITMQ_USER,
+} from './config';
+import { AmqplibInstrumentation } from '../src';
+import {
+  getTestSpans,
+  registerInstrumentationTesting,
+} from '@opentelemetry/contrib-test-utils';
+
+const instrumentation = registerInstrumentationTesting(
+  new AmqplibInstrumentation()
+);
+registerInstrumentationTesting(new AmqplibInstrumentation());
+
+import * as amqp from 'amqplib';
+import {
+  ATTR_NETWORK_PEER_ADDRESS,
+  ATTR_NETWORK_PEER_PORT,
+  ATTR_NETWORK_PROTOCOL_NAME,
+  ATTR_NETWORK_PROTOCOL_VERSION,
+  ATTR_SERVER_ADDRESS,
+  ATTR_SERVER_PORT,
+} from '@opentelemetry/semantic-conventions';
+import { SemconvStability } from '@opentelemetry/instrumentation';
+import { ATTR_MESSAGING_SYSTEM } from '@opentelemetry/semantic-conventions/incubating';
+
+describe('amqplib instrumentation connection - stable semconv', () => {
+  before(function () {
+    instrumentation['_semconvStability'] = SemconvStability.STABLE;
+
+    if (!shouldTest) {
+      this.skip();
+    }
+  });
+  after(async () => {
+    instrumentation['_semconvStability'] = SemconvStability.OLD;
+  });
+
+  describe('connect with url object', () => {
+    it('should extract connection attributes form url options', async function () {
+      const testName = this.test!.title;
+      const conn = await amqp.connect({
+        protocol: 'amqp',
+        username: TEST_RABBITMQ_USER,
+        password: TEST_RABBITMQ_PASS,
+        hostname: TEST_RABBITMQ_HOST,
+        port: TEST_RABBITMQ_PORT,
+      });
+
+      try {
+        const channel = await conn.createChannel();
+        channel.sendToQueue(
+          testName,
+          Buffer.from('message created only to test connection attributes')
+        );
+        const [publishSpan] = getTestSpans();
+
+        expect(publishSpan.attributes).toEqual(
+          expect.objectContaining({
+            [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+            [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+            [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+            [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+            [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+            [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+            [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+          })
+        );
+      } finally {
+        await conn.close();
+      }
+    });
+
+    it('should use default protocol', async function () {
+      const testName = this.test!.title;
+      const conn = await amqp.connect({
+        username: TEST_RABBITMQ_USER,
+        password: TEST_RABBITMQ_PASS,
+        hostname: TEST_RABBITMQ_HOST,
+        port: TEST_RABBITMQ_PORT,
+      });
+
+      try {
+        const channel = await conn.createChannel();
+        channel.sendToQueue(
+          testName,
+          Buffer.from('message created only to test connection attributes')
+        );
+        const [publishSpan] = getTestSpans();
+        expect(publishSpan.attributes).toEqual(
+          expect.objectContaining({
+            [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+            [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+            [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+            [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+            [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+            [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+            [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+          })
+        );
+      } finally {
+        await conn.close();
+      }
+    });
+
+    it('should use default host', async function () {
+      if (TEST_RABBITMQ_HOST !== 'localhost') {
+        return;
+      }
+
+      const testName = this.test!.title;
+      const conn = await amqp.connect({
+        protocol: 'amqp',
+        username: TEST_RABBITMQ_USER,
+        password: TEST_RABBITMQ_PASS,
+        port: TEST_RABBITMQ_PORT,
+      });
+
+      try {
+        const channel = await conn.createChannel();
+        channel.sendToQueue(
+          testName,
+          Buffer.from('message created only to test connection attributes')
+        );
+        const [publishSpan] = getTestSpans();
+        expect(publishSpan.attributes).toEqual(
+          expect.objectContaining({
+            [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+            [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+            [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+            [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+            [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+            [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+            [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+          })
+        );
+      } finally {
+        await conn.close();
+      }
+    });
+  });
+
+  describe('connect with url string', () => {
+    it('should extract connection attributes from url options', async function () {
+      const testName = this.test!.title;
+      const conn = await amqp.connect(rabbitMqUrl);
+
+      try {
+        const msgPayload = Buffer.from(
+          'message created only to test connection attributes'
+        );
+
+        const channel = await conn.createChannel();
+        channel.sendToQueue(testName, msgPayload);
+        const [publishSpan] = getTestSpans();
+
+        expect(publishSpan.attributes).toEqual(
+          expect.objectContaining({
+            [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+            [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+            [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+            [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+            [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+            [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+            [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+          })
+        );
+      } finally {
+        await conn.close();
+      }
+    });
+  });
+});

--- a/packages/instrumentation-amqplib/test/amqplib-connection-stable.test.ts
+++ b/packages/instrumentation-amqplib/test/amqplib-connection-stable.test.ts
@@ -48,14 +48,14 @@ import { ATTR_MESSAGING_SYSTEM } from '@opentelemetry/semantic-conventions/incub
 
 describe('amqplib instrumentation connection - stable semconv', () => {
   before(function () {
-    instrumentation['_semconvStability'] = SemconvStability.STABLE;
+    instrumentation['_messagingSemconvStability'] = SemconvStability.STABLE;
 
     if (!shouldTest) {
       this.skip();
     }
   });
   after(async () => {
-    instrumentation['_semconvStability'] = SemconvStability.OLD;
+    instrumentation['_messagingSemconvStability'] = SemconvStability.OLD;
   });
 
   describe('connect with url object', () => {

--- a/packages/instrumentation-amqplib/test/amqplib-promise-stable.test.ts
+++ b/packages/instrumentation-amqplib/test/amqplib-promise-stable.test.ts
@@ -1,0 +1,1571 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import 'mocha';
+import { expect } from 'expect';
+import * as sinon from 'sinon';
+import * as lodash from 'lodash';
+import {
+  AmqplibInstrumentation,
+  ConsumeEndInfo,
+  ConsumeInfo,
+  EndOperation,
+  PublishInfo,
+} from '../src';
+import {
+  getTestSpans,
+  registerInstrumentationTesting,
+} from '@opentelemetry/contrib-test-utils';
+
+const instrumentation = registerInstrumentationTesting(
+  new AmqplibInstrumentation()
+);
+
+import * as amqp from 'amqplib';
+import { ConsumeMessage } from 'amqplib';
+import {
+  ATTR_MESSAGING_DESTINATION_NAME,
+  ATTR_MESSAGING_MESSAGE_BODY_SIZE,
+  ATTR_MESSAGING_OPERATION_NAME,
+  ATTR_MESSAGING_OPERATION_TYPE,
+  ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY,
+  ATTR_MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG,
+  ATTR_MESSAGING_SYSTEM,
+  ATTR_NETWORK_PEER_ADDRESS,
+  ATTR_NETWORK_PEER_PORT,
+  ATTR_NETWORK_PROTOCOL_NAME,
+  ATTR_NETWORK_PROTOCOL_VERSION,
+  ATTR_SERVER_ADDRESS,
+  ATTR_SERVER_PORT,
+  MESSAGING_OPERATION_TYPE_VALUE_PROCESS,
+  MESSAGING_OPERATION_TYPE_VALUE_SEND,
+} from '@opentelemetry/semantic-conventions/incubating';
+import { Span, SpanKind, SpanStatusCode } from '@opentelemetry/api';
+import { asyncConfirmPublish, asyncConfirmSend, asyncConsume } from './utils';
+import { shouldTest } from './utils';
+import { rabbitMqUrl, TEST_RABBITMQ_HOST, TEST_RABBITMQ_PORT } from './config';
+import { SinonSpy } from 'sinon';
+import { SemconvStability } from '@opentelemetry/instrumentation';
+
+const msgPayload = 'payload from test';
+const queueName = 'queue-name-from-unittest';
+
+// signal that the channel is closed in test, thus it should not be closed again in afterEach.
+// could not find a way to get this from amqplib directly.
+const CHANNEL_CLOSED_IN_TEST = Symbol(
+  'opentelemetry.amqplib.unittest.channel_closed_in_test'
+);
+
+describe('amqplib instrumentation promise model - stable semconv', () => {
+  let conn: amqp.Connection;
+  before(async function () {
+    instrumentation['_semconvStability'] = SemconvStability.STABLE;
+
+    if (!shouldTest) {
+      this.skip();
+    } else {
+      conn = await amqp.connect(rabbitMqUrl);
+    }
+  });
+  after(async () => {
+    instrumentation['_semconvStability'] = SemconvStability.OLD;
+
+    if (shouldTest) {
+      await conn.close();
+    }
+  });
+
+  let endHookSpy: SinonSpy;
+  const expectConsumeEndSpyStatus = (
+    expectedEndOperations: EndOperation[]
+  ): void => {
+    expect(endHookSpy.callCount).toBe(expectedEndOperations.length);
+    expectedEndOperations.forEach(
+      (endOperation: EndOperation, index: number) => {
+        expect(endHookSpy.args[index][1].endOperation).toEqual(endOperation);
+        switch (endOperation) {
+          case EndOperation.AutoAck:
+          case EndOperation.Ack:
+          case EndOperation.AckAll:
+            expect(endHookSpy.args[index][1].rejected).toBeFalsy();
+            break;
+
+          case EndOperation.Reject:
+          case EndOperation.Nack:
+          case EndOperation.NackAll:
+          case EndOperation.ChannelClosed:
+          case EndOperation.ChannelError:
+            expect(endHookSpy.args[index][1].rejected).toBeTruthy();
+            break;
+        }
+      }
+    );
+  };
+
+  describe('channel', () => {
+    let channel: amqp.Channel & { [CHANNEL_CLOSED_IN_TEST]?: boolean };
+    beforeEach(async () => {
+      endHookSpy = sinon.spy();
+      instrumentation.setConfig({
+        consumeEndHook: endHookSpy,
+      });
+
+      channel = await conn.createChannel();
+      await channel.assertQueue(queueName, { durable: false });
+      await channel.purgeQueue(queueName);
+      // install an error handler, otherwise when we have tests that create error on the channel,
+      // it throws and crash process
+      channel.on('error', (err: Error) => {});
+    });
+    afterEach(async () => {
+      if (!channel[CHANNEL_CLOSED_IN_TEST]) {
+        try {
+          await new Promise<void>(resolve => {
+            channel.on('close', resolve);
+            channel.close();
+          });
+        } catch {}
+      }
+    });
+
+    it('simple publish and consume from queue', async () => {
+      const hadSpaceInBuffer = channel.sendToQueue(
+        queueName,
+        Buffer.from(msgPayload)
+      );
+      expect(hadSpaceInBuffer).toBeTruthy();
+
+      await asyncConsume(
+        channel,
+        queueName,
+        [msg => expect(msg.content.toString()).toEqual(msgPayload)],
+        {
+          noAck: true,
+        }
+      );
+      const [publishSpan, consumeSpan] = getTestSpans();
+
+      // assert publish span
+      expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
+      expect(publishSpan.name).toEqual(`publish ${queueName}`);
+      expect(publishSpan.attributes).toEqual({
+        [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+        [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+        [ATTR_MESSAGING_OPERATION_TYPE]: MESSAGING_OPERATION_TYPE_VALUE_SEND,
+        [ATTR_MESSAGING_OPERATION_NAME]: 'publish',
+        [ATTR_MESSAGING_DESTINATION_NAME]: queueName, // for default exchange, destination name is the routing key (queue name)
+        [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: queueName,
+        [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+        [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+        [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+        [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+        [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+        [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+      });
+
+      // assert consume span
+      expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
+      expect(consumeSpan.name).toEqual(`consume ${queueName}`);
+      expect(consumeSpan.attributes).toEqual({
+        [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+        [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+        [ATTR_MESSAGING_OPERATION_TYPE]: MESSAGING_OPERATION_TYPE_VALUE_PROCESS,
+        [ATTR_MESSAGING_OPERATION_NAME]: 'consume',
+        [ATTR_MESSAGING_DESTINATION_NAME]: queueName,
+        [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: queueName,
+        [ATTR_MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG]: 1,
+        [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+        [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+        [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+        [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+        [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+        [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+      });
+
+      // assert context propagation
+      expect(consumeSpan.spanContext().traceId).toEqual(
+        publishSpan.spanContext().traceId
+      );
+      expect(consumeSpan.parentSpanContext?.spanId).toEqual(
+        publishSpan.spanContext().spanId
+      );
+
+      expectConsumeEndSpyStatus([EndOperation.AutoAck]);
+    });
+
+    describe('ending consume spans', () => {
+      it('message acked sync', async () => {
+        channel.sendToQueue(queueName, Buffer.from(msgPayload));
+
+        await asyncConsume(channel, queueName, [msg => channel.ack(msg)]);
+        // assert consumed message span has ended
+        expect(getTestSpans().length).toBe(2);
+        expectConsumeEndSpyStatus([EndOperation.Ack]);
+      });
+
+      it('message acked async', async () => {
+        channel.sendToQueue(queueName, Buffer.from(msgPayload));
+
+        // start async timer and ack the message after the callback returns
+        await new Promise<void>(resolve => {
+          asyncConsume(channel, queueName, [
+            msg =>
+              setTimeout(() => {
+                channel.ack(msg);
+                resolve();
+              }, 1),
+          ]);
+        });
+        // assert consumed message span has ended
+        expect(getTestSpans().length).toBe(2);
+        expectConsumeEndSpyStatus([EndOperation.Ack]);
+      });
+
+      it('message nack no requeue', async () => {
+        channel.sendToQueue(queueName, Buffer.from(msgPayload));
+
+        await asyncConsume(channel, queueName, [
+          msg => channel.nack(msg, false, false),
+        ]);
+        await new Promise(resolve => setTimeout(resolve, 20)); // just make sure we don't get it again
+        // assert consumed message span has ended
+        expect(getTestSpans().length).toBe(2);
+        const [_, consumerSpan] = getTestSpans();
+        expect(consumerSpan.status.code).toEqual(SpanStatusCode.ERROR);
+        expect(consumerSpan.status.message).toEqual(
+          'nack called on message without requeue'
+        );
+        expectConsumeEndSpyStatus([EndOperation.Nack]);
+      });
+
+      it('message nack requeue, then acked', async () => {
+        channel.sendToQueue(queueName, Buffer.from(msgPayload));
+
+        await asyncConsume(channel, queueName, [
+          (msg: amqp.Message) => channel.nack(msg, false, true),
+          (msg: amqp.Message) => channel.ack(msg),
+        ]);
+        // assert we have the requeued message sent again
+        expect(getTestSpans().length).toBe(3);
+        const [_, rejectedConsumerSpan, successConsumerSpan] = getTestSpans();
+        expect(rejectedConsumerSpan.status.code).toEqual(SpanStatusCode.ERROR);
+        expect(rejectedConsumerSpan.status.message).toEqual(
+          'nack called on message with requeue'
+        );
+        expect(successConsumerSpan.status.code).toEqual(SpanStatusCode.UNSET);
+        expectConsumeEndSpyStatus([EndOperation.Nack, EndOperation.Ack]);
+      });
+
+      it('ack allUpTo 2 msgs sync', async () => {
+        lodash.times(3, () =>
+          channel.sendToQueue(queueName, Buffer.from(msgPayload))
+        );
+
+        await asyncConsume(channel, queueName, [
+          null,
+          msg => channel.ack(msg, true),
+          msg => channel.ack(msg),
+        ]);
+        // assert all 3 messages are acked, including the first one which is acked by allUpTo
+        expect(getTestSpans().length).toBe(6);
+        expectConsumeEndSpyStatus([
+          EndOperation.Ack,
+          EndOperation.Ack,
+          EndOperation.Ack,
+        ]);
+      });
+
+      it('nack allUpTo 2 msgs sync', async () => {
+        lodash.times(3, () =>
+          channel.sendToQueue(queueName, Buffer.from(msgPayload))
+        );
+
+        await asyncConsume(channel, queueName, [
+          null,
+          msg => channel.nack(msg, true, false),
+          msg => channel.nack(msg, false, false),
+        ]);
+        // assert all 3 messages are acked, including the first one which is acked by allUpTo
+        expect(getTestSpans().length).toBe(6);
+        lodash.range(3, 6).forEach(i => {
+          expect(getTestSpans()[i].status.code).toEqual(SpanStatusCode.ERROR);
+          expect(getTestSpans()[i].status.message).toEqual(
+            'nack called on message without requeue'
+          );
+        });
+        expectConsumeEndSpyStatus([
+          EndOperation.Nack,
+          EndOperation.Nack,
+          EndOperation.Nack,
+        ]);
+      });
+
+      it('ack not in received order', async () => {
+        lodash.times(3, () =>
+          channel.sendToQueue(queueName, Buffer.from(msgPayload))
+        );
+
+        const msgs = await asyncConsume(channel, queueName, [null, null, null]);
+        channel.ack(msgs[1]);
+        channel.ack(msgs[2]);
+        channel.ack(msgs[0]);
+        // assert all 3 span messages are ended
+        expect(getTestSpans().length).toBe(6);
+        expectConsumeEndSpyStatus([
+          EndOperation.Ack,
+          EndOperation.Ack,
+          EndOperation.Ack,
+        ]);
+      });
+
+      it('ackAll', async () => {
+        lodash.times(2, () =>
+          channel.sendToQueue(queueName, Buffer.from(msgPayload))
+        );
+
+        await asyncConsume(channel, queueName, [null, () => channel.ackAll()]);
+        // assert all 2 span messages are ended by call to ackAll
+        expect(getTestSpans().length).toBe(4);
+        expectConsumeEndSpyStatus([EndOperation.AckAll, EndOperation.AckAll]);
+      });
+
+      it('nackAll', async () => {
+        lodash.times(2, () =>
+          channel.sendToQueue(queueName, Buffer.from(msgPayload))
+        );
+
+        await asyncConsume(channel, queueName, [
+          null,
+          () => channel.nackAll(false),
+        ]);
+        // assert all 2 span messages are ended by calling nackAll
+        expect(getTestSpans().length).toBe(4);
+        lodash.range(2, 4).forEach(i => {
+          expect(getTestSpans()[i].status.code).toEqual(SpanStatusCode.ERROR);
+          expect(getTestSpans()[i].status.message).toEqual(
+            'nackAll called on message without requeue'
+          );
+        });
+        expectConsumeEndSpyStatus([EndOperation.NackAll, EndOperation.NackAll]);
+      });
+
+      it('reject', async () => {
+        lodash.times(1, () =>
+          channel.sendToQueue(queueName, Buffer.from(msgPayload))
+        );
+
+        await asyncConsume(channel, queueName, [
+          msg => channel.reject(msg, false),
+        ]);
+        expect(getTestSpans().length).toBe(2);
+        expect(getTestSpans()[1].status.code).toEqual(SpanStatusCode.ERROR);
+        expect(getTestSpans()[1].status.message).toEqual(
+          'reject called on message without requeue'
+        );
+        expectConsumeEndSpyStatus([EndOperation.Reject]);
+      });
+
+      it('reject with requeue', async () => {
+        lodash.times(1, () =>
+          channel.sendToQueue(queueName, Buffer.from(msgPayload))
+        );
+
+        await asyncConsume(channel, queueName, [
+          msg => channel.reject(msg, true),
+          msg => channel.reject(msg, false),
+        ]);
+        expect(getTestSpans().length).toBe(3);
+        expect(getTestSpans()[1].status.code).toEqual(SpanStatusCode.ERROR);
+        expect(getTestSpans()[1].status.message).toEqual(
+          'reject called on message with requeue'
+        );
+        expect(getTestSpans()[2].status.code).toEqual(SpanStatusCode.ERROR);
+        expect(getTestSpans()[2].status.message).toEqual(
+          'reject called on message without requeue'
+        );
+        expectConsumeEndSpyStatus([EndOperation.Reject, EndOperation.Reject]);
+      });
+
+      it('closing channel should end all open spans on it', async () => {
+        lodash.times(1, () =>
+          channel.sendToQueue(queueName, Buffer.from(msgPayload))
+        );
+
+        await new Promise<void>(resolve =>
+          asyncConsume(channel, queueName, [
+            async msg => {
+              await channel.close();
+              resolve();
+              channel[CHANNEL_CLOSED_IN_TEST] = true;
+            },
+          ])
+        );
+
+        expect(getTestSpans().length).toBe(2);
+        expect(getTestSpans()[1].status.code).toEqual(SpanStatusCode.ERROR);
+        expect(getTestSpans()[1].status.message).toEqual('channel closed');
+        expectConsumeEndSpyStatus([EndOperation.ChannelClosed]);
+      });
+
+      it('error on channel should end all open spans on it', done => {
+        lodash.times(2, () =>
+          channel.sendToQueue(queueName, Buffer.from(msgPayload))
+        );
+
+        channel.on('close', () => {
+          expect(getTestSpans().length).toBe(4);
+          // second consume ended with valid ack, previous message not acked when channel is errored.
+          // since we first ack the second message, it appear first in the finished spans array
+          expect(getTestSpans()[2].status.code).toEqual(SpanStatusCode.UNSET);
+          expect(getTestSpans()[3].status.code).toEqual(SpanStatusCode.ERROR);
+          expect(getTestSpans()[3].status.message).toEqual('channel error');
+          expectConsumeEndSpyStatus([
+            EndOperation.Ack,
+            EndOperation.ChannelError,
+          ]);
+          done();
+        });
+        asyncConsume(channel, queueName, [
+          null,
+          msg => {
+            try {
+              channel.ack(msg);
+              channel[CHANNEL_CLOSED_IN_TEST] = true;
+              // ack the same msg again, this is not valid and should close the channel
+              channel.ack(msg);
+            } catch {}
+          },
+        ]);
+      });
+
+      it('not acking the message trigger timeout', async () => {
+        instrumentation.setConfig({
+          consumeEndHook: endHookSpy,
+          consumeTimeoutMs: 1,
+        });
+
+        lodash.times(1, () =>
+          channel.sendToQueue(queueName, Buffer.from(msgPayload))
+        );
+
+        await asyncConsume(channel, queueName, [null]);
+
+        // we have timeout of 1 ms, so we wait more than that and check span indeed ended
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(getTestSpans().length).toBe(2);
+        expectConsumeEndSpyStatus([EndOperation.InstrumentationTimeout]);
+      });
+    });
+
+    describe('routing and exchange', () => {
+      it('topic exchange', async () => {
+        const exchangeName = 'topic exchange';
+        const routingKey = 'topic.name.from.unittest';
+        await channel.assertExchange(exchangeName, 'topic', { durable: false });
+
+        const { queue: queueName } = await channel.assertQueue('', {
+          durable: false,
+        });
+        await channel.bindQueue(queueName, exchangeName, '#');
+
+        channel.publish(exchangeName, routingKey, Buffer.from(msgPayload));
+
+        await asyncConsume(channel, queueName, [null], {
+          noAck: true,
+        });
+
+        const [publishSpan, consumeSpan] = getTestSpans();
+
+        // assert publish span
+        expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
+        expect(publishSpan.name).toEqual(
+          `publish ${exchangeName}:${routingKey}`
+        );
+        expect(publishSpan.attributes).toEqual({
+          [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+          [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+          [ATTR_MESSAGING_OPERATION_TYPE]: MESSAGING_OPERATION_TYPE_VALUE_SEND,
+          [ATTR_MESSAGING_OPERATION_NAME]: 'publish',
+          [ATTR_MESSAGING_DESTINATION_NAME]: `${exchangeName}:${routingKey}`,
+          [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: routingKey,
+          [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+          [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+          [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+          [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+        });
+
+        // assert consume span
+        expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
+        expect(consumeSpan.name).toEqual(
+          `consume ${exchangeName}:${routingKey}:${queueName}`
+        );
+        expect(consumeSpan.attributes).toEqual({
+          [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+          [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+          [ATTR_MESSAGING_DESTINATION_NAME]: `${exchangeName}:${routingKey}:${queueName}`,
+          [ATTR_MESSAGING_OPERATION_TYPE]:
+            MESSAGING_OPERATION_TYPE_VALUE_PROCESS,
+          [ATTR_MESSAGING_OPERATION_NAME]: 'consume',
+          [ATTR_MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG]: 1,
+          [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: routingKey,
+          [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+          [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+          [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+          [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+        });
+
+        // assert context propagation
+        expect(consumeSpan.spanContext().traceId).toEqual(
+          publishSpan.spanContext().traceId
+        );
+        expect(consumeSpan.parentSpanContext?.spanId).toEqual(
+          publishSpan.spanContext().spanId
+        );
+      });
+    });
+
+    describe('hooks', () => {
+      it('publish and consume hooks success', async () => {
+        const attributeNameFromHook = 'attribute.name.from.hook';
+        const hookAttributeValue = 'attribute value from hook';
+        const attributeNameFromEndHook = 'attribute.name.from.endhook';
+        const endHookAttributeValue = 'attribute value from end hook';
+        instrumentation.setConfig({
+          publishHook: (span: Span, publishParams: PublishInfo): void => {
+            expect(publishParams.exchange).toEqual('');
+            expect(publishParams.routingKey).toEqual(queueName);
+            expect(publishParams.content.toString()).toEqual(msgPayload);
+            span.setAttribute(attributeNameFromHook, hookAttributeValue);
+          },
+          consumeHook: (span: Span, consumeInfo: ConsumeInfo): void => {
+            expect(consumeInfo.msg!.content.toString()).toEqual(msgPayload);
+            span.setAttribute(attributeNameFromHook, hookAttributeValue);
+          },
+          consumeEndHook: (
+            span: Span,
+            consumeEndInfo: ConsumeEndInfo
+          ): void => {
+            expect(consumeEndInfo.endOperation).toEqual(EndOperation.AutoAck);
+            span.setAttribute(attributeNameFromEndHook, endHookAttributeValue);
+          },
+        });
+
+        channel.sendToQueue(queueName, Buffer.from(msgPayload));
+
+        await asyncConsume(channel, queueName, [null], {
+          noAck: true,
+        });
+        expect(getTestSpans().length).toBe(2);
+        expect(getTestSpans()[0].attributes[attributeNameFromHook]).toEqual(
+          hookAttributeValue
+        );
+        expect(getTestSpans()[1].attributes[attributeNameFromHook]).toEqual(
+          hookAttributeValue
+        );
+        expect(getTestSpans()[1].attributes[attributeNameFromEndHook]).toEqual(
+          endHookAttributeValue
+        );
+      });
+
+      it('hooks throw should not affect user flow or span creation', async () => {
+        const attributeNameFromHook = 'attribute.name.from.hook';
+        const hookAttributeValue = 'attribute value from hook';
+        instrumentation.setConfig({
+          publishHook: (span: Span, publishParams: PublishInfo): void => {
+            span.setAttribute(attributeNameFromHook, hookAttributeValue);
+            throw new Error('error from hook');
+          },
+          consumeHook: (span: Span, consumeInfo: ConsumeInfo): void => {
+            span.setAttribute(attributeNameFromHook, hookAttributeValue);
+            throw new Error('error from hook');
+          },
+        });
+
+        channel.sendToQueue(queueName, Buffer.from(msgPayload));
+
+        await asyncConsume(channel, queueName, [null], {
+          noAck: true,
+        });
+        expect(getTestSpans().length).toBe(2);
+        getTestSpans().forEach(s =>
+          expect(s.attributes[attributeNameFromHook]).toEqual(
+            hookAttributeValue
+          )
+        );
+      });
+    });
+
+    describe('delete queue', () => {
+      it('consumer receives null msg when a queue is deleted in broker', async () => {
+        const queueNameForDeletion = 'queue-to-be-deleted';
+        await channel.assertQueue(queueNameForDeletion, { durable: false });
+        await channel.purgeQueue(queueNameForDeletion);
+
+        await channel.consume(
+          queueNameForDeletion,
+          (msg: ConsumeMessage | null) => {},
+          { noAck: true }
+        );
+        await channel.deleteQueue(queueNameForDeletion);
+      });
+    });
+  });
+
+  describe('confirm channel', () => {
+    let confirmChannel: amqp.ConfirmChannel & {
+      [CHANNEL_CLOSED_IN_TEST]?: boolean;
+    };
+    beforeEach(async () => {
+      endHookSpy = sinon.spy();
+      instrumentation.setConfig({
+        consumeEndHook: endHookSpy,
+      });
+
+      confirmChannel = await conn.createConfirmChannel();
+      await confirmChannel.assertQueue(queueName, { durable: false });
+      await confirmChannel.purgeQueue(queueName);
+      // install an error handler, otherwise when we have tests that create error on the channel,
+      // it throws and crash process
+      confirmChannel.on('error', (err: Error) => {});
+    });
+    afterEach(async () => {
+      if (!confirmChannel[CHANNEL_CLOSED_IN_TEST]) {
+        try {
+          await new Promise<void>(resolve => {
+            confirmChannel.on('close', resolve);
+            confirmChannel.close();
+          });
+        } catch {}
+      }
+    });
+
+    it('simple publish with confirm and consume from queue', async () => {
+      await asyncConfirmSend(confirmChannel, queueName, msgPayload);
+
+      await asyncConsume(
+        confirmChannel,
+        queueName,
+        [msg => expect(msg.content.toString()).toEqual(msgPayload)],
+        {
+          noAck: true,
+        }
+      );
+      const [publishSpan, consumeSpan] = getTestSpans();
+
+      // assert publish span
+      expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
+      expect(publishSpan.name).toEqual(`publish ${queueName}`);
+      expect(publishSpan.attributes).toEqual({
+        [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+        [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+        [ATTR_MESSAGING_OPERATION_TYPE]: MESSAGING_OPERATION_TYPE_VALUE_SEND,
+        [ATTR_MESSAGING_OPERATION_NAME]: 'publish',
+        [ATTR_MESSAGING_DESTINATION_NAME]: queueName,
+        [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: queueName,
+        [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+        [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+        [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+        [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+        [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+        [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+      });
+
+      // assert consume span
+      expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
+      expect(consumeSpan.name).toEqual(`consume ${queueName}`);
+      expect(consumeSpan.attributes).toEqual({
+        [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+        [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+        [ATTR_MESSAGING_OPERATION_TYPE]: MESSAGING_OPERATION_TYPE_VALUE_PROCESS,
+        [ATTR_MESSAGING_OPERATION_NAME]: 'consume',
+        [ATTR_MESSAGING_DESTINATION_NAME]: queueName,
+        [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: queueName,
+        [ATTR_MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG]: 1,
+        [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+        [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+        [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+        [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+        [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+        [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+      });
+
+      // assert context propagation
+      expect(consumeSpan.spanContext().traceId).toEqual(
+        publishSpan.spanContext().traceId
+      );
+
+      expectConsumeEndSpyStatus([EndOperation.AutoAck]);
+    });
+
+    it('confirm throw should not affect span end', async () => {
+      const confirmUserError = new Error('callback error');
+      await asyncConfirmSend(confirmChannel, queueName, msgPayload, () => {
+        throw confirmUserError;
+      }).catch(reject => expect(reject).toEqual(confirmUserError));
+
+      await asyncConsume(
+        confirmChannel,
+        queueName,
+        [msg => expect(msg.content.toString()).toEqual(msgPayload)],
+        {
+          noAck: true,
+        }
+      );
+
+      expect(getTestSpans()).toHaveLength(2);
+      expectConsumeEndSpyStatus([EndOperation.AutoAck]);
+    });
+
+    describe('ending consume spans', () => {
+      it('message acked sync', async () => {
+        await asyncConfirmSend(confirmChannel, queueName, msgPayload);
+
+        await asyncConsume(confirmChannel, queueName, [
+          msg => confirmChannel.ack(msg),
+        ]);
+        // assert consumed message span has ended
+        expect(getTestSpans().length).toBe(2);
+        expectConsumeEndSpyStatus([EndOperation.Ack]);
+      });
+
+      it('message acked async', async () => {
+        await asyncConfirmSend(confirmChannel, queueName, msgPayload);
+
+        // start async timer and ack the message after the callback returns
+        await new Promise<void>(resolve => {
+          asyncConsume(confirmChannel, queueName, [
+            msg =>
+              setTimeout(() => {
+                confirmChannel.ack(msg);
+                resolve();
+              }, 1),
+          ]);
+        });
+        // assert consumed message span has ended
+        expect(getTestSpans().length).toBe(2);
+        expectConsumeEndSpyStatus([EndOperation.Ack]);
+      });
+
+      it('message nack no requeue', async () => {
+        await asyncConfirmSend(confirmChannel, queueName, msgPayload);
+
+        await asyncConsume(confirmChannel, queueName, [
+          msg => confirmChannel.nack(msg, false, false),
+        ]);
+        await new Promise(resolve => setTimeout(resolve, 20)); // just make sure we don't get it again
+        // assert consumed message span has ended
+        expect(getTestSpans().length).toBe(2);
+        const [_, consumerSpan] = getTestSpans();
+        expect(consumerSpan.status.code).toEqual(SpanStatusCode.ERROR);
+        expect(consumerSpan.status.message).toEqual(
+          'nack called on message without requeue'
+        );
+        expectConsumeEndSpyStatus([EndOperation.Nack]);
+      });
+
+      it('message nack requeue, then acked', async () => {
+        await asyncConfirmSend(confirmChannel, queueName, msgPayload);
+
+        await asyncConsume(confirmChannel, queueName, [
+          (msg: amqp.Message) => confirmChannel.nack(msg, false, true),
+          (msg: amqp.Message) => confirmChannel.ack(msg),
+        ]);
+        // assert we have the requeued message sent again
+        expect(getTestSpans().length).toBe(3);
+        const [_, rejectedConsumerSpan, successConsumerSpan] = getTestSpans();
+        expect(rejectedConsumerSpan.status.code).toEqual(SpanStatusCode.ERROR);
+        expect(rejectedConsumerSpan.status.message).toEqual(
+          'nack called on message with requeue'
+        );
+        expect(successConsumerSpan.status.code).toEqual(SpanStatusCode.UNSET);
+        expectConsumeEndSpyStatus([EndOperation.Nack, EndOperation.Ack]);
+      });
+
+      it('ack allUpTo 2 msgs sync', async () => {
+        await Promise.all(
+          lodash.times(3, () =>
+            asyncConfirmSend(confirmChannel, queueName, msgPayload)
+          )
+        );
+
+        await asyncConsume(confirmChannel, queueName, [
+          null,
+          msg => confirmChannel.ack(msg, true),
+          msg => confirmChannel.ack(msg),
+        ]);
+        // assert all 3 messages are acked, including the first one which is acked by allUpTo
+        expect(getTestSpans().length).toBe(6);
+        expectConsumeEndSpyStatus([
+          EndOperation.Ack,
+          EndOperation.Ack,
+          EndOperation.Ack,
+        ]);
+      });
+
+      it('nack allUpTo 2 msgs sync', async () => {
+        await Promise.all(
+          lodash.times(3, () =>
+            asyncConfirmSend(confirmChannel, queueName, msgPayload)
+          )
+        );
+
+        await asyncConsume(confirmChannel, queueName, [
+          null,
+          msg => confirmChannel.nack(msg, true, false),
+          msg => confirmChannel.nack(msg, false, false),
+        ]);
+        // assert all 3 messages are acked, including the first one which is acked by allUpTo
+        expect(getTestSpans().length).toBe(6);
+        lodash.range(3, 6).forEach(i => {
+          expect(getTestSpans()[i].status.code).toEqual(SpanStatusCode.ERROR);
+          expect(getTestSpans()[i].status.message).toEqual(
+            'nack called on message without requeue'
+          );
+        });
+        expectConsumeEndSpyStatus([
+          EndOperation.Nack,
+          EndOperation.Nack,
+          EndOperation.Nack,
+        ]);
+      });
+
+      it('ack not in received order', async () => {
+        await Promise.all(
+          lodash.times(3, () =>
+            asyncConfirmSend(confirmChannel, queueName, msgPayload)
+          )
+        );
+
+        const msgs = await asyncConsume(confirmChannel, queueName, [
+          null,
+          null,
+          null,
+        ]);
+        confirmChannel.ack(msgs[1]);
+        confirmChannel.ack(msgs[2]);
+        confirmChannel.ack(msgs[0]);
+        // assert all 3 span messages are ended
+        expect(getTestSpans().length).toBe(6);
+        expectConsumeEndSpyStatus([
+          EndOperation.Ack,
+          EndOperation.Ack,
+          EndOperation.Ack,
+        ]);
+      });
+
+      it('ackAll', async () => {
+        await Promise.all(
+          lodash.times(2, () =>
+            asyncConfirmSend(confirmChannel, queueName, msgPayload)
+          )
+        );
+
+        await asyncConsume(confirmChannel, queueName, [
+          null,
+          () => confirmChannel.ackAll(),
+        ]);
+        // assert all 2 span messages are ended by call to ackAll
+        expect(getTestSpans().length).toBe(4);
+        expectConsumeEndSpyStatus([EndOperation.AckAll, EndOperation.AckAll]);
+      });
+
+      it('nackAll', async () => {
+        await Promise.all(
+          lodash.times(2, () =>
+            asyncConfirmSend(confirmChannel, queueName, msgPayload)
+          )
+        );
+
+        await asyncConsume(confirmChannel, queueName, [
+          null,
+          () => confirmChannel.nackAll(false),
+        ]);
+        // assert all 2 span messages are ended by calling nackAll
+        expect(getTestSpans().length).toBe(4);
+        lodash.range(2, 4).forEach(i => {
+          expect(getTestSpans()[i].status.code).toEqual(SpanStatusCode.ERROR);
+          expect(getTestSpans()[i].status.message).toEqual(
+            'nackAll called on message without requeue'
+          );
+        });
+        expectConsumeEndSpyStatus([EndOperation.NackAll, EndOperation.NackAll]);
+      });
+
+      it('reject', async () => {
+        await Promise.all(
+          lodash.times(1, () =>
+            asyncConfirmSend(confirmChannel, queueName, msgPayload)
+          )
+        );
+
+        await asyncConsume(confirmChannel, queueName, [
+          msg => confirmChannel.reject(msg, false),
+        ]);
+        expect(getTestSpans().length).toBe(2);
+        expect(getTestSpans()[1].status.code).toEqual(SpanStatusCode.ERROR);
+        expect(getTestSpans()[1].status.message).toEqual(
+          'reject called on message without requeue'
+        );
+        expectConsumeEndSpyStatus([EndOperation.Reject]);
+      });
+
+      it('reject with requeue', async () => {
+        await Promise.all(
+          lodash.times(1, () =>
+            asyncConfirmSend(confirmChannel, queueName, msgPayload)
+          )
+        );
+
+        await asyncConsume(confirmChannel, queueName, [
+          msg => confirmChannel.reject(msg, true),
+          msg => confirmChannel.reject(msg, false),
+        ]);
+        expect(getTestSpans().length).toBe(3);
+        expect(getTestSpans()[1].status.code).toEqual(SpanStatusCode.ERROR);
+        expect(getTestSpans()[1].status.message).toEqual(
+          'reject called on message with requeue'
+        );
+        expect(getTestSpans()[2].status.code).toEqual(SpanStatusCode.ERROR);
+        expect(getTestSpans()[2].status.message).toEqual(
+          'reject called on message without requeue'
+        );
+        expectConsumeEndSpyStatus([EndOperation.Reject, EndOperation.Reject]);
+      });
+
+      it('closing channel should end all open spans on it', async () => {
+        await Promise.all(
+          lodash.times(1, () =>
+            asyncConfirmSend(confirmChannel, queueName, msgPayload)
+          )
+        );
+
+        await new Promise<void>(resolve =>
+          asyncConsume(confirmChannel, queueName, [
+            async msg => {
+              await confirmChannel.close();
+              resolve();
+              confirmChannel[CHANNEL_CLOSED_IN_TEST] = true;
+            },
+          ])
+        );
+
+        expect(getTestSpans().length).toBe(2);
+        expect(getTestSpans()[1].status.code).toEqual(SpanStatusCode.ERROR);
+        expect(getTestSpans()[1].status.message).toEqual('channel closed');
+        expectConsumeEndSpyStatus([EndOperation.ChannelClosed]);
+      });
+
+      it('error on channel should end all open spans on it', done => {
+        Promise.all(
+          lodash.times(2, () =>
+            asyncConfirmSend(confirmChannel, queueName, msgPayload)
+          )
+        ).then(() => {
+          confirmChannel.on('close', () => {
+            expect(getTestSpans().length).toBe(4);
+            // second consume ended with valid ack, previous message not acked when channel is errored.
+            // since we first ack the second message, it appear first in the finished spans array
+            expect(getTestSpans()[2].status.code).toEqual(SpanStatusCode.UNSET);
+            expect(getTestSpans()[3].status.code).toEqual(SpanStatusCode.ERROR);
+            expect(getTestSpans()[3].status.message).toEqual('channel error');
+            expectConsumeEndSpyStatus([
+              EndOperation.Ack,
+              EndOperation.ChannelError,
+            ]);
+            done();
+          });
+          asyncConsume(confirmChannel, queueName, [
+            null,
+            msg => {
+              try {
+                confirmChannel.ack(msg);
+                confirmChannel[CHANNEL_CLOSED_IN_TEST] = true;
+                // ack the same msg again, this is not valid and should close the channel
+                confirmChannel.ack(msg);
+              } catch {}
+            },
+          ]);
+        });
+      });
+
+      it('not acking the message trigger timeout', async () => {
+        instrumentation.setConfig({
+          consumeEndHook: endHookSpy,
+          consumeTimeoutMs: 1,
+        });
+
+        await Promise.all(
+          lodash.times(1, () =>
+            asyncConfirmSend(confirmChannel, queueName, msgPayload)
+          )
+        );
+
+        await asyncConsume(confirmChannel, queueName, [null]);
+
+        // we have timeout of 1 ms, so we wait more than that and check span indeed ended
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        expect(getTestSpans().length).toBe(2);
+        expectConsumeEndSpyStatus([EndOperation.InstrumentationTimeout]);
+      });
+    });
+
+    describe('routing and exchange', () => {
+      it('topic exchange', async () => {
+        const exchangeName = 'topic exchange';
+        const routingKey = 'topic.name.from.unittest';
+        await confirmChannel.assertExchange(exchangeName, 'topic', {
+          durable: false,
+        });
+
+        const { queue: queueName } = await confirmChannel.assertQueue('', {
+          durable: false,
+        });
+        await confirmChannel.bindQueue(queueName, exchangeName, '#');
+
+        await asyncConfirmPublish(
+          confirmChannel,
+          exchangeName,
+          routingKey,
+          msgPayload
+        );
+
+        await asyncConsume(confirmChannel, queueName, [null], {
+          noAck: true,
+        });
+
+        const [publishSpan, consumeSpan] = getTestSpans();
+
+        // assert publish span
+        expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
+        expect(publishSpan.name).toEqual(
+          `publish ${exchangeName}:${routingKey}`
+        );
+        expect(publishSpan.attributes).toEqual({
+          [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+          [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+          [ATTR_MESSAGING_OPERATION_TYPE]: MESSAGING_OPERATION_TYPE_VALUE_SEND,
+          [ATTR_MESSAGING_OPERATION_NAME]: 'publish',
+          [ATTR_MESSAGING_DESTINATION_NAME]: `${exchangeName}:${routingKey}`,
+          [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: routingKey,
+          [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+          [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+          [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+          [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+        });
+
+        // assert consume span
+        expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
+        expect(consumeSpan.name).toEqual(
+          `consume ${exchangeName}:${routingKey}:${queueName}`
+        );
+        expect(consumeSpan.attributes).toEqual({
+          [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+          [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+          [ATTR_MESSAGING_OPERATION_TYPE]:
+            MESSAGING_OPERATION_TYPE_VALUE_PROCESS,
+          [ATTR_MESSAGING_OPERATION_NAME]: 'consume',
+          [ATTR_MESSAGING_DESTINATION_NAME]: `${exchangeName}:${routingKey}:${queueName}`,
+          [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: routingKey,
+          [ATTR_MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG]: 1,
+          [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+          [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+          [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+          [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+        });
+
+        // assert context propagation
+        expect(consumeSpan.spanContext().traceId).toEqual(
+          publishSpan.spanContext().traceId
+        );
+        expect(consumeSpan.parentSpanContext?.spanId).toEqual(
+          publishSpan.spanContext().spanId
+        );
+      });
+
+      describe('hooks', () => {
+        it('publish and consume hooks success', async () => {
+          const attributeNameFromHook = 'attribute.name.from.hook';
+          const hookAttributeValue = 'attribute value from hook';
+          const attributeNameFromConfirmEndHook =
+            'attribute.name.from.confirm.endhook';
+          const confirmEndHookAttributeValue =
+            'attribute value from confirm end hook';
+          const attributeNameFromConsumeEndHook =
+            'attribute.name.from.consume.endhook';
+          const consumeEndHookAttributeValue =
+            'attribute value from consume end hook';
+          instrumentation.setConfig({
+            publishHook: (span: Span, publishParams: PublishInfo) => {
+              expect(publishParams.exchange).toEqual('');
+              expect(publishParams.routingKey).toEqual(queueName);
+              expect(publishParams.content.toString()).toEqual(msgPayload);
+              expect(publishParams.isConfirmChannel).toBe(true);
+              span.setAttribute(attributeNameFromHook, hookAttributeValue);
+            },
+            publishConfirmHook: (span, publishParams) => {
+              expect(publishParams.exchange).toEqual('');
+              expect(publishParams.routingKey).toEqual(queueName);
+              expect(publishParams.content.toString()).toEqual(msgPayload);
+              span.setAttribute(
+                attributeNameFromConfirmEndHook,
+                confirmEndHookAttributeValue
+              );
+            },
+            consumeHook: (span: Span, consumeInfo: ConsumeInfo) => {
+              expect(consumeInfo.msg!.content.toString()).toEqual(msgPayload);
+              span.setAttribute(attributeNameFromHook, hookAttributeValue);
+            },
+            consumeEndHook: (
+              span: Span,
+              consumeEndInfo: ConsumeEndInfo
+            ): void => {
+              span.setAttribute(
+                attributeNameFromConsumeEndHook,
+                consumeEndHookAttributeValue
+              );
+              expect(consumeEndInfo.endOperation).toEqual(EndOperation.AutoAck);
+            },
+          });
+
+          await asyncConfirmSend(confirmChannel, queueName, msgPayload);
+
+          await asyncConsume(confirmChannel, queueName, [null], {
+            noAck: true,
+          });
+          expect(getTestSpans().length).toBe(2);
+          expect(getTestSpans()[0].attributes[attributeNameFromHook]).toEqual(
+            hookAttributeValue
+          );
+          expect(
+            getTestSpans()[0].attributes[attributeNameFromConfirmEndHook]
+          ).toEqual(confirmEndHookAttributeValue);
+          expect(getTestSpans()[1].attributes[attributeNameFromHook]).toEqual(
+            hookAttributeValue
+          );
+          expect(
+            getTestSpans()[1].attributes[attributeNameFromConsumeEndHook]
+          ).toEqual(consumeEndHookAttributeValue);
+        });
+
+        it('hooks throw should not affect user flow or span creation', async () => {
+          const attributeNameFromHook = 'attribute.name.from.hook';
+          const hookAttributeValue = 'attribute value from hook';
+          instrumentation.setConfig({
+            publishHook: (span: Span, publishParams: PublishInfo): void => {
+              span.setAttribute(attributeNameFromHook, hookAttributeValue);
+              throw new Error('error from hook');
+            },
+            publishConfirmHook: (
+              span: Span,
+              publishParams: PublishInfo
+            ): void => {
+              span.setAttribute(attributeNameFromHook, hookAttributeValue);
+              throw new Error('error from hook');
+            },
+            consumeHook: (span: Span, consumeInfo: ConsumeInfo): void => {
+              span.setAttribute(attributeNameFromHook, hookAttributeValue);
+              throw new Error('error from hook');
+            },
+          });
+
+          await asyncConfirmSend(confirmChannel, queueName, msgPayload);
+
+          await asyncConsume(confirmChannel, queueName, [null], {
+            noAck: true,
+          });
+          expect(getTestSpans().length).toBe(2);
+          getTestSpans().forEach(s =>
+            expect(s.attributes[attributeNameFromHook]).toEqual(
+              hookAttributeValue
+            )
+          );
+        });
+      });
+    });
+  });
+
+  describe('channel using links config', () => {
+    let channel: amqp.Channel & { [CHANNEL_CLOSED_IN_TEST]?: boolean };
+    beforeEach(async () => {
+      endHookSpy = sinon.spy();
+      instrumentation.setConfig({
+        consumeEndHook: endHookSpy,
+        useLinksForConsume: true,
+      });
+
+      channel = await conn.createChannel();
+      await channel.assertQueue(queueName, { durable: false });
+      await channel.purgeQueue(queueName);
+      // install an error handler, otherwise when we have tests that create error on the channel,
+      // it throws and crash process
+      channel.on('error', (err: Error) => {});
+    });
+    afterEach(async () => {
+      if (!channel[CHANNEL_CLOSED_IN_TEST]) {
+        try {
+          await new Promise<void>(resolve => {
+            channel.on('close', resolve);
+            channel.close();
+          });
+        } catch {}
+      }
+    });
+
+    it('simple publish and consume from queue', async () => {
+      const hadSpaceInBuffer = channel.sendToQueue(
+        queueName,
+        Buffer.from(msgPayload)
+      );
+      expect(hadSpaceInBuffer).toBeTruthy();
+
+      await asyncConsume(
+        channel,
+        queueName,
+        [msg => expect(msg.content.toString()).toEqual(msgPayload)],
+        {
+          noAck: true,
+        }
+      );
+      const [publishSpan, consumeSpan] = getTestSpans();
+
+      // assert publish span
+      expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
+      expect(publishSpan.name).toEqual(`publish ${queueName}`);
+      expect(publishSpan.attributes).toEqual({
+        [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+        [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+        [ATTR_MESSAGING_OPERATION_TYPE]: MESSAGING_OPERATION_TYPE_VALUE_SEND,
+        [ATTR_MESSAGING_OPERATION_NAME]: 'publish',
+        [ATTR_MESSAGING_DESTINATION_NAME]: queueName,
+        [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: queueName,
+        [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+        [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+        [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+        [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+        [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+        [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+      });
+
+      // assert consume span
+      expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
+      expect(consumeSpan.name).toEqual(`consume ${queueName}`);
+      expect(consumeSpan.attributes).toEqual({
+        [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+        [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+        [ATTR_MESSAGING_OPERATION_TYPE]: MESSAGING_OPERATION_TYPE_VALUE_PROCESS,
+        [ATTR_MESSAGING_OPERATION_NAME]: 'consume',
+        [ATTR_MESSAGING_DESTINATION_NAME]: queueName,
+        [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: queueName,
+        [ATTR_MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG]: 1,
+        [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+        [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+        [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+        [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+        [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+        [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+      });
+
+      // new trace should be created
+      expect(consumeSpan.spanContext().traceId).not.toEqual(
+        publishSpan.spanContext().traceId
+      );
+      expect(consumeSpan.parentSpanContext?.spanId).toBeUndefined();
+
+      // link back to publish span
+      expect(consumeSpan.links.length).toBe(1);
+      expect(consumeSpan.links[0].context.traceId).toEqual(
+        publishSpan.spanContext().traceId
+      );
+      expect(consumeSpan.links[0].context.spanId).toEqual(
+        publishSpan.spanContext().spanId
+      );
+
+      expectConsumeEndSpyStatus([EndOperation.AutoAck]);
+    });
+
+    describe('routing and exchange', () => {
+      it('topic exchange', async () => {
+        const exchangeName = 'topic exchange';
+        const routingKey = 'topic.name.from.unittest';
+        await channel.assertExchange(exchangeName, 'topic', {
+          durable: false,
+        });
+
+        const { queue: queueName } = await channel.assertQueue('', {
+          durable: false,
+        });
+        await channel.bindQueue(queueName, exchangeName, '#');
+
+        channel.publish(exchangeName, routingKey, Buffer.from(msgPayload));
+
+        await asyncConsume(channel, queueName, [null], {
+          noAck: true,
+        });
+
+        const [publishSpan, consumeSpan] = getTestSpans();
+
+        // assert publish span
+        expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
+        expect(publishSpan.name).toEqual(
+          `publish ${exchangeName}:${routingKey}`
+        );
+        expect(publishSpan.attributes).toEqual({
+          [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+          [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+          [ATTR_MESSAGING_OPERATION_TYPE]: MESSAGING_OPERATION_TYPE_VALUE_SEND,
+          [ATTR_MESSAGING_OPERATION_NAME]: 'publish',
+          [ATTR_MESSAGING_DESTINATION_NAME]: `${exchangeName}:${routingKey}`,
+          [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: routingKey,
+          [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+          [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+          [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+          [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+        });
+
+        // assert consume span
+        expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
+        expect(consumeSpan.name).toEqual(
+          `consume ${exchangeName}:${routingKey}:${queueName}`
+        );
+        expect(consumeSpan.attributes).toEqual({
+          [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+          [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+          [ATTR_MESSAGING_OPERATION_TYPE]:
+            MESSAGING_OPERATION_TYPE_VALUE_PROCESS,
+          [ATTR_MESSAGING_OPERATION_NAME]: 'consume',
+          [ATTR_MESSAGING_DESTINATION_NAME]: `${exchangeName}:${routingKey}:${queueName}`,
+          [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: routingKey,
+          [ATTR_MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG]: 1,
+          [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+          [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+          [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+          [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+        });
+
+        // new trace should be created
+        expect(consumeSpan.spanContext().traceId).not.toEqual(
+          publishSpan.spanContext().traceId
+        );
+        expect(consumeSpan.parentSpanContext?.spanId).toBeUndefined();
+
+        // link back to publish span
+        expect(consumeSpan.links.length).toBe(1);
+        expect(consumeSpan.links[0].context.traceId).toEqual(
+          publishSpan.spanContext().traceId
+        );
+        expect(consumeSpan.links[0].context.spanId).toEqual(
+          publishSpan.spanContext().spanId
+        );
+      });
+    });
+  });
+
+  describe('confirm channel links config', () => {
+    let confirmChannel: amqp.ConfirmChannel & {
+      [CHANNEL_CLOSED_IN_TEST]?: boolean;
+    };
+    beforeEach(async () => {
+      endHookSpy = sinon.spy();
+      instrumentation.setConfig({
+        consumeEndHook: endHookSpy,
+        useLinksForConsume: true,
+      });
+
+      confirmChannel = await conn.createConfirmChannel();
+      await confirmChannel.assertQueue(queueName, { durable: false });
+      await confirmChannel.purgeQueue(queueName);
+      // install an error handler, otherwise when we have tests that create error on the channel,
+      // it throws and crash process
+      confirmChannel.on('error', (err: Error) => {});
+    });
+    afterEach(async () => {
+      if (!confirmChannel[CHANNEL_CLOSED_IN_TEST]) {
+        try {
+          await new Promise<void>(resolve => {
+            confirmChannel.on('close', resolve);
+            confirmChannel.close();
+          });
+        } catch {}
+      }
+    });
+
+    it('simple publish with confirm and consume from queue', async () => {
+      await asyncConfirmSend(confirmChannel, queueName, msgPayload);
+
+      await asyncConsume(
+        confirmChannel,
+        queueName,
+        [msg => expect(msg.content.toString()).toEqual(msgPayload)],
+        {
+          noAck: true,
+        }
+      );
+      const [publishSpan, consumeSpan] = getTestSpans();
+
+      // assert publish span
+      expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
+      expect(publishSpan.name).toEqual(`publish ${queueName}`);
+      expect(publishSpan.attributes).toEqual({
+        [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+        [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+        [ATTR_MESSAGING_OPERATION_TYPE]: MESSAGING_OPERATION_TYPE_VALUE_SEND,
+        [ATTR_MESSAGING_OPERATION_NAME]: 'publish',
+        [ATTR_MESSAGING_DESTINATION_NAME]: queueName,
+        [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: queueName,
+        [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+        [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+        [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+        [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+        [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+        [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+      });
+
+      // assert consume span
+      expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
+      expect(consumeSpan.name).toEqual(`consume ${queueName}`);
+      expect(consumeSpan.attributes).toEqual({
+        [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+        [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+        [ATTR_MESSAGING_OPERATION_TYPE]: MESSAGING_OPERATION_TYPE_VALUE_PROCESS,
+        [ATTR_MESSAGING_OPERATION_NAME]: 'consume',
+        [ATTR_MESSAGING_DESTINATION_NAME]: queueName,
+        [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: queueName,
+        [ATTR_MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG]: 1,
+        [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+        [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+        [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+        [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+        [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+        [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+      });
+
+      // new trace should be created
+      expect(consumeSpan.spanContext().traceId).not.toEqual(
+        publishSpan.spanContext().traceId
+      );
+      expect(consumeSpan.parentSpanContext?.spanId).toBeUndefined();
+
+      // link back to publish span
+      expect(consumeSpan.links.length).toBe(1);
+      expect(consumeSpan.links[0].context.traceId).toEqual(
+        publishSpan.spanContext().traceId
+      );
+      expect(consumeSpan.links[0].context.spanId).toEqual(
+        publishSpan.spanContext().spanId
+      );
+
+      expectConsumeEndSpyStatus([EndOperation.AutoAck]);
+    });
+
+    describe('routing and exchange', () => {
+      it('topic exchange', async () => {
+        const exchangeName = 'topic exchange';
+        const routingKey = 'topic.name.from.unittest';
+        await confirmChannel.assertExchange(exchangeName, 'topic', {
+          durable: false,
+        });
+
+        const { queue: queueName } = await confirmChannel.assertQueue('', {
+          durable: false,
+        });
+        await confirmChannel.bindQueue(queueName, exchangeName, '#');
+
+        await asyncConfirmPublish(
+          confirmChannel,
+          exchangeName,
+          routingKey,
+          msgPayload
+        );
+
+        await asyncConsume(confirmChannel, queueName, [null], {
+          noAck: true,
+        });
+
+        const [publishSpan, consumeSpan] = getTestSpans();
+
+        // assert publish span
+        expect(publishSpan.kind).toEqual(SpanKind.PRODUCER);
+        expect(publishSpan.name).toEqual(
+          `publish ${exchangeName}:${routingKey}`
+        );
+        expect(publishSpan.attributes).toEqual({
+          [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+          [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+          [ATTR_MESSAGING_OPERATION_TYPE]: MESSAGING_OPERATION_TYPE_VALUE_SEND,
+          [ATTR_MESSAGING_OPERATION_NAME]: 'publish',
+          [ATTR_MESSAGING_DESTINATION_NAME]: `${exchangeName}:${routingKey}`,
+          [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: routingKey,
+          [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+          [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+          [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+          [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+        });
+
+        // assert consume span
+        expect(consumeSpan.kind).toEqual(SpanKind.CONSUMER);
+        expect(consumeSpan.name).toEqual(
+          `consume ${exchangeName}:${routingKey}:${queueName}`
+        );
+        expect(consumeSpan.attributes).toEqual({
+          [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
+          [ATTR_MESSAGING_MESSAGE_BODY_SIZE]: msgPayload.length,
+          [ATTR_MESSAGING_OPERATION_TYPE]:
+            MESSAGING_OPERATION_TYPE_VALUE_PROCESS,
+          [ATTR_MESSAGING_OPERATION_NAME]: 'consume',
+          [ATTR_MESSAGING_DESTINATION_NAME]: `${exchangeName}:${routingKey}:${queueName}`,
+          [ATTR_MESSAGING_RABBITMQ_DESTINATION_ROUTING_KEY]: routingKey,
+          [ATTR_MESSAGING_RABBITMQ_MESSAGE_DELIVERY_TAG]: 1,
+          [ATTR_NETWORK_PROTOCOL_NAME]: 'AMQP',
+          [ATTR_NETWORK_PROTOCOL_VERSION]: '0.9.1',
+          [ATTR_NETWORK_PEER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_NETWORK_PEER_PORT]: TEST_RABBITMQ_PORT,
+          [ATTR_SERVER_ADDRESS]: TEST_RABBITMQ_HOST,
+          [ATTR_SERVER_PORT]: TEST_RABBITMQ_PORT,
+        });
+
+        // new trace should be created
+        expect(consumeSpan.spanContext().traceId).not.toEqual(
+          publishSpan.spanContext().traceId
+        );
+        expect(consumeSpan.parentSpanContext?.spanId).toBeUndefined();
+
+        // link back to publish span
+        expect(consumeSpan.links.length).toBe(1);
+        expect(consumeSpan.links[0].context.traceId).toEqual(
+          publishSpan.spanContext().traceId
+        );
+        expect(consumeSpan.links[0].context.spanId).toEqual(
+          publishSpan.spanContext().spanId
+        );
+      });
+    });
+  });
+});

--- a/packages/instrumentation-amqplib/test/amqplib-promise-stable.test.ts
+++ b/packages/instrumentation-amqplib/test/amqplib-promise-stable.test.ts
@@ -69,9 +69,9 @@ const CHANNEL_CLOSED_IN_TEST = Symbol(
 );
 
 describe('amqplib instrumentation promise model - stable semconv', () => {
-  let conn: amqp.Connection;
+  let conn: amqp.ChannelModel;
   before(async function () {
-    instrumentation['_semconvStability'] = SemconvStability.STABLE;
+    instrumentation['_messagingSemconvStability'] = SemconvStability.STABLE;
 
     if (!shouldTest) {
       this.skip();
@@ -80,7 +80,7 @@ describe('amqplib instrumentation promise model - stable semconv', () => {
     }
   });
   after(async () => {
-    instrumentation['_semconvStability'] = SemconvStability.OLD;
+    instrumentation['_messagingSemconvStability'] = SemconvStability.OLD;
 
     if (shouldTest) {
       await conn.close();

--- a/packages/instrumentation-amqplib/test/utils.test.ts
+++ b/packages/instrumentation-amqplib/test/utils.test.ts
@@ -21,6 +21,8 @@ import {
   getConnectionAttributesFromUrl,
 } from '../src/utils';
 import {
+  ATTR_NETWORK_PROTOCOL_NAME,
+  ATTR_NETWORK_PROTOCOL_VERSION,
   ATTR_SERVER_ADDRESS,
   ATTR_SERVER_PORT,
 } from '@opentelemetry/semantic-conventions';
@@ -66,6 +68,7 @@ describe('utils', () => {
     it('all features', () => {
       const attributes = getConnectionAttributesFromUrl(
         'amqp://user:pass@host:10000/vhost',
+        SemconvStability.OLD,
         SemconvStability.OLD
       );
       expect(attributes).toStrictEqual({
@@ -80,6 +83,7 @@ describe('utils', () => {
     it('all features encoded', () => {
       const attributes = getConnectionAttributesFromUrl(
         'amqp://user%61:%61pass@ho%61st:10000/v%2fhost',
+        SemconvStability.OLD,
         SemconvStability.OLD
       );
       expect(attributes).toStrictEqual({
@@ -94,6 +98,7 @@ describe('utils', () => {
     it('only protocol', () => {
       const attributes = getConnectionAttributesFromUrl(
         'amqp://',
+        SemconvStability.OLD,
         SemconvStability.OLD
       );
       expect(attributes).toStrictEqual({
@@ -108,6 +113,7 @@ describe('utils', () => {
     it('empty username and password', () => {
       const attributes = getConnectionAttributesFromUrl(
         'amqp://:@/',
+        SemconvStability.OLD,
         SemconvStability.OLD
       );
       expect(attributes).toStrictEqual({
@@ -119,6 +125,7 @@ describe('utils', () => {
     it('username and no password', () => {
       const attributes = getConnectionAttributesFromUrl(
         'amqp://user@',
+        SemconvStability.OLD,
         SemconvStability.OLD
       );
       expect(attributes).toStrictEqual({
@@ -130,6 +137,7 @@ describe('utils', () => {
     it('username and password, no host', () => {
       const attributes = getConnectionAttributesFromUrl(
         'amqp://user:pass@',
+        SemconvStability.OLD,
         SemconvStability.OLD
       );
       expect(attributes).toStrictEqual({
@@ -141,6 +149,7 @@ describe('utils', () => {
     it('host only', () => {
       const attributes = getConnectionAttributesFromUrl(
         'amqp://host',
+        SemconvStability.OLD,
         SemconvStability.OLD
       );
       expect(attributes).toStrictEqual({
@@ -155,6 +164,7 @@ describe('utils', () => {
     it('vhost only', () => {
       const attributes = getConnectionAttributesFromUrl(
         'amqp:///vhost',
+        SemconvStability.OLD,
         SemconvStability.OLD
       );
       expect(attributes).toStrictEqual({
@@ -169,6 +179,7 @@ describe('utils', () => {
     it('host only, trailing slash', () => {
       const attributes = getConnectionAttributesFromUrl(
         'amqp://host/',
+        SemconvStability.OLD,
         SemconvStability.OLD
       );
       expect(attributes).toStrictEqual({
@@ -183,6 +194,7 @@ describe('utils', () => {
     it('vhost encoded', () => {
       const attributes = getConnectionAttributesFromUrl(
         'amqp://host/%2f',
+        SemconvStability.OLD,
         SemconvStability.OLD
       );
       expect(attributes).toStrictEqual({
@@ -197,6 +209,7 @@ describe('utils', () => {
     it('IPv6 host', () => {
       const attributes = getConnectionAttributesFromUrl(
         'amqp://[::1]',
+        SemconvStability.OLD,
         SemconvStability.OLD
       );
       expect(attributes).toStrictEqual({
@@ -208,10 +221,11 @@ describe('utils', () => {
       });
     });
 
-    describe('semconv stability', () => {
+    describe('net semconv stability', () => {
       it('OLD semconv emits net.peer.* attributes', () => {
         const attributes = getConnectionAttributesFromUrl(
           'amqp://user:pass@host:10000/vhost',
+          SemconvStability.OLD,
           SemconvStability.OLD
         );
         expect(attributes[ATTR_NET_PEER_NAME]).toEqual('host');
@@ -223,7 +237,8 @@ describe('utils', () => {
       it('STABLE semconv emits server.* attributes', () => {
         const attributes = getConnectionAttributesFromUrl(
           'amqp://user:pass@host:10000/vhost',
-          SemconvStability.STABLE
+          SemconvStability.STABLE,
+          SemconvStability.OLD
         );
         expect(attributes[ATTR_NET_PEER_NAME]).toBeUndefined();
         expect(attributes[ATTR_NET_PEER_PORT]).toBeUndefined();
@@ -234,7 +249,8 @@ describe('utils', () => {
       it('DUPLICATE semconv emits both old and stable attributes', () => {
         const attributes = getConnectionAttributesFromUrl(
           'amqp://user:pass@host:10000/vhost',
-          SemconvStability.DUPLICATE
+          SemconvStability.DUPLICATE,
+          SemconvStability.OLD
         );
         expect(attributes[ATTR_NET_PEER_NAME]).toEqual('host');
         expect(attributes[ATTR_NET_PEER_PORT]).toEqual(10000);
@@ -249,6 +265,7 @@ describe('utils', () => {
             hostname: 'testhost',
             port: 5673,
           },
+          SemconvStability.OLD,
           SemconvStability.OLD
         );
         expect(attributes[ATTR_NET_PEER_NAME]).toEqual('testhost');
@@ -264,7 +281,8 @@ describe('utils', () => {
             hostname: 'testhost',
             port: 5673,
           },
-          SemconvStability.STABLE
+          SemconvStability.STABLE,
+          SemconvStability.OLD
         );
         expect(attributes[ATTR_NET_PEER_NAME]).toBeUndefined();
         expect(attributes[ATTR_NET_PEER_PORT]).toBeUndefined();
@@ -279,7 +297,8 @@ describe('utils', () => {
             hostname: 'testhost',
             port: 5673,
           },
-          SemconvStability.DUPLICATE
+          SemconvStability.DUPLICATE,
+          SemconvStability.OLD
         );
         expect(attributes[ATTR_NET_PEER_NAME]).toEqual('testhost');
         expect(attributes[ATTR_NET_PEER_PORT]).toEqual(5673);
@@ -287,5 +306,43 @@ describe('utils', () => {
         expect(attributes[ATTR_SERVER_PORT]).toEqual(5673);
       });
     });
+
+    describe('messaging semconv stability', () => {
+      it('OLD semconv emits messaging.* attributes', () => {
+        const attributes = getConnectionAttributesFromUrl(
+          'amqp://user:pass@host:10000/vhost',
+          SemconvStability.OLD,
+          SemconvStability.OLD
+        );
+        expect(attributes[ATTR_MESSAGING_PROTOCOL]).toEqual('AMQP');
+        expect(attributes[ATTR_MESSAGING_PROTOCOL_VERSION]).toEqual('0.9.1');
+        expect(attributes[ATTR_NETWORK_PROTOCOL_NAME]).toBeUndefined();
+        expect(attributes[ATTR_NETWORK_PROTOCOL_VERSION]).toBeUndefined();
+      });
+
+      it('STABLE semconv emits network.protocol.* attributes', () => {
+        const attributes = getConnectionAttributesFromUrl(
+          'amqp://user:pass@host:10000/vhost',
+          SemconvStability.OLD,
+          SemconvStability.STABLE
+        );
+        expect(attributes[ATTR_MESSAGING_PROTOCOL]).toBeUndefined();
+        expect(attributes[ATTR_MESSAGING_PROTOCOL_VERSION]).toBeUndefined();
+        expect(attributes[ATTR_NETWORK_PROTOCOL_NAME]).toEqual('AMQP');
+        expect(attributes[ATTR_NETWORK_PROTOCOL_VERSION]).toEqual('0.9.1');
+      });
+
+      it('DUPLICATE semconv emits both old and stable attributes', () => {
+        const attributes = getConnectionAttributesFromUrl(
+          'amqp://user:pass@host:10000/vhost',
+          SemconvStability.OLD,
+          SemconvStability.DUPLICATE
+        );
+        expect(attributes[ATTR_MESSAGING_PROTOCOL]).toEqual('AMQP');
+        expect(attributes[ATTR_MESSAGING_PROTOCOL_VERSION]).toEqual('0.9.1');
+        expect(attributes[ATTR_NETWORK_PROTOCOL_NAME]).toEqual('AMQP');
+        expect(attributes[ATTR_NETWORK_PROTOCOL_VERSION]).toEqual('0.9.1');
+      });
+    })
   });
 });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Currently, the `amqplib` instrumentation only exports legacy attributes. 
However, according to the OpenTelemetry specifications, we will have to migrate to new attributes to ensure better compatibility and consistency across tools and libraries. 
The v1.36.0+ conventions are not yet stable but will become stable in the future, so I think it's important to begin implementing the export of these new attributes, in order to anticipate the deprecation of the legacy ones, improve interoperability with other tools, and align with community best practices.

## Short description of the changes

Adds support for stable semantic conventions in the amqplib instrumentation, controlled by the `OTEL_SEMCONV_STABILITY_OPT_IN=messaging` environment variable.

Key changes:

- Updates the instrumentation to use stable span names and attributes.
- Introduces new tests to validate stable semantic conventions.
- Updates README with migration guide and semantic conventions for both legacy and stable versions.

I used these specifications for implementing new attributes:
- [messaging spec v1.36](https://github.com/open-telemetry/semantic-conventions/blob/v1.36.0/docs/messaging/messaging-spans.md)
- [RabbitMQ messaging spec v1.36](https://github.com/open-telemetry/semantic-conventions/blob/v1.36.0/docs/messaging/rabbitmq.md)

## Migration guide

When upgrading to the new semantic conventions, it is recommended to follow this migration path:

1. **Upgrade** `@opentelemetry/instrumentation-amqplib` to the latest version
2. **Enable dual mode**: Set `OTEL_SEMCONV_STABILITY_OPT_IN=messaging/dup` to emit both old and new semantic conventions
3. **Update monitoring**: Modify alerts, dashboards, metrics, and other processes to use the new semantic conventions
4. **Switch to stable**: Set `OTEL_SEMCONV_STABILITY_OPT_IN=messaging` to emit only the new semantic conventions
