### PR TITLE
chore: update undici tests

### DIFF
--- a/packages/instrumentation-undici/test/metrics.test.ts
+++ b/packages/instrumentation-undici/test/metrics.test.ts
@@ -63,6 +63,11 @@ describe('UndiciInstrumentation metrics tests', function () {
     );
     mockServer.start(done);
     mockServer.mockListener((req, res) => {
+      if (req.url === '/error') {
+        // Simulate an error
+        res.destroy();
+        return;
+      }
       // Return a valid response always
       res.statusCode = 200;
       res.setHeader('content-type', 'application/json');
@@ -143,7 +148,7 @@ describe('UndiciInstrumentation metrics tests', function () {
     });
 
     it('should have error.type in "http.client.request.duration" metric', async () => {
-      const fetchUrl = 'http://unknownhost/';
+      const fetchUrl = `${protocol}://${hostname}:${mockServer.port}/error`;
 
       try {
         await fetch(fetchUrl);
@@ -181,9 +186,12 @@ describe('UndiciInstrumentation metrics tests', function () {
       );
       assert.strictEqual(
         metricAttributes[SemanticAttributes.SERVER_ADDRESS],
-        'unknownhost'
+        hostname
       );
-      assert.strictEqual(metricAttributes[SemanticAttributes.SERVER_PORT], 80);
+      assert.strictEqual(
+        metricAttributes[SemanticAttributes.SERVER_PORT],
+        mockServer.port
+      );
       assert.ok(
         metricAttributes[SemanticAttributes.ERROR_TYPE],
         `the metric contains "${SemanticAttributes.ERROR_TYPE}" attribute if request failed`


### PR DESCRIPTION
## Which problem is this PR solving?

Not a problem but this PR has a couple of objectives

- Improves the tests (speed) by taking code from https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2994 (kudos to @ugzuzg)
- Validates the new test workflow. There are other PRs failing like https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3013 but it seems the error has nothing to do with the workflow (see [comment](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3013#issuecomment-3256423776)). This PR is not changing the conflictive packages so it should pass the tests-

## Short description of the changes

- updated undici tests
