### PR TITLE
chore(examples-express): call setupTracing before module imports

### DIFF
--- a/examples/express/src/client.ts
+++ b/examples/express/src/client.ts
@@ -16,10 +16,11 @@
 
 import { setupTracing } from './tracer';
 
+// Initialize tracing before importing other moduless
+const tracer = setupTracing('example-express-client');
+
 import * as api from '@opentelemetry/api';
 import * as axios from 'axios';
-
-const tracer = setupTracing('example-express-client');
 
 async function makeRequest() {
   const span = tracer.startSpan('client.makeRequest()', {

--- a/examples/express/src/server.ts
+++ b/examples/express/src/server.ts
@@ -16,12 +16,13 @@
 
 import { setupTracing } from './tracer';
 
+// Initialize tracing before importing other modules
+setupTracing('example-express-server');
+
 // Require in rest of modules
 import * as express from 'express';
 import * as axios from 'axios';
 import { RequestHandler } from 'express';
-
-setupTracing('example-express-server');
 
 // Setup express
 const app = express();


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- The Express example was not generating traces because `express` (and other modules) were being imported before `setupTracing` was called.

- This ordering prevented instrumentation from being applied correctly.

## Short description of the changes

- Reordered imports in `server.js` and `client.js` so that `setupTracing` is called before importing express and other modules.

- Added a brief inline comment.
