### PR TITLE
ci: harden publish workflow by switching to OIDC

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,35 +8,37 @@ permissions:
 
 name: Run Release Please
 jobs:
+  # creates the release PR, and publishes releases
   release-please:
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: write # required for pushing changes
-      id-token: write
     steps:
-      # The logic below handles the npm publication:
       - name: Checkout Repository
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      # If you update this version make sure to keep in sync:
-      # - `build-and-cache` job of unit-test workflow
-      # - `build-and-cache` job of test-all-versions workflow
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 18
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install packages
         run: |
           npm ci
 
+      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        id: otelbot-token
+        with:
+          app-id: ${{ vars.OTELBOT_JS_APP_ID }}
+          private-key: ${{ secrets.OTELBOT_JS_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
         id: release
         with:
-          token: ${{secrets.RELEASE_PR_TOKEN}}
+          token: ${{ steps.otelbot-token.outputs.token }}
           target-branch: main
 
       # get release PR as we're currently on main
@@ -47,7 +49,7 @@ jobs:
         with:
           ref: release-please--branches--main
           # use a token so that workflows on the PR run when we push later
-          token: ${{ secrets.RELEASE_PR_TOKEN }}
+          token: ${{ steps.otelbot-token.outputs.token }}
 
       # release-please does not do this on its own, so we do it here instead
       - name: Update package-lock.json in PR
@@ -56,33 +58,59 @@ jobs:
         run: |
           npm install --ignore-scripts --package-lock-only
           git add package-lock.json
-          git config user.name opentelemetrybot
-          git config user.email 107717825+opentelemetrybot@users.noreply.github.com
+          git config user.name otelbot
+          git config user.email 197425009+otelbot@users.noreply.github.com
           git commit -m "chore: sync package-lock.json"
           git push
 
-      # get main again
+  install-and-compile:
+    needs: release-please
+    # only if a release has been created
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout Repository
-        # only checkout if a release has been created
-        if: ${{ steps.release.outputs.releases_created }}
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-
       - name: Rebuild Packages
-        # only rebuild if a release has been created
-        if: ${{ steps.release.outputs.releases_created }}
         run: |
           npm ci
           npm run compile
+      - name: Upload contents for publish
+        uses: actions/upload-artifact@v4
+        with:
+          name: publish-cache-${{ github.run_number }}
+          path: .
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 10
 
+  npm-publish:
+    needs:
+      - release-please
+      - install-and-compile
+    # only if a release has been created
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # to generate npm provenance statements
+    environment: npm-publish-environment
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+      - name: Download contents for publish
+        uses: actions/download-artifact@v4
+        with:
+          name: publish-cache-${{ github.run_number }}
       # Release Please has already incremented versions and published tags, so we just
       # need to publish all unpublished versions to npm here
       # See: https://github.com/lerna/lerna/tree/main/libs/commands/publish#bump-from-package
       - name: Publish to npm
-        # only publish if a release has been created
-        if: ${{ steps.release.outputs.releases_created }}
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
           NPM_CONFIG_PROVENANCE: true
         run: npx lerna publish from-package --no-push --no-private --no-git-tag-version --yes

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 24
+          node-version: 18
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install packages


### PR DESCRIPTION
## Which problem is this PR solving?

Similar to https://github.com/open-telemetry/opentelemetry-js/pull/5946

Nothing has happened to us, but with everything that's been happening recently, this PR does a few things to harden our publishing process:

- switches publishing from token-based to OIDC
  - I have already updated all packages to disallow token publish, and set up OIDC for all of the packages published from this repo
 - makes use of a new `npm-publish-environment` environment, to lock down who can actually publish to npm
        until recently access was more broad, but additonal maintainer approval will now be required for publishing here and in contrib
   - requiring the environment and OIDC will also limit a potential blast radius to one repo, we can set up to require multiple more than one maintainer approval before publishing.
- I have moved npm ci to run outside of the deploy environment to further increase complexity of smuggling things in that don't belong here.
- I switched from `opentelemetrybot` to `otelbot` while at it

Tokens that we previously used for publishing are already revoked. ✅
