### PR TITLE
chore(instrumentation-aws-lambda): move aws lambda types dependency to dev dependencies

### DIFF
--- a/packages/instrumentation-aws-lambda/package.json
+++ b/packages/instrumentation-aws-lambda/package.json
@@ -51,6 +51,7 @@
     "@opentelemetry/sdk-metrics": "^2.0.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "@opentelemetry/sdk-trace-node": "^2.0.0",
+    "@types/aws-lambda": "8.10.155",
     "@types/mocha": "10.0.10",
     "@types/node": "18.18.14",
     "nyc": "17.1.0",
@@ -59,8 +60,7 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.207.0",
-    "@opentelemetry/semantic-conventions": "^1.27.0",
-    "@types/aws-lambda": "8.10.155"
+    "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-aws-lambda#readme"
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- The `@types/aws-lambda` dependency is currently a dependency in the instrumentation-aws-lambda package. This is causing some version conflicts in https://github.com/open-telemetry/opentelemetry-lambda where we use the types package as a devDependency. Since the types package is only useful at compile time I don't see why it should not be a dev dependency here either.

## Short description of the changes

- Moved the `@types/aws-lambda` dependency to dev dependencies
