### PR TITLE
feat(instrumentation-nestjs-core): support migration to stable HTTP semconv

### DIFF
--- a/packages/instrumentation-nestjs-core/README.md
+++ b/packages/instrumentation-nestjs-core/README.md
@@ -62,11 +62,36 @@ Attributes collected:
 | `nestjs.module`     | Nest module class name                             |
 | `nestjs.controller` | Nest controller class name                         |
 | `nestjs.callback`   | The function name of the member in the controller  |
-| `http.method`       | HTTP method                                        |
-| `http.url`          | Full request URL                                   |
 | `http.route`        | Route assigned to handler. Ex: `/users/:id`        |
+| `http.method` / `http.request.method` | HTTP method. See "HTTP Semantic Convention migration" note below. |
+| `http.url` / `url.full` | Full request URL. See "HTTP Semantic Convention migration" note below. |
 
 \* included in all of the spans.
+
+### HTTP Semantic Convention migration
+
+HTTP semantic conventions (semconv) were stabilized in v1.23.0, and a [migration process](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/non-normative/http-migration.md#http-semantic-convention-stability-migration)
+was defined.  This instrumentations adds some minimal HTTP-related
+attributes on created spans. Starting with `instrumentation-nestjs-core` version
+0.52.0, the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable can be used to
+customize which HTTP semantic conventions are used for those HTTP-related
+attributes.
+
+To select which semconv version(s) is emitted from this instrumentation, use the
+`OTEL_SEMCONV_STABILITY_OPT_IN` environment variable.
+
+- `http`: emit the new (stable) v1.23.0+ semantics
+- `http/dup`: emit **both** the old v1.7.0 and the new (stable) v1.23.0+ semantics
+- By default, if `OTEL_SEMCONV_STABILITY_OPT_IN` includes neither of the above tokens, the old v1.7.0 semconv is used.
+
+For this instrumentation, the only impacted attributes are as follows:
+
+| v1.7.0 semconv | v1.23.0 semconv       |
+| -------------- | --------------------- |
+| `http.method`  | `http.request.method` |
+| `http.url`     | `url.full`            |
+
+See the [HTTP semconv migration plan for OpenTelemetry JS instrumentations](https://github.com/open-telemetry/opentelemetry-js/issues/5646) for more details.
 
 ## Useful links
 


### PR DESCRIPTION
This adds support for using the OTEL_SEMCONV_STABILITY_OPT_IN envvar
to control migration to the stable HTTP semantic conventions for
telemetry from this instrumentation.

Refs: https://github.com/open-telemetry/opentelemetry-js/issues/5663
