### PR TITLE
test(mysql2): reduce number of versions tested

### DIFF
--- a/packages/instrumentation-mysql2/.tav.yml
+++ b/packages/instrumentation-mysql2/.tav.yml
@@ -1,8 +1,12 @@
 mysql2:
-  versions:
-    include: ">=1.4.2 <4"
-    # Skip v1.6.2, which is broken
-    # Skip 2.3.3 which installs types from git which takes 10m on it's own
-    exclude: "1.6.2 || 2.3.3"
-    mode: latest-minors
-  commands: npm run test
+  - versions:
+      include: ">=1.4.2 <3"
+      # Skip v1.6.2, which is broken
+      # Skip 2.3.3 which installs types from git which takes 10m on its own
+      exclude: "1.6.2 || 2.3.3"
+      mode: max-3
+      commands: npm run test
+  - versions:
+      include: ">=3 <4"
+      mode: max-7
+      commands: npm run test


### PR DESCRIPTION
## Which problem is this PR solving?

Reduces the number of versions tested when running `test-all-versions` - with newer major versions being tested more thoroughly than older ones.

**Currently we test:**
```
-- 24 package versions matching filter: 1.4.2, 1.5.3, 1.6.6, 1.7.0, 2.0.2, 2.1.0, 2.2.5, 2.3.2, 3.0.1, 3.1.2, 3.2.4, 3.3.5, 3.4.5, 3.5.2, 3.6.5, 3.7.1, 3.8.0, 3.9.9, 3.10.3, 3.11.5, 3.12.0, 3.13.0, 3.14.5, 3.15.1
```

**With this PR we test:**
```
-- 7 package versions matching filter: 3.0.0, 3.3.1, 3.5.1, 3.9.2, 3.11.0, 3.14.5, 3.15.1
-- 3 package versions matching filter: 1.4.2, 2.3.0, 2.3.2
```
