### PR TITLE
test: replace bitnami/cassandra imgage with cassandra

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -125,7 +125,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       cassandra:
-        image: bitnami/cassandra:3
+        image: cassandra:3
         ports:
         - 9042:9042
       rabbitmq:


### PR DESCRIPTION
## Which problem is this PR solving?

Replaces `bitnami/cassandra:3` with `cassandra:3`, since tags from `bitnami/cassandra` are being retired. We already use the `cassandra:3` image in local test files.