### PR TITLE
fix: force new release PR

### DIFF
--- a/packages/instrumentation-bunyan/README.md
+++ b/packages/instrumentation-bunyan/README.md
@@ -136,4 +136,4 @@ Apache 2.0 - See [LICENSE][license-url] for more information.
 [license-url]: https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/LICENSE
 [license-image]: https://img.shields.io/badge/license-Apache_2.0-green.svg?style=flat
 [npm-url]: https://www.npmjs.com/package/@opentelemetry/instrumentation-bunyan
-[npm-img]: https://badge.fury.io/js/%40opentelemetry%2Finstrumentation-bunyan.svg
+[npm-img]: https://img.shields.io/npm/v/%40opentelemetry%2Finstrumentation-bunyan.svg


### PR DESCRIPTION
## Which problem is this PR solving?

We're still having problems with the new release workflow. ODIC support was added in `lerna@9`, so the run likely failed for that reason. 

This PR is intended for another round of testing the release-please workflow, after updating to `lerna@9` #3114. It triggers a new release PR for `@opentelemetry/instrumentation-bunyan`, by making a minimal `README.md` change. 

Refs:
- tracking issue #3099
- https://github.com/open-telemetry/opentelemetry-js-contrib/actions/runs/18020717167/job/51277286471 -failed workflow run
- #3111 - to force a PR for all packages when we know the workflow works.