### PR TITLE
Return underlying modules from redis instrumentation

### DIFF
--- a/packages/instrumentation-redis/package.json
+++ b/packages/instrumentation-redis/package.json
@@ -19,7 +19,7 @@
     "prepublishOnly": "npm run compile",
     "tdd": "npm run test -- --watch-extensions ts --watch",
     "test-v2-v3": "nyc --no-clean mocha --require '@opentelemetry/contrib-test-utils' 'test/v2-v3/*.test.ts'",
-    "test": "nyc --no-clean mocha --require '@opentelemetry/contrib-test-utils' 'test/v4-v5/*.test.ts'",
+    "test": "nyc --no-clean mocha --require '@opentelemetry/contrib-test-utils' 'test/v4-v5/*.test.ts' 'test/*.test.ts'",
     "test:debug": "cross-env RUN_REDIS_TESTS=true mocha --inspect-brk --no-timeouts 'test/**/*.test.ts'",
     "test:with-services-env": "cross-env NODE_OPTIONS='-r dotenv/config' DOTENV_CONFIG_PATH=../../test/test-services.env npm test",
     "test-all-versions": "tav",

--- a/packages/instrumentation-redis/src/redis.ts
+++ b/packages/instrumentation-redis/src/redis.ts
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { InstrumentationBase } from '@opentelemetry/instrumentation';
+import {
+  InstrumentationBase,
+  InstrumentationModuleDefinition,
+} from '@opentelemetry/instrumentation';
 import { RedisInstrumentationConfig } from './types';
 /** @knipignore */
 import { PACKAGE_NAME, PACKAGE_VERSION } from './version';
@@ -55,6 +58,15 @@ export class RedisInstrumentation extends InstrumentationBase<RedisInstrumentati
   }
 
   override init() {}
+
+  // Return underlying modules, as consumers (like https://github.com/DrewCorlin/opentelemetry-node-bundler-plugins) may
+  // expect them to be populated without knowing that this module wraps 2 instrumentations
+  override getModuleDefinitions(): InstrumentationModuleDefinition[] {
+    return [
+      ...this.instrumentationV2_V3.getModuleDefinitions(),
+      ...this.instrumentationV4_V5.getModuleDefinitions(),
+    ];
+  }
 
   override setTracerProvider(tracerProvider: TracerProvider) {
     super.setTracerProvider(tracerProvider);

--- a/packages/instrumentation-redis/test/redis.test.ts
+++ b/packages/instrumentation-redis/test/redis.test.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RedisInstrumentation } from '../src';
+import * as assert from 'assert';
+describe('redis', () => {
+  it('Returns module definitions of sub-instrumentations', () => {
+    const instrumentation = new RedisInstrumentation();
+    const moduleDefinitions = instrumentation.getModuleDefinitions();
+    assert.ok(moduleDefinitions.length >= 1);
+  });
+});


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?
Return version-specific module instrumentations from version-agnostic instrumentation, to enable consumers of this library to get access to the instrumentations that are being applied without having to know this instrumentation is really just a wrapper for 2 others.

## Short description of the changes

I'm the author of https://github.com/DrewCorlin/opentelemetry-node-bundler-plugins. This library depends on `getModuleDefinitions()` to know what modules to patch (in it's case to patch them during the bundling of an app). Updating to the latest version to support instrumentation of redis@v5 uncovered this.

Rather than special casing this in my plugin I thought it made sense to have this module behave consistently with the rest. 

Also let me know if I should remove the link to my plugin here. I thought it was useful context, but understand if links to other projects that depend on this aren't desired.