### PR TITLE
docs(instrumentation-express): update README to note that express@5 is supported

### DIFF
--- a/packages/instrumentation-express/README.md
+++ b/packages/instrumentation-express/README.md
@@ -19,7 +19,7 @@ npm install --save @opentelemetry/instrumentation-http @opentelemetry/instrument
 
 ### Supported Versions
 
-- [`express`](https://www.npmjs.com/package/express) version `>=4.0.0 <5`
+- [`express`](https://www.npmjs.com/package/express) version `>=4.0.0 <6`
 
 ## Usage
 


### PR DESCRIPTION
Refs: #2801

---

h/t this comment on a closed issue: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2801#issuecomment-3181224090