### PR TITLE
test: separate the unit-test and test-all-versions jobs in the main Test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,7 @@ jobs:
 
   unit-test:
     needs: compile
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -64,8 +65,9 @@ jobs:
           - "20"
           - "22"
           - "24"
-    runs-on: ubuntu-latest
-    services:
+    # `&foo` syntax is a YAML anchor. See:
+    # https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations#yaml-anchors-and-aliases
+    services: &test_services
       memcached:
         image: memcached:1.6.39-alpine
         ports:
@@ -147,7 +149,7 @@ jobs:
         env:
           RABBITMQ_DEFAULT_USER: username
           RABBITMQ_DEFAULT_PASS: password
-    env:
+    env: &test_env
       RUN_CASSANDRA_TESTS: 1
       RUN_MEMCACHED_TESTS: 1
       RUN_MONGODB_TESTS: 1
@@ -218,6 +220,46 @@ jobs:
         run: npm run test:browser:ci:affected
       - name: Unit tests (Nodejs - Delta)
         run: npm run test:ci:affected
+
+  test-all-versions:
+    needs: unit-test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node:
+          - "18"
+          - "20"
+          - "22"
+          - "24"
+    services: *test_services
+    #XXX why lint error on env: here with the YAML alias
+    env: *test_env
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm ci
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@v5
+        with:
+          name: compile-cache-${{ github.run_number }}
+          path: .nx
+      # Note: see comment in the compile job
+      - name: Set base and head commits
+        run: |
+          if [ "${{github.event_name}}" == "push" ]; then
+            echo "NX_BASE=origin/main~1" >> "$GITHUB_ENV"
+            echo "NX_HEAD=origin/main" >> "$GITHUB_ENV"
+          else
+            echo "NX_BASE=origin/main" >> "$GITHUB_ENV"
+            echo "NX_HEAD=HEAD" >> "$GITHUB_ENV"
+          fi
+      - name: Compile (Delta)
+        run: npm run compile:ci:affected
       - name: Test All Versions (Delta)
         run: npm run test-all-versions:ci:affected
       - name: Upload Test Artifacts
@@ -232,9 +274,9 @@ jobs:
             packages/*/.nyc_output/**
             LICENSE
 
-  test-coverage-report:
+  coverage-report:
+    needs: test-all-versions
     runs-on: ubuntu-latest
-    needs: unit-test
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -245,26 +287,16 @@ jobs:
           node-version: 18
       - name: Install
         run: npm ci --ignore-scripts
-      # NOTE: keep this in sync with the node versions from `unit-test` job
+      # Note: Keep this in sync with the node versions from `test-all-versions` job.
       - name: Download Test Artifacts (18)
         uses: actions/download-artifact@v5
         with:
           name: tests-coverage-cache-${{ github.run_number }}-18
           path: .
-      - name: Download Test Artifacts (18.19.0)
-        uses: actions/download-artifact@v5
-        with:
-          name: tests-coverage-cache-${{ github.run_number }}-18.19.0
-          path: .
       - name: Download Test Artifacts (20)
         uses: actions/download-artifact@v5
         with:
           name: tests-coverage-cache-${{ github.run_number }}-20
-          path: .
-      - name: Download Test Artifacts (20.6.0)
-        uses: actions/download-artifact@v5
-        with:
-          name: tests-coverage-cache-${{ github.run_number }}-20.6.0
           path: .
       - name: Download Test Artifacts (22)
         uses: actions/download-artifact@v5


### PR DESCRIPTION
IMHO the "unit tests" (i.e. running `npm test` for each affected package) and the test-all-versions ("TAV") tests (running tav, `npm run test-all-versions`, for affected packages) have slightly different requirements:

- We *require* that unit tests pass on a PR to merge it (excepting special circumstances, e.g. when there are multiple failures being handled by separate PRs).
- We *aspire* to have TAV tests pass for all PRs. (An example of an exception to this is if a new version of a module being tested is published that breaks an instrumentation. It isn't necessarily the responsibility of the current PR to fix that.)

Some open questions:
- I've reduced the node version matrix for the TAV tests. Are we okay with this? (Note that it will then match the node versions in the matrix in test-all-versions.yml -- the daily TAV test run.)
- I'm using the fairly recent YAML anchor/alias support (https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations#yaml-anchors-and-aliases) to reduce duplication. I'm not sure this'll work as I have it.