### PR TITLE
chore: run prettier fix on packages

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -157,12 +157,15 @@ const baseConfig = tseslint.config(
       '@typescript-eslint/no-empty-function': ['off'],
       '@typescript-eslint/no-shadow': ['warn'],
       'prefer-rest-params': 'off',
-      '@typescript-eslint/explicit-member-accessibility': ['error', {
-        overrides: {
-          // `constructor` is public by default.
-          'constructors': 'no-public',
+      '@typescript-eslint/explicit-member-accessibility': [
+        'error',
+        {
+          overrides: {
+            // `constructor` is public by default.
+            constructors: 'no-public',
+          },
         },
-      }],
+      ],
     },
   },
 
@@ -234,13 +237,11 @@ const baseConfig = tseslint.config(
 
   // Gradual adoption of explicit-member-accessibility
   {
-    files: [
-      '**/packages/instrumentation-*/**',
-    ],
+    files: ['**/packages/instrumentation-*/**'],
     rules: {
       '@typescript-eslint/explicit-member-accessibility': 'off',
     },
-  },
+  }
 );
 
 export default baseConfig;

--- a/packages/propagator-aws-xray-lambda/src/AWSXRayLambdaPropagator.ts
+++ b/packages/propagator-aws-xray-lambda/src/AWSXRayLambdaPropagator.ts
@@ -44,7 +44,11 @@ export class AWSXRayLambdaPropagator implements TextMapPropagator {
     this._awsXrayPropagator.inject(context, carrier, setter);
   }
 
-  public extract(context: Context, carrier: unknown, getter: TextMapGetter): Context {
+  public extract(
+    context: Context,
+    carrier: unknown,
+    getter: TextMapGetter
+  ): Context {
     const xrayContext = this._awsXrayPropagator.extract(
       context,
       carrier,

--- a/packages/propagator-aws-xray/src/AWSXRayPropagator.ts
+++ b/packages/propagator-aws-xray/src/AWSXRayPropagator.ts
@@ -77,7 +77,11 @@ export class AWSXRayPropagator implements TextMapPropagator {
     setter.set(carrier, AWSXRAY_TRACE_ID_HEADER, traceHeader);
   }
 
-  public extract(context: Context, carrier: unknown, getter: TextMapGetter): Context {
+  public extract(
+    context: Context,
+    carrier: unknown,
+    getter: TextMapGetter
+  ): Context {
     const spanContext = this.getSpanContextFromHeader(carrier, getter);
     if (!isSpanContextValid(spanContext)) return context;
 

--- a/packages/propagator-instana/src/InstanaPropagator.ts
+++ b/packages/propagator-instana/src/InstanaPropagator.ts
@@ -78,7 +78,11 @@ export class InstanaPropagator implements TextMapPropagator {
    * Extracts the span context from Instana's vendor specific trace correlation headers (X-INSTANA-T, X-INSTANA-S
    * and X-INSTANA-L).
    */
-  public extract(context: Context, carrier: unknown, getter: TextMapGetter): Context {
+  public extract(
+    context: Context,
+    carrier: unknown,
+    getter: TextMapGetter
+  ): Context {
     let traceId = readHeader(carrier, getter, INSTANA_TRACE_ID_HEADER);
     if (traceId && traceId.length < 32) {
       traceId = traceId.padStart(32, '0');

--- a/packages/propagator-ot-trace/src/OTTracePropagator.ts
+++ b/packages/propagator-ot-trace/src/OTTracePropagator.ts
@@ -85,7 +85,11 @@ export class OTTracePropagator implements TextMapPropagator {
     });
   }
 
-  public extract(context: Context, carrier: unknown, getter: TextMapGetter): Context {
+  public extract(
+    context: Context,
+    carrier: unknown,
+    getter: TextMapGetter
+  ): Context {
     let traceId = readHeader(carrier, getter, OT_TRACE_ID_HEADER);
     if (traceId.length === 16) traceId = `${PADDING}${traceId}`;
     const spanId = readHeader(carrier, getter, OT_SPAN_ID_HEADER);

--- a/packages/resource-detector-aws/src/detectors/AwsEc2Detector.ts
+++ b/packages/resource-detector-aws/src/detectors/AwsEc2Detector.ts
@@ -49,8 +49,10 @@ class AwsEc2Detector implements ResourceDetector {
   public readonly AWS_INSTANCE_TOKEN_DOCUMENT_PATH = '/latest/api/token';
   public readonly AWS_INSTANCE_IDENTITY_DOCUMENT_PATH =
     '/latest/dynamic/instance-identity/document';
-  public readonly AWS_INSTANCE_HOST_DOCUMENT_PATH = '/latest/meta-data/hostname';
-  public readonly AWS_METADATA_TTL_HEADER = 'X-aws-ec2-metadata-token-ttl-seconds';
+  public readonly AWS_INSTANCE_HOST_DOCUMENT_PATH =
+    '/latest/meta-data/hostname';
+  public readonly AWS_METADATA_TTL_HEADER =
+    'X-aws-ec2-metadata-token-ttl-seconds';
   public readonly AWS_METADATA_TOKEN_HEADER = 'X-aws-ec2-metadata-token';
   public readonly MILLISECOND_TIME_OUT = 5000;
 


### PR DESCRIPTION
When the new eslint rule was applied
some things moved and needed to be
reformatted; noticed upon merge to main

- Follow-up to https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3250

See lint failure here: https://github.com/open-telemetry/opentelemetry-js-contrib/actions/runs/20248189620/job/58133619152
