### PR TITLE
chore: lint CHANGELOG.md files a little more loosely

### DIFF
--- a/packages/auto-configuration-propagators/CHANGELOG.md
+++ b/packages/auto-configuration-propagators/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.4.2](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/auto-configuration-propagators-v0.4.1...auto-configuration-propagators-v0.4.2) (2025-09-01)
@@ -85,5 +86,3 @@
 ### Features
 
 * Add package for automatic propagator configuration ([#2299](https://github.com/open-telemetry/opentelemetry-js-contrib/issues/2299)) ([4bb28c9](https://github.com/open-telemetry/opentelemetry-js-contrib/commit/4bb28c99c29b52193bcd9d0f14202beac6c5dfa6))
-
-## Changelog

--- a/packages/auto-instrumentations-node/CHANGELOG.md
+++ b/packages/auto-instrumentations-node/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.64.1](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/auto-instrumentations-node-v0.64.0...auto-instrumentations-node-v0.64.1) (2025-09-11)

--- a/packages/auto-instrumentations-web/CHANGELOG.md
+++ b/packages/auto-instrumentations-web/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.51.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/auto-instrumentations-web-v0.50.0...auto-instrumentations-web-v0.51.0) (2025-09-10)

--- a/packages/baggage-log-record-processor/CHANGELOG.md
+++ b/packages/baggage-log-record-processor/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.6.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/baggage-log-record-processor-v0.5.0...baggage-log-record-processor-v0.6.0) (2025-09-10)

--- a/packages/baggage-span-processor/CHANGELOG.md
+++ b/packages/baggage-span-processor/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.4.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/baggage-span-processor-v0.3.1...baggage-span-processor-v0.4.0) (2025-03-18)

--- a/packages/contrib-test-utils/CHANGELOG.md
+++ b/packages/contrib-test-utils/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.51.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/contrib-test-utils-v0.50.0...contrib-test-utils-v0.51.0) (2025-09-10)

--- a/packages/host-metrics/CHANGELOG.md
+++ b/packages/host-metrics/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.36.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/host-metrics-v0.35.5...host-metrics-v0.36.0) (2025-03-18)

--- a/packages/id-generator-aws-xray/CHANGELOG.md
+++ b/packages/id-generator-aws-xray/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [2.0.1](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/id-generator-aws-xray-v2.0.0...id-generator-aws-xray-v2.0.1) (2025-09-01)

--- a/packages/instrumentation-amqplib/CHANGELOG.md
+++ b/packages/instrumentation-amqplib/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.52.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-amqplib-v0.51.0...instrumentation-amqplib-v0.52.0) (2025-09-10)

--- a/packages/instrumentation-aws-lambda/CHANGELOG.md
+++ b/packages/instrumentation-aws-lambda/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.56.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-aws-lambda-v0.55.0...instrumentation-aws-lambda-v0.56.0) (2025-09-10)

--- a/packages/instrumentation-aws-sdk/CHANGELOG.md
+++ b/packages/instrumentation-aws-sdk/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.60.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-aws-sdk-v0.59.0...instrumentation-aws-sdk-v0.60.0) (2025-09-10)

--- a/packages/instrumentation-bunyan/CHANGELOG.md
+++ b/packages/instrumentation-bunyan/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.51.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-bunyan-v0.50.0...instrumentation-bunyan-v0.51.0) (2025-09-10)

--- a/packages/instrumentation-cassandra-driver/CHANGELOG.md
+++ b/packages/instrumentation-cassandra-driver/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.51.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-cassandra-driver-v0.50.0...instrumentation-cassandra-driver-v0.51.0) (2025-09-10)

--- a/packages/instrumentation-connect/CHANGELOG.md
+++ b/packages/instrumentation-connect/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.49.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-connect-v0.48.0...instrumentation-connect-v0.49.0) (2025-09-10)

--- a/packages/instrumentation-cucumber/CHANGELOG.md
+++ b/packages/instrumentation-cucumber/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.21.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-cucumber-v0.20.0...instrumentation-cucumber-v0.21.0) (2025-09-10)

--- a/packages/instrumentation-dataloader/CHANGELOG.md
+++ b/packages/instrumentation-dataloader/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.23.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-dataloader-v0.22.0...instrumentation-dataloader-v0.23.0) (2025-09-10)
@@ -285,5 +286,3 @@
 
 * add dataloader instrumentation ([#1171](https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1171)) ([3898b11](https://github.com/open-telemetry/opentelemetry-js-contrib/commit/3898b11800f857c75c286f22c4633b5baf4e1f84))
 * upstream mocha instrumentation testing plugin from ext-js [#621](https://github.com/open-telemetry/opentelemetry-js-contrib/issues/621) ([#669](https://github.com/open-telemetry/opentelemetry-js-contrib/issues/669)) ([a5170c4](https://github.com/open-telemetry/opentelemetry-js-contrib/commit/a5170c494706a2bec3ba51e59966d0ca8a41d00e))
-
-## Changelog

--- a/packages/instrumentation-dns/CHANGELOG.md
+++ b/packages/instrumentation-dns/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.49.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-dns-v0.48.0...instrumentation-dns-v0.49.0) (2025-09-10)

--- a/packages/instrumentation-document-load/CHANGELOG.md
+++ b/packages/instrumentation-document-load/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.50.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-document-load-v0.49.0...instrumentation-document-load-v0.50.0) (2025-09-10)

--- a/packages/instrumentation-express/CHANGELOG.md
+++ b/packages/instrumentation-express/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.54.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-express-v0.53.0...instrumentation-express-v0.54.0) (2025-09-10)

--- a/packages/instrumentation-fastify/CHANGELOG.md
+++ b/packages/instrumentation-fastify/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.50.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-fastify-v0.49.0...instrumentation-fastify-v0.50.0) (2025-09-10)

--- a/packages/instrumentation-fs/CHANGELOG.md
+++ b/packages/instrumentation-fs/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.25.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-fs-v0.24.0...instrumentation-fs-v0.25.0) (2025-09-10)

--- a/packages/instrumentation-generic-pool/CHANGELOG.md
+++ b/packages/instrumentation-generic-pool/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.49.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-generic-pool-v0.48.0...instrumentation-generic-pool-v0.49.0) (2025-09-10)

--- a/packages/instrumentation-graphql/CHANGELOG.md
+++ b/packages/instrumentation-graphql/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.53.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-graphql-v0.52.0...instrumentation-graphql-v0.53.0) (2025-09-10)

--- a/packages/instrumentation-hapi/CHANGELOG.md
+++ b/packages/instrumentation-hapi/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.52.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-hapi-v0.51.0...instrumentation-hapi-v0.52.0) (2025-09-10)

--- a/packages/instrumentation-ioredis/CHANGELOG.md
+++ b/packages/instrumentation-ioredis/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.53.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-ioredis-v0.52.0...instrumentation-ioredis-v0.53.0) (2025-09-10)

--- a/packages/instrumentation-kafkajs/CHANGELOG.md
+++ b/packages/instrumentation-kafkajs/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.15.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-kafkajs-v0.14.0...instrumentation-kafkajs-v0.15.0) (2025-09-10)

--- a/packages/instrumentation-knex/CHANGELOG.md
+++ b/packages/instrumentation-knex/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.50.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-knex-v0.49.0...instrumentation-knex-v0.50.0) (2025-09-10)

--- a/packages/instrumentation-koa/CHANGELOG.md
+++ b/packages/instrumentation-koa/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.53.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-koa-v0.52.0...instrumentation-koa-v0.53.0) (2025-09-10)

--- a/packages/instrumentation-long-task/CHANGELOG.md
+++ b/packages/instrumentation-long-task/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.50.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-long-task-v0.49.0...instrumentation-long-task-v0.50.0) (2025-09-10)

--- a/packages/instrumentation-lru-memoizer/CHANGELOG.md
+++ b/packages/instrumentation-lru-memoizer/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.50.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-lru-memoizer-v0.49.0...instrumentation-lru-memoizer-v0.50.0) (2025-09-10)

--- a/packages/instrumentation-memcached/CHANGELOG.md
+++ b/packages/instrumentation-memcached/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.49.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-memcached-v0.48.0...instrumentation-memcached-v0.49.0) (2025-09-10)

--- a/packages/instrumentation-mongodb/CHANGELOG.md
+++ b/packages/instrumentation-mongodb/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.58.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-mongodb-v0.57.0...instrumentation-mongodb-v0.58.0) (2025-09-10)

--- a/packages/instrumentation-mongoose/CHANGELOG.md
+++ b/packages/instrumentation-mongoose/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.52.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-mongoose-v0.51.0...instrumentation-mongoose-v0.52.0) (2025-09-10)

--- a/packages/instrumentation-mysql/CHANGELOG.md
+++ b/packages/instrumentation-mysql/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.51.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-mysql-v0.50.0...instrumentation-mysql-v0.51.0) (2025-09-10)

--- a/packages/instrumentation-mysql2/CHANGELOG.md
+++ b/packages/instrumentation-mysql2/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.52.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-mysql2-v0.51.0...instrumentation-mysql2-v0.52.0) (2025-09-10)

--- a/packages/instrumentation-nestjs-core/CHANGELOG.md
+++ b/packages/instrumentation-nestjs-core/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.51.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-nestjs-core-v0.50.0...instrumentation-nestjs-core-v0.51.0) (2025-09-10)

--- a/packages/instrumentation-net/CHANGELOG.md
+++ b/packages/instrumentation-net/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.49.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-net-v0.48.0...instrumentation-net-v0.49.0) (2025-09-10)

--- a/packages/instrumentation-openai/CHANGELOG.md
+++ b/packages/instrumentation-openai/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.3.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-openai-v0.2.0...instrumentation-openai-v0.3.0) (2025-09-10)

--- a/packages/instrumentation-oracledb/CHANGELOG.md
+++ b/packages/instrumentation-oracledb/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.31.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-oracledb-v0.30.0...instrumentation-oracledb-v0.31.0) (2025-09-10)

--- a/packages/instrumentation-pg/CHANGELOG.md
+++ b/packages/instrumentation-pg/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.58.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-pg-v0.57.0...instrumentation-pg-v0.58.0) (2025-09-10)

--- a/packages/instrumentation-pino/CHANGELOG.md
+++ b/packages/instrumentation-pino/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.52.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-pino-v0.51.0...instrumentation-pino-v0.52.0) (2025-09-10)

--- a/packages/instrumentation-redis/CHANGELOG.md
+++ b/packages/instrumentation-redis/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.54.1](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-redis-v0.54.0...instrumentation-redis-v0.54.1) (2025-09-11)

--- a/packages/instrumentation-restify/CHANGELOG.md
+++ b/packages/instrumentation-restify/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.51.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-restify-v0.50.0...instrumentation-restify-v0.51.0) (2025-09-10)

--- a/packages/instrumentation-router/CHANGELOG.md
+++ b/packages/instrumentation-router/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.50.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-router-v0.49.0...instrumentation-router-v0.50.0) (2025-09-10)

--- a/packages/instrumentation-runtime-node/CHANGELOG.md
+++ b/packages/instrumentation-runtime-node/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.19.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-runtime-node-v0.18.0...instrumentation-runtime-node-v0.19.0) (2025-09-10)

--- a/packages/instrumentation-socket.io/CHANGELOG.md
+++ b/packages/instrumentation-socket.io/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.52.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-socket.io-v0.51.0...instrumentation-socket.io-v0.52.0) (2025-09-10)

--- a/packages/instrumentation-tedious/CHANGELOG.md
+++ b/packages/instrumentation-tedious/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.24.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-tedious-v0.23.0...instrumentation-tedious-v0.24.0) (2025-09-10)

--- a/packages/instrumentation-typeorm/CHANGELOG.md
+++ b/packages/instrumentation-typeorm/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.6.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-typeorm-v0.5.0...instrumentation-typeorm-v0.6.0) (2025-09-10)

--- a/packages/instrumentation-undici/CHANGELOG.md
+++ b/packages/instrumentation-undici/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.16.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-undici-v0.15.0...instrumentation-undici-v0.16.0) (2025-09-10)

--- a/packages/instrumentation-user-interaction/CHANGELOG.md
+++ b/packages/instrumentation-user-interaction/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.50.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-user-interaction-v0.49.0...instrumentation-user-interaction-v0.50.0) (2025-09-10)

--- a/packages/instrumentation-winston/CHANGELOG.md
+++ b/packages/instrumentation-winston/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.50.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/instrumentation-winston-v0.49.0...instrumentation-winston-v0.50.0) (2025-09-10)

--- a/packages/plugin-react-load/CHANGELOG.md
+++ b/packages/plugin-react-load/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.37.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/plugin-react-load-v0.36.0...plugin-react-load-v0.37.0) (2025-09-10)

--- a/packages/propagation-utils/CHANGELOG.md
+++ b/packages/propagation-utils/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.31.5](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/propagation-utils-v0.31.4...propagation-utils-v0.31.5) (2025-09-10)

--- a/packages/propagator-aws-xray-lambda/CHANGELOG.md
+++ b/packages/propagator-aws-xray-lambda/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.55.1](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/propagator-aws-xray-lambda-v0.55.0...propagator-aws-xray-lambda-v0.55.1) (2025-09-01)

--- a/packages/propagator-aws-xray/CHANGELOG.md
+++ b/packages/propagator-aws-xray/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [2.1.1](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/propagator-aws-xray-v2.1.0...propagator-aws-xray-v2.1.1) (2025-09-01)

--- a/packages/propagator-instana/CHANGELOG.md
+++ b/packages/propagator-instana/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.4.1](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/propagator-instana-v0.4.0...propagator-instana-v0.4.1) (2025-09-01)

--- a/packages/propagator-ot-trace/CHANGELOG.md
+++ b/packages/propagator-ot-trace/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.28.1](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/propagator-ot-trace-v0.28.0...propagator-ot-trace-v0.28.1) (2025-09-01)

--- a/packages/redis-common/CHANGELOG.md
+++ b/packages/redis-common/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.38.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/redis-common-v0.37.0...redis-common-v0.38.0) (2025-07-04)

--- a/packages/resource-detector-alibaba-cloud/CHANGELOG.md
+++ b/packages/resource-detector-alibaba-cloud/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.31.5](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/resource-detector-alibaba-cloud-v0.31.4...resource-detector-alibaba-cloud-v0.31.5) (2025-09-10)

--- a/packages/resource-detector-aws/CHANGELOG.md
+++ b/packages/resource-detector-aws/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [2.5.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/resource-detector-aws-v2.4.0...resource-detector-aws-v2.5.0) (2025-09-10)

--- a/packages/resource-detector-azure/CHANGELOG.md
+++ b/packages/resource-detector-azure/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.12.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/resource-detector-azure-v0.11.0...resource-detector-azure-v0.12.0) (2025-09-10)

--- a/packages/resource-detector-container/CHANGELOG.md
+++ b/packages/resource-detector-container/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.7.5](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/resource-detector-container-v0.7.4...resource-detector-container-v0.7.5) (2025-09-10)

--- a/packages/resource-detector-gcp/CHANGELOG.md
+++ b/packages/resource-detector-gcp/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.40.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/resource-detector-gcp-v0.39.0...resource-detector-gcp-v0.40.0) (2025-09-11)

--- a/packages/resource-detector-github/CHANGELOG.md
+++ b/packages/resource-detector-github/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.31.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/resource-detector-github-v0.30.0...resource-detector-github-v0.31.0) (2025-03-18)

--- a/packages/resource-detector-instana/CHANGELOG.md
+++ b/packages/resource-detector-instana/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.24.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/resource-detector-instana-v0.23.0...resource-detector-instana-v0.24.0) (2025-09-10)

--- a/packages/sql-common/CHANGELOG.md
+++ b/packages/sql-common/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.41.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/sql-common-v0.40.1...sql-common-v0.41.0) (2025-03-18)

--- a/packages/winston-transport/CHANGELOG.md
+++ b/packages/winston-transport/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
 # Changelog
 
 ## [0.16.0](https://github.com/open-telemetry/opentelemetry-js-contrib/compare/winston-transport-v0.15.0...winston-transport-v0.16.0) (2025-09-10)


### PR DESCRIPTION
- ignore 'MD007/ul-indent' (https://github.com/DavidAnson/markdownlint/blob/main/doc/md007.md) rule because changelog additions by release-please sometimes use 2-spaces (e.g. https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3033/files#diff-bbed5176d1ba38f7f8f16103189e27b107fd64a1dcfd50fe98e3a24d24c096b7R13-R15) and sometimes use 4-spaces (with commit overrides: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3063 becomes 4-spaces https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3072/files#diff-bbed5176d1ba38f7f8f16103189e27b107fd64a1dcfd50fe98e3a24d24c096b7R8-R14)
- ignore 'MD034/no-bare-urls' (https://github.com/DavidAnson/markdownlint/blob/main/doc/md034.md): The requirement to use angle-brackets is *fine*, but over-strong as a *requirement*, especially when it comes as part of a commit-override in a PR comment. The issue is that the lint failure because subtle/complex.

Refs: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3072#issuecomment-3320224717
