### PR TITLE
build(instrumentation-winston): fix phantom deps

### DIFF
--- a/packages/instrumentation-winston/package.json
+++ b/packages/instrumentation-winston/package.json
@@ -49,7 +49,6 @@
     "@opentelemetry/context-async-hooks": "^2.0.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "@opentelemetry/sdk-trace-node": "^2.0.0",
-    "@opentelemetry/winston-transport": "^0.17.0",
     "@types/mocha": "10.0.10",
     "@types/node": "18.18.14",
     "@types/sinon": "17.0.4",
@@ -64,7 +63,8 @@
   },
   "dependencies": {
     "@opentelemetry/api-logs": "^0.206.0",
-    "@opentelemetry/instrumentation": "^0.206.0"
+    "@opentelemetry/instrumentation": "^0.206.0",
+    "@opentelemetry/winston-transport": "^0.17.0",
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-winston#readme"
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

`types.ts` depends on  `@opentelemetry/winston-transport`, causing a [phantom dependency](https://rushjs.io/pages/advanced/phantom_deps/).

## Short description of the changes

It should be in **`dependencies`**, not `devDependencies`.

**Why `dependencies` is required here:**
- `WinstonInstrumentationConfig extends InstrumentationConfig` - the interface is extended and exported
- Any consumer importing this type needs to resolve `InstrumentationConfig` at compile time
- The type is part of the public API surface

**When `devDependencies` would be acceptable:**
- If using `import type` for types that are ONLY used internally and never re-exported
- Example: `import type { InstrumentationConfig } from '...'` for local type constraints only

**Rule of thumb:** If you extend or re-export a type from a package, that package must be in `dependencies`.
