### PR TITLE
ci(release-please): avoid re-writing commits on release PR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -53,18 +53,16 @@ jobs:
           fetch-depth: 0
 
       # If we've created/updated a PR:
-      # 1. Amend the author to 'otelbot', which passes EasyCLA.
-      # 2. Sync the legacy "dependencies" key in package-lock.json.
+      # Sync the legacy "dependencies" key in package-lock.json.
       - name: Update package-lock.json in PR
         if: ${{ steps.release.outputs.pr }}
         run: |
           git config user.name otelbot
           git config user.email 197425009+otelbot@users.noreply.github.com
-          git rebase main -x "git commit --amend --reset-author --no-edit"
           npm install --ignore-scripts --package-lock-only
           git add package-lock.json
           git commit -m "chore: sync package-lock.json 'dependencies' key"
-          git push --force
+          git push
 
   install-and-compile:
     needs: release-please


### PR DESCRIPTION
## Which problem is this PR solving?

Alternative to #3104 
Refs #3099 

`otelbot-js-contrib` now has the CLA signed, we can merge this and avoid re-writing commits all together.
