### PR TITLE
feat(instrumentation-net): support `net.*` semconv migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38531,7 +38531,8 @@
       "version": "0.52.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.208.0"
+        "@opentelemetry/instrumentation": "^0.208.0",
+        "@opentelemetry/semantic-conventions": "^1.33.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",

--- a/packages/instrumentation-net/README.md
+++ b/packages/instrumentation-net/README.md
@@ -41,18 +41,28 @@ registerInstrumentations({
 
 ## Semantic Conventions
 
-This package uses `@opentelemetry/semantic-conventions` version `1.22+`, which implements Semantic Convention [Version 1.7.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/semantic_conventions/README.md)
+This instrumentation implements Semantic Conventions (semconv) v1.7.0. Since then, many networking-related semantic conventions (in semconv v1.21.0 and v1.23.1) were stabilized. As of `@opentelemetry/instrumentation-net@0.53.0` support has been added for migrating to the stable semantic conventions using the `OTEL_SEMCONV_STABILITY_OPT_IN` environment variable as follows:
 
-Attributes added to `connect` spans:
+1. Upgrade to the latest version of this instrumentation package.
+2. Set `OTEL_SEMCONV_STABILITY_OPT_IN=http/dup` to emit both old and stable semantic conventions. (The [`http` token is used to control the `net.*` attributes](https://github.com/open-telemetry/opentelemetry-js/issues/5663#issuecomment-3349204546).)
+3. Modify alerts, dashboards, metrics, and other processes in your Observability system to use the stable semantic conventions.
+4. Set `OTEL_SEMCONV_STABILITY_OPT_IN=http` to emit only the stable semantic conventions.
 
-| Attribute                 | Short Description                                                        |
-| ------------------------- | ------------------------------------------------------------------------ |
-| `net.transport`           | `IP.TCP`, `pipe` or `Unix`                                               |
-| `net.peer.name`           | Host name or the IPC file path                                           |
-| `net.peer.ip` (for TCP)   | Remote address of the peer (dotted decimal for IPv4 or RFC5952 for IPv6) |
-| `net.peer.port` (for TCP) | Remote port number                                                       |
-| `net.host.ip` (for TCP)   | Like net.peer.ip but for the host IP. Useful in case of a multi-IP host  |
-| `net.host.port` (for TCP) | Like net.peer.port but for the host port                                 |
+By default, if `OTEL_SEMCONV_STABILITY_OPT_IN` is not set or does not include `http`, then the old v1.7.0 semconv is used.
+The intent is to provide an approximate 6 month time window for users of this instrumentation to migrate to the new networking semconv, after which a new minor version will use the new semconv by default and drop support for the old semconv.
+See [the HTTP migration guide](https://opentelemetry.io/docs/specs/semconv/non-normative/http-migration/) and [deprecated network attributes](https://opentelemetry.io/docs/specs/semconv/registry/attributes/network/#deprecated-network-attributes) for details.
+
+Attributes collected:
+
+| Old semconv     | Stable semconv          | Description                                                                       |
+| --------------- | ----------------------- | --------------------------------------------------------------------------------- |
+| `net.transport` | `network.transport`     | One of `pipe`, `unix`, `ip_tcp` (old) or `tcp` (stable)                           |
+| `net.peer.name` | `server.address`        | Host name or the IPC file path                                                    |
+| `net.peer.port` | `server.port`           | Remote port number                                                                |
+| `net.peer.ip`   | `network.peer.address`  | Peer address of the network connection - IP address or Unix domain socket name.   |
+| `net.host.ip`   | `network.local.address` | Local address of the network connection - IP address or Unix domain socket name.  |
+| `net.host.port` | `network.local.port`    | Local port number of the network connection.                                      |
+
 
 ## Useful links
 

--- a/packages/instrumentation-net/package.json
+++ b/packages/instrumentation-net/package.json
@@ -51,7 +51,8 @@
     "@opentelemetry/sdk-trace-node": "^2.0.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.208.0"
+    "@opentelemetry/instrumentation": "^0.208.0",
+    "@opentelemetry/semantic-conventions": "^1.33.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-net#readme"
 }

--- a/packages/instrumentation-net/src/utils.ts
+++ b/packages/instrumentation-net/src/utils.ts
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
+import { platform } from 'os';
+import {
+  NETWORK_TRANSPORT_VALUE_PIPE,
+  NETWORK_TRANSPORT_VALUE_UNIX,
+} from '@opentelemetry/semantic-conventions';
 import { NormalizedOptions } from './internal-types';
 import { NET_TRANSPORT_VALUE_PIPE } from './semconv';
-import { platform } from 'os';
 
-// Currently the `IPC_TRANSPORT` values are for 'net.transport'. In semconv
-// v1.21.0 a breaking change (https://github.com/open-telemetry/opentelemetry-specification/pull/3426)
-// replaced 'net.transport' with 'network.transport'. The deprecated
-// 'net.transport' *removed* the 'unix' value (not sure if intentional). As a
-// result, the JS `@opentelemetry/semantic-conventions` package does not export
-// a `NET_TRANSPORT_VALUE_UNIX`.
-//
-// (TODO: update instrumentation-net (per PR-3426) to use 'network.transport',
-// then the `NETWORK_TRANSPORT_VALUE_UNIX` constant can be used.)
-export const IPC_TRANSPORT =
+// There is no `NET_TRANSPORT_VALUE_UNIX` because breaking change
+// https://github.com/open-telemetry/opentelemetry-specification/pull/3426
+// *removed* it. This was from before semconv got more careful of removals.
+export const OLD_IPC_TRANSPORT_VALUE =
   platform() === 'win32' ? NET_TRANSPORT_VALUE_PIPE : 'unix';
+export const STABLE_IPC_TRANSPORT_VALUE =
+  platform() === 'win32' ? NETWORK_TRANSPORT_VALUE_PIPE : NETWORK_TRANSPORT_VALUE_UNIX;
 
 function getHost(args: unknown[]) {
   return typeof args[1] === 'string' ? args[1] : 'localhost';

--- a/packages/instrumentation-net/test/connect.test.ts
+++ b/packages/instrumentation-net/test/connect.test.ts
@@ -19,13 +19,18 @@ import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
-import { ATTR_NET_TRANSPORT } from '../src/semconv';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { SemconvStability } from '@opentelemetry/instrumentation';
 import * as net from 'net';
 import * as assert from 'assert';
 import { NetInstrumentation } from '../src';
 import { SocketEvent } from '../src/internal-types';
 import { assertIpcSpan, assertTcpSpan, IPC_PATH, HOST, PORT } from './utils';
+
+// By default tests run with both old and stable semconv. Some test cases
+// specifically test the various values of OTEL_SEMCONV_STABILITY_OPT_IN.
+process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'http/dup';
+const DEFAULT_NET_SEMCONV_STABILITY = SemconvStability.DUPLICATE;
 
 const memoryExporter = new InMemorySpanExporter();
 const provider = new NodeTracerProvider({
@@ -79,14 +84,14 @@ describe('NetInstrumentation', () => {
   describe('successful net.connect produces a span', () => {
     it('should produce a span given port and host', done => {
       socket = net.connect(PORT, HOST, () => {
-        assertTcpSpan(getSpan(), socket);
+        assertTcpSpan(getSpan(), socket, DEFAULT_NET_SEMCONV_STABILITY);
         done();
       });
     });
 
     it('should produce a span for IPC', done => {
       socket = net.connect(IPC_PATH, () => {
-        assertIpcSpan(getSpan());
+        assertIpcSpan(getSpan(), DEFAULT_NET_SEMCONV_STABILITY);
         done();
       });
     });
@@ -98,7 +103,7 @@ describe('NetInstrumentation', () => {
           host: HOST,
         },
         () => {
-          assertTcpSpan(getSpan(), socket);
+          assertTcpSpan(getSpan(), socket, DEFAULT_NET_SEMCONV_STABILITY);
           done();
         }
       );
@@ -108,14 +113,14 @@ describe('NetInstrumentation', () => {
   describe('successful net.createConnection produces a span', () => {
     it('should produce a span given port and host', done => {
       socket = net.createConnection(PORT, HOST, () => {
-        assertTcpSpan(getSpan(), socket);
+        assertTcpSpan(getSpan(), socket, DEFAULT_NET_SEMCONV_STABILITY);
         done();
       });
     });
 
     it('should produce a span for IPC', done => {
       socket = net.createConnection(IPC_PATH, () => {
-        assertIpcSpan(getSpan());
+        assertIpcSpan(getSpan(), DEFAULT_NET_SEMCONV_STABILITY);
         done();
       });
     });
@@ -127,7 +132,7 @@ describe('NetInstrumentation', () => {
           host: HOST,
         },
         () => {
-          assertTcpSpan(getSpan(), socket);
+          assertTcpSpan(getSpan(), socket, DEFAULT_NET_SEMCONV_STABILITY);
           done();
         }
       );
@@ -137,21 +142,21 @@ describe('NetInstrumentation', () => {
   describe('successful Socket.connect produces a span', () => {
     it('should produce a span given port and host', done => {
       socket.connect(PORT, HOST, () => {
-        assertTcpSpan(getSpan(), socket);
+        assertTcpSpan(getSpan(), socket, DEFAULT_NET_SEMCONV_STABILITY);
         done();
       });
     });
 
     it('should produce a span for IPC', done => {
       socket.connect(IPC_PATH, () => {
-        assertIpcSpan(getSpan());
+        assertIpcSpan(getSpan(), DEFAULT_NET_SEMCONV_STABILITY);
         done();
       });
     });
 
     it('should create a tcp span when port is given as string', done => {
       socket = socket.connect(String(PORT) as unknown as number, HOST, () => {
-        assertTcpSpan(getSpan(), socket);
+        assertTcpSpan(getSpan(), socket, DEFAULT_NET_SEMCONV_STABILITY);
         done();
       });
     });
@@ -163,7 +168,7 @@ describe('NetInstrumentation', () => {
           host: HOST,
         },
         () => {
-          assertTcpSpan(getSpan(), socket);
+          assertTcpSpan(getSpan(), socket, DEFAULT_NET_SEMCONV_STABILITY);
           done();
         }
       );
@@ -186,7 +191,7 @@ describe('NetInstrumentation', () => {
       const assertSpan = () => {
         try {
           const span = getSpan();
-          assert.strictEqual(span.attributes[ATTR_NET_TRANSPORT], undefined);
+          assert.deepEqual(span.attributes, {});
           assert.strictEqual(span.status.code, SpanStatusCode.ERROR);
           done();
         } catch (e) {
@@ -206,6 +211,58 @@ describe('NetInstrumentation', () => {
         );
         assertSpan();
       }
+    });
+  });
+
+  describe('various values of OTEL_SEMCONV_STABILITY_OPT_IN', () => {
+    const _origOptInEnv = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+    after(() => {
+      process.env.OTEL_SEMCONV_STABILITY_OPT_IN = _origOptInEnv;
+      (instrumentation as any)._setSemconvStabilityFromEnv();
+    });
+
+    it('tcp with OTEL_SEMCONV_STABILITY_OPT_IN=(empty)', (done) => {
+      process.env.OTEL_SEMCONV_STABILITY_OPT_IN = '';
+      (instrumentation as any)._setSemconvStabilityFromEnv();
+      memoryExporter.reset();
+
+      socket = net.connect(PORT, HOST, () => {
+        assertTcpSpan(getSpan(), socket, SemconvStability.OLD);
+        done();
+      });
+    });
+
+    it('tcp with OTEL_SEMCONV_STABILITY_OPT_IN=http', (done) => {
+      process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'http';
+      (instrumentation as any)._setSemconvStabilityFromEnv();
+      memoryExporter.reset();
+
+      socket = net.connect(PORT, HOST, () => {
+        assertTcpSpan(getSpan(), socket, SemconvStability.STABLE);
+        done();
+      });
+    });
+
+    it('ipc with OTEL_SEMCONV_STABILITY_OPT_IN=(empty)', (done) => {
+      process.env.OTEL_SEMCONV_STABILITY_OPT_IN = '';
+      (instrumentation as any)._setSemconvStabilityFromEnv();
+      memoryExporter.reset();
+
+      socket.connect(IPC_PATH, () => {
+        assertIpcSpan(getSpan(), SemconvStability.OLD);
+        done();
+      });
+    });
+
+    it('ipc with OTEL_SEMCONV_STABILITY_OPT_IN=http', (done) => {
+      process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'http';
+      (instrumentation as any)._setSemconvStabilityFromEnv();
+      memoryExporter.reset();
+
+      socket.connect(IPC_PATH, () => {
+        assertIpcSpan(getSpan(), SemconvStability.STABLE);
+        done();
+      });
     });
   });
 

--- a/packages/instrumentation-net/test/tls.test.ts
+++ b/packages/instrumentation-net/test/tls.test.ts
@@ -21,6 +21,7 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import { SemconvStability } from '@opentelemetry/instrumentation';
 import * as assert from 'assert';
 import * as tls from 'tls';
 import { NetInstrumentation } from '../src';
@@ -32,6 +33,10 @@ import {
   TLS_SERVER_KEY,
   PORT,
 } from './utils';
+
+// By default tests run with both old and stable semconv.
+process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'http/dup';
+const DEFAULT_NET_SEMCONV_STABILITY = SemconvStability.DUPLICATE;
 
 const memoryExporter = new InMemorySpanExporter();
 const provider = new NodeTracerProvider({
@@ -95,7 +100,7 @@ describe('NetInstrumentation', () => {
           },
         },
         () => {
-          assertTLSSpan(getTLSSpans(), tlsSocket);
+          assertTLSSpan(getTLSSpans(), tlsSocket, DEFAULT_NET_SEMCONV_STABILITY);
           done();
         }
       );
@@ -112,7 +117,7 @@ describe('NetInstrumentation', () => {
         c.end();
       });
       tlsSocket.once('end', () => {
-        assertTLSSpan(getTLSSpans(), tlsSocket);
+        assertTLSSpan(getTLSSpans(), tlsSocket, DEFAULT_NET_SEMCONV_STABILITY);
         done();
       });
     });
@@ -128,7 +133,7 @@ describe('NetInstrumentation', () => {
           },
         },
         () => {
-          assertTLSSpan(getTLSSpans(), tlsSocket);
+          assertTLSSpan(getTLSSpans(), tlsSocket, DEFAULT_NET_SEMCONV_STABILITY);
           done();
         }
       );


### PR DESCRIPTION
This adds support for using `OTEL_SEMCONV_STABILITY_OPT_IN` for controlled migration to stable `net.*` semconv. The `net.*` attributes are controlled by the `http[/dup]` token in `OTEL_SEMCONV_STABILITY_OPT_IN` (as [discussed here](https://github.com/open-telemetry/opentelemetry-js/issues/5663#issuecomment-3314043915)).

Refs: https://github.com/open-telemetry/opentelemetry-js/issues/5663
