### PR TITLE
fix(instrumentation-oracledb): Modify checking the db.namespace attribute value for roundtrip span.

### DIFF
--- a/packages/instrumentation-oracledb/test/oracle.test.ts
+++ b/packages/instrumentation-oracledb/test/oracle.test.ts
@@ -198,10 +198,17 @@ function updateAttrSpanList(connection: oracledb.Connection) {
   if (serverVersion >= VER_23_4) {
     if (oracledb.thin) {
       // for round trips.
-      connAttrList.push({ ...attributes });
-      poolConnAttrList.push({ ...attributes, ...POOL_ATTRIBUTES });
-      poolConnAttrList.push({ ...connAttributes, ...POOL_ATTRIBUTES });
-      connAttrList.push({ ...connAttributes });
+      connAttrList.push({ ...attributes }); // FastAuth standalone
+      poolConnAttrList.push({ ...attributes, ...POOL_ATTRIBUTES }); // FastAuth pool
+      if (oracledb.version < 61000) {
+        connAttrList.push({ ...connAttributes }); // OAUTH
+        poolConnAttrList.push({ ...connAttributes, ...POOL_ATTRIBUTES }); // OAUTH
+      } else {
+        // From oracledb version 6.10 onwards, the db instance name is not populated
+        // until all validations for connection establishment is done.
+        connAttrList.push({ ...attributes }); // OAUTH
+        poolConnAttrList.push({ ...attributes, ...POOL_ATTRIBUTES }); // OAUTH
+      }
       failedConnAttrList = [...connAttrList];
       failedConnAttrList[2] = { ...CONN_FAILED_ATTRIBUTES };
       failedConnAttrList[1] = { ...attributes };
@@ -217,11 +224,16 @@ function updateAttrSpanList(connection: oracledb.Connection) {
       connAttrList.push({ ...attributes });
       connAttrList.push({ ...attributes });
       connAttrList.push({ ...attributes });
-      connAttrList.push({ ...connAttributes });
       poolConnAttrList.push({ ...attributes, ...POOL_ATTRIBUTES });
       poolConnAttrList.push({ ...attributes, ...POOL_ATTRIBUTES });
       poolConnAttrList.push({ ...attributes, ...POOL_ATTRIBUTES });
-      poolConnAttrList.push({ ...connAttributes, ...POOL_ATTRIBUTES });
+      if (oracledb.version < 61000) {
+        connAttrList.push({ ...attributes });
+        poolConnAttrList.push({ ...attributes, ...POOL_ATTRIBUTES });
+      } else {
+        connAttrList.push({ ...connAttributes });
+        poolConnAttrList.push({ ...connAttributes, ...POOL_ATTRIBUTES });
+      }
       failedConnAttrList = [...connAttrList];
       failedConnAttrList[4] = { ...CONN_FAILED_ATTRIBUTES };
       failedConnAttrList[3] = { ...attributes };
@@ -236,7 +248,7 @@ function updateAttrSpanList(connection: oracledb.Connection) {
       failedConnAttrList = [{ ...CONN_FAILED_ATTRIBUTES }];
     }
   }
-  // for getConnection
+  // for getConnection public API span
   connAttrList.push({ ...connAttributes });
   poolConnAttrList.push({ ...poolAttributes });
   spanNamesList.push(SpanNames.CONNECT);


### PR DESCRIPTION
  version release

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

As reported [here](https://github.com/open-telemetry/opentelemetry-js-contrib/issues/3180) , the test failure occurs when validating span attributes — specifically the database `instanceName` — for one of the internal roundtrip spans created during `getConnection`. In that case, the `instanceName` is coming through as null. Hence `db.namespace` was coming as   `"||freepdb1"` where `instanceName` and `pdbName` are coming as null for internal round trip instead of  `"FREE|FREEPDB1|freepdb1"`

During `oracledb.getConnection`, three spans (above oracledb23c version) are generated:

- two for the internal TTC roundtrips, and
- one for the public API call (`oracledb.getConnection`).

Previously, span attributes like the DB instance name were available during the second roundtrip. However, with the latest node-oracledb driver, these attributes are only available after both roundtrips complete — that is, once the connection is fully established. 

The third span (for the public API call) still contains the correct db.instanceName value and remains verified by existing tests. Therefore, it’s acceptable to skip checking the `db.instanceName` for 2nd internal roundtrip spans also  (along with 1st round trip which is already skipped ) since the attributes for the main `oracledb.getConnection` span are final and correct.


Once Connection is established, the db.namespace is already validated for subsequent operations on connection like `connection.execute` (execute a statement)


## Short description of the changes
With oracledb 6.10 onwards, the parameters are not populated until getConnection completes . Made changes to not check for the `instanceName` and `pdbName`  for roundtrips in tests , where connection establishment is still in progress. 

