### PR TITLE
chore(instr-pg): fix imports for ESM in tests

### DIFF
--- a/packages/instrumentation-pg/test/pg-pool.test.ts
+++ b/packages/instrumentation-pg/test/pg-pool.test.ts
@@ -24,11 +24,6 @@ import {
   trace,
 } from '@opentelemetry/api';
 import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
-import {
-  PgInstrumentation,
-  PgInstrumentationConfig,
-  PgResponseHookInformation,
-} from '../src';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import * as testUtils from '@opentelemetry/contrib-test-utils';
 import {
@@ -38,6 +33,11 @@ import {
 import * as assert from 'assert';
 import * as pg from 'pg';
 import * as pgPool from 'pg-pool';
+import type {
+  PgInstrumentationConfig,
+  PgResponseHookInformation,
+} from '../src/types';
+import { PgInstrumentation } from '../src/instrumentation';
 import { AttributeNames } from '../src/enums/AttributeNames';
 import { TimedEvent } from './types';
 import {

--- a/packages/instrumentation-pg/test/pg.test.ts
+++ b/packages/instrumentation-pg/test/pg.test.ts
@@ -35,11 +35,11 @@ import * as assert from 'assert';
 import type * as pg from 'pg';
 import * as sinon from 'sinon';
 import stringify from 'safe-stable-stringify';
-import {
-  PgInstrumentation,
+import type {
   PgInstrumentationConfig,
   PgResponseHookInformation,
-} from '../src';
+} from '../src/types';
+import { PgInstrumentation } from '../src/instrumentation';
 import { AttributeNames } from '../src/enums/AttributeNames';
 import { TimedEvent } from './types';
 import {

--- a/packages/instrumentation-pg/test/utils.test.ts
+++ b/packages/instrumentation-pg/test/utils.test.ts
@@ -27,7 +27,7 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 import * as assert from 'assert';
 import * as pg from 'pg';
-import { PgInstrumentationConfig } from '../src';
+import { PgInstrumentationConfig } from '../src/types';
 import { AttributeNames } from '../src/enums/AttributeNames';
 import { PgClientExtended, PgPoolOptionsParams } from '../src/internal-types';
 import * as utils from '../src/utils';


### PR DESCRIPTION
## Which problem is this PR solving?

When running `test-all-versions` we may get an error related to ESM modules. An example
```
> @opentelemetry/instrumentation-pg@0.56.1 test
  > nyc mocha 'test/**/*.test.ts'
  
  
   Exception during run: Error: Directory import '/home/runner/work/opentelemetry-js-contrib/opentelemetry-js-contrib/packages/instrumentation-pg/src' is not supported resolving ES modules imported from /home/runner/work/opentelemetry-js-contrib/opentelemetry-js-contrib/packages/instrumentation-pg/test/pg-pool.test.ts
      at finalizeResolution (node:internal/modules/esm/resolve:262:11)
      at moduleResolve (node:internal/modules/esm/resolve:864:10)
      at defaultResolve (node:internal/modules/esm/resolve:990:11)
      at ModuleLoader.#cachedDefaultResolve (node:internal/modules/esm/loader:749:20)
      at ModuleLoader.resolve (node:internal/modules/esm/loader:726:38)
      at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:312:38)
      at ModuleJob.#link (node:internal/modules/esm/module_job:208:49) {
    code: 'ERR_UNSUPPORTED_DIR_IMPORT',
    url: 'file:///home/runner/work/opentelemetry-js-contrib/opentelemetry-js-contrib/packages/instrumentation-pg/src'
  }
```

The reason might be that the test file is considered an ESM module in a specific situations (no sure which one yet) and ESM does not accept the import of directories.

## Short description of the changes

- update imports in test files
