### PR TITLE
chore: update gpg command

### DIFF
--- a/scripts/codecov-upload-flags.mjs
+++ b/scripts/codecov-upload-flags.mjs
@@ -93,7 +93,7 @@ if (existsSync(codecovPath)) {
   );
   execSync(`curl -O "${url}.SHA256SUM"`, execOpts);
   execSync(`curl -O "${url}.SHA256SUM.sig"`, execOpts);
-  execSync('gpg --verify "codecov.SHA256SUM.sig" "codecov.SHA256SUM"', execOpts);
+  execSync('gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM', execOpts);
 }
 // make sure we have exec perms
 chmodSync(codecovPath, 0o555);


### PR DESCRIPTION
## Which problem is this PR solving?

- gpg verify command failed when checking the integrity of `codecov` binary. Example https://github.com/open-telemetry/opentelemetry-js-contrib/actions/runs/19463307736/job/55698568099?pr=3225

## Short description of the changes

- tweak the coverage script to pass the validation.
