### PR TITLE
test(typeorm): reduce number of versions tested

### DIFF
--- a/packages/instrumentation-typeorm/.tav.yml
+++ b/packages/instrumentation-typeorm/.tav.yml
@@ -1,4 +1,5 @@
-'typeorm':
-  versions: ">=0.3.0"
-  commands:
-    - npm run test
+typeorm:
+  versions:
+    include: ">=0.3.0"
+    mode: max-7
+    commands: npm run test


### PR DESCRIPTION
## Which problem is this PR solving?

Reduces the number of versions tested when running test-all-versions.

**Currently we test:**
```
-- 28 package versions matching filter: 0.3.0, 0.3.1, 0.3.2, 0.3.3, 0.3.4, 0.3.5, 0.3.6, 0.3.7, 0.3.8, 0.3.9, 0.3.10, 0.3.11, 0.3.12, 0.3.13, 0.3.14, 0.3.15, 0.3.16, 0.3.17, 0.3.18, 0.3.19, 0.3.20, 0.3.21, 0.3.22, 0.3.23, 0.3.24, 0.3.25, 0.3.26, 0.3.27
```

**With this PR we test:**
```
-- 7 package versions matching filter: 0.3.0, 0.3.4, 0.3.9, 0.3.14, 0.3.19, 0.3.25, 0.3.27
```
