### PR TITLE
ci(test): use environment variables over shell evaluation when reporting coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -277,5 +277,8 @@ jobs:
           name: tests-coverage-cache-${{ github.run_number }}-24
           path: .
       - name: Report Coverage with Flags
-        run: node ./scripts/codecov-upload-flags.mjs ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.head.label }}
+        run: node ./scripts/codecov-upload-flags.mjs
+        env:
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BRANCH_NAME: ${{ github.event.pull_request.head.label }}
 

--- a/scripts/codecov-upload-flags.mjs
+++ b/scripts/codecov-upload-flags.mjs
@@ -6,8 +6,8 @@ import path from 'path';
 // Usage
 // node ./scripts/codecov-upload-flags.mjs
 
-const commitSha = process.argv[2];
-const branchName = process.argv[3];
+const commitSha = process.env.COMMIT_SHA;
+const branchName = process.env.PR_BRANCH_NAME;
 
 const readPkg = (dir) => JSON.parse(readFileSync(path.join(dir, 'package.json'), 'utf8'));
 const pkgInfo = readPkg('.');


### PR DESCRIPTION
## Which problem is this PR solving?

I noticed this earlier and **I disabled the workflow** (re-enabled for a second to make the required checks pass) until this is merged:
- `github.event.pull_request.head.label` is user-controlled
- we have been using it in like so `node ./scripts/codecov-upload-flags.mjs ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.head.label }}`, which bears the risk of shell injection via a malicious branch names
  - we need to manually enable workflow runs for unknown contributors, and forks are the only way people can use it, so there was **no access to secrets**, since the workflow runs in the context of the fork
  - **branch protection rules prevent his from being exploited in the repo context** by users who happen to have write access to the repo (which are trusted users anyway)