### PR TITLE
feat(tedious): context propagation to SQL Server

### DIFF
--- a/packages/instrumentation-tedious/README.md
+++ b/packages/instrumentation-tedious/README.md
@@ -56,6 +56,13 @@ Attributes collected:
 | `net.peer.name`         | Remote hostname or similar.                                                    |
 | `net.peer.port`         | Remote port number.                                                            |
 
+### Trace Context Propagation
+
+Database trace context propagation can be enabled by setting `enableTraceContextPropagation`to `true`.
+This uses the [SET CONTEXT_INFO](https://learn.microsoft.com/en-us/sql/t-sql/statements/set-context-info-transact-sql?view=sql-server-ver16)
+command to set [traceparent](https://www.w3.org/TR/trace-context/#traceparent-header)information
+for the current connection, which results in **an additional round-trip to the database**.
+
 ## Useful links
 
 - For more information on OpenTelemetry, visit: <https://opentelemetry.io/>

--- a/packages/instrumentation-tedious/src/types.ts
+++ b/packages/instrumentation-tedious/src/types.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 export interface TediousInstrumentationConfig extends InstrumentationConfig {
   /**

--- a/packages/instrumentation-tedious/src/types.ts
+++ b/packages/instrumentation-tedious/src/types.ts
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
-import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 
-export type TediousInstrumentationConfig = InstrumentationConfig;
+import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+export interface TediousInstrumentationConfig extends InstrumentationConfig {
+  /**
+   * If true, injects the current DB span's W3C traceparent into SQL Server
+   * session state via `SET CONTEXT_INFO @opentelemetry_traceparent` (varbinary).
+   * Off by default to avoid the extra round-trip per request.
+   */
+  enableTraceContextPropagation?: boolean;
+}

--- a/packages/instrumentation-tedious/test/api.ts
+++ b/packages/instrumentation-tedious/test/api.ts
@@ -68,7 +68,7 @@ export const makeApi = (tedious: tedious) => {
     connection: Connection,
     params: string,
     method: Method = 'execSql',
-    noTracking?: boolean,
+    noTracking?: boolean
   ): Promise<any[]> => {
     return new Promise((resolve, reject) => {
       const result: any[] = [];

--- a/packages/instrumentation-tedious/test/api.ts
+++ b/packages/instrumentation-tedious/test/api.ts
@@ -17,7 +17,7 @@
 import * as assert from 'assert';
 import { promisify } from 'util';
 import type { Connection, Request, TYPES } from 'tedious';
-
+import { INJECTED_CTX } from '../src/instrumentation';
 type Method = keyof Connection & ('execSql' | 'execSqlBatch' | 'prepare');
 export type tedious = {
   Connection: typeof Connection;
@@ -67,7 +67,8 @@ export const makeApi = (tedious: tedious) => {
   const query = (
     connection: Connection,
     params: string,
-    method: Method = 'execSql'
+    method: Method = 'execSql',
+    noTracking?: boolean,
   ): Promise<any[]> => {
     return new Promise((resolve, reject) => {
       const result: any[] = [];
@@ -78,7 +79,9 @@ export const makeApi = (tedious: tedious) => {
           resolve(result);
         }
       });
-
+      if (noTracking) {
+        Object.defineProperty(request, INJECTED_CTX, { value: true });
+      }
       // request.on('returnValue', console.log.bind(console, /*request.sqlTextOrProcedure,*/ 'returnValue:'));
       // request.on('error', console.log.bind(console, /*request.sqlTextOrProcedure,*/ 'error:'));
       // request.on('row', console.log.bind(console, /*request.sqlTextOrProcedure,*/ 'row:'));
@@ -314,7 +317,9 @@ export const makeApi = (tedious: tedious) => {
       if exists(SELECT * FROM sysobjects WHERE name='test_transact' AND xtype='U') DROP TABLE ${transaction.tableName};
       if exists(SELECT * FROM sysobjects WHERE name='test_proced' AND xtype='U') DROP PROCEDURE ${storedProcedure.procedureName};
       if exists(SELECT * FROM sys.databases WHERE name = 'temp_otel_db') DROP DATABASE temp_otel_db;
-    `.trim()
+    `.trim(),
+      'execSql',
+      true
     );
   };
 

--- a/packages/instrumentation-tedious/test/instrumentation.test.ts
+++ b/packages/instrumentation-tedious/test/instrumentation.test.ts
@@ -308,10 +308,9 @@ describe('tedious', () => {
   });
 
   describe('trace context propagation via CONTEXT_INFO', () => {
-
     function traceparentFromSpan(span: ReadableSpan) {
       const sc = span.spanContext();
-      const flags = (sc.traceFlags & 0x01) ? '01' : '00';
+      const flags = sc.traceFlags & 0x01 ? '01' : '00';
       return `00-${sc.traceId}-${sc.spanId}-${flags}`;
     }
 
@@ -331,18 +330,23 @@ describe('tedious', () => {
     });
 
     after(() => {
-      instrumentation.setConfig({enableTraceContextPropagation: false});
+      instrumentation.setConfig({ enableTraceContextPropagation: false });
     });
 
     it('injects DB-span traceparent for execSql', async function () {
-      const sql  = "SELECT REPLACE(CONVERT(varchar(128), CONTEXT_INFO()), CHAR(0), '') AS traceparent";
-      const result = await tedious.query(connection, sql)
+      const sql =
+        "SELECT REPLACE(CONVERT(varchar(128), CONTEXT_INFO()), CHAR(0), '') AS traceparent";
+      const result = await tedious.query(connection, sql);
 
       const spans = memoryExporter.getFinishedSpans();
       assert.strictEqual(spans.length, 1);
       const dbSpan = findDbSpan(spans, 'execSql');
       const expectedTp = traceparentFromSpan(dbSpan);
-      assert.strictEqual(result[0], expectedTp, 'CONTEXT_INFO traceparent should match DB span');
+      assert.strictEqual(
+        result[0],
+        expectedTp,
+        'CONTEXT_INFO traceparent should match DB span'
+      );
     });
 
     it('injects for execSqlBatch', async function () {
@@ -375,7 +379,6 @@ describe('tedious', () => {
       const spans = memoryExporter.getFinishedSpans();
       assert.strictEqual(spans.length, 1);
     });
-
   });
 });
 


### PR DESCRIPTION
Calls `set context_info` before methods that actually execute user's SQL(omitting prepare and execBulkLoad). Relevant [specification](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/sql-server.md#set-context_info).  This is opt in as it causes an extra round trip per request. 