### PR TITLE
ci: use --ignore-scripts wherever possible

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: 18
           cache: 'npm'
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - name: Lint
         run: |
           npm run lint

--- a/.github/workflows/peer-api.yaml
+++ b/.github/workflows/peer-api.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install script dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Check API dependency semantics
         run: node ./scripts/peer-api-check.js

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install packages
         run: |
-          npm ci
+          npm ci --ignore-scripts
 
       - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         id: otelbot-token
@@ -80,7 +80,7 @@ jobs:
           # Require npm 11.5.1 or later for https://docs.npmjs.com/trusted-publishers.
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npm run compile
       # Release Please has already incremented versions and published tags, so we just
       # need to publish all unpublished versions to npm here

--- a/.github/workflows/test-all-versions.yml
+++ b/.github/workflows/test-all-versions.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           node-version: 18
       - name: Install
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Build
         run: npm run compile
       - name: Upload Build Artifacts
@@ -168,7 +168,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Install
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Download Build Artifacts
         uses: actions/download-artifact@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: 18
       - name: Install
-        run: npm ci
+        run: npm ci --ignore-scripts
       # Note: when pushing to main we want to test only what changed in
       # last commit. Otherwise we want to test all changes from origin/main.
       # So we set the right values for base and head commits depending
@@ -195,7 +195,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Install
-        run: npm ci
+        run: npm ci --ignore-scripts
       - name: Download Build Artifacts
         uses: actions/download-artifact@v5
         with:
@@ -244,7 +244,7 @@ jobs:
         with:
           node-version: 18
       - name: Install
-        run: npm ci
+        run: npm ci --ignore-scripts
       # NOTE: keep this in sync with the node versions from `unit-test` job
       - name: Download Test Artifacts (18)
         uses: actions/download-artifact@v5

--- a/.github/workflows/update-otel-deps.yaml
+++ b/.github/workflows/update-otel-deps.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - run: npm install -g npm@latest
 
-      - run: npm ci
+      - run: npm ci --ignore-scripts
 
       - name: Create/Update Release PR
         run: |


### PR DESCRIPTION
## Which problem is this PR solving?

I have checked some postinstall scripts, but they seem to mostly be for for warning users of improper usage and can therefore be safely ignored in CI. Ignoring the scripts also reduces attack surface a bit further.