### PR TITLE
feat(instrumentation-document-load): support migration to stable HTTP semconv, v1.23.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34261,7 +34261,8 @@
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/instrumentation": "^0.205.0",
-        "@opentelemetry/sdk-trace-web": "^2.0.0"
+        "@opentelemetry/sdk-trace-web": "^2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.23.0"
       },
       "devDependencies": {
         "@babel/core": "7.22.17",
@@ -45613,6 +45614,7 @@
         "@opentelemetry/instrumentation": "^0.205.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0",
         "@opentelemetry/sdk-trace-web": "^2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.23.0",
         "@rollup/plugin-commonjs": "^26.0.0",
         "@rollup/plugin-node-resolve": "^16.0.0",
         "@types/chai": "^4.3.10",

--- a/packages/instrumentation-document-load/README.md
+++ b/packages/instrumentation-document-load/README.md
@@ -117,24 +117,33 @@ See [examples/tracer-web](https://github.com/open-telemetry/opentelemetry-js/tre
 
 The document load instrumentation plugin has few options available to choose from. You can set the following:
 
-| Options                                                                                                                                                                  | Type                          | Description                                                                             |
-|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------|-----------------------------------------------------------------------------------------|
+| Options | Type | Description |
+|---------|------|-------------|
 | `applyCustomAttributesOnSpan.documentLoad`| `DocumentLoadCustomAttributeFunction` | Function for adding custom attributes to `documentLoad` spans.                                                  |
 | `applyCustomAttributesOnSpan.documentFetch`                      | `DocumentLoadCustomAttributeFunction`                     | Function for adding custom attributes to `documentFetch` spans.  |
 | `applyCustomAttributesOnSpan.resourceFetch`                      | `ResourceFetchCustomAttributeFunction`                     | Function for adding custom attributes to `resourceFetch` spans  |
 | `ignoreNetworkEvents`                      | `boolean`                     | Ignore adding [network events as span events](https://github.com/open-telemetry/opentelemetry-js/blob/e49c4c7f42c6c444da3f802687cfa4f2d6983f46/packages/opentelemetry-sdk-trace-web/src/enums/PerformanceTimingNames.ts#L17) for document fetch and resource fetch spans.  |
 | `ignorePerformancePaintEvents`                      | `boolean`                     | Ignore adding performance resource paint span events to document load spans.  |
+| `semconvStabilityOptIn` | string | A comma-separated string of tokens as described for `OTEL_SEMCONV_STABILITY_OPT_IN` in the [HTTP semantic convention stability migration](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/non-normative/http-migration.md) guide. See the "Semantic Conventions" section below. |
 
 ## Semantic Conventions
 
-This package uses `@opentelemetry/semantic-conventions` version `1.22+`, which implements Semantic Convention [Version 1.7.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/semantic_conventions/README.md)
+This instrumentation creates spans that include some HTTP-related data as span attributes (URL, User-Agent header).
+Up to and including v0.50.0, `instrumentation-document-load` follows [Semantic Conventions v1.22.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.22.0/semantic_conventions/README.md) for these attributes.
 
-Attributes collected:
+HTTP semantic conventions (semconv) were stabilized in semconv v1.23.0, and a [migration process](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/non-normative/http-migration.md#http-semantic-convention-stability-migration) was defined. `instrumentation-document-load` versions 0.51.0 and later include support for migrating to stable HTTP semantic conventions, as described below. The intent is to provide an approximate 6 month time window for users of this instrumentation to migrate to the new HTTP semconv, after which a new minor version will change to use the *new* semconv by default and drop support for the old semconv. See the [HTTP semconv migration plan for OpenTelemetry JS instrumentations](https://github.com/open-telemetry/opentelemetry-js/issues/5646).
 
-| Attribute         | Short Description                                                              |
-| ----------------- | ------------------------------------------------------------------------------ |
-| `http.url`        | Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]` |
-| `http.user_agent` | Value of the HTTP User-Agent header sent by the client                         |
+To select which semconv version(s) is emitted from this instrumentation, use the `semconvStabilityOptIn` configuration option. This option works [as described for `OTEL_SEMCONV_STABILITY_OPT_IN`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/non-normative/http-migration.md):
+
+- `http`: emit the new (stable) v1.23.0 semantics
+- `http/dup`: emit **both** the old and the new (stable) v1.23.0 semantics
+- By default, if `semconvStabilityOptIn` includes neither of the above tokens, the old semconv is used.
+
+| v1.22.0 semconv   | v1.23.0 semconv       | Notes |
+| ----------------- | --------------------- | ----- |
+| `http.url`        | `url.full`            | Full HTTP request URL |
+| `http.user_agent` | `user_agent.original` | Value of the [HTTP User-Agent](https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent) header sent by the client. |
+
 
 ## Useful links
 

--- a/packages/instrumentation-document-load/package.json
+++ b/packages/instrumentation-document-load/package.json
@@ -75,7 +75,8 @@
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",
     "@opentelemetry/instrumentation": "^0.205.0",
-    "@opentelemetry/sdk-trace-web": "^2.0.0"
+    "@opentelemetry/sdk-trace-web": "^2.0.0",
+    "@opentelemetry/semantic-conventions": "^1.23.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-document-load#readme"
 }

--- a/packages/instrumentation-document-load/src/instrumentation.ts
+++ b/packages/instrumentation-document-load/src/instrumentation.ts
@@ -30,9 +30,15 @@ import {
   PerformanceTimingNames as PTN,
 } from '@opentelemetry/sdk-trace-web';
 import {
+  SemconvStability,
+  semconvStabilityFromStr,
   InstrumentationBase,
   safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
+import {
+  ATTR_URL_FULL,
+  ATTR_USER_AGENT_ORIGINAL,
+} from '@opentelemetry/semantic-conventions';
 import {
   DocumentLoadCustomAttributeFunction,
   DocumentLoadInstrumentationConfig,
@@ -55,8 +61,14 @@ export class DocumentLoadInstrumentation extends InstrumentationBase<DocumentLoa
   readonly version: string = '1';
   moduleName = this.component;
 
+  private _semconvStability: SemconvStability;
+
   constructor(config: DocumentLoadInstrumentationConfig = {}) {
     super(PACKAGE_NAME, PACKAGE_VERSION, config);
+    this._semconvStability = semconvStabilityFromStr(
+      'http',
+      config?.semconvStabilityOptIn
+    );
   }
 
   init() {}
@@ -112,12 +124,22 @@ export class DocumentLoadInstrumentation extends InstrumentationBase<DocumentLoa
           entries
         );
         if (fetchSpan) {
-          fetchSpan.setAttribute(ATTR_HTTP_URL, location.href);
+          if (this._semconvStability & SemconvStability.OLD) {
+            fetchSpan.setAttribute(ATTR_HTTP_URL, location.href);
+          }
+          if (this._semconvStability & SemconvStability.STABLE) {
+            fetchSpan.setAttribute(ATTR_URL_FULL, location.href);
+          }
           context.with(trace.setSpan(context.active(), fetchSpan), () => {
+            const skipOldSemconvContentLengthAttrs = !(
+              this._semconvStability & SemconvStability.OLD
+            );
             addSpanNetworkEvents(
               fetchSpan,
               entries,
-              this.getConfig().ignoreNetworkEvents
+              this.getConfig().ignoreNetworkEvents,
+              undefined,
+              skipOldSemconvContentLengthAttrs
             );
             this._addCustomAttributesOnSpan(
               fetchSpan,
@@ -128,8 +150,14 @@ export class DocumentLoadInstrumentation extends InstrumentationBase<DocumentLoa
         }
       });
 
-      rootSpan.setAttribute(ATTR_HTTP_URL, location.href);
-      rootSpan.setAttribute(ATTR_HTTP_USER_AGENT, navigator.userAgent);
+      if (this._semconvStability & SemconvStability.OLD) {
+        rootSpan.setAttribute(ATTR_HTTP_URL, location.href);
+        rootSpan.setAttribute(ATTR_HTTP_USER_AGENT, navigator.userAgent);
+      }
+      if (this._semconvStability & SemconvStability.STABLE) {
+        rootSpan.setAttribute(ATTR_URL_FULL, location.href);
+        rootSpan.setAttribute(ATTR_USER_AGENT_ORIGINAL, navigator.userAgent);
+      }
 
       this._addResourcesSpans(rootSpan);
 
@@ -203,11 +231,22 @@ export class DocumentLoadInstrumentation extends InstrumentationBase<DocumentLoa
       parentSpan
     );
     if (span) {
-      span.setAttribute(ATTR_HTTP_URL, resource.name);
+      if (this._semconvStability & SemconvStability.OLD) {
+        span.setAttribute(ATTR_HTTP_URL, resource.name);
+      }
+      if (this._semconvStability & SemconvStability.STABLE) {
+        span.setAttribute(ATTR_URL_FULL, resource.name);
+      }
+
+      const skipOldSemconvContentLengthAttrs = !(
+        this._semconvStability & SemconvStability.OLD
+      );
       addSpanNetworkEvents(
         span,
         resource,
-        this.getConfig().ignoreNetworkEvents
+        this.getConfig().ignoreNetworkEvents,
+        undefined,
+        skipOldSemconvContentLengthAttrs
       );
       this._addCustomAttributesOnResourceSpan(
         span,

--- a/packages/instrumentation-document-load/src/types.ts
+++ b/packages/instrumentation-document-load/src/types.ts
@@ -69,4 +69,7 @@ export interface DocumentLoadInstrumentationConfig
    * firstPaint
    */
   ignorePerformancePaintEvents?: boolean;
+
+  /** Select the HTTP semantic conventions version(s) used. */
+  semconvStabilityOptIn?: string;
 }


### PR DESCRIPTION
Configure the instrumentation with `semconvStabilityOptIn: 'http'` to use the new, stable HTTP semconv v1.23.1 semantics or `'http/dup'` for both old (v1.22.0) and stable semantics. When `semconvStabilityOptIn` is not specified (or does not contain these values), it uses the old semconv v1.22.0. I.e. the default behavior is unchanged.

Refs: https://github.com/open-telemetry/opentelemetry-js/issues/5663
