### PR TITLE
chore(lint): restore running prettier as part of linting

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,10 +1,6 @@
 {
-  "extension": [
-    ".ts"
-  ],
-  "include": [
-    "src/**"
-  ],
+  "extension": [".ts"],
+  "include": ["src/**"],
   "reporter": ["text", "json"],
   "exclude": [
     "**/*.d.ts",

--- a/examples/react-load/preact/.babelrc
+++ b/examples/react-load/preact/.babelrc
@@ -1,9 +1,7 @@
 {
   "env": {
     "test": {
-      "presets": [
-        ["preact-cli/babel", { "modules": "commonjs" }]
-      ]
+      "presets": [["preact-cli/babel", { "modules": "commonjs" }]]
     }
   }
 }

--- a/examples/react-load/preact/public/index.html
+++ b/examples/react-load/preact/public/index.html
@@ -1,10 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
-    <meta charset=utf-8 />
+    <meta charset="utf-8" />
     <title>React Load Example: Preact</title>
   </head>
   <body>
-  <div id="root"></div>
+    <div id="root"></div>
   </body>
 </html>

--- a/examples/react-load/react/public/index.html
+++ b/examples/react-load/react/public/index.html
@@ -1,11 +1,11 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
-    <meta charset=utf-8 />
+    <meta charset="utf-8" />
     <title>React Load Example</title>
     <script type="text/jsx"></script>
   </head>
   <body>
-  <div id="root"></div>
+    <div id="root"></div>
   </body>
 </html>

--- a/examples/react-load/react/src/Content.jsx
+++ b/examples/react-load/react/src/Content.jsx
@@ -1,61 +1,55 @@
 import React from 'react';
-import { Button} from 'reactstrap';
-import { BaseOpenTelemetryComponent } from '@opentelemetry/plugin-react-load'
+import { Button } from 'reactstrap';
+import { BaseOpenTelemetryComponent } from '@opentelemetry/plugin-react-load';
 
 class Content extends BaseOpenTelemetryComponent {
-  constructor(props){
-    super(props)
+  constructor(props) {
+    super(props);
     this.state = {
       results: null,
-      isLoading: false
-    }
+      isLoading: false,
+    };
   }
 
-  componentDidMount(){
+  componentDidMount() {
     // Example, do something here
   }
 
   buttonHandler() {
-    this.setState({isLoading: true})
-    const randomDelay = Math.random() * 10000; 
+    this.setState({ isLoading: true });
+    const randomDelay = Math.random() * 10000;
     setTimeout(() => {
       this.setState({
         isLoading: false,
-        results: randomDelay
-      })
-    }, 
-    randomDelay);
+        results: randomDelay,
+      });
+    }, randomDelay);
   }
 
-  renderResults(){
-    if(this.state.isLoading){
+  renderResults() {
+    if (this.state.isLoading) {
       return <div> Loading results...</div>;
-    } 
-    if (!this.state.results){
-      return (
-        <div>No Results</div>
-      )
     }
-    return (
-      <div>
-        Request was delayed {this.state.results} ms
-      </div>
-    )
+    if (!this.state.results) {
+      return <div>No Results</div>;
+    }
+    return <div>Request was delayed {this.state.results} ms</div>;
   }
 
   render() {
     return (
       <div>
         <h1>React Plugin Demo App</h1>
-        <Button onClick={() => this.buttonHandler()} style={{marginBottom: '20px'}}>
+        <Button
+          onClick={() => this.buttonHandler()}
+          style={{ marginBottom: '20px' }}
+        >
           Make Request
         </Button>
-        <div id="results">
-          {this.renderResults()}
-        </div>
+        <div id="results">{this.renderResults()}</div>
       </div>
-    )
+    );
   }
 }
-        
+
 export default Content;

--- a/examples/react-load/react/src/Home.jsx
+++ b/examples/react-load/react/src/Home.jsx
@@ -6,12 +6,12 @@ class Home extends BaseOpenTelemetryComponent {
   render() {
     return (
       <div>
-        <h1>
-          React Plugin Demo App
-        </h1>
-        <Link to='/test'><button>Enter</button></Link>
+        <h1>React Plugin Demo App</h1>
+        <Link to="/test">
+          <button>Enter</button>
+        </Link>
       </div>
-    )
+    );
   }
 }
 

--- a/examples/react-load/react/src/index.jsx
+++ b/examples/react-load/react/src/index.jsx
@@ -1,17 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {BrowserRouter as Router, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Route } from 'react-router-dom';
 import Home from './Home';
 import Content from './Content';
 import Tracer from './web-tracer.js';
 
-Tracer('example-react-load')
+Tracer('example-react-load');
 
 ReactDOM.render(
-	<Router>
-	  <main>
-		  <Route exact path='/' component={Home}/>
-		  <Route exact path='/test' component={Content}/>
-	  </main>
-	</Router>
-,document.getElementById('root'));
+  <Router>
+    <main>
+      <Route exact path="/" component={Home} />
+      <Route exact path="/test" component={Content} />
+    </main>
+  </Router>,
+  document.getElementById('root')
+);

--- a/examples/web/examples/document-load/index.html
+++ b/examples/web/examples/document-load/index.html
@@ -1,12 +1,11 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Document Load Plugin Example</title>
+    <base href="/" />
 
-<head>
-  <meta charset="utf-8">
-  <title>Document Load Plugin Example</title>
-  <base href="/">
-
-  <!--
+    <!--
     https://www.w3.org/TR/trace-context/
     Set the `traceparent` in the server's HTML template code. It should be
     dynamically generated server side to have the server's request trace Id,
@@ -15,17 +14,16 @@
     (01 = sampled, 00 = notsampled).
     '{version}-{traceId}-{spanId}-{sampleDecision}'
   -->
-<!--  <meta name="traceparent" content="00-ab42124a3c573678d4d8b21ba52df3bf-d21f7bc17caa5aba-01">-->
+    <!--  <meta name="traceparent" content="00-ab42124a3c573678d4d8b21ba52df3bf-d21f7bc17caa5aba-01">-->
 
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-</head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
 
-<body>
-  Example of using Web Tracer with document load plugin with console exporter and collector exporter
-  <script type="text/javascript" src="document-load.js"></script>
-  <br/>
-  <button id="button1">Test WebTracer with ZoneContextManager - async</button>
-
-</body>
-
+  <body>
+    Example of using Web Tracer with document load plugin with console exporter
+    and collector exporter
+    <script type="text/javascript" src="document-load.js"></script>
+    <br />
+    <button id="button1">Test WebTracer with ZoneContextManager - async</button>
+  </body>
 </html>

--- a/examples/web/examples/meta/index.html
+++ b/examples/web/examples/meta/index.html
@@ -1,12 +1,11 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>User Interaction Example</title>
+    <base href="/" />
 
-<head>
-  <meta charset="utf-8">
-  <title>User Interaction Example</title>
-  <base href="/">
-
-  <!--
+    <!--
     https://www.w3.org/TR/trace-context/
     Set the `traceparent` in the server's HTML template code. It should be
     dynamically generated server side to have the server's request trace Id,
@@ -15,25 +14,24 @@
     (01 = sampled, 00 = notsampled).
     '{version}-{traceId}-{spanId}-{sampleDecision}'
   -->
-<!--  <meta name="traceparent" content="00-ab42124a3c573678d4d8b21ba52df3bf-d21f7bc17caa5aba-01">-->
+    <!--  <meta name="traceparent" content="00-ab42124a3c573678d4d8b21ba52df3bf-d21f7bc17caa5aba-01">-->
 
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-</head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
 
-<body>
-  Example of using Web Tracer with meta package and with console exporter and collector exporter
-  <script type="text/javascript" src="meta.js"></script>
-  <br/>
-  <button id="btnAdd" class="btnAddClass">Add button</button>
-  <div>
-    <div></div>
-    <div></div>
-    <div></div>
-    <div id="buttons"></div>
-    <div></div>
-  </div>
-  <br/>
-
-</body>
-
+  <body>
+    Example of using Web Tracer with meta package and with console exporter and
+    collector exporter
+    <script type="text/javascript" src="meta.js"></script>
+    <br />
+    <button id="btnAdd" class="btnAddClass">Add button</button>
+    <div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div id="buttons"></div>
+      <div></div>
+    </div>
+    <br />
+  </body>
 </html>

--- a/examples/web/examples/user-interaction/index.html
+++ b/examples/web/examples/user-interaction/index.html
@@ -1,12 +1,11 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>User Interaction Example</title>
+    <base href="/" />
 
-<head>
-  <meta charset="utf-8">
-  <title>User Interaction Example</title>
-  <base href="/">
-
-  <!--
+    <!--
     https://www.w3.org/TR/trace-context/
     Set the `traceparent` in the server's HTML template code. It should be
     dynamically generated server side to have the server's request trace Id,
@@ -15,25 +14,24 @@
     (01 = sampled, 00 = notsampled).
     '{version}-{traceId}-{spanId}-{sampleDecision}'
   -->
-<!--  <meta name="traceparent" content="00-ab42124a3c573678d4d8b21ba52df3bf-d21f7bc17caa5aba-01">-->
+    <!--  <meta name="traceparent" content="00-ab42124a3c573678d4d8b21ba52df3bf-d21f7bc17caa5aba-01">-->
 
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-</head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
 
-<body>
-  Example of using Web Tracer with UserInteractionInstrumentation and XMLHttpRequestInstrumentation with console exporter and collector exporter
-  <script type="text/javascript" src="user-interaction.js"></script>
-  <br/>
-  <button id="btnAdd" class="btnAddClass">Add button</button>
-  <div>
-    <div></div>
-    <div></div>
-    <div></div>
-    <div id="buttons"></div>
-    <div></div>
-  </div>
-  <br/>
-
-</body>
-
+  <body>
+    Example of using Web Tracer with UserInteractionInstrumentation and
+    XMLHttpRequestInstrumentation with console exporter and collector exporter
+    <script type="text/javascript" src="user-interaction.js"></script>
+    <br />
+    <button id="btnAdd" class="btnAddClass">Add button</button>
+    <div>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div id="buttons"></div>
+      <div></div>
+    </div>
+    <br />
+  </body>
 </html>

--- a/karma.webpack.js
+++ b/karma.webpack.js
@@ -36,8 +36,8 @@ module.exports = {
       // because the `util` package expects there to be a global variable named `process`.
       // Thanks to https://stackoverflow.com/a/65018686/14239942
       // NOTE: I wish there was a better way as this pollutes the tests with a defined 'process' global.
-      process: 'process/browser.js'
-    })
+      process: 'process/browser.js',
+    }),
   ],
   module: {
     rules: [

--- a/packages/instrumentation-amqplib/src/amqplib.ts
+++ b/packages/instrumentation-amqplib/src/amqplib.ts
@@ -692,8 +692,8 @@ export class AmqplibInstrumentation extends InstrumentationBase<AmqplibInstrumen
                 requeue === true
                   ? ' with requeue'
                   : requeue === false
-                  ? ' without requeue'
-                  : ''
+                    ? ' without requeue'
+                    : ''
               }`
             : operation,
       });

--- a/packages/instrumentation-aws-lambda/src/instrumentation.ts
+++ b/packages/instrumentation-aws-lambda/src/instrumentation.ts
@@ -92,8 +92,8 @@ function isSupportingCallbacks(): boolean {
 }
 
 export class AwsLambdaInstrumentation extends InstrumentationBase<AwsLambdaInstrumentationConfig> {
-  private declare _traceForceFlusher?: () => Promise<void>;
-  private declare _metricForceFlusher?: () => Promise<void>;
+  declare private _traceForceFlusher?: () => Promise<void>;
+  declare private _metricForceFlusher?: () => Promise<void>;
 
   constructor(config: AwsLambdaInstrumentationConfig = {}) {
     super(PACKAGE_NAME, PACKAGE_VERSION, config);
@@ -337,7 +337,13 @@ export class AwsLambdaInstrumentation extends InstrumentationBase<AwsLambdaInstr
           } else {
             // Promise-based handler
             const maybePromise = safeExecuteInTheMiddle(
-              () => (original as (event: any, context: Context) => Promise<any> | any).apply(this, [event, context]),
+              () =>
+                (
+                  original as (
+                    event: any,
+                    context: Context
+                  ) => Promise<any> | any
+                ).apply(this, [event, context]),
               error => {
                 if (error != null) {
                   // Exception thrown synchronously before resolving promise.
@@ -376,7 +382,10 @@ export class AwsLambdaInstrumentation extends InstrumentationBase<AwsLambdaInstr
         return otelContext.with(trace.setSpan(parent, span), () => {
           // Promise-based handler only (Node.js 24+)
           const maybePromise = safeExecuteInTheMiddle(
-            () => (original as (event: any, context: Context) => Promise<any> | any).apply(this, [event, context]),
+            () =>
+              (
+                original as (event: any, context: Context) => Promise<any> | any
+              ).apply(this, [event, context]),
             error => {
               if (error != null) {
                 // Exception thrown synchronously before resolving promise.

--- a/packages/instrumentation-aws-lambda/test/integrations/lambda-handler.test.ts
+++ b/packages/instrumentation-aws-lambda/test/integrations/lambda-handler.test.ts
@@ -242,7 +242,10 @@ describe('lambda handler', () => {
     it('should export a valid span', async () => {
       initializeHandler('lambda-test/sync.handler');
 
-      const result = await lambdaRequire('lambda-test/sync').handler('arg', ctx);
+      const result = await lambdaRequire('lambda-test/sync').handler(
+        'arg',
+        ctx
+      );
       assert.strictEqual(result, 'ok');
       const spans = memoryExporter.getFinishedSpans();
       const [span] = spans;
@@ -280,7 +283,10 @@ describe('lambda handler', () => {
 
       initializeHandler('lambda-test/sync.handler');
 
-      const result = await lambdaRequire('lambda-test/sync').handler('arg', ctx);
+      const result = await lambdaRequire('lambda-test/sync').handler(
+        'arg',
+        ctx
+      );
       assert.strictEqual(result, 'ok');
       const spans = memoryExporter.getFinishedSpans();
       const [span] = spans;
@@ -295,7 +301,10 @@ describe('lambda handler', () => {
         lambdaStartTime: Date.now() - 2 * lambdaMaxInitInMilliseconds,
       });
 
-      const result = await lambdaRequire('lambda-test/sync').handler('arg', ctx);
+      const result = await lambdaRequire('lambda-test/sync').handler(
+        'arg',
+        ctx
+      );
       assert.strictEqual(result, 'ok');
       const spans = memoryExporter.getFinishedSpans();
       const [span] = spans;
@@ -359,7 +368,10 @@ describe('lambda handler', () => {
     it('context should have parent trace', async () => {
       initializeHandler('lambda-test/sync.context');
 
-      const result = await lambdaRequire('lambda-test/sync').context('arg', ctx);
+      const result = await lambdaRequire('lambda-test/sync').context(
+        'arg',
+        ctx
+      );
       const spans = memoryExporter.getFinishedSpans();
       const [span] = spans;
       assert.strictEqual(span.spanContext().traceId, result);
@@ -368,7 +380,10 @@ describe('lambda handler', () => {
     it('context should have parent trace', async () => {
       initializeHandler('lambda-test/sync.context');
 
-      const result = await lambdaRequire('lambda-test/sync').context('arg', ctx);
+      const result = await lambdaRequire('lambda-test/sync').context(
+        'arg',
+        ctx
+      );
       const spans = memoryExporter.getFinishedSpans();
       const [span] = spans;
       assert.strictEqual(span.spanContext().traceId, result);
@@ -669,7 +684,10 @@ describe('lambda handler', () => {
       it('sync - success', async () => {
         initializeHandler('lambda-test/sync.handler', config);
 
-        const result = await lambdaRequire('lambda-test/sync').handler('arg', ctx);
+        const result = await lambdaRequire('lambda-test/sync').handler(
+          'arg',
+          ctx
+        );
         const [span] = memoryExporter.getFinishedSpans();
         assert.strictEqual(span.attributes[RES_ATTR], result);
       });
@@ -760,8 +778,8 @@ describe('lambda handler', () => {
       assert.ok(
         span.attributes[ATTR_URL_FULL] ===
           'http://www.example.com:1234/lambda/test/path?key=value&key2=value2' ||
-        span.attributes[ATTR_URL_FULL] ===
-          'http://www.example.com:1234/lambda/test/path?key2=value2&key=value'
+          span.attributes[ATTR_URL_FULL] ===
+            'http://www.example.com:1234/lambda/test/path?key2=value2&key=value'
       );
     });
     it('pulls url from api gateway http events', async () => {

--- a/packages/instrumentation-aws-lambda/test/lambda-test/commonjs.cjs
+++ b/packages/instrumentation-aws-lambda/test/lambda-test/commonjs.cjs
@@ -1,3 +1,3 @@
 exports.handler = async function (event, context) {
-	return "ok";
+  return 'ok';
 };

--- a/packages/instrumentation-aws-sdk/src/aws-sdk.ts
+++ b/packages/instrumentation-aws-sdk/src/aws-sdk.ts
@@ -71,7 +71,7 @@ type V3PluginCommand = AwsV3Command<any, any, any, any, any> & {
 export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentationConfig> {
   static readonly component = 'aws-sdk';
   // need declare since initialized in callbacks from super constructor
-  private declare servicesExtensions: ServicesExtensions;
+  declare private servicesExtensions: ServicesExtensions;
 
   private _semconvStability: SemconvStability;
 

--- a/packages/instrumentation-bunyan/src/instrumentation.ts
+++ b/packages/instrumentation-bunyan/src/instrumentation.ts
@@ -16,7 +16,11 @@
 
 import { inherits } from 'util';
 import { context, trace, isSpanContextValid, Span } from '@opentelemetry/api';
-import { InstrumentationBase, InstrumentationNodeModuleDefinition, safeExecuteInTheMiddle } from '@opentelemetry/instrumentation';
+import {
+  InstrumentationBase,
+  InstrumentationNodeModuleDefinition,
+  safeExecuteInTheMiddle,
+} from '@opentelemetry/instrumentation';
 import { BunyanInstrumentationConfig } from './types';
 /** @knipignore */
 import { PACKAGE_NAME, PACKAGE_VERSION } from './version';

--- a/packages/instrumentation-dns/src/internal-types.ts
+++ b/packages/instrumentation-dns/src/internal-types.ts
@@ -49,7 +49,7 @@ export type LookupSimpleArgs = [number, LookupSimpleCallback];
 export type LookupOneArgs = [dns.LookupOneOptions, LookupSimpleCallback];
 export type LookupAllArgs = [
   dns.LookupAllOptions,
-  (err: NodeJS.ErrnoException | null, addresses: dns.LookupAddress[]) => void
+  (err: NodeJS.ErrnoException | null, addresses: dns.LookupAddress[]) => void,
 ];
 export type LookupArgs = [
   dns.LookupOptions,
@@ -57,7 +57,7 @@ export type LookupArgs = [
     err: NodeJS.ErrnoException | null,
     address: string | dns.LookupAddress[],
     family: number
-  ) => void
+  ) => void,
 ];
 export type LookupArgSignature = LookupSimpleArgs &
   LookupSimpleCallback &

--- a/packages/instrumentation-fs/src/instrumentation.ts
+++ b/packages/instrumentation-fs/src/instrumentation.ts
@@ -47,7 +47,7 @@ type FSPromises = (typeof fs)['promises'];
  * when patching the 1st-level.
  */
 function patchedFunctionWithOriginalProperties<
-  T extends (...args: any[]) => ReturnType<T>
+  T extends (...args: any[]) => ReturnType<T>,
 >(patchedFunction: T, original: T): T {
   return Object.assign(patchedFunction, original);
 }
@@ -296,7 +296,7 @@ export class FsInstrumentation extends InstrumentationBase<FsInstrumentationConf
   }
 
   protected _patchExistsCallbackFunction<
-    T extends (...args: any[]) => ReturnType<T>
+    T extends (...args: any[]) => ReturnType<T>,
   >(functionName: 'exists', original: T): T {
     const instrumentation = this;
     const patchedFunction = <any>function (this: any, ...args: any[]) {

--- a/packages/instrumentation-graphql/src/internal-types.ts
+++ b/packages/instrumentation-graphql/src/internal-types.ts
@@ -39,7 +39,7 @@ export type executeArgumentsArray = [
   Maybe<{ [key: string]: any }>,
   Maybe<string>,
   Maybe<graphqlTypes.GraphQLFieldResolver<any, any>>,
-  Maybe<graphqlTypes.GraphQLTypeResolver<any, any>>
+  Maybe<graphqlTypes.GraphQLTypeResolver<any, any>>,
 ];
 
 export type executeFunctionWithArgs = (

--- a/packages/instrumentation-hapi/src/internal-types.ts
+++ b/packages/instrumentation-hapi/src/internal-types.ts
@@ -54,7 +54,7 @@ export type PatchableExtMethod = Hapi.Lifecycle.Method & {
 export type ServerExtDirectInput = [
   Hapi.ServerRequestExtType,
   Hapi.Lifecycle.Method,
-  (Hapi.ServerExtOptions | undefined)?
+  (Hapi.ServerExtOptions | undefined)?,
 ];
 
 export const HapiLayerType = {

--- a/packages/instrumentation-ioredis/src/instrumentation.ts
+++ b/packages/instrumentation-ioredis/src/instrumentation.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { diag, trace, context, SpanKind, type Attributes } from '@opentelemetry/api';
+import {
+  diag,
+  trace,
+  context,
+  SpanKind,
+  type Attributes,
+} from '@opentelemetry/api';
 import {
   InstrumentationBase,
   InstrumentationNodeModuleDefinition,
@@ -187,7 +193,6 @@ export class IORedisInstrumentation extends InstrumentationBase<IORedisInstrumen
           true
         );
       }
-
 
       try {
         const result = original.apply(this, arguments);

--- a/packages/instrumentation-ioredis/test/ioredis.test.ts
+++ b/packages/instrumentation-ioredis/test/ioredis.test.ts
@@ -962,7 +962,7 @@ describe('ioredis', () => {
           Span,
           string,
           unknown,
-          Buffer
+          Buffer,
         ];
         assert.strictEqual(cmdName, 'set');
         assert.strictEqual(response.toString(), 'OK');
@@ -1063,7 +1063,7 @@ describe('ioredis', () => {
       try {
         // Act
         const tracer = provider.getTracer('ioredis-test');
-        await tracer.startActiveSpan('parent', async (parentSpan) => {
+        await tracer.startActiveSpan('parent', async parentSpan => {
           await client.set(testKeyName, 'aValue');
           parentSpan.end();
         });
@@ -1096,7 +1096,7 @@ describe('ioredis', () => {
       try {
         // Act
         const tracer = provider.getTracer('ioredis-test');
-        await tracer.startActiveSpan('parent', async (parentSpan) => {
+        await tracer.startActiveSpan('parent', async parentSpan => {
           await client.set(testKeyName, 'aValue');
           parentSpan.end();
         });

--- a/packages/instrumentation-kafkajs/src/instrumentation.ts
+++ b/packages/instrumentation-kafkajs/src/instrumentation.ts
@@ -163,10 +163,10 @@ const HISTOGRAM_BUCKET_BOUNDARIES = [
   0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10,
 ];
 export class KafkaJsInstrumentation extends InstrumentationBase<KafkaJsInstrumentationConfig> {
-  private declare _clientDuration: Histogram<ClientDurationAttributes>;
-  private declare _sentMessages: Counter<SentMessagesAttributes>;
-  private declare _consumedMessages: Counter<ConsumedMessagesAttributes>;
-  private declare _processDuration: Histogram<MessageProcessDurationAttributes>;
+  declare private _clientDuration: Histogram<ClientDurationAttributes>;
+  declare private _sentMessages: Counter<SentMessagesAttributes>;
+  declare private _consumedMessages: Counter<ConsumedMessagesAttributes>;
+  declare private _processDuration: Histogram<MessageProcessDurationAttributes>;
 
   constructor(config: KafkaJsInstrumentationConfig = {}) {
     super(PACKAGE_NAME, PACKAGE_VERSION, config);

--- a/packages/instrumentation-kafkajs/test/utils.ts
+++ b/packages/instrumentation-kafkajs/test/utils.ts
@@ -61,12 +61,15 @@ export function assertMetricCollection(
       values.forEach(({ buckets }, i) => {
         if (buckets) {
           const { boundaries, counts } = match.dataPoints[i].value.buckets;
-          const actualBuckets = counts.reduce((acc, n, j) => {
-            if (n > 0) {
-              acc[boundaries[j]] = n;
-            }
-            return acc;
-          }, {} as Record<number, number>);
+          const actualBuckets = counts.reduce(
+            (acc, n, j) => {
+              if (n > 0) {
+                acc[boundaries[j]] = n;
+              }
+              return acc;
+            },
+            {} as Record<number, number>
+          );
           assert.deepStrictEqual(actualBuckets, buckets);
         }
       });

--- a/packages/instrumentation-koa/src/types.ts
+++ b/packages/instrumentation-koa/src/types.ts
@@ -55,7 +55,7 @@ export type KoaRequestInfo<KoaContextType = any, KoaMiddlewareType = any> = {
  */
 export interface KoaRequestCustomAttributeFunction<
   KoaContextType = any,
-  KoaMiddlewareType = any
+  KoaMiddlewareType = any,
 > {
   (span: Span, info: KoaRequestInfo<KoaContextType, KoaMiddlewareType>): void;
 }
@@ -65,7 +65,7 @@ export interface KoaRequestCustomAttributeFunction<
  */
 export interface KoaInstrumentationConfig<
   KoaContextType = any,
-  KoaMiddlewareType = any
+  KoaMiddlewareType = any,
 > extends InstrumentationConfig {
   /** Ignore specific layers based on their type */
   ignoreLayersType?: KoaLayerType[];

--- a/packages/instrumentation-memcached/src/utils.ts
+++ b/packages/instrumentation-memcached/src/utils.ts
@@ -15,10 +15,7 @@
  */
 
 import type * as Memcached from 'memcached';
-import {
-  ATTR_NET_PEER_NAME,
-  ATTR_NET_PEER_PORT,
-} from './semconv';
+import { ATTR_NET_PEER_NAME, ATTR_NET_PEER_PORT } from './semconv';
 import {
   ATTR_SERVER_ADDRESS,
   ATTR_SERVER_PORT,

--- a/packages/instrumentation-memcached/test/index.test.ts
+++ b/packages/instrumentation-memcached/test/index.test.ts
@@ -299,7 +299,10 @@ describe('memcached@2.x', () => {
 
       const span = instrumentationSpans[1]; // get operation
       // old `db.*`
-      assert.strictEqual(span.attributes[ATTR_DB_SYSTEM], DB_SYSTEM_VALUE_MEMCACHED);
+      assert.strictEqual(
+        span.attributes[ATTR_DB_SYSTEM],
+        DB_SYSTEM_VALUE_MEMCACHED
+      );
       assert.strictEqual(span.attributes[ATTR_DB_OPERATION], 'get');
       // stable `db.*`
       assert.strictEqual(span.attributes[ATTR_DB_SYSTEM_NAME], undefined);
@@ -332,7 +335,10 @@ describe('memcached@2.x', () => {
       assert.strictEqual(span.attributes[ATTR_DB_SYSTEM], undefined);
       assert.strictEqual(span.attributes[ATTR_DB_OPERATION], undefined);
       // stable `db.*`
-      assert.strictEqual(span.attributes[ATTR_DB_SYSTEM_NAME], DB_SYSTEM_NAME_VALUE_MEMCACHED);
+      assert.strictEqual(
+        span.attributes[ATTR_DB_SYSTEM_NAME],
+        DB_SYSTEM_NAME_VALUE_MEMCACHED
+      );
       assert.strictEqual(span.attributes[ATTR_DB_OPERATION_NAME], 'get');
 
       // old `net.*`

--- a/packages/instrumentation-mongodb/src/instrumentation.ts
+++ b/packages/instrumentation-mongodb/src/instrumentation.ts
@@ -63,8 +63,8 @@ const DEFAULT_CONFIG: MongoDBInstrumentationConfig = {
 
 /** mongodb instrumentation plugin for OpenTelemetry */
 export class MongoDBInstrumentation extends InstrumentationBase<MongoDBInstrumentationConfig> {
-  private declare _connectionsUsage: UpDownCounter;
-  private declare _poolName: string;
+  declare private _connectionsUsage: UpDownCounter;
+  declare private _poolName: string;
 
   constructor(config: MongoDBInstrumentationConfig = {}) {
     super(PACKAGE_NAME, PACKAGE_VERSION, { ...DEFAULT_CONFIG, ...config });

--- a/packages/instrumentation-mysql/src/instrumentation.ts
+++ b/packages/instrumentation-mysql/src/instrumentation.ts
@@ -56,7 +56,7 @@ export class MySQLInstrumentation extends InstrumentationBase<MySQLInstrumentati
   static readonly COMMON_ATTRIBUTES = {
     [ATTR_DB_SYSTEM]: DB_SYSTEM_VALUE_MYSQL,
   };
-  private declare _connectionsUsage: UpDownCounter;
+  declare private _connectionsUsage: UpDownCounter;
 
   constructor(config: MySQLInstrumentationConfig = {}) {
     super(PACKAGE_NAME, PACKAGE_VERSION, config);

--- a/packages/instrumentation-nestjs-core/test/setup.ts
+++ b/packages/instrumentation-nestjs-core/test/setup.ts
@@ -41,9 +41,12 @@ const __decorate = function (
         return (d && d(o)) || o;
       }, target);
     case 3:
-      return decorators.reduceRight((o: any, d: Function) => {
-        return (d && d(target, key)) || o;
-      }, void 0);
+      return decorators.reduceRight(
+        (o: any, d: Function) => {
+          return (d && d(target, key)) || o;
+        },
+        void 0
+      );
     case 4:
       return decorators.reduceRight((o: any, d: Function) => {
         return (d && d(target, key, o)) || o;

--- a/packages/instrumentation-net/src/instrumentation.ts
+++ b/packages/instrumentation-net/src/instrumentation.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { Span, SpanStatusCode, context, trace, type Attributes } from '@opentelemetry/api';
+import {
+  Span,
+  SpanStatusCode,
+  context,
+  trace,
+  type Attributes,
+} from '@opentelemetry/api';
 import {
   InstrumentationBase,
   InstrumentationConfig,
@@ -44,7 +50,11 @@ import {
 } from './semconv';
 import { TLSAttributes } from './types';
 import { NormalizedOptions, SocketEvent } from './internal-types';
-import { getNormalizedArgs, OLD_IPC_TRANSPORT_VALUE, STABLE_IPC_TRANSPORT_VALUE } from './utils';
+import {
+  getNormalizedArgs,
+  OLD_IPC_TRANSPORT_VALUE,
+  STABLE_IPC_TRANSPORT_VALUE,
+} from './utils';
 /** @knipignore */
 import { PACKAGE_NAME, PACKAGE_VERSION } from './version';
 import { Socket } from 'net';
@@ -271,7 +281,7 @@ function registerListeners(
   socket: Socket,
   span: Span,
   hostAttributes: boolean,
-  netSemconvStability: SemconvStability,
+  netSemconvStability: SemconvStability
 ) {
   const setSpanError = spanErrorHandler(span);
   const setSpanEnd = spanEndHandler(span);

--- a/packages/instrumentation-net/src/utils.ts
+++ b/packages/instrumentation-net/src/utils.ts
@@ -28,7 +28,9 @@ import { NET_TRANSPORT_VALUE_PIPE } from './semconv';
 export const OLD_IPC_TRANSPORT_VALUE =
   platform() === 'win32' ? NET_TRANSPORT_VALUE_PIPE : 'unix';
 export const STABLE_IPC_TRANSPORT_VALUE =
-  platform() === 'win32' ? NETWORK_TRANSPORT_VALUE_PIPE : NETWORK_TRANSPORT_VALUE_UNIX;
+  platform() === 'win32'
+    ? NETWORK_TRANSPORT_VALUE_PIPE
+    : NETWORK_TRANSPORT_VALUE_UNIX;
 
 function getHost(args: unknown[]) {
   return typeof args[1] === 'string' ? args[1] : 'localhost';

--- a/packages/instrumentation-net/test/connect.test.ts
+++ b/packages/instrumentation-net/test/connect.test.ts
@@ -221,7 +221,7 @@ describe('NetInstrumentation', () => {
       (instrumentation as any)._setSemconvStabilityFromEnv();
     });
 
-    it('tcp with OTEL_SEMCONV_STABILITY_OPT_IN=(empty)', (done) => {
+    it('tcp with OTEL_SEMCONV_STABILITY_OPT_IN=(empty)', done => {
       process.env.OTEL_SEMCONV_STABILITY_OPT_IN = '';
       (instrumentation as any)._setSemconvStabilityFromEnv();
       memoryExporter.reset();
@@ -232,7 +232,7 @@ describe('NetInstrumentation', () => {
       });
     });
 
-    it('tcp with OTEL_SEMCONV_STABILITY_OPT_IN=http', (done) => {
+    it('tcp with OTEL_SEMCONV_STABILITY_OPT_IN=http', done => {
       process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'http';
       (instrumentation as any)._setSemconvStabilityFromEnv();
       memoryExporter.reset();
@@ -243,7 +243,7 @@ describe('NetInstrumentation', () => {
       });
     });
 
-    it('ipc with OTEL_SEMCONV_STABILITY_OPT_IN=(empty)', (done) => {
+    it('ipc with OTEL_SEMCONV_STABILITY_OPT_IN=(empty)', done => {
       process.env.OTEL_SEMCONV_STABILITY_OPT_IN = '';
       (instrumentation as any)._setSemconvStabilityFromEnv();
       memoryExporter.reset();
@@ -254,7 +254,7 @@ describe('NetInstrumentation', () => {
       });
     });
 
-    it('ipc with OTEL_SEMCONV_STABILITY_OPT_IN=http', (done) => {
+    it('ipc with OTEL_SEMCONV_STABILITY_OPT_IN=http', done => {
       process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'http';
       (instrumentation as any)._setSemconvStabilityFromEnv();
       memoryExporter.reset();

--- a/packages/instrumentation-net/test/tls.test.ts
+++ b/packages/instrumentation-net/test/tls.test.ts
@@ -100,7 +100,11 @@ describe('NetInstrumentation', () => {
           },
         },
         () => {
-          assertTLSSpan(getTLSSpans(), tlsSocket, DEFAULT_NET_SEMCONV_STABILITY);
+          assertTLSSpan(
+            getTLSSpans(),
+            tlsSocket,
+            DEFAULT_NET_SEMCONV_STABILITY
+          );
           done();
         }
       );
@@ -133,7 +137,11 @@ describe('NetInstrumentation', () => {
           },
         },
         () => {
-          assertTLSSpan(getTLSSpans(), tlsSocket, DEFAULT_NET_SEMCONV_STABILITY);
+          assertTLSSpan(
+            getTLSSpans(),
+            tlsSocket,
+            DEFAULT_NET_SEMCONV_STABILITY
+          );
           done();
         }
       );

--- a/packages/instrumentation-net/test/utils.ts
+++ b/packages/instrumentation-net/test/utils.ts
@@ -17,7 +17,15 @@
 import { SpanKind, type Attributes } from '@opentelemetry/api';
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { SemconvStability } from '@opentelemetry/instrumentation';
-import { ATTR_NETWORK_LOCAL_ADDRESS, ATTR_NETWORK_LOCAL_PORT, ATTR_NETWORK_PEER_ADDRESS, ATTR_NETWORK_TRANSPORT, ATTR_SERVER_ADDRESS, ATTR_SERVER_PORT, NETWORK_TRANSPORT_VALUE_TCP } from '@opentelemetry/semantic-conventions';
+import {
+  ATTR_NETWORK_LOCAL_ADDRESS,
+  ATTR_NETWORK_LOCAL_PORT,
+  ATTR_NETWORK_PEER_ADDRESS,
+  ATTR_NETWORK_TRANSPORT,
+  ATTR_SERVER_ADDRESS,
+  ATTR_SERVER_PORT,
+  NETWORK_TRANSPORT_VALUE_TCP,
+} from '@opentelemetry/semantic-conventions';
 import {
   ATTR_NET_HOST_IP,
   ATTR_NET_HOST_PORT,
@@ -31,7 +39,10 @@ import * as assert from 'assert';
 import * as path from 'path';
 import * as os from 'os';
 import { Socket } from 'net';
-import { OLD_IPC_TRANSPORT_VALUE, STABLE_IPC_TRANSPORT_VALUE } from '../src/utils';
+import {
+  OLD_IPC_TRANSPORT_VALUE,
+  STABLE_IPC_TRANSPORT_VALUE,
+} from '../src/utils';
 import { TLSAttributes } from '../src/types';
 import * as fs from 'fs';
 
@@ -42,7 +53,11 @@ export const IPC_PATH =
     ? path.join(os.tmpdir(), 'otel-js-net-test-ipc')
     : '\\\\.\\pipe\\otel-js-net-test-ipc';
 
-export function assertTcpSpan(span: ReadableSpan, socket: Socket, netSemconvStability: SemconvStability) {
+export function assertTcpSpan(
+  span: ReadableSpan,
+  socket: Socket,
+  netSemconvStability: SemconvStability
+) {
   assertSpanKind(span);
 
   const attributes: Attributes = {};
@@ -65,7 +80,10 @@ export function assertTcpSpan(span: ReadableSpan, socket: Socket, netSemconvStab
   assert.deepEqual(span.attributes, attributes);
 }
 
-export function assertIpcSpan(span: ReadableSpan, netSemconvStability: SemconvStability) {
+export function assertIpcSpan(
+  span: ReadableSpan,
+  netSemconvStability: SemconvStability
+) {
   assertSpanKind(span);
   const attributes: Attributes = {};
   if (netSemconvStability & SemconvStability.OLD) {
@@ -82,7 +100,7 @@ export function assertIpcSpan(span: ReadableSpan, netSemconvStability: SemconvSt
 export function assertTLSSpan(
   { netSpan, tlsSpan }: { netSpan: ReadableSpan; tlsSpan: ReadableSpan },
   _socket: Socket,
-  netSemconvStability: SemconvStability,
+  netSemconvStability: SemconvStability
 ) {
   assertParentChild(tlsSpan, netSpan);
   assertSpanKind(netSpan);

--- a/packages/instrumentation-pg/src/instrumentation.ts
+++ b/packages/instrumentation-pg/src/instrumentation.ts
@@ -78,9 +78,9 @@ function extractModuleExports(module: any) {
 }
 
 export class PgInstrumentation extends InstrumentationBase<PgInstrumentationConfig> {
-  private declare _operationDuration: Histogram;
-  private declare _connectionsCount: UpDownCounter;
-  private declare _connectionPendingRequests: UpDownCounter;
+  declare private _operationDuration: Histogram;
+  declare private _connectionsCount: UpDownCounter;
+  declare private _connectionPendingRequests: UpDownCounter;
   // Pool events connect, acquire, release and remove can be called
   // multiple times without changing the values of total, idle and waiting
   // connections. The _connectionsCounter is used to keep track of latest

--- a/packages/instrumentation-pino/src/log-sending-utils.ts
+++ b/packages/instrumentation-pino/src/log-sending-utils.ts
@@ -131,10 +131,10 @@ interface OTelPinoStreamOptions {
  *   The event arguments are: `logLine: string`, `err: string | Error`.
  */
 export class OTelPinoStream extends Writable {
-  private declare _otelLogger: Logger;
-  private declare _messageKey: string;
-  private declare _levels;
-  private declare _otelTimestampFromTime;
+  declare private _otelLogger: Logger;
+  declare private _messageKey: string;
+  declare private _levels;
+  declare private _otelTimestampFromTime;
 
   constructor(options: OTelPinoStreamOptions) {
     super();

--- a/packages/instrumentation-redis/src/v4-v5/instrumentation.ts
+++ b/packages/instrumentation-redis/src/v4-v5/instrumentation.ts
@@ -501,8 +501,8 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
     const operationName = allSameCommand
       ? (isPipeline ? 'PIPELINE ' : 'MULTI ') + allCommands[0]
       : isPipeline
-      ? 'PIPELINE'
-      : 'MULTI';
+        ? 'PIPELINE'
+        : 'MULTI';
 
     for (let i = 0; i < openSpans.length; i++) {
       const { span, commandArgs } = openSpans[i];

--- a/packages/instrumentation-router/src/router.d.ts
+++ b/packages/instrumentation-router/src/router.d.ts
@@ -240,7 +240,9 @@ declare module 'router' {
     }
 
     interface RouterConstructor extends IRouter {
-      new (options?: RouterOptions): IRouter &
+      new (
+        options?: RouterOptions
+      ): IRouter &
         ((
           req: http.IncomingMessage,
           res: http.ServerResponse,

--- a/packages/instrumentation-runtime-node/src/semconv.ts
+++ b/packages/instrumentation-runtime-node/src/semconv.ts
@@ -50,7 +50,8 @@ export const ATTR_V8JS_HEAP_SPACE_NAME = 'v8js.heap.space.name' as const;
  *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const METRIC_NODEJS_EVENTLOOP_DELAY_MAX = 'nodejs.eventloop.delay.max' as const;
+export const METRIC_NODEJS_EVENTLOOP_DELAY_MAX =
+  'nodejs.eventloop.delay.max' as const;
 
 /**
  * Event loop mean delay.
@@ -59,7 +60,8 @@ export const METRIC_NODEJS_EVENTLOOP_DELAY_MAX = 'nodejs.eventloop.delay.max' as
  *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const METRIC_NODEJS_EVENTLOOP_DELAY_MEAN = 'nodejs.eventloop.delay.mean' as const;
+export const METRIC_NODEJS_EVENTLOOP_DELAY_MEAN =
+  'nodejs.eventloop.delay.mean' as const;
 
 /**
  * Event loop minimum delay.
@@ -68,7 +70,8 @@ export const METRIC_NODEJS_EVENTLOOP_DELAY_MEAN = 'nodejs.eventloop.delay.mean' 
  *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const METRIC_NODEJS_EVENTLOOP_DELAY_MIN = 'nodejs.eventloop.delay.min' as const;
+export const METRIC_NODEJS_EVENTLOOP_DELAY_MIN =
+  'nodejs.eventloop.delay.min' as const;
 
 /**
  * Event loop 50 percentile delay.
@@ -77,7 +80,8 @@ export const METRIC_NODEJS_EVENTLOOP_DELAY_MIN = 'nodejs.eventloop.delay.min' as
  *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const METRIC_NODEJS_EVENTLOOP_DELAY_P50 = 'nodejs.eventloop.delay.p50' as const;
+export const METRIC_NODEJS_EVENTLOOP_DELAY_P50 =
+  'nodejs.eventloop.delay.p50' as const;
 
 /**
  * Event loop 90 percentile delay.
@@ -86,7 +90,8 @@ export const METRIC_NODEJS_EVENTLOOP_DELAY_P50 = 'nodejs.eventloop.delay.p50' as
  *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const METRIC_NODEJS_EVENTLOOP_DELAY_P90 = 'nodejs.eventloop.delay.p90' as const;
+export const METRIC_NODEJS_EVENTLOOP_DELAY_P90 =
+  'nodejs.eventloop.delay.p90' as const;
 
 /**
  * Event loop 99 percentile delay.
@@ -95,7 +100,8 @@ export const METRIC_NODEJS_EVENTLOOP_DELAY_P90 = 'nodejs.eventloop.delay.p90' as
  *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const METRIC_NODEJS_EVENTLOOP_DELAY_P99 = 'nodejs.eventloop.delay.p99' as const;
+export const METRIC_NODEJS_EVENTLOOP_DELAY_P99 =
+  'nodejs.eventloop.delay.p99' as const;
 
 /**
  * Event loop standard deviation delay.
@@ -104,7 +110,8 @@ export const METRIC_NODEJS_EVENTLOOP_DELAY_P99 = 'nodejs.eventloop.delay.p99' as
  *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const METRIC_NODEJS_EVENTLOOP_DELAY_STDDEV = 'nodejs.eventloop.delay.stddev' as const;
+export const METRIC_NODEJS_EVENTLOOP_DELAY_STDDEV =
+  'nodejs.eventloop.delay.stddev' as const;
 
 /**
  * Cumulative duration of time the event loop has been in each state.
@@ -122,7 +129,8 @@ export const METRIC_NODEJS_EVENTLOOP_TIME = 'nodejs.eventloop.time' as const;
  *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const METRIC_NODEJS_EVENTLOOP_UTILIZATION = 'nodejs.eventloop.utilization' as const;
+export const METRIC_NODEJS_EVENTLOOP_UTILIZATION =
+  'nodejs.eventloop.utilization' as const;
 
 /**
  * Garbage collection duration.
@@ -149,7 +157,8 @@ export const METRIC_V8JS_MEMORY_HEAP_LIMIT = 'v8js.memory.heap.limit' as const;
  *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const METRIC_V8JS_MEMORY_HEAP_SPACE_AVAILABLE_SIZE = 'v8js.memory.heap.space.available_size' as const;
+export const METRIC_V8JS_MEMORY_HEAP_SPACE_AVAILABLE_SIZE =
+  'v8js.memory.heap.space.available_size' as const;
 
 /**
  * Committed size of a heap space.
@@ -158,7 +167,8 @@ export const METRIC_V8JS_MEMORY_HEAP_SPACE_AVAILABLE_SIZE = 'v8js.memory.heap.sp
  *
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
-export const METRIC_V8JS_MEMORY_HEAP_SPACE_PHYSICAL_SIZE = 'v8js.memory.heap.space.physical_size' as const;
+export const METRIC_V8JS_MEMORY_HEAP_SPACE_PHYSICAL_SIZE =
+  'v8js.memory.heap.space.physical_size' as const;
 
 /**
  * Heap Memory size allocated.

--- a/packages/instrumentation-runtime-node/test/event_loop_utilization.test.ts
+++ b/packages/instrumentation-runtime-node/test/event_loop_utilization.test.ts
@@ -120,8 +120,8 @@ describe('nodejs.eventloop.utilization', function () {
       const { resourceMetrics } = await metricReader.collect();
       const scopeMetrics = resourceMetrics.scopeMetrics;
       const utilizationMetric = scopeMetrics[0].metrics.find(
-      x => x.descriptor.name === METRIC_NODEJS_EVENTLOOP_UTILIZATION
-    );
+        x => x.descriptor.name === METRIC_NODEJS_EVENTLOOP_UTILIZATION
+      );
 
       assert.notEqual(utilizationMetric, undefined, 'metric not found');
       assert.strictEqual(

--- a/packages/instrumentation-tedious/src/instrumentation.ts
+++ b/packages/instrumentation-tedious/src/instrumentation.ts
@@ -279,7 +279,7 @@ export class TediousInstrumentation extends InstrumentationBase<TediousInstrumen
         if (!shouldInject) return runUserRequest();
 
         const traceparent = thisPlugin._buildTraceparent(span);
-        
+
         void thisPlugin
           ._injectContextInfo(this, tediousModule, traceparent)
           .finally(runUserRequest);

--- a/packages/instrumentation-undici/src/types.ts
+++ b/packages/instrumentation-undici/src/types.ts
@@ -55,7 +55,7 @@ export interface RequestHookFunction<T = UndiciRequest> {
 
 export interface ResponseHookFunction<
   RequestType = UndiciRequest,
-  ResponseType = UndiciResponse
+  ResponseType = UndiciResponse,
 > {
   (span: Span, info: { request: RequestType; response: ResponseType }): void;
 }
@@ -68,7 +68,7 @@ export interface StartSpanHookFunction<T = UndiciRequest> {
 // so it seems logical to have similar options than the HTTP instrumentation
 export interface UndiciInstrumentationConfig<
   RequestType = UndiciRequest,
-  ResponseType = UndiciResponse
+  ResponseType = UndiciResponse,
 > extends InstrumentationConfig {
   /** Not trace all outgoing requests that matched with custom function */
   ignoreRequestHook?: IgnoreRequestFunction<RequestType>;

--- a/packages/instrumentation-undici/src/undici.ts
+++ b/packages/instrumentation-undici/src/undici.ts
@@ -78,10 +78,10 @@ interface InstrumentationRecord {
 export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumentationConfig> {
   // Keep ref to avoid https://github.com/nodejs/node/issues/42170 bug and for
   // unsubscribing.
-  private declare _channelSubs: Array<ListenerRecord>;
+  declare private _channelSubs: Array<ListenerRecord>;
   private _recordFromReq = new WeakMap<UndiciRequest, InstrumentationRecord>();
 
-  private declare _httpClientDurationHistogram: Histogram;
+  declare private _httpClientDurationHistogram: Histogram;
 
   constructor(config: UndiciInstrumentationConfig = {}) {
     super(PACKAGE_NAME, PACKAGE_VERSION, config);

--- a/packages/instrumentation-user-interaction/src/instrumentation.ts
+++ b/packages/instrumentation-user-interaction/src/instrumentation.ts
@@ -54,7 +54,7 @@ export class UserInteractionInstrumentation extends InstrumentationBase<UserInte
   readonly version = PACKAGE_VERSION;
   readonly moduleName: string = 'user-interaction';
   private _spansData = new WeakMap<api.Span, SpanData>();
-  private declare _zonePatched?: boolean;
+  declare private _zonePatched?: boolean;
   // for addEventListener/removeEventListener state
   private _wrappedListeners = new WeakMap<
     Function | EventListenerObject,

--- a/packages/instrumentation-web-exception/src/instrumentation.ts
+++ b/packages/instrumentation-web-exception/src/instrumentation.ts
@@ -52,7 +52,7 @@ export class ExceptionInstrumentation extends InstrumentationBase<GlobalErrorsIn
     this.onError = this.onError.bind(this);
   }
 
-  init() { }
+  init() {}
 
   onError(event: ErrorEvent | PromiseRejectionEvent) {
     const EXCEPTION_EVENT_NAME = 'exception';

--- a/packages/instrumentation-web-exception/test/instrumentation.test.ts
+++ b/packages/instrumentation-web-exception/test/instrumentation.test.ts
@@ -31,12 +31,14 @@ import {
 import { logs } from '@opentelemetry/api-logs';
 const assert = chai.assert;
 
-const STRING_ERROR = 'Some error string.'
+const STRING_ERROR = 'Some error string.';
 
 describe('ExceptionInstrumentation', () => {
   const exporter = new InMemoryLogRecordExporter();
   const logRecordProcessor = new SimpleLogRecordProcessor(exporter);
-  const loggerProvider = new LoggerProvider({processors:[logRecordProcessor]});
+  const loggerProvider = new LoggerProvider({
+    processors: [logRecordProcessor],
+  });
   logs.setGlobalLoggerProvider(loggerProvider);
 
   // Helper function to throw an error of a specific type so that we can allow the error to propagate and test the instrumentation.
@@ -139,8 +141,14 @@ describe('ExceptionInstrumentation', () => {
         const events = exporter.getFinishedLogRecords();
         assert.ok(events.length > 0, 'Expected at least one log record');
         const event = events[0];
-        assert.strictEqual(event.attributes[ATTR_EXCEPTION_MESSAGE], 'Something happened!');
-        assert.strictEqual(event.attributes[ATTR_EXCEPTION_TYPE], 'ValidationError');
+        assert.strictEqual(
+          event.attributes[ATTR_EXCEPTION_MESSAGE],
+          'Something happened!'
+        );
+        assert.strictEqual(
+          event.attributes[ATTR_EXCEPTION_TYPE],
+          'ValidationError'
+        );
         assert.strictEqual(event.attributes[ATTR_EXCEPTION_STACKTRACE], stack);
       }, 0);
     });
@@ -154,7 +162,10 @@ describe('ExceptionInstrumentation', () => {
         const events = exporter.getFinishedLogRecords();
         assert.ok(events.length > 0, 'Expected at least one log record');
         const event = events[0];
-        assert.strictEqual(event.attributes[ATTR_EXCEPTION_MESSAGE], STRING_ERROR);
+        assert.strictEqual(
+          event.attributes[ATTR_EXCEPTION_MESSAGE],
+          STRING_ERROR
+        );
       }, 0);
     });
   });
@@ -208,8 +219,14 @@ describe('ExceptionInstrumentation', () => {
         const events = exporter.getFinishedLogRecords();
         assert.ok(events.length > 0, 'Expected at least one log record');
         const event = events[0];
-        assert.strictEqual(event.attributes[ATTR_EXCEPTION_MESSAGE], STRING_ERROR);
-        assert.strictEqual(event.attributes['app.custom.exception'], STRING_ERROR.toLocaleUpperCase());
+        assert.strictEqual(
+          event.attributes[ATTR_EXCEPTION_MESSAGE],
+          STRING_ERROR
+        );
+        assert.strictEqual(
+          event.attributes['app.custom.exception'],
+          STRING_ERROR.toLocaleUpperCase()
+        );
       }, 0);
     });
   });

--- a/packages/propagator-aws-xray/src/AWSXRayPropagator.ts
+++ b/packages/propagator-aws-xray/src/AWSXRayPropagator.ts
@@ -85,7 +85,7 @@ export class AWSXRayPropagator implements TextMapPropagator {
     const existingSpan = trace.getSpan(context);
     const existingTraceState = existingSpan?.spanContext()?.traceState;
     if (existingTraceState) {
-      spanContext.traceState = existingTraceState
+      spanContext.traceState = existingTraceState;
     }
     return trace.setSpan(context, trace.wrapSpanContext(spanContext));
   }

--- a/packages/resource-detector-azure/src/types.ts
+++ b/packages/resource-detector-azure/src/types.ts
@@ -82,7 +82,7 @@ export interface AzureVmMetadata {
     {
       keyData?: string;
       path?: string;
-    }
+    },
   ];
   publisher?: string;
   resourceGroupName?: string;
@@ -118,7 +118,7 @@ export interface AzureVmMetadata {
           uri?: string;
         };
         writeAcceleratorEnabled?: string;
-      }
+      },
     ];
     imageReference?: {
       id?: string;

--- a/packages/sampler-aws-xray/test/aws-xray-sampling-client.test.ts
+++ b/packages/sampler-aws-xray/test/aws-xray-sampling-client.test.ts
@@ -173,8 +173,9 @@ describe('AWSXRaySamplingClient', () => {
   });
 
   it('testGetSamplingTargets', done => {
-    const data = require(DATA_DIR +
-      '/get-sampling-targets-response-sample.json');
+    const data = require(
+      DATA_DIR + '/get-sampling-targets-response-sample.json'
+    );
     nock(TEST_URL).post('/SamplingTargets').reply(200, data);
 
     const client = new AWSXRaySamplingClient(TEST_URL, new DiagConsoleLogger());

--- a/packages/sampler-aws-xray/test/sampling-rule-applier.test.ts
+++ b/packages/sampler-aws-xray/test/sampling-rule-applier.test.ts
@@ -41,8 +41,9 @@ const DATA_DIR = __dirname + '/data';
 
 describe('SamplingRuleApplier', () => {
   it('testApplierAttributeMatchingFromXRayResponse', () => {
-    const sampleData = require(DATA_DIR +
-      '/get-sampling-rules-response-sample-2.json');
+    const sampleData = require(
+      DATA_DIR + '/get-sampling-rules-response-sample-2.json'
+    );
 
     const allRules = sampleData['SamplingRuleRecords'];
     const defaultRule: SamplingRule = allRules[0]['SamplingRule'];

--- a/scripts/codecov-upload-flags.mjs
+++ b/scripts/codecov-upload-flags.mjs
@@ -42,6 +42,7 @@ const pkgsWithFlag = pkgFiles.flat().map(f => {
   //   ./codecov --verbose upload-coverage --help
   // ```
   // or check https://docs.codecov.com/docs/cli-options
+  // prettier-ignore
   const command = [
     './codecov --verbose',
     'upload-coverage',
@@ -93,7 +94,10 @@ if (existsSync(codecovPath)) {
   );
   execSync(`curl -O "${url}.SHA256SUM"`, execOpts);
   execSync(`curl -O "${url}.SHA256SUM.sig"`, execOpts);
-  execSync('gpg --verify "codecov.SHA256SUM.sig" "codecov.SHA256SUM"', execOpts);
+  execSync(
+    'gpg --verify "codecov.SHA256SUM.sig" "codecov.SHA256SUM"',
+    execOpts
+  );
 }
 // make sure we have exec perms
 chmodSync(codecovPath, 0o555);

--- a/scripts/gen-semconv-ts.js
+++ b/scripts/gen-semconv-ts.js
@@ -72,10 +72,9 @@ function genSemconvTs(wsDir) {
     paths: [path.join(wsDir, 'node_modules')],
   });
   const semconvStable = require(semconvPath);
-  const semconvVer = require(path.resolve(
-    semconvPath,
-    '../../../package.json'
-  )).version;
+  const semconvVer = require(
+    path.resolve(semconvPath, '../../../package.json')
+  ).version;
 
   // Gather unstable semconv imports. Consider any imports from
   // '@opentelemetry/semantic-conventions/incubating' or from an existing local

--- a/scripts/lint-readme.js
+++ b/scripts/lint-readme.js
@@ -20,10 +20,12 @@ const path = require('path');
 const packageRoot = process.cwd();
 const monorepoRoot = path.resolve(__dirname, '..');
 
-const autoInstrumentationNodeDeps =
-  require(`${monorepoRoot}/packages/auto-instrumentations-node/package.json`).dependencies;
-const autoInstrumentationWebDeps =
-  require(`${monorepoRoot}/packages/auto-instrumentations-web/package.json`).dependencies;
+const autoInstrumentationNodeDeps = require(
+  `${monorepoRoot}/packages/auto-instrumentations-node/package.json`
+).dependencies;
+const autoInstrumentationWebDeps = require(
+  `${monorepoRoot}/packages/auto-instrumentations-web/package.json`
+).dependencies;
 
 // remove exempt instrumentations
 delete autoInstrumentationNodeDeps['@opentelemetry/instrumentation-fastify'];


### PR DESCRIPTION
This re-adds running prettier as part of the 'lint' step. There are separate
`lint:prettier` and `lint:prettier:fix` scripts if one wants to run just style checking.

Refs: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3001

---

AFAICT prettier is no longer being run. My theory is that #3001 accidentally caused that. 

Update: The accident is that we didn't follow-up after 3001 to add running `prettier` *separately*. Prettier's [recommendation is to run prettier separate from linters](https://prettier.io/docs/integrating-with-linters#notes), which I can get behind.