### PR TITLE
ci(test-all-versions): this workflow needs install scripts for tests to pass

### DIFF
--- a/.github/workflows/test-all-versions.yml
+++ b/.github/workflows/test-all-versions.yml
@@ -168,7 +168,9 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Install
-        run: npm ci --ignore-scripts
+        # Post install scripts are required for some deps for successful test
+        # runs: sqlite3, better-sqlite3, and possibly esbuild.
+        run: npm ci
       - name: Download Build Artifacts
         uses: actions/download-artifact@v5
         with:


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-js-contrib/actions/workflows/test-all-versions.yml started
failing last week after #3121. We cannot use --ignore-scripts in this case. This is
the equivalent change as was done for test.yml in #3122.
