### PR TITLE
fix: use absolute results in eventLoopUtilization computation

### DIFF
--- a/packages/instrumentation-runtime-node/src/metrics/eventLoopUtilizationCollector.ts
+++ b/packages/instrumentation-runtime-node/src/metrics/eventLoopUtilizationCollector.ts
@@ -46,7 +46,7 @@ export class EventLoopUtilizationCollector extends BaseCollector {
 
         const elu = eventLoopUtilizationCollector(this._lastValue);
         observableResult.observe(elu.utilization);
-        this._lastValue = elu;
+        this._lastValue = eventLoopUtilizationCollector();
       });
   }
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

The current implementation of the Event Loop Utilization passes a delta value to the call instead of an absolute one.
The [NodeJS perf_hooks documentation](https://nodejs.org/api/perf_hooks.html#performanceeventlooputilizationutilization1-utilization2) is a little ambiguous but it does say that if calling `eventLoopUtilization()` with 1 argument, it should be the result of a call to that same function without argument : 
> `utilization1` [<Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object) The result of a previous call to *eventLoopUtilization()*.
(Emphasis is mine)

The result of this bug is that the value tends to stabilize over time because we pass a diff of a diff of a diff and we tend to just return the value since the start of the process instead of a delta since last execution

## Short description of the changes

Replaced the setting of the `lastValue` internal variable with a call to the argument-less perf_hook.

As a reference, Datadog library fixed the same bug last month, but they chose to disregard nodejs autocalculation of the utilization ratio and just do it themselves
https://github.com/DataDog/dd-trace-js/pull/6344
(line 259 in the new version of the file, search for "elu" if needed)
