### PR TITLE
fix(pg-instrumentation): capture query props when passed as class instance

### DIFF
--- a/packages/instrumentation-pg/src/instrumentation.ts
+++ b/packages/instrumentation-pg/src/instrumentation.ts
@@ -333,24 +333,21 @@ export class PgInstrumentation extends InstrumentationBase<PgInstrumentationConf
         // TODO: remove the `as ...` casts below when the TS version is upgraded.
         // Newer TS versions will use the result of firstArgIsQueryObjectWithText
         // to properly narrow arg0, but TS 4.3.5 does not.
-        let queryConfig: any;
-
-        if (firstArgIsString) {
-          queryConfig = {
-            text: arg0 as string,
-            values: Array.isArray(args[1]) ? args[1] : undefined,
-          };
-        } else if (firstArgIsQueryObjectWithText) {
-          const q = arg0 as any;
-
-          if (q.values === undefined && Array.isArray(args[1])) {
-            q.values = args[1];
-          }
-
-          queryConfig = q;
-        } else {
-          queryConfig = undefined;
-        }
+        const queryConfig = firstArgIsString
+          ? {
+              text: arg0 as string,
+              values: Array.isArray(args[1]) ? args[1] : undefined,
+            }
+          : firstArgIsQueryObjectWithText
+            ? {
+                ...(arg0 as any),
+                name: arg0.name,
+                text: arg0.text,
+                values:
+                  (arg0 as any).values ??
+                  (Array.isArray(args[1]) ? args[1] : undefined),
+              }
+            : undefined;
 
         const attributes: Attributes = {
           [ATTR_DB_SYSTEM]: DB_SYSTEM_VALUE_POSTGRESQL,


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

When using sql-templating libraries such  as [sql-template-strings](https://www.npmjs.com/package/sql-template-strings), the query object is usually not a plain object, and instead a class instance.

An [extracted](https://github.com/felixfbecker/node-sql-template-strings/blob/master/index.js) snippet:

```js
class SQLStatement {
  constructor(strings, values) {
    this.strings = strings
    this.values = values
  }

  /** Returns the SQL Statement for node-postgres */
  get text() {
    return this.strings.reduce((prev, curr, i) => prev + '$' + i + curr)
  }

  setName(name) {
    this.name = name
    return this
  }
}

function SQL(strings) {
  return new SQLStatement(strings.slice(0), Array.from(arguments).slice(1))
}
```

This class would be instantiated, for example, when using template string:

```js
client.query(SQL`select ...`);
```

With the changes added in PR #3196, the `text` property from the `Statement` class above would not be captured when using the spread operator i.e. `{ ...arg0 }`.

For example,

```js
class Klass {
  constructor() {
    this.foo = 1;
  }
  get bar() {
    return 2;
  }
}
const instance = new Klass();
const obj = { ...instance };

assert(obj.foo === 1);
assert(obj.bar === undefined); // `bar` is not set!
```

## Short description of the changes

The current fix is to explicitly capture `name` and `text` props while still using the spread operator.