### PR TITLE
fix(instrumentation-openai)!: add missing access modifiers to private methods

### DIFF
--- a/packages/instrumentation-openai/src/instrumentation.ts
+++ b/packages/instrumentation-openai/src/instrumentation.ts
@@ -169,7 +169,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<OpenAIInstrumenta
     );
   }
 
-  _getPatchedChatCompletionsCreate(): any {
+  private _getPatchedChatCompletionsCreate(): any {
     const self = this;
     return (original: ChatCompletions['create']) => {
       // https://platform.openai.com/docs/api-reference/chat/create
@@ -251,7 +251,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<OpenAIInstrumenta
    * Start a span for this chat-completion API call. This also emits log events
    * as appropriate for the request params.
    */
-  _startChatCompletionsSpan(
+  private _startChatCompletionsSpan(
     params: ChatCompletionCreateParams,
     config: OpenAIInstrumentationConfig,
     baseURL: string | undefined
@@ -449,7 +449,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<OpenAIInstrumenta
    * async iterator. It should yield the chunks unchanged, and gather telemetry
    * data from those chunks, then end the span.
    */
-  async *_onChatCompletionsStreamIterator(
+  private async *_onChatCompletionsStreamIterator(
     streamIter: AsyncIterator<ChatCompletionChunk>,
     span: Span,
     startNow: number,
@@ -604,7 +604,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<OpenAIInstrumenta
     span.end();
   }
 
-  _onChatCompletionsCreateResult(
+  private _onChatCompletionsCreateResult(
     span: Span,
     startNow: number,
     commonAttrs: Attributes,
@@ -702,7 +702,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<OpenAIInstrumenta
     span.end();
   }
 
-  _createAPIPromiseRejectionHandler(
+  private _createAPIPromiseRejectionHandler(
     startNow: number,
     span: Span,
     commonAttrs: Attributes
@@ -734,7 +734,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<OpenAIInstrumenta
     };
   }
 
-  _getPatchedEmbeddingsCreate(): any {
+  private _getPatchedEmbeddingsCreate(): any {
     const self = this;
     return (original: Embeddings['create']) => {
       // https://platform.openai.com/docs/api-reference/embeddings/create
@@ -778,7 +778,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<OpenAIInstrumenta
    * Start a span for this chat-completion API call. This also emits log events
    * as appropriate for the request params.
    */
-  _startEmbeddingsSpan(
+  private _startEmbeddingsSpan(
     params: EmbeddingCreateParams,
     baseURL: string | undefined
   ) {
@@ -810,7 +810,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<OpenAIInstrumenta
     return { span, ctx, commonAttrs };
   }
 
-  _onEmbeddingsCreateResult(
+  private _onEmbeddingsCreateResult(
     span: Span,
     startNow: number,
     commonAttrs: Attributes,


### PR DESCRIPTION
Fixes #3240 
Introduced via #3164 -> #3157

Errors stem from OpenAI types being used in the instrumentation's public interface. Instrumentations are supposed to no-op without causing errors even if the instrumented package is not installed.

This PR fixes this by adding `private` access modifiers the `OpenAIInstrumentation` intended private properties. This will rease the types in the compile output and removes the imports.

You can test this by following  these steps:
- check out `main`
- run `npm ci && npm run compile`
- inspect `./packages/instrumentation-openai/build/src/instrumentation.d.ts`
  - you'll see type-imports from `openai`
- check out this PRs branch
- run `npm ci && npm run compile`
- inspect `./packages/instrumentation-openai/build/src/instrumentation.d.ts`
  - type imports from `openai` should be gone

**Before** this change the compiled output looks like this:
```ts
// instrumentation.d.ts
import type { Attributes, Context, Span } from '@opentelemetry/api';
import { InstrumentationBase, InstrumentationNodeModuleDefinition } from '@opentelemetry/instrumentation';
import type { ChatCompletion, ChatCompletionCreateParams, ChatCompletionChunk } from 'openai/resources/chat/completions';
import type { CreateEmbeddingResponse, EmbeddingCreateParams } from 'openai/resources/embeddings';
import { OpenAIInstrumentationConfig } from './types';
export declare class OpenAIInstrumentation extends InstrumentationBase<OpenAIInstrumentationConfig> {
    private _genaiClientOperationDuration;
    private _genaiClientTokenUsage;
    constructor(config?: OpenAIInstrumentationConfig);
    setConfig(config?: OpenAIInstrumentationConfig): void;
    protected init(): InstrumentationNodeModuleDefinition[];
    _updateMetricInstruments(): void;
    _getPatchedChatCompletionsCreate(): any;
    /**
     * Start a span for this chat-completion API call. This also emits log events
     * as appropriate for the request params.
     */
    _startChatCompletionsSpan(params: ChatCompletionCreateParams, config: OpenAIInstrumentationConfig, baseURL: string | undefined): {
        span: Span;
        ctx: Context;
        commonAttrs: Attributes;
    };
    /**
     * This wraps an instance of a `openai/streaming.Stream.iterator()`, an
     * async iterator. It should yield the chunks unchanged, and gather telemetry
     * data from those chunks, then end the span.
     */
    _onChatCompletionsStreamIterator(streamIter: AsyncIterator<ChatCompletionChunk>, span: Span, startNow: number, config: OpenAIInstrumentationConfig, commonAttrs: Attributes, ctx: Context): AsyncGenerator<any, void, unknown>;
    _onChatCompletionsCreateResult(span: Span, startNow: number, commonAttrs: Attributes, result: ChatCompletion, config: OpenAIInstrumentationConfig, ctx: Context): void;
    _createAPIPromiseRejectionHandler(startNow: number, span: Span, commonAttrs: Attributes): (err: Error) => void;
    _getPatchedEmbeddingsCreate(): any;
    /**
     * Start a span for this chat-completion API call. This also emits log events
     * as appropriate for the request params.
     */
    _startEmbeddingsSpan(params: EmbeddingCreateParams, baseURL: string | undefined): {
        span: Span;
        ctx: Context;
        commonAttrs: Attributes;
    };
    _onEmbeddingsCreateResult(span: Span, startNow: number, commonAttrs: Attributes, result: CreateEmbeddingResponse): void;
}
//# sourceMappingURL=instrumentation.d.ts.map
```

**After** this change the compiled output will looks like this:

```ts
// instrumentation.d.ts
import { InstrumentationBase, InstrumentationNodeModuleDefinition } from '@opentelemetry/instrumentation';
import { OpenAIInstrumentationConfig } from './types';
export declare class OpenAIInstrumentation extends InstrumentationBase<OpenAIInstrumentationConfig> {
    private _genaiClientOperationDuration;
    private _genaiClientTokenUsage;
    constructor(config?: OpenAIInstrumentationConfig);
    setConfig(config?: OpenAIInstrumentationConfig): void;
    protected init(): InstrumentationNodeModuleDefinition[];
    _updateMetricInstruments(): void;
    private _getPatchedChatCompletionsCreate;
    /**
     * Start a span for this chat-completion API call. This also emits log events
     * as appropriate for the request params.
     */
    private _startChatCompletionsSpan;
    /**
     * This wraps an instance of a `openai/streaming.Stream.iterator()`, an
     * async iterator. It should yield the chunks unchanged, and gather telemetry
     * data from those chunks, then end the span.
     */
    private _onChatCompletionsStreamIterator;
    private _onChatCompletionsCreateResult;
    private _createAPIPromiseRejectionHandler;
    private _getPatchedEmbeddingsCreate;
    /**
     * Start a span for this chat-completion API call. This also emits log events
     * as appropriate for the request params.
     */
    private _startEmbeddingsSpan;
    private _onEmbeddingsCreateResult;
}
//# sourceMappingURL=instrumentation.d.ts.map
```