### PR TITLE
test(instr-mongodb): fix tests mongdb tests for 6.19.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24502,13 +24502,13 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.15.0.tgz",
-      "integrity": "sha512-ifBhQ0rRzHDzqp9jAQP6OwHSH7dbYIQjD3SbJs9YYk9AikKEettW/9s/tbSFDTpXcRbF+u1aLrhHxDFaYtZpFQ==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.19.0.tgz",
+      "integrity": "sha512-H3GtYujOJdeKIMLKBT9PwlDhGrQfplABNF1G904w6r5ZXKWyv77aB0X9B+rhmaAwjtllHzaEkvi9mkGVZxs2Bw==",
       "dev": true,
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.9",
-        "bson": "^6.10.3",
+        "bson": "^6.10.4",
         "mongodb-connection-string-url": "^3.0.0"
       },
       "engines": {
@@ -24520,7 +24520,7 @@
         "gcp-metadata": "^5.2.0",
         "kerberos": "^2.0.1",
         "mongodb-client-encryption": ">=6.0.0 <7",
-        "snappy": "^7.2.2",
+        "snappy": "^7.3.2",
         "socks": "^2.7.1"
       },
       "peerDependenciesMeta": {
@@ -34671,7 +34671,7 @@
         "@types/mocha": "10.0.10",
         "@types/node": "18.18.14",
         "cross-env": "7.0.3",
-        "mongodb": "6.15.0",
+        "mongodb": "6.19.0",
         "nyc": "17.1.0",
         "rimraf": "5.0.10",
         "test-all-versions": "6.1.0",
@@ -45817,7 +45817,7 @@
         "@types/mocha": "10.0.10",
         "@types/node": "18.18.14",
         "cross-env": "7.0.3",
-        "mongodb": "6.15.0",
+        "mongodb": "6.19.0",
         "nyc": "17.1.0",
         "rimraf": "5.0.10",
         "test-all-versions": "6.1.0",
@@ -59154,13 +59154,13 @@
       "optional": true
     },
     "mongodb": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.15.0.tgz",
-      "integrity": "sha512-ifBhQ0rRzHDzqp9jAQP6OwHSH7dbYIQjD3SbJs9YYk9AikKEettW/9s/tbSFDTpXcRbF+u1aLrhHxDFaYtZpFQ==",
+      "version": "6.19.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.19.0.tgz",
+      "integrity": "sha512-H3GtYujOJdeKIMLKBT9PwlDhGrQfplABNF1G904w6r5ZXKWyv77aB0X9B+rhmaAwjtllHzaEkvi9mkGVZxs2Bw==",
       "dev": true,
       "requires": {
         "@mongodb-js/saslprep": "^1.1.9",
-        "bson": "^6.10.3",
+        "bson": "^6.10.4",
         "mongodb-connection-string-url": "^3.0.0"
       }
     },

--- a/packages/instrumentation-mongodb/package.json
+++ b/packages/instrumentation-mongodb/package.json
@@ -65,7 +65,7 @@
     "@types/mocha": "10.0.10",
     "@types/node": "18.18.14",
     "cross-env": "7.0.3",
-    "mongodb": "6.15.0",
+    "mongodb": "6.19.0",
     "nyc": "17.1.0",
     "rimraf": "5.0.10",
     "test-all-versions": "6.1.0",


### PR DESCRIPTION
## Which problem is this PR solving?

The new release of `mongodb@6.19.0` changed the internal model of, at least, the insert command response. this does not break the instrumentation but the `responseHook` tests were relying on that to make certain assertions. As a result running `test-all-versions` failed when selecting such version of the package.

## Short description of the changes

- update dependency to v6.19.0
- change test code to consider both models in the response object
