### PR TITLE
refactor(instrumentation-web-exception): remove devDeps from package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,20 +63,6 @@
         "webpack-merge": "6.0.1"
       }
     },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
@@ -38673,70 +38659,22 @@
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
-        "@babel/core": "7.22.17",
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/sdk-logs": "^0.207.0",
         "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@rollup/plugin-commonjs": "^26.0.0",
         "@rollup/plugin-node-resolve": "^15.2.3",
-        "@types/chai": "^4.3.10",
-        "@types/mocha": "10.0.10",
-        "@types/node": "18.18.14",
-        "@types/sinon": "17.0.4",
         "@web/dev-server-esbuild": "^1.0.1",
         "@web/dev-server-rollup": "^0.6.1",
         "@web/test-runner": "^0.18.0",
-        "chai": "^4.3.10",
-        "sinon": "15.2.0",
-        "typescript": "^5.0.4"
+        "chai": "^4.3.10"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "packages/instrumentation-web-exception/node_modules/@babel/core": {
-      "version": "7.22.17",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.17.tgz",
-      "integrity": "sha512-2EENLmhpwplDux5PSsZnSbnSkB3tZ6QTksgO25xwEL7pIDcNOMhF5v/s6RzwjMZzZzw9Ofc30gHv5ChCC8pifQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.22.15",
-        "@babel/helper-compilation-targets": "^7.22.15",
-        "@babel/helper-module-transforms": "^7.22.17",
-        "@babel/helpers": "^7.22.15",
-        "@babel/parser": "^7.22.16",
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.22.17",
-        "@babel/types": "^7.22.17",
-        "convert-source-map": "^1.7.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "packages/instrumentation-web-exception/node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "packages/instrumentation-web-exception/node_modules/@opentelemetry/api-logs": {
@@ -38937,23 +38875,6 @@
         }
       }
     },
-    "packages/instrumentation-web-exception/node_modules/@types/chai": {
-      "version": "4.3.20",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
-      "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "packages/instrumentation-web-exception/node_modules/@types/node": {
-      "version": "18.18.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.14.tgz",
-      "integrity": "sha512-iSOeNeXYNYNLLOMDSVPvIFojclvMZ/HDY2dU17kUlcsOsSQETbWIslJbYLZgA+ox8g2XQwSHKTkght1a5X26lQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
     "packages/instrumentation-web-exception/node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -38982,13 +38903,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "packages/instrumentation-web-exception/node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/instrumentation-web-exception/node_modules/glob": {
       "version": "10.4.5",
@@ -39086,13 +39000,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "packages/instrumentation-web-exception/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/instrumentation-winston": {
       "name": "@opentelemetry/instrumentation-winston",

--- a/packages/instrumentation-web-exception/package.json
+++ b/packages/instrumentation-web-exception/package.json
@@ -51,23 +51,16 @@
     "@opentelemetry/api": "^1.3.0"
   },
   "devDependencies": {
-    "@babel/core": "7.22.17",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/sdk-logs": "^0.207.0",
     "@opentelemetry/sdk-trace-base": "^1.0.0",
     "@rollup/plugin-commonjs": "^26.0.0",
     "@rollup/plugin-node-resolve": "^15.2.3",
-    "@types/chai": "^4.3.10",
-    "@types/mocha": "10.0.10",
-    "@types/node": "18.18.14",
-    "@types/sinon": "17.0.4",
     "@web/dev-server-esbuild": "^1.0.1",
     "@web/dev-server-rollup": "^0.6.1",
     "@web/test-runner": "^0.18.0",
-    "chai": "^4.3.10",
-    "sinon": "15.2.0",
-    "typescript": "^5.0.4"
+    "chai": "^4.3.10"
   },
   "dependencies": {
     "@opentelemetry/api-logs": "^0.207.0",


### PR DESCRIPTION
## What this does

Removes devDependencies from @opentelemetry/instrumentation-web-exception package that was merged after #3032.

## Key changes

- Removed `@babel/core`, `@types/chai`, `@types/mocha`, `@types/node`, `@types/sinon`, `sinon`, and `typescript` from devDependencies
- These dependencies are now inherited from root package.json
- Kept only package-specific devDependencies (`chai` for tests)