### PR TITLE
chore(instrumentation-pg): skip test if db not running

### DIFF
--- a/packages/instrumentation-pg/test/pg-pool.test.ts
+++ b/packages/instrumentation-pg/test/pg-pool.test.ts
@@ -937,6 +937,22 @@ describe('pg-pool', () => {
 });
 
 describe('pg-pool (ESM)', () => {
+  const testPostgres = process.env.RUN_POSTGRES_TESTS;
+  const shouldTest = testPostgres; // Skips these tests if false (default)
+
+  before(function () {
+    const skip = () => {
+      // this.skip() workaround
+      // https://github.com/mochajs/mocha/issues/2683#issuecomment-375629901
+      this.test!.parent!.pending = true;
+      this.skip();
+    };
+
+    if (!shouldTest) {
+      skip();
+    }
+  });
+
   it('should work with ESM usage', async () => {
     await testUtils.runTestFixture({
       cwd: __dirname,

--- a/packages/instrumentation-pg/test/pg.test.ts
+++ b/packages/instrumentation-pg/test/pg.test.ts
@@ -1087,6 +1087,22 @@ describe('pg', () => {
 });
 
 describe('pg (ESM)', () => {
+  const testPostgres = process.env.RUN_POSTGRES_TESTS;
+  const shouldTest = testPostgres; // Skips these tests if false (default)
+
+  before(function () {
+    const skip = () => {
+      // this.skip() workaround
+      // https://github.com/mochajs/mocha/issues/2683#issuecomment-375629901
+      this.test!.parent!.pending = true;
+      this.skip();
+    };
+
+    if (!shouldTest) {
+      skip();
+    }
+  });
+
   it('should work with ESM usage', async () => {
     await testUtils.runTestFixture({
       cwd: __dirname,


### PR DESCRIPTION
## Which problem is this PR solving?

- Locally I was unable to pass `npm run test` if the db service was not started.

## Short description of the changes

- I copied the guard from the regular test to the ESM version. I have no prior experience with the db packages so please close this if it's off base.
