### PR TITLE
chore(release-please): drop unneeded package-lock sync as part of the release PR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,18 +52,6 @@ jobs:
           token: ${{ steps.otelbot-token.outputs.token }}
           fetch-depth: 0
 
-      # If we've created/updated a PR:
-      # Sync the legacy "dependencies" key in package-lock.json.
-      - name: Update package-lock.json in PR
-        if: ${{ steps.release.outputs.pr }}
-        run: |
-          git config user.name otelbot
-          git config user.email 197425009+otelbot@users.noreply.github.com
-          npm install --ignore-scripts --package-lock-only
-          git add package-lock.json
-          git commit -m "chore: sync package-lock.json 'dependencies' key"
-          git push
-
   # If releases have been created, then publish to npm.
   npm-publish:
     needs: release-please


### PR DESCRIPTION
Now that we are on npm lockfileVersion=3, which doesn't have the 'dependencies'
legacy key, we *should* no longer need this sync.
Note that for the recent release-please PR there *was* some churn in 'peer'
entries in the package-lock file from this step:
https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3135/commits/54c1f5beafcc91e4cab497edfea738e3b25599b9
My educated guess is that this is *not* impactful, not necessary for
the release-please workflow.
