### PR TITLE
ci(release-please): combine npm publish workflow jobs to avoid file perm issues from zip files used by upload-artifact

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -64,50 +64,24 @@ jobs:
           git commit -m "chore: sync package-lock.json 'dependencies' key"
           git push
 
-  install-and-compile:
-    needs: release-please
-    # only if a release has been created
-    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - name: Rebuild Packages
-        run: |
-          npm ci
-          npm run compile
-      - name: Upload contents for publish
-        uses: actions/upload-artifact@v4
-        with:
-          name: publish-cache-${{ github.run_number }}
-          path: .
-          include-hidden-files: true
-          if-no-files-found: error
-          retention-days: 10
-
+  # If releases have been created, then publish to npm.
   npm-publish:
-    needs:
-      - release-please
-      - install-and-compile
-    # only if a release has been created
+    needs: release-please
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
-    runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write # to generate npm provenance statements
+      id-token: write # needed for OIDC and provenance
+    runs-on: ubuntu-latest
     environment: npm-publish-environment
     steps:
-      - name: Setup Node
-        uses: actions/setup-node@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
+          # Require npm 11.5.1 or later for https://docs.npmjs.com/trusted-publishers.
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
-      - name: Download contents for publish
-        uses: actions/download-artifact@v5
-        with:
-          name: publish-cache-${{ github.run_number }}
+      - run: npm ci
+      - run: npm run compile
       # Release Please has already incremented versions and published tags, so we just
       # need to publish all unpublished versions to npm here
       # See: https://github.com/lerna/lerna/tree/main/libs/commands/publish#bump-from-package


### PR DESCRIPTION
With the previous separate of jobs, the built files to publish were shared
across jobs with upload/download-artifact. This uses zip files, which cannot
handle the execute bit on files. This resulted in lerna publish spuriously
erroring out thinking there were uncommited changes to the handful of
files in scripts/ that intentional have the execute file perm set.

Refs: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3107#issuecomment-3335487278
