### PR TITLE
ci(release-please): ensure main exists when rebasing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -60,7 +60,8 @@ jobs:
         run: |
           git config user.name otelbot
           git config user.email 197425009+otelbot@users.noreply.github.com
-          git rebase main -x "git commit --amend --reset-author --no-edit"
+          git fetch origin main:refs/remotes/origin/main
+          git rebase origin/main -x "git commit --amend --reset-author --no-edit"
           npm install --ignore-scripts --package-lock-only
           git add package-lock.json
           git commit -m "chore: sync package-lock.json 'dependencies' key"


### PR DESCRIPTION
## Which problem is this PR solving?

Workflow is still failing, as the branch does not seem to be fetched yet, see: https://github.com/open-telemetry/opentelemetry-js-contrib/actions/runs/18001532367/job/51211746942

This adds a fetch before doing the rebase.