### PR TITLE
deps(instrumentation-openai): remove unused dependency @types/glob

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11720,24 +11720,6 @@
         "generic-pool": "*"
       }
     },
-    "node_modules/@types/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/minimatch": "^5.1.2",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/glob/node_modules/@types/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/http-assert": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.6.tgz",
@@ -34946,7 +34928,6 @@
         "@opentelemetry/sdk-logs": "^0.203.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0",
         "@opentelemetry/sdk-trace-node": "^2.0.0",
-        "@types/glob": "^8.1.0",
         "@types/node": "18.18.14",
         "@typescript-eslint/eslint-plugin": "5.8.1",
         "@typescript-eslint/parser": "5.8.1",
@@ -46045,7 +46026,6 @@
         "@opentelemetry/sdk-trace-base": "^2.0.0",
         "@opentelemetry/sdk-trace-node": "^2.0.0",
         "@opentelemetry/semantic-conventions": "^1.36.0",
-        "@types/glob": "^8.1.0",
         "@types/node": "18.18.14",
         "@typescript-eslint/eslint-plugin": "5.8.1",
         "@typescript-eslint/parser": "5.8.1",
@@ -49322,24 +49302,6 @@
       "dev": true,
       "requires": {
         "generic-pool": "*"
-      }
-    },
-    "@types/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
-      "dev": true,
-      "requires": {
-        "@types/minimatch": "^5.1.2",
-        "@types/node": "*"
-      },
-      "dependencies": {
-        "@types/minimatch": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-          "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-          "dev": true
-        }
       }
     },
     "@types/http-assert": {

--- a/packages/instrumentation-openai/package.json
+++ b/packages/instrumentation-openai/package.json
@@ -52,7 +52,6 @@
     "@opentelemetry/sdk-logs": "^0.203.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "@opentelemetry/sdk-trace-node": "^2.0.0",
-    "@types/glob": "^8.1.0",
     "@types/node": "18.18.14",
     "@typescript-eslint/eslint-plugin": "5.8.1",
     "@typescript-eslint/parser": "5.8.1",


### PR DESCRIPTION
## Which problem is this PR solving?

`glob` includes types in its latest version, also `glob` is not used in `@opentelemetry/instrumentation-openai`. The old `@types/glob` package breaks the package lock sync PR as its types are outdated: see https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2989