### PR TITLE
ci(release-please): pass EasyCLA, correct if-logic for releases_created var

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -64,7 +64,7 @@ jobs:
           npm install --ignore-scripts --package-lock-only
           git add package-lock.json
           git commit -m "chore: sync package-lock.json 'dependencies' key"
-          git push
+          git push --force
 
   install-and-compile:
     needs: release-please

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,23 +52,24 @@ jobs:
           token: ${{ steps.otelbot-token.outputs.token }}
           fetch-depth: 0
 
-      # previous commiter does not have CLA signed, and the commit is missing updates to package-lock.json,
-      # so we re-write that commit here with the proper changes
+      # If we've created/updated a PR:
+      # 1. Amend the author to 'otelbot', which passes EasyCLA.
+      # 2. Sync the legacy "dependencies" key in package-lock.json.
       - name: Update package-lock.json in PR
-        # only update if a PR has been created
         if: ${{ steps.release.outputs.pr }}
         run: |
-          npm install --ignore-scripts --package-lock-only
-          git add package-lock.json
           git config user.name otelbot
           git config user.email 197425009+otelbot@users.noreply.github.com
-          git commit --amend --reset-author --no-edit
-          git push --force
+          git rebase main -x "git commit --amend --reset-author --no-edit"
+          npm install --ignore-scripts --package-lock-only
+          git add package-lock.json
+          git commit -m "chore: sync package-lock.json 'dependencies' key"
+          git push
 
   install-and-compile:
     needs: release-please
     # only if a release has been created
-    if: ${{ needs.release-please.outputs.releases_created }}
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -93,7 +94,7 @@ jobs:
       - release-please
       - install-and-compile
     # only if a release has been created
-    if: ${{ needs.release-please.outputs.releases_created }}
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
- The release-please PR can include *multiple* commits, so we need to amend
  the author on all of them to pass EasyCLA.
- The logic for guarding on releases_created was wrong: I believe because
  it is a *string* true or false, rather than a boolean that works the
  way it was previously.

Refs: https://github.com/open-telemetry/opentelemetry-js-contrib/issues/3099
