### PR TITLE
chore(instrumentation-aws-sdk): update metric names to semconv `METRIC_*` exports (take 2)

### DIFF
--- a/packages/instrumentation-aws-sdk/src/semconv.ts
+++ b/packages/instrumentation-aws-sdk/src/semconv.ts
@@ -603,6 +603,14 @@ export const GEN_AI_TOKEN_TYPE_VALUE_INPUT = 'input' as const;
 export const GEN_AI_TOKEN_TYPE_VALUE_OUTPUT = 'output' as const;
 
 /**
+ * GenAI operation duration.
+ *
+ * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const METRIC_GEN_AI_CLIENT_OPERATION_DURATION =
+  'gen_ai.client.operation.duration' as const;
+
+/**
  * Number of input and output tokens used.
  *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.

--- a/packages/instrumentation-aws-sdk/src/services/bedrock-runtime.ts
+++ b/packages/instrumentation-aws-sdk/src/services/bedrock-runtime.ts
@@ -40,6 +40,7 @@ import {
   GEN_AI_SYSTEM_VALUE_AWS_BEDROCK,
   GEN_AI_TOKEN_TYPE_VALUE_INPUT,
   GEN_AI_TOKEN_TYPE_VALUE_OUTPUT,
+  METRIC_GEN_AI_CLIENT_OPERATION_DURATION,
   METRIC_GEN_AI_CLIENT_TOKEN_USAGE,
 } from '../semconv';
 import {
@@ -77,7 +78,7 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
 
     // https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiclientoperationduration
     this.operationDuration = meter.createHistogram(
-      'gen_ai.client.operation.duration',
+      METRIC_GEN_AI_CLIENT_OPERATION_DURATION,
       {
         unit: 's',
         description: 'GenAI operation duration',


### PR DESCRIPTION
I missed one in #3126.

Refs: https://github.com/open-telemetry/opentelemetry-js/issues/5956
