### PR TITLE
chore: typos in docs and ci

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,14 +10,14 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
         with:
           node-version: 18
-          cache: 'npm'
+          cache: npm
       - run: npm ci --ignore-scripts
       - name: Lint
         run: |

--- a/packages/instrumentation-aws-sdk/README.md
+++ b/packages/instrumentation-aws-sdk/README.md
@@ -63,7 +63,7 @@ The instrumentations are collecting the following attributes:
 | Attribute Name | Type | Description | Example |
 | -------------- | ---- | ----------- | ------- |
 | `rpc.system` | string | Always equals "aws-api" | |
-| `rpc.method` | string | he name of the operation corresponding to the request, as returned by the AWS SDK. If the SDK does not provide a way to retrieve a name, the name of the command SHOULD be used, removing the suffix `Command` if present, resulting in a PascalCase name with no spaces. | `PutObject` |
+| `rpc.method` | string | The name of the operation corresponding to the request, as returned by the AWS SDK. If the SDK does not provide a way to retrieve a name, the name of the command SHOULD be used, removing the suffix `Command` if present, resulting in a PascalCase name with no spaces. | `PutObject` |
 | `rpc.service` | string | The name of the service to which a request is made, as returned by the AWS SDK. If the SDK does not provide a away to retrieve a name, the name of the SDK's client interface for a service SHOULD be used, removing the suffix `Client` if present, resulting in a PascalCase name with no spaces. | `S3`, `DynamoDB`, `Route53` |
 | `cloud.region` | string | Region name for the request | "eu-west-1" |
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Small typo in AWS docs
- Lint CI task renamed from 'build' to 'lint'
