### PR TITLE
ci(test): allow install scripts in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -195,7 +195,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Install
-        run: npm ci --ignore-scripts
+        run: npm ci
       - name: Download Build Artifacts
         uses: actions/download-artifact@v5
         with:


### PR DESCRIPTION
## Which problem is this PR solving?

Follow-up to #3121 

Looks like `knex`' and `typeorm` actually need it for `sqlite3` bindings. But that only seems to affect test behavior, not compile. This PR allows the scripts for the test job only.

Example failing tests:
- https://github.com/open-telemetry/opentelemetry-js-contrib/actions/runs/18097248494/job/51491595184?pr=3116
