### PR TITLE
chore(contrib-test-utils)!: update semconv usage to ATTR_ exports

### DIFF
--- a/packages/contrib-test-utils/src/instrumentations/index.ts
+++ b/packages/contrib-test-utils/src/instrumentations/index.ts
@@ -15,7 +15,7 @@
  */
 
 import { resourceFromAttributes } from '@opentelemetry/resources';
-import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
 import { getInstrumentation } from './instrumentation-singleton';
 import { registerInstrumentationTestingProvider } from './otel-default-provider';
 import { resetMemoryExporter } from './otel-provider-api';
@@ -49,7 +49,7 @@ export const mochaHooks = {
     }
     const provider = registerInstrumentationTestingProvider({
       resource: resourceFromAttributes({
-        [SEMRESATTRS_SERVICE_NAME]: serviceName,
+        [ATTR_SERVICE_NAME]: serviceName,
       }),
     });
     getInstrumentation()?.setTracerProvider(provider);

--- a/packages/contrib-test-utils/src/resource-assertions.ts
+++ b/packages/contrib-test-utils/src/resource-assertions.ts
@@ -18,36 +18,37 @@ import { SDK_INFO } from '@opentelemetry/core';
 import * as assert from 'assert';
 import { Resource } from '@opentelemetry/resources';
 import {
-  SEMRESATTRS_CLOUD_ACCOUNT_ID,
-  SEMRESATTRS_CLOUD_AVAILABILITY_ZONE,
-  SEMRESATTRS_CLOUD_PROVIDER,
-  SEMRESATTRS_CLOUD_REGION,
-  SEMRESATTRS_CONTAINER_ID,
-  SEMRESATTRS_CONTAINER_IMAGE_NAME,
-  SEMRESATTRS_CONTAINER_IMAGE_TAG,
-  SEMRESATTRS_CONTAINER_NAME,
-  SEMRESATTRS_HOST_ID,
-  SEMRESATTRS_HOST_IMAGE_ID,
-  SEMRESATTRS_HOST_IMAGE_NAME,
-  SEMRESATTRS_HOST_IMAGE_VERSION,
-  SEMRESATTRS_HOST_NAME,
-  SEMRESATTRS_HOST_TYPE,
-  SEMRESATTRS_K8S_CLUSTER_NAME,
-  SEMRESATTRS_K8S_DEPLOYMENT_NAME,
-  SEMRESATTRS_K8S_NAMESPACE_NAME,
-  SEMRESATTRS_K8S_POD_NAME,
-  SEMRESATTRS_PROCESS_COMMAND,
-  SEMRESATTRS_PROCESS_COMMAND_LINE,
-  SEMRESATTRS_PROCESS_EXECUTABLE_NAME,
-  SEMRESATTRS_PROCESS_PID,
-  SEMRESATTRS_SERVICE_INSTANCE_ID,
-  SEMRESATTRS_SERVICE_NAME,
-  SEMRESATTRS_SERVICE_NAMESPACE,
-  SEMRESATTRS_SERVICE_VERSION,
-  SEMRESATTRS_TELEMETRY_SDK_LANGUAGE,
-  SEMRESATTRS_TELEMETRY_SDK_NAME,
-  SEMRESATTRS_TELEMETRY_SDK_VERSION,
+  ATTR_SERVICE_NAME,
+  ATTR_SERVICE_VERSION,
+  ATTR_TELEMETRY_SDK_LANGUAGE,
+  ATTR_TELEMETRY_SDK_NAME,
+  ATTR_TELEMETRY_SDK_VERSION,
 } from '@opentelemetry/semantic-conventions';
+import {
+  ATTR_CLOUD_ACCOUNT_ID,
+  ATTR_CLOUD_AVAILABILITY_ZONE,
+  ATTR_CLOUD_PROVIDER,
+  ATTR_CLOUD_REGION,
+  ATTR_CONTAINER_ID,
+  ATTR_CONTAINER_IMAGE_NAME,
+  ATTR_CONTAINER_NAME,
+  ATTR_HOST_ID,
+  ATTR_HOST_IMAGE_ID,
+  ATTR_HOST_IMAGE_NAME,
+  ATTR_HOST_IMAGE_VERSION,
+  ATTR_HOST_NAME,
+  ATTR_HOST_TYPE,
+  ATTR_K8S_CLUSTER_NAME,
+  ATTR_K8S_DEPLOYMENT_NAME,
+  ATTR_K8S_NAMESPACE_NAME,
+  ATTR_K8S_POD_NAME,
+  ATTR_PROCESS_COMMAND,
+  ATTR_PROCESS_COMMAND_LINE,
+  ATTR_PROCESS_EXECUTABLE_NAME,
+  ATTR_PROCESS_PID,
+  ATTR_SERVICE_INSTANCE_ID,
+  ATTR_SERVICE_NAMESPACE,
+} from './semconv';
 import * as semconv from '@opentelemetry/semantic-conventions';
 
 /**
@@ -68,22 +69,22 @@ export const assertCloudResource = (
   assertHasOneLabel('cloud', resource);
   if (validations.provider)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_CLOUD_PROVIDER],
+      resource.attributes[ATTR_CLOUD_PROVIDER],
       validations.provider
     );
   if (validations.accountId)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_CLOUD_ACCOUNT_ID],
+      resource.attributes[ATTR_CLOUD_ACCOUNT_ID],
       validations.accountId
     );
   if (validations.region)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_CLOUD_REGION],
+      resource.attributes[ATTR_CLOUD_REGION],
       validations.region
     );
   if (validations.zone)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_CLOUD_AVAILABILITY_ZONE],
+      resource.attributes[ATTR_CLOUD_AVAILABILITY_ZONE],
       validations.zone
     );
 };
@@ -100,29 +101,20 @@ export const assertContainerResource = (
     name?: string;
     id?: string;
     imageName?: string;
-    imageTag?: string;
   }
 ) => {
   assertHasOneLabel('container', resource);
   if (validations.name)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_CONTAINER_NAME],
+      resource.attributes[ATTR_CONTAINER_NAME],
       validations.name
     );
   if (validations.id)
-    assert.strictEqual(
-      resource.attributes[SEMRESATTRS_CONTAINER_ID],
-      validations.id
-    );
+    assert.strictEqual(resource.attributes[ATTR_CONTAINER_ID], validations.id);
   if (validations.imageName)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_CONTAINER_IMAGE_NAME],
+      resource.attributes[ATTR_CONTAINER_IMAGE_NAME],
       validations.imageName
-    );
-  if (validations.imageTag)
-    assert.strictEqual(
-      resource.attributes[SEMRESATTRS_CONTAINER_IMAGE_TAG],
-      validations.imageTag
     );
 };
 
@@ -145,33 +137,27 @@ export const assertHostResource = (
 ) => {
   assertHasOneLabel('host', resource);
   if (validations.id)
-    assert.strictEqual(
-      resource.attributes[SEMRESATTRS_HOST_ID],
-      validations.id
-    );
+    assert.strictEqual(resource.attributes[ATTR_HOST_ID], validations.id);
   if (validations.name)
-    assert.strictEqual(
-      resource.attributes[SEMRESATTRS_HOST_NAME],
-      validations.name
-    );
+    assert.strictEqual(resource.attributes[ATTR_HOST_NAME], validations.name);
   if (validations.hostType)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_HOST_TYPE],
+      resource.attributes[ATTR_HOST_TYPE],
       validations.hostType
     );
   if (validations.imageName)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_HOST_IMAGE_NAME],
+      resource.attributes[ATTR_HOST_IMAGE_NAME],
       validations.imageName
     );
   if (validations.imageId)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_HOST_IMAGE_ID],
+      resource.attributes[ATTR_HOST_IMAGE_ID],
       validations.imageId
     );
   if (validations.imageVersion)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_HOST_IMAGE_VERSION],
+      resource.attributes[ATTR_HOST_IMAGE_VERSION],
       validations.imageVersion
     );
 };
@@ -194,22 +180,22 @@ export const assertK8sResource = (
   assertHasOneLabel('k8s', resource);
   if (validations.clusterName)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_K8S_CLUSTER_NAME],
+      resource.attributes[ATTR_K8S_CLUSTER_NAME],
       validations.clusterName
     );
   if (validations.namespaceName)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_K8S_NAMESPACE_NAME],
+      resource.attributes[ATTR_K8S_NAMESPACE_NAME],
       validations.namespaceName
     );
   if (validations.podName)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_K8S_POD_NAME],
+      resource.attributes[ATTR_K8S_POD_NAME],
       validations.podName
     );
   if (validations.deploymentName)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_K8S_DEPLOYMENT_NAME],
+      resource.attributes[ATTR_K8S_DEPLOYMENT_NAME],
       validations.deploymentName
     );
 };
@@ -229,25 +215,25 @@ export const assertTelemetrySDKResource = (
   }
 ) => {
   const defaults = {
-    name: SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_NAME],
-    language: SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE],
-    version: SDK_INFO[SEMRESATTRS_TELEMETRY_SDK_VERSION],
+    name: SDK_INFO[ATTR_TELEMETRY_SDK_NAME],
+    language: SDK_INFO[ATTR_TELEMETRY_SDK_LANGUAGE],
+    version: SDK_INFO[ATTR_TELEMETRY_SDK_VERSION],
   };
   validations = { ...defaults, ...validations };
 
   if (validations.name)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_TELEMETRY_SDK_NAME],
+      resource.attributes[ATTR_TELEMETRY_SDK_NAME],
       validations.name
     );
   if (validations.language)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_TELEMETRY_SDK_LANGUAGE],
+      resource.attributes[ATTR_TELEMETRY_SDK_LANGUAGE],
       validations.language
     );
   if (validations.version)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_TELEMETRY_SDK_VERSION],
+      resource.attributes[ATTR_TELEMETRY_SDK_VERSION],
       validations.version
     );
 };
@@ -267,22 +253,19 @@ export const assertServiceResource = (
     version?: string;
   }
 ) => {
+  assert.strictEqual(resource.attributes[ATTR_SERVICE_NAME], validations.name);
   assert.strictEqual(
-    resource.attributes[SEMRESATTRS_SERVICE_NAME],
-    validations.name
-  );
-  assert.strictEqual(
-    resource.attributes[SEMRESATTRS_SERVICE_INSTANCE_ID],
+    resource.attributes[ATTR_SERVICE_INSTANCE_ID],
     validations.instanceId
   );
   if (validations.namespace)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_SERVICE_NAMESPACE],
+      resource.attributes[ATTR_SERVICE_NAMESPACE],
       validations.namespace
     );
   if (validations.version)
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_SERVICE_VERSION],
+      resource.attributes[ATTR_SERVICE_VERSION],
       validations.version
     );
 };
@@ -302,25 +285,22 @@ export const assertProcessResource = (
     commandLine?: string;
   }
 ) => {
-  assert.strictEqual(
-    resource.attributes[SEMRESATTRS_PROCESS_PID],
-    validations.pid
-  );
+  assert.strictEqual(resource.attributes[ATTR_PROCESS_PID], validations.pid);
   if (validations.name) {
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_PROCESS_EXECUTABLE_NAME],
+      resource.attributes[ATTR_PROCESS_EXECUTABLE_NAME],
       validations.name
     );
   }
   if (validations.command) {
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_PROCESS_COMMAND],
+      resource.attributes[ATTR_PROCESS_COMMAND],
       validations.command
     );
   }
   if (validations.commandLine) {
     assert.strictEqual(
-      resource.attributes[SEMRESATTRS_PROCESS_COMMAND_LINE],
+      resource.attributes[ATTR_PROCESS_COMMAND_LINE],
       validations.commandLine
     );
   }
@@ -340,7 +320,7 @@ export const assertEmptyResource = (resource: Resource) => {
  * `prefix`. By "known", we mean it is an attribute defined in semconv.
  */
 const assertHasOneLabel = (prefix: string, resource: Resource): void => {
-  const semconvModPrefix = `SEMRESATTRS_${prefix.toUpperCase()}_`;
+  const semconvModPrefix = `ATTR_${prefix.toUpperCase()}_`;
   const knownAttrs: Set<string> = new Set(
     Object.entries(semconv)
       .filter(

--- a/packages/contrib-test-utils/src/semconv.ts
+++ b/packages/contrib-test-utils/src/semconv.ts
@@ -1,0 +1,262 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This file contains a copy of unstable semantic convention definitions
+ * used by this package.
+ * @see https://github.com/open-telemetry/opentelemetry-js/tree/main/semantic-conventions#unstable-semconv
+ */
+
+/**
+ * The cloud account ID the resource is assigned to.
+ *
+ * @example 111111111111
+ * @example opentelemetry
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_CLOUD_ACCOUNT_ID = 'cloud.account.id' as const;
+
+/**
+ * Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running.
+ *
+ * @example us-east-1c
+ *
+ * @note Availability zones are called "zones" on Alibaba Cloud and Google Cloud.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_CLOUD_AVAILABILITY_ZONE = 'cloud.availability_zone' as const;
+
+/**
+ * Name of the cloud provider.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_CLOUD_PROVIDER = 'cloud.provider' as const;
+
+/**
+ * The geographical region within a cloud provider. When associated with a resource, this attribute specifies the region where the resource operates. When calling services or APIs deployed on a cloud, this attribute identifies the region where the called destination is deployed.
+ *
+ * @example us-central1
+ * @example us-east-1
+ *
+ * @note Refer to your provider's docs to see the available regions, for example [Alibaba Cloud regions](https://www.alibabacloud.com/help/doc-detail/40654.htm), [AWS regions](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/), [Azure regions](https://azure.microsoft.com/global-infrastructure/geographies/), [Google Cloud regions](https://cloud.google.com/about/locations), or [Tencent Cloud regions](https://www.tencentcloud.com/document/product/213/6091).
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_CLOUD_REGION = 'cloud.region' as const;
+
+/**
+ * Container ID. Usually a UUID, as for example used to [identify Docker containers](https://docs.docker.com/engine/containers/run/#container-identification). The UUID might be abbreviated.
+ *
+ * @example a3bf90e006b2
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_CONTAINER_ID = 'container.id' as const;
+
+/**
+ * Name of the image the container was built on.
+ *
+ * @example gcr.io/opentelemetry/operator
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_CONTAINER_IMAGE_NAME = 'container.image.name' as const;
+
+/**
+ * Container name used by container runtime.
+ *
+ * @example opentelemetry-autoconf
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_CONTAINER_NAME = 'container.name' as const;
+
+/**
+ * Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For non-containerized systems, this should be the `machine-id`. See the table below for the sources to use to determine the `machine-id` based on operating system.
+ *
+ * @example fdbf79e8af94cb7f9e8df36789187052
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HOST_ID = 'host.id' as const;
+
+/**
+ * VM image ID or host OS image ID. For Cloud, this value is from the provider.
+ *
+ * @example ami-07b06b442921831e5
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HOST_IMAGE_ID = 'host.image.id' as const;
+
+/**
+ * Name of the VM image or OS install the host was instantiated from.
+ *
+ * @example infra-ami-eks-worker-node-7d4ec78312
+ * @example CentOS-8-x86_64-1905
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HOST_IMAGE_NAME = 'host.image.name' as const;
+
+/**
+ * The version string of the VM image or host OS as defined in [Version Attributes](/docs/resource/README.md#version-attributes).
+ *
+ * @example 0.1
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HOST_IMAGE_VERSION = 'host.image.version' as const;
+
+/**
+ * Name of the host. On Unix systems, it may contain what the hostname command returns, or the fully qualified hostname, or another name specified by the user.
+ *
+ * @example opentelemetry-test
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HOST_NAME = 'host.name' as const;
+
+/**
+ * Type of host. For Cloud, this must be the machine type.
+ *
+ * @example n1-standard-1
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_HOST_TYPE = 'host.type' as const;
+
+/**
+ * The name of the cluster.
+ *
+ * @example opentelemetry-cluster
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_K8S_CLUSTER_NAME = 'k8s.cluster.name' as const;
+
+/**
+ * The name of the Deployment.
+ *
+ * @example opentelemetry
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_K8S_DEPLOYMENT_NAME = 'k8s.deployment.name' as const;
+
+/**
+ * The name of the namespace that the pod is running in.
+ *
+ * @example default
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_K8S_NAMESPACE_NAME = 'k8s.namespace.name' as const;
+
+/**
+ * The name of the Pod.
+ *
+ * @example opentelemetry-pod-autoconf
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_K8S_POD_NAME = 'k8s.pod.name' as const;
+
+/**
+ * The command used to launch the process (i.e. the command name). On Linux based systems, can be set to the zeroth string in `proc/[pid]/cmdline`. On Windows, can be set to the first parameter extracted from `GetCommandLineW`.
+ *
+ * @example cmd/otelcol
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_PROCESS_COMMAND = 'process.command' as const;
+
+/**
+ * The full command used to launch the process as a single string representing the full command. On Windows, can be set to the result of `GetCommandLineW`. Do not set this if you have to assemble it just for monitoring; use `process.command_args` instead. **SHOULD NOT** be collected by default unless there is sanitization that excludes sensitive data.
+ *
+ * @example C:\\cmd\\otecol --config="my directory\\config.yaml"
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_PROCESS_COMMAND_LINE = 'process.command_line' as const;
+
+/**
+ * The name of the process executable. On Linux based systems, this **SHOULD** be set to the base name of the target of `/proc/[pid]/exe`. On Windows, this **SHOULD** be set to the base name of `GetProcessImageFileNameW`.
+ *
+ * @example otelcol
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_PROCESS_EXECUTABLE_NAME = 'process.executable.name' as const;
+
+/**
+ * Process identifier (PID).
+ *
+ * @example 1234
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_PROCESS_PID = 'process.pid' as const;
+
+/**
+ * The string ID of the service instance.
+ *
+ * @example 627cc493-f310-47de-96bd-71410b7dec09
+ *
+ * @note **MUST** be unique for each instance of the same `service.namespace,service.name` pair (in other words
+ * `service.namespace,service.name,service.instance.id` triplet **MUST** be globally unique). The ID helps to
+ * distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled
+ * service).
+ *
+ * Implementations, such as SDKs, are recommended to generate a random Version 1 or Version 4 [RFC
+ * 4122](https://www.ietf.org/rfc/rfc4122.txt) UUID, but are free to use an inherent unique ID as the source of
+ * this value if stability is desirable. In that case, the ID **SHOULD** be used as source of a UUID Version 5 and
+ * **SHOULD** use the following UUID as the namespace: `4d63009a-8d0f-11ee-aad7-4c796ed8e320`.
+ *
+ * UUIDs are typically recommended, as only an opaque value for the purposes of identifying a service instance is
+ * needed. Similar to what can be seen in the man page for the
+ * [`/etc/machine-id`](https://www.freedesktop.org/software/systemd/man/latest/machine-id.html) file, the underlying
+ * data, such as pod name and namespace should be treated as confidential, being the user's choice to expose it
+ * or not via another resource attribute.
+ *
+ * For applications running behind an application server (like unicorn), we do not recommend using one identifier
+ * for all processes participating in the application. Instead, it's recommended each division (e.g. a worker
+ * thread in unicorn) to have its own instance.id.
+ *
+ * It's not recommended for a Collector to set `service.instance.id` if it can't unambiguously determine the
+ * service instance that is generating that telemetry. For instance, creating an UUID based on `pod.name` will
+ * likely be wrong, as the Collector might not know from which container within that pod the telemetry originated.
+ * However, Collectors can set the `service.instance.id` if they can unambiguously determine the service instance
+ * for that telemetry. This is typically the case for scraping receivers, as they know the target address and
+ * port.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_SERVICE_INSTANCE_ID = 'service.instance.id' as const;
+
+/**
+ * A namespace for `service.name`.
+ *
+ * @example Shop
+ *
+ * @note A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_SERVICE_NAMESPACE = 'service.namespace' as const;


### PR DESCRIPTION
This also drops the `imageTag` option to `assertContainerResource`.
This option is unused by all users of `assertContainerResource` in the
repo. (It dates back to when `@opentelemetry/resources` in the core
repo used contrib-test-utils. It no longer does.)  Dropping this
option allows us to not have to deal with the Semantic Conventions
change of 'container.image.tag' to container.image.tags' (plural)
in semconv v1.22.0.

Refs: #2377
