### PR TITLE
feat(instrumentation-graphql): Add option to put all resolve spans under the same parent span

### DIFF
--- a/packages/instrumentation-graphql/src/internal-types.ts
+++ b/packages/instrumentation-graphql/src/internal-types.ts
@@ -80,9 +80,7 @@ export type validateType = (
 ) => ReadonlyArray<graphqlTypes.GraphQLError>;
 
 export interface GraphQLField {
-  parent: api.Span;
   span: api.Span;
-  error: Error | null;
 }
 
 interface OtelGraphQLData {

--- a/packages/instrumentation-graphql/src/types.ts
+++ b/packages/instrumentation-graphql/src/types.ts
@@ -59,6 +59,13 @@ export interface GraphQLInstrumentationConfig extends InstrumentationConfig {
   ignoreTrivialResolveSpans?: boolean;
 
   /**
+   * Place all resolve spans under the same parent instead of producing a nested tree structure.
+   *
+   * @default false
+   */
+  flatResolveSpans?: boolean;
+
+  /**
    * Whether to merge list items into a single element.
    *
    * @example `users.*.name` instead of `users.0.name`, `users.1.name`

--- a/packages/instrumentation-graphql/src/utils.ts
+++ b/packages/instrumentation-graphql/src/utils.ts
@@ -83,34 +83,33 @@ function createFieldIfNotExists(
   info: graphqlTypes.GraphQLResolveInfo,
   path: string[]
 ): {
-  field: any;
+  field: GraphQLField;
   spanAdded: boolean;
 } {
   let field = getField(contextValue, path);
-
-  let spanAdded = false;
-
-  if (!field) {
-    spanAdded = true;
-    const parent = getParentField(contextValue, path);
-
-    field = {
-      parent,
-      span: createResolverSpan(
-        tracer,
-        getConfig,
-        contextValue,
-        info,
-        path,
-        parent.span
-      ),
-      error: null,
-    };
-
-    addField(contextValue, path, field);
+  if (field) {
+    return { field, spanAdded: false };
   }
 
-  return { spanAdded, field };
+  const config = getConfig();
+  const parentSpan = config.flatResolveSpans
+    ? getRootSpan(contextValue)
+    : getParentFieldSpan(contextValue, path);
+
+  field = {
+    span: createResolverSpan(
+      tracer,
+      getConfig,
+      contextValue,
+      info,
+      path,
+      parentSpan
+    ),
+  };
+
+  addField(contextValue, path, field);
+
+  return { field, spanAdded: true };
 }
 
 function createResolverSpan(
@@ -188,22 +187,24 @@ function addField(contextValue: any, path: string[], field: GraphQLField) {
     field);
 }
 
-function getField(contextValue: any, path: string[]) {
+function getField(contextValue: any, path: string[]): GraphQLField {
   return contextValue[OTEL_GRAPHQL_DATA_SYMBOL].fields[path.join('.')];
 }
 
-function getParentField(contextValue: any, path: string[]) {
+function getParentFieldSpan(contextValue: any, path: string[]): api.Span {
   for (let i = path.length - 1; i > 0; i--) {
     const field = getField(contextValue, path.slice(0, i));
 
     if (field) {
-      return field;
+      return field.span;
     }
   }
 
-  return {
-    span: contextValue[OTEL_GRAPHQL_DATA_SYMBOL].span,
-  };
+  return getRootSpan(contextValue);
+}
+
+function getRootSpan(contextValue: any): api.Span {
+  return contextValue[OTEL_GRAPHQL_DATA_SYMBOL].span;
 }
 
 function pathToArray(mergeItems: boolean, path: GraphQLPath): string[] {
@@ -444,24 +445,24 @@ export function wrapFieldResolver<TSource = any, TContext = any, TArgs = any>(
     const path = pathToArray(config.mergeItems, info && info.path);
     const depth = path.filter((item: any) => typeof item === 'string').length;
 
-    let field: any;
+    let span: api.Span;
     let shouldEndSpan = false;
     if (config.depth >= 0 && config.depth < depth) {
-      field = getParentField(contextValue, path);
+      span = getParentFieldSpan(contextValue, path);
     } else {
-      const newField = createFieldIfNotExists(
+      const { field, spanAdded } = createFieldIfNotExists(
         tracer,
         getConfig,
         contextValue,
         info,
         path
       );
-      field = newField.field;
-      shouldEndSpan = newField.spanAdded;
+      span = field.span;
+      shouldEndSpan = spanAdded;
     }
 
     return api.context.with(
-      api.trace.setSpan(api.context.active(), field.span),
+      api.trace.setSpan(api.context.active(), span),
       () => {
         try {
           const res = fieldResolver.call(
@@ -474,20 +475,20 @@ export function wrapFieldResolver<TSource = any, TContext = any, TArgs = any>(
           if (isPromise(res)) {
             return res.then(
               (r: any) => {
-                handleResolveSpanSuccess(field.span, shouldEndSpan);
+                handleResolveSpanSuccess(span, shouldEndSpan);
                 return r;
               },
               (err: Error) => {
-                handleResolveSpanError(field.span, err, shouldEndSpan);
+                handleResolveSpanError(span, err, shouldEndSpan);
                 throw err;
               }
             );
           } else {
-            handleResolveSpanSuccess(field.span, shouldEndSpan);
+            handleResolveSpanSuccess(span, shouldEndSpan);
             return res;
           }
         } catch (err: any) {
-          handleResolveSpanError(field.span, err, shouldEndSpan);
+          handleResolveSpanError(span, err, shouldEndSpan);
           throw err;
         }
       }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

At the moment, GraphQL "resolve" spans (spans generated for each resolver/sub-resolver in a GraphQL request) are generated in a tree structure that reflects the GraphQL resolution tree. This sounds great in theory, but in practice it generates this kind of traces, where child spans start when their parent spans end.

```
 v root span                             | ----------------------------------------
 |  v resolve thing                      | ----------
 |  |  v resolve thing.field1            |           ----------
 |  |  \-    resolve thing.field1.nested |                     --------------------
 \- \-   resolve thing.field2            |           --------------------
```

Although it may look fine at a glance, it has issues:

  - Collapsing a span with child spans in a trace viewer (maybe some of them handle this better?) results in some amount of time seemingly unaccounted for in the root span. E.g.:

    ```
     v root span                             | ----------------------------------------
     |  v resolve thing                      | ----------
     |  |  > resolve thing.field1            |           ----------
     \- \-   resolve thing.field2            |           --------------------
    ```
    ```
     v root span                             | ----------------------------------------
     \- > resolve thing                      | ----------
     ```
    
  - Critical path in viewers like Jaeger does not generate properly

## Short description of the changes

The solution is to never have a span end before all its child spans have ended. I can imagine two ways to achieve this:

 1. Add an extra layer of spans for the tree structure, and put the "resolve" spans under their tree structure node.

    ```
     v root span                    | ----------------------------------------
     |  v thing                     | ----------------------------------------
     |  |    resolve                | ----------
     |  |  v thing.field1           |           ------------------------------
     |  |  |    resolve             |           ----------
     |  |  |  v thing.field1.nested |                     --------------------
     |  |  \- \-   resolve          |                     --------------------
     |  |  v thing.field2           |           --------------------
     \- \- \-   resolve             |           --------------------
    ```

 2. Put all "resolve" spans under the same parent.
 
     ```
      v root span                      | ----------------------------------------
     |    resolve thing               | ----------
     |    resolve thing.field1        |           ----------
     |    resolve thing.field2        |           --------------------
     \-   resolve thing.field1.nested |                     --------------------
    ```

This PR implements option 2. for simplicity, although I am open to work toward option 1. if preferred.

