### PR TITLE
chore(gen-semconv-ts): update to use prettier for formatting

### DIFF
--- a/scripts/gen-semconv-ts.js
+++ b/scripts/gen-semconv-ts.js
@@ -231,7 +231,9 @@ ${chunks.join('\n\n')}
   );
   console.log(`Generated "${semconvTsPath}".`);
 
-  console.log('Running "npx prettier --write src/semconv.ts" to fix formatting.');
+  console.log(
+    'Running "npx prettier --write src/semconv.ts" to fix formatting.'
+  );
   execSync('npx prettier --write src/semconv.ts', { cwd: wsDir });
 }
 


### PR DESCRIPTION
A little while back the use of prettier for formatting was
taken *out* of the eslint invocation, to run it separately.
The gen-semconv-ts tool wasn't updated for that.
