### PR TITLE
docs(instrumentation-pg): document span types created by instrumentation

### DIFF
--- a/packages/instrumentation-pg/README.md
+++ b/packages/instrumentation-pg/README.md
@@ -39,6 +39,18 @@ registerInstrumentations({
 
 PgInstrumentation contains both pg and [`pg.Pool`](https://node-postgres.com/api/pool) so it will be instrumented automatically.
 
+### Span Types Created
+
+This instrumentation creates the following span types:
+
+| Span Name | Description | When Created |
+| --------- | ----------- | ------------ |
+| `pg.query:<OPERATION> <database>` | Database query execution | When `client.query()` is called |
+| `pg.connect` | Client connection to database | When `new Client().connect()` is called directly |
+| `pg-pool.connect` | Pool connection acquisition wait time | When acquiring a connection from `pg-pool` |
+
+The `pg-pool.connect` spans measure the time spent waiting to acquire a connection from the pool. This can be valuable for identifying connection pool exhaustion or sizing issues. However, in high-throughput scenarios where connections are readily available, these spans may add noise with minimal diagnostic value. Consider using the `requireParentSpan` option or sampling strategies if pool connect spans become excessive.
+
 ### PostgreSQL Instrumentation Options
 
 PostgreSQL instrumentation has few options available to choose from. You can set the following:


### PR DESCRIPTION
## Description

Add documentation to README.md explaining the span types created by the pg instrumentation.

When adding an instrumentation, users often want to know what spans it will create - especially if they want to filter or customize them later. This is particularly relevant for `pg-pool.connect` spans which measure connection pool wait time but can add noise in high-throughput scenarios.

## Changes

Added a new "Span Types Created" section to README.md after "## Usage" with:

| Span Name | Description | When Created |
| --------- | ----------- | ------------ |
| `pg.query:<OPERATION> <database>` | Database query execution | When `client.query()` is called |
| `pg.connect` | Client connection to database | When `new Client().connect()` is called directly |
| `pg-pool.connect` | Pool connection acquisition wait time | When acquiring a connection from `pg-pool` |

Also included an explanation of what `pg-pool.connect` spans measure and when they might be useful vs noisy.

## Checklist

- [x] Documentation updated