### PR TITLE
chore(ci): limit installs to 10 minutes

### DIFF
--- a/.github/workflows/test-all-versions.yml
+++ b/.github/workflows/test-all-versions.yml
@@ -34,6 +34,7 @@ jobs:
           node-version: 18
       - name: Install
         run: npm ci --ignore-scripts
+        timeout-minutes: 10
       - name: Build
         run: npm run compile
       - name: Upload Build Artifacts
@@ -57,14 +58,14 @@ jobs:
       mongo:
         image: mongo
         ports:
-        - 27017:27017
+          - 27017:27017
       mssql:
         image: mcr.microsoft.com/mssql/server:2022-latest
         env:
           MSSQL_SA_PASSWORD: mssql_passw0rd
           ACCEPT_EULA: Y
         ports:
-        - 1433:1433
+          - 1433:1433
         options: >-
           --health-cmd "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P $MSSQL_SA_PASSWORD -C -Q 'select 1' -b -o /dev/null"
           --health-interval 1s
@@ -79,7 +80,7 @@ jobs:
           MYSQL_DATABASE: otel_mysql_database
           MYSQL_ROOT_PASSWORD: rootpw
         ports:
-        - 3306:3306
+          - 3306:3306
         options: >-
           --health-cmd="mysqladmin ping"
           --health-interval 10s
@@ -105,7 +106,7 @@ jobs:
           POSTGRES_DB: otel_pg_database
           POSTGRES_PASSWORD: postgres
         ports:
-        - 5432:5432
+          - 5432:5432
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -114,14 +115,14 @@ jobs:
       rabbitmq:
         image: rabbitmq:3
         ports:
-        - 22221:5672
+          - 22221:5672
         env:
           RABBITMQ_DEFAULT_USER: username
           RABBITMQ_DEFAULT_PASS: password
       redis:
         image: redis
         ports:
-        - 6379:6379
+          - 6379:6379
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s
@@ -171,6 +172,7 @@ jobs:
         # Post install scripts are required for some deps for successful test
         # runs: sqlite3, better-sqlite3, and possibly esbuild.
         run: npm ci
+        timeout-minutes: 10
       - name: Download Build Artifacts
         uses: actions/download-artifact@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
           node-version: 18
       - name: Install
         run: npm ci --ignore-scripts
+        timeout-minutes: 10
       # Note: when pushing to main we want to test only what changed in
       # last commit. Otherwise we want to test all changes from origin/main.
       # So we set the right values for base and head commits depending
@@ -71,18 +72,18 @@ jobs:
       memcached:
         image: memcached:1.6.39-alpine
         ports:
-        - 11211:11211
+          - 11211:11211
       mongo:
         image: mongo
         ports:
-        - 27017:27017
+          - 27017:27017
       mssql:
         image: mcr.microsoft.com/mssql/server:2022-latest
         env:
           MSSQL_SA_PASSWORD: mssql_passw0rd
           ACCEPT_EULA: Y
         ports:
-        - 1433:1433
+          - 1433:1433
         options: >-
           --health-cmd "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P $MSSQL_SA_PASSWORD -C -Q 'select 1' -b -o /dev/null"
           --health-interval 1s
@@ -97,7 +98,7 @@ jobs:
           MYSQL_DATABASE: otel_mysql_database
           MYSQL_ROOT_PASSWORD: rootpw
         ports:
-        - 3306:3306
+          - 3306:3306
         options: >-
           --health-cmd="mysqladmin ping"
           --health-interval 10s
@@ -123,7 +124,7 @@ jobs:
           POSTGRES_DB: otel_pg_database
           POSTGRES_PASSWORD: postgres
         ports:
-        - 5432:5432
+          - 5432:5432
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -132,7 +133,7 @@ jobs:
       redis:
         image: redis
         ports:
-        - 6379:6379
+          - 6379:6379
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s
@@ -141,11 +142,11 @@ jobs:
       cassandra:
         image: cassandra:3
         ports:
-        - 9042:9042
+          - 9042:9042
       rabbitmq:
         image: rabbitmq:3
         ports:
-        - 22221:5672
+          - 22221:5672
         env:
           RABBITMQ_DEFAULT_USER: username
           RABBITMQ_DEFAULT_PASS: password
@@ -198,6 +199,7 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Install
         run: npm ci
+        timeout-minutes: 10
       - name: Download Build Artifacts
         uses: actions/download-artifact@v5
         with:
@@ -242,6 +244,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - run: npm ci
+        timeout-minutes: 10
       - name: Download Build Artifacts
         uses: actions/download-artifact@v5
         with:
@@ -286,6 +289,7 @@ jobs:
           node-version: 18
       - name: Install
         run: npm ci --ignore-scripts
+        timeout-minutes: 10
       # Note: Keep this in sync with the node versions from `test-all-versions` job.
       - name: Download Test Artifacts (18)
         uses: actions/download-artifact@v5
@@ -312,4 +316,3 @@ jobs:
         env:
           COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
           PR_BRANCH_NAME: ${{ github.event.pull_request.head.label }}
-


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?
I have a PR that has been running for three hours (and I don't have permission to cancel it).
https://github.com/open-telemetry/opentelemetry-js-contrib/actions/runs/18913134967/job/53989890872?pr=3032

## Short description of the changes
Added a timeout to all install CI commands. I modified every install in test and test-all-versions, please advise if that's not correct.
