### PR TITLE
feat(instrumentation-pino): support pino@10

### DIFF
--- a/packages/instrumentation-pino/.tav.yml
+++ b/packages/instrumentation-pino/.tav.yml
@@ -1,11 +1,16 @@
 pino:
   - versions:
-      include: '>=9.0.0 <10'
+      include: '>=10.0.0 <11'
       mode: latest-minors
+    node: ">=20"
+    commands: npm run test
+  - versions:
+      include: '>=9.0.0 <10'
+      mode: max-5
     node: ">=18"
     commands: npm run test
   - versions:
       include: '>=5.14.0 <9'
-      mode: max-7
+      mode: max-3
     node: ">=14"
     commands: npm run test

--- a/packages/instrumentation-pino/src/instrumentation.ts
+++ b/packages/instrumentation-pino/src/instrumentation.ts
@@ -31,7 +31,7 @@ import { PinoInstrumentationConfig } from './types';
 import { PACKAGE_NAME, PACKAGE_VERSION } from './version';
 import { getTimeConverter, OTelPinoStream } from './log-sending-utils';
 
-const pinoVersions = ['>=5.14.0 <10'];
+const pinoVersions = ['>=5.14.0 <11'];
 
 const DEFAULT_LOG_KEYS = {
   traceId: 'trace_id',


### PR DESCRIPTION
Pino 10 was released recently. Node.js 18 support was dropped.

Fixes: https://github.com/open-telemetry/opentelemetry-js-contrib/issues/3143
