### PR TITLE
fix(instrumentation-aws-sdk): use `skipLibCheck` option to avoid compilation error

### DIFF
--- a/packages/instrumentation-aws-sdk/tsconfig.json
+++ b/packages/instrumentation-aws-sdk/tsconfig.json
@@ -3,9 +3,9 @@
     "compilerOptions": {
       "rootDir": ".",
       "outDir": "build",
-      // @smithy/core upgrade to TS@5.8.3 in https://github.com/smithy-lang/smithy-typescript/pull/1579
+      // @smithy/core upgraded to TS@5.8.3 in https://github.com/smithy-lang/smithy-typescript/pull/1579
       // resulting in this issue https://github.com/microsoft/TypeScript/issues/60638
-      // which is a braking change for us. We should keep this option until we update to
+      // which is a breaking change for us. We should keep this option until we update to
       // TypeScript 5.7+
       "skipLibCheck": true
     },


### PR DESCRIPTION
## Which problem is this PR solving?

aws-sdk is using a newer version of typescript (5.8.3) which comes with breaking changes in type definitions. This caused the compilation process to fail for `@opentelemetry/instrumentation-aws-sdk`.
ref: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2989#issuecomment-3275237616

The TS team has decided not to plan any backwards compatibility with this change and we do not want to pin the the instrumented packages to a specific version. The conclusion here is to use `skipLibCheck` compiler option until we upgrade our typescript version to 5.7+

## Short description of the changes

- add `skipLibCheck=true` in the compiler options for the aws-sdk instrumentation.
