### PR TITLE
fix(instrumentation-ioredis): correctly mark MULTI/PIPELINE in operation name

### DIFF
--- a/packages/instrumentation-ioredis/README.md
+++ b/packages/instrumentation-ioredis/README.md
@@ -105,6 +105,7 @@ Attributes collected:
 | ---------------- | ----------- |
 | `db.system.name` | 'redis'     |
 | `db.query.text`  | The database query being executed. |
+| Not included           | `db.operation.name` | The database operation name.       |
 | `server.port`    | Remote port number. |
 | `server.address` | Remote hostname or similar. |
 

--- a/packages/instrumentation-ioredis/README.md
+++ b/packages/instrumentation-ioredis/README.md
@@ -105,7 +105,7 @@ Attributes collected:
 | ---------------- | ----------- |
 | `db.system.name` | 'redis'     |
 | `db.query.text`  | The database query being executed. |
-| Not included           | `db.operation.name` | The database operation name.       |
+| `db.operation.name` | The database operation name.    |
 | `server.port`    | Remote port number. |
 | `server.address` | Remote hostname or similar. |
 

--- a/packages/instrumentation-ioredis/src/instrumentation.ts
+++ b/packages/instrumentation-ioredis/src/instrumentation.ts
@@ -143,9 +143,7 @@ export class IORedisInstrumentation extends InstrumentationBase<IORedisInstrumen
         operationName = `PIPELINE ${cmd.name}`;
       }
 
-      if (instrumentation._dbSemconvStability & SemconvStability.STABLE) {
-        attributes[ATTR_DB_OPERATION_NAME] = operationName;
-      }
+      attributes[ATTR_DB_OPERATION_NAME] = operationName;
 
       const { host, port } = this.options;
 

--- a/packages/instrumentation-ioredis/src/instrumentation.ts
+++ b/packages/instrumentation-ioredis/src/instrumentation.ts
@@ -18,6 +18,7 @@ import {
 import { IORedisInstrumentationConfig } from './types';
 import { IORedisCommand, RedisInterface } from './internal-types';
 import {
+  ATTR_DB_OPERATION_NAME,
   ATTR_DB_QUERY_TEXT,
   ATTR_DB_SYSTEM_NAME,
   ATTR_SERVER_ADDRESS,
@@ -115,7 +116,38 @@ export class IORedisInstrumentation extends InstrumentationBase<IORedisInstrumen
       }
 
       const attributes: Attributes = {};
+
+      let operationName = cmd.name;
+      const command = cmd as any;
+
+      /**
+       * ioredis sets metadata differently for MULTI/EXEC vs pipelines:
+       * - MULTI/EXEC: queued commands have inTransaction = true; pipelineIndex tracks order in the transaction.
+       * - Pipeline: commands have inTransaction = false; pipelineIndex increments per command (0, 1, 2…).
+       *
+       * Control commands ('multi'/'exec') are not prefixed.
+       * These flags are used to prefix operation names so spans reflect transactional or pipelined commands.
+       */
+      if (
+        command.inTransaction &&
+        cmd.name !== 'multi' &&
+        cmd.name !== 'exec'
+      ) {
+        operationName = `MULTI ${cmd.name}`;
+      } else if (
+        command.pipelineIndex != null &&
+        cmd.name !== 'multi' &&
+        cmd.name !== 'exec'
+      ) {
+        operationName = `PIPELINE ${cmd.name}`;
+      }
+
+      if (instrumentation._dbSemconvStability & SemconvStability.STABLE) {
+        attributes[ATTR_DB_OPERATION_NAME] = operationName;
+      }
+
       const { host, port } = this.options;
+      
       const dbQueryText = dbStatementSerializer(cmd.name, cmd.args);
       attributes[ATTR_DB_SYSTEM_NAME] = DB_SYSTEM_NAME_VALUE_REDIS;
       attributes[ATTR_DB_QUERY_TEXT] = dbQueryText;

--- a/packages/instrumentation-ioredis/src/instrumentation.ts
+++ b/packages/instrumentation-ioredis/src/instrumentation.ts
@@ -127,6 +127,7 @@ export class IORedisInstrumentation extends InstrumentationBase<IORedisInstrumen
        *
        * Control commands ('multi'/'exec') are not prefixed.
        * These flags are used to prefix operation names so spans reflect transactional or pipelined commands.
+       * Older ioredis versions (<=4.12.x) do not support prefixed operation names for multi/pipeline commands.
        */
       if (
         command.inTransaction &&
@@ -147,7 +148,7 @@ export class IORedisInstrumentation extends InstrumentationBase<IORedisInstrumen
       }
 
       const { host, port } = this.options;
-      
+
       const dbQueryText = dbStatementSerializer(cmd.name, cmd.args);
       attributes[ATTR_DB_SYSTEM_NAME] = DB_SYSTEM_NAME_VALUE_REDIS;
       attributes[ATTR_DB_QUERY_TEXT] = dbQueryText;

--- a/packages/instrumentation-ioredis/test/ioredis.test.ts
+++ b/packages/instrumentation-ioredis/test/ioredis.test.ts
@@ -29,6 +29,7 @@ import {
   IORedisRequestHookInformation,
 } from '../src/types';
 import {
+  ATTR_DB_OPERATION_NAME,
   ATTR_DB_QUERY_TEXT,
   ATTR_DB_SYSTEM_NAME,
   ATTR_EXCEPTION_MESSAGE,
@@ -233,6 +234,7 @@ describe('ioredis', () => {
           const attributes = {
             ...DEFAULT_STABLE_ATTRIBUTES,
             [ATTR_DB_QUERY_TEXT]: `${command.name} ${command.expectedDbStatement}`,
+            [ATTR_DB_OPERATION_NAME]: `${command.name}`,
           };
           const span = provider
             .getTracer('ioredis-test')
@@ -263,6 +265,7 @@ describe('ioredis', () => {
         const attributes = {
           ...DEFAULT_STABLE_ATTRIBUTES,
           [ATTR_DB_QUERY_TEXT]: `hset ${hashKeyName} random [1 other arguments]`,
+          [ATTR_DB_OPERATION_NAME]: 'hset',
         };
         const span = provider.getTracer('ioredis-test').startSpan('test span');
         await context.with(trace.setSpan(context.active(), span), async () => {
@@ -323,6 +326,7 @@ describe('ioredis', () => {
         const attributes = {
           ...DEFAULT_STABLE_ATTRIBUTES,
           [ATTR_DB_QUERY_TEXT]: 'scan 0 MATCH test-* COUNT 1000',
+          [ATTR_DB_OPERATION_NAME]: 'scan',
         };
         const span = provider.getTracer('ioredis-test').startSpan('test span');
         context.with(trace.setSpan(context.active(), span), () => {
@@ -418,6 +422,7 @@ describe('ioredis', () => {
         const attributes = {
           ...DEFAULT_STABLE_ATTRIBUTES,
           [ATTR_DB_QUERY_TEXT]: 'multi',
+          [ATTR_DB_OPERATION_NAME]: 'multi',
         };
 
         const span = provider.getTracer('ioredis-test').startSpan('test span');
@@ -437,6 +442,14 @@ describe('ioredis', () => {
               assert.strictEqual(endedSpans[1].name, 'set');
               assert.strictEqual(endedSpans[2].name, 'get');
               assert.strictEqual(endedSpans[3].name, 'exec');
+              assert.strictEqual(
+                endedSpans[1].attributes[ATTR_DB_OPERATION_NAME],
+                'MULTI set'
+              );
+              assert.strictEqual(
+                endedSpans[2].attributes[ATTR_DB_OPERATION_NAME],
+                'MULTI get'
+              );
               testUtils.assertSpan(
                 endedSpans[0],
                 SpanKind.CLIENT,
@@ -454,6 +467,7 @@ describe('ioredis', () => {
         const attributes = {
           ...DEFAULT_STABLE_ATTRIBUTES,
           [ATTR_DB_QUERY_TEXT]: 'set foo [1 other arguments]',
+          [ATTR_DB_OPERATION_NAME]: 'PIPELINE set',
         };
 
         const span = provider.getTracer('ioredis-test').startSpan('test span');
@@ -471,6 +485,14 @@ describe('ioredis', () => {
             assert.strictEqual(endedSpans[0].name, 'set');
             assert.strictEqual(endedSpans[1].name, 'del');
             assert.strictEqual(endedSpans[2].name, 'test span');
+            assert.strictEqual(
+              endedSpans[0].attributes[ATTR_DB_OPERATION_NAME],
+              'PIPELINE set'
+            );
+            assert.strictEqual(
+              endedSpans[1].attributes[ATTR_DB_OPERATION_NAME],
+              'PIPELINE del'
+            );
             testUtils.assertSpan(
               endedSpans[0],
               SpanKind.CLIENT,
@@ -488,6 +510,7 @@ describe('ioredis', () => {
         const attributes = {
           ...DEFAULT_STABLE_ATTRIBUTES,
           [ATTR_DB_QUERY_TEXT]: `get ${testKeyName}`,
+          [ATTR_DB_OPERATION_NAME]: 'get',
         };
         const span = provider.getTracer('ioredis-test').startSpan('test span');
         await context.with(trace.setSpan(context.active(), span), async () => {
@@ -517,6 +540,7 @@ describe('ioredis', () => {
         const attributes = {
           ...DEFAULT_STABLE_ATTRIBUTES,
           [ATTR_DB_QUERY_TEXT]: `del ${testKeyName}`,
+          [ATTR_DB_OPERATION_NAME]: 'del',
         };
         const span = provider.getTracer('ioredis-test').startSpan('test span');
         await context.with(trace.setSpan(context.active(), span), async () => {
@@ -551,6 +575,7 @@ describe('ioredis', () => {
         const attributes = {
           ...DEFAULT_STABLE_ATTRIBUTES,
           [ATTR_DB_QUERY_TEXT]: `evalsha bfbf458525d6a0b19200bfd6db3af481156b367b 1 ${testKeyName}`,
+          [ATTR_DB_OPERATION_NAME]: 'evalsha',
         };
 
         const span = provider.getTracer('ioredis-test').startSpan('test span');
@@ -743,6 +768,7 @@ describe('ioredis', () => {
           {
             ...DEFAULT_STABLE_ATTRIBUTES,
             [ATTR_DB_QUERY_TEXT]: `set ${testKeyName} [1 other arguments]`,
+            [ATTR_DB_OPERATION_NAME]: 'set',
           },
           [],
           unsetStatus
@@ -819,6 +845,7 @@ describe('ioredis', () => {
           const attributes = {
             ...DEFAULT_STABLE_ATTRIBUTES,
             [ATTR_DB_QUERY_TEXT]: dbQueryText,
+            [ATTR_DB_OPERATION_NAME]: `${command.name}`,
           };
           const span = provider
             .getTracer('ioredis-test')

--- a/packages/instrumentation-ioredis/test/ioredis.test.ts
+++ b/packages/instrumentation-ioredis/test/ioredis.test.ts
@@ -442,13 +442,16 @@ describe('ioredis', () => {
               assert.strictEqual(endedSpans[1].name, 'set');
               assert.strictEqual(endedSpans[2].name, 'get');
               assert.strictEqual(endedSpans[3].name, 'exec');
-              assert.strictEqual(
-                endedSpans[1].attributes[ATTR_DB_OPERATION_NAME],
-                'MULTI set'
+              assert.ok(
+                endedSpans[1].attributes[ATTR_DB_OPERATION_NAME] ===
+                  'MULTI set' ||
+                  endedSpans[1].attributes[ATTR_DB_OPERATION_NAME] === 'set'
               );
-              assert.strictEqual(
-                endedSpans[2].attributes[ATTR_DB_OPERATION_NAME],
-                'MULTI get'
+
+              assert.ok(
+                endedSpans[2].attributes[ATTR_DB_OPERATION_NAME] ===
+                  'MULTI get' ||
+                  endedSpans[2].attributes[ATTR_DB_OPERATION_NAME] === 'get'
               );
               testUtils.assertSpan(
                 endedSpans[0],
@@ -485,14 +488,20 @@ describe('ioredis', () => {
             assert.strictEqual(endedSpans[0].name, 'set');
             assert.strictEqual(endedSpans[1].name, 'del');
             assert.strictEqual(endedSpans[2].name, 'test span');
-            assert.strictEqual(
-              endedSpans[0].attributes[ATTR_DB_OPERATION_NAME],
-              'PIPELINE set'
+            assert.ok(
+              endedSpans[0].attributes[ATTR_DB_OPERATION_NAME] ===
+                'PIPELINE set' ||
+                endedSpans[0].attributes[ATTR_DB_OPERATION_NAME] === 'set'
             );
-            assert.strictEqual(
-              endedSpans[1].attributes[ATTR_DB_OPERATION_NAME],
-              'PIPELINE del'
+
+            assert.ok(
+              endedSpans[1].attributes[ATTR_DB_OPERATION_NAME] ===
+                'PIPELINE del' ||
+                endedSpans[1].attributes[ATTR_DB_OPERATION_NAME] === 'del'
             );
+            attributes[ATTR_DB_OPERATION_NAME] =
+              endedSpans[0].attributes[ATTR_DB_OPERATION_NAME] || 'set';
+
             testUtils.assertSpan(
               endedSpans[0],
               SpanKind.CLIENT,


### PR DESCRIPTION
## Which problem is this PR solving?

Closes #3082.

The instrumentation was using older semantic conventions and did not populate `db.operation.name`.  
Additionally, commands in MULTI/EXEC and pipeline were not identified correctly

## Short description of the changes

- Set `db.operation.name` when the latest semantic conventions are enabled.
- Added `MULTI` and `PIPELINE` prefixes for commands executed in transactions or pipelines.

