### PR TITLE
feat(instrumentation-mysql): Add `maskStatement` config option

### DIFF
--- a/packages/instrumentation-mysql/README.md
+++ b/packages/instrumentation-mysql/README.md
@@ -44,9 +44,11 @@ See [examples/mysql](https://github.com/open-telemetry/opentelemetry-js-contrib/
 
 ### MySQL instrumentation Options
 
-| Options                                           | Type      | Default | Description |
-| ------------------------------------------------- | --------- | ------- | ----------- |
-| [`enhancedDatabaseReporting`](./src/types.ts#L24) | `boolean` | `false` | If true, a `db.mysql.values` attribute containing the query's parameters will be add to database spans. Note that this is not an attribute defined in [Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/database/mysql/). |
+| Options                                           | Type       | Default     | Description |
+| ------------------------------------------------- | ---------- | ----------- | ----------- |
+| [`enhancedDatabaseReporting`](./src/types.ts#L28) | `boolean`  | `false`     | If true, a `db.mysql.values` attribute containing the query's parameters will be added to database spans. Note that this is not an attribute defined in [Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/database/mysql/). |
+| `maskStatement`                                   | `boolean`  | `false`     | If true, masks the `db.statement` and `db.query.text` attributes in spans using the `maskStatementHook`. This replaces sensitive values (strings, numbers) with `?` placeholders to prevent PII exposure. |
+| `maskStatementHook`                               | `function` | See below   | Function for masking the query string before setting it as span attribute. Only called when `maskStatement` is `true`. Default: `(query) => query.replace(/\b\d+\b/g, '?').replace(/(["'])(?:(?=(\\?))\2.)*?\1/g, '?')` |
 
 ## Semantic Conventions
 

--- a/packages/instrumentation-mysql/src/instrumentation.ts
+++ b/packages/instrumentation-mysql/src/instrumentation.ts
@@ -342,7 +342,12 @@ export class MySQLInstrumentation extends InstrumentationBase<MySQLInstrumentati
         const attributes: Attributes = {};
         const { host, port, database, user } = getConfig(connection.config);
         const portNumber = parseInt(port, 10);
-        const dbQueryText = getDbQueryText(query);
+        const { maskStatement, maskStatementHook } = thisPlugin.getConfig();
+        const dbQueryText = getDbQueryText(
+          query,
+          maskStatement,
+          maskStatementHook
+        );
         if (thisPlugin._dbSemconvStability & SemconvStability.OLD) {
           attributes[ATTR_DB_SYSTEM] = DB_SYSTEM_VALUE_MYSQL;
           attributes[ATTR_DB_CONNECTION_STRING] = getJDBCString(

--- a/packages/instrumentation-mysql/src/types.ts
+++ b/packages/instrumentation-mysql/src/types.ts
@@ -16,10 +16,31 @@
 
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 
+export interface MySQLInstrumentationQueryMaskingHook {
+  (query: string): string;
+}
+
 export interface MySQLInstrumentationConfig extends InstrumentationConfig {
   /**
    * If true, an attribute containing the query's parameters will be attached
    * the spans generated to represent the query.
    */
   enhancedDatabaseReporting?: boolean;
+
+  /**
+   * If true, the query will be masked before setting it as a span attribute,
+   * using the {@link maskStatementHook}.
+   *
+   * @default false
+   * @see maskStatementHook
+   */
+  maskStatement?: boolean;
+
+  /**
+   * Hook that allows masking the query string before setting it as span attribute.
+   * Only called when {@link maskStatement} is `true`.
+   *
+   * @default (query: string) => query.replace(/\b\d+\b/g, '?').replace(/(["'])(?:(?=(\\?))\2.)*?\1/g, '?')
+   */
+  maskStatementHook?: MySQLInstrumentationQueryMaskingHook;
 }

--- a/packages/instrumentation-mysql/test/utils.test.ts
+++ b/packages/instrumentation-mysql/test/utils.test.ts
@@ -18,6 +18,111 @@ import * as assert from 'assert';
 import * as mysqlTypes from 'mysql';
 
 describe('utils.ts', () => {
+  describe('getDbQueryText()', () => {
+    it('should return raw query when maskStatement is false', () => {
+      const query = "SELECT * FROM users WHERE email = 'test@example.com'";
+      const result = utils.getDbQueryText(query, false);
+      assert.strictEqual(result, query);
+    });
+
+    it('should return raw query when maskStatement is not provided', () => {
+      const query = "SELECT * FROM users WHERE email = 'test@example.com'";
+      const result = utils.getDbQueryText(query);
+      assert.strictEqual(result, query);
+    });
+
+    it('should mask query when maskStatement is true', () => {
+      const query = "SELECT * FROM users WHERE email = 'test@example.com'";
+      const result = utils.getDbQueryText(query, true);
+      assert.strictEqual(result, 'SELECT * FROM users WHERE email = ?');
+    });
+
+    it('should mask numeric literals', () => {
+      const query = 'SELECT * FROM users WHERE id = 123';
+      const result = utils.getDbQueryText(query, true);
+      assert.strictEqual(result, 'SELECT * FROM users WHERE id = ?');
+    });
+
+    it('should mask double-quoted strings', () => {
+      const query = 'SELECT * FROM users WHERE name = "John Doe"';
+      const result = utils.getDbQueryText(query, true);
+      assert.strictEqual(result, 'SELECT * FROM users WHERE name = ?');
+    });
+
+    it('should handle escaped quotes inside strings', () => {
+      const query = "SELECT * FROM users WHERE name = 'O\\'Brien'";
+      const result = utils.getDbQueryText(query, true);
+      assert.strictEqual(result, 'SELECT * FROM users WHERE name = ?');
+    });
+
+    it('should mask multiple values', () => {
+      const query =
+        "INSERT INTO users (id, name, email) VALUES (123, 'John', 'john@example.com')";
+      const result = utils.getDbQueryText(query, true);
+      assert.strictEqual(
+        result,
+        'INSERT INTO users (id, name, email) VALUES (?, ?, ?)'
+      );
+    });
+
+    it('should preserve SQL structure', () => {
+      const query =
+        'SELECT id, name FROM users WHERE age > 18 ORDER BY created_at';
+      const result = utils.getDbQueryText(query, true);
+      assert.strictEqual(
+        result,
+        'SELECT id, name FROM users WHERE age > ? ORDER BY created_at'
+      );
+    });
+
+    it('should mask floating point numbers', () => {
+      const query = 'SELECT * FROM products WHERE price > 19.99';
+      // Note: The regex only matches integers with word boundaries, so 19.99 becomes ?.?
+      const result = utils.getDbQueryText(query, true);
+      assert.strictEqual(result, 'SELECT * FROM products WHERE price > ?.?');
+    });
+
+    it('should handle empty strings', () => {
+      const query = "SELECT * FROM users WHERE name = ''";
+      const result = utils.getDbQueryText(query, true);
+      assert.strictEqual(result, 'SELECT * FROM users WHERE name = ?');
+    });
+
+    it('should use custom maskStatementHook when provided', () => {
+      const query = 'SELECT * FROM users WHERE id = 123';
+      const customHook = (q: string) => q.replace(/\d+/g, 'REDACTED');
+      const result = utils.getDbQueryText(query, true, customHook);
+      assert.strictEqual(result, 'SELECT * FROM users WHERE id = REDACTED');
+    });
+
+    it('should extract sql from Query object', () => {
+      const query = { sql: 'SELECT * FROM users WHERE id = 123' };
+      const result = utils.getDbQueryText(query, true);
+      assert.strictEqual(result, 'SELECT * FROM users WHERE id = ?');
+    });
+
+    it('should extract sql from QueryOptions object', () => {
+      const query = {
+        sql: "SELECT * FROM users WHERE name = 'John'",
+        values: ['John'],
+      };
+      const result = utils.getDbQueryText(query, true);
+      assert.strictEqual(result, 'SELECT * FROM users WHERE name = ?');
+    });
+
+    it('should handle masking hook that throws an error', () => {
+      const query = 'SELECT * FROM users';
+      const throwingHook = () => {
+        throw new Error('Hook failed');
+      };
+      const result = utils.getDbQueryText(query, true, throwingHook);
+      assert.strictEqual(
+        result,
+        'Could not determine the query due to an error in masking'
+      );
+    });
+  });
+
   describe('getPoolNameOld()', () => {
     let pool: mysqlTypes.Pool;
 


### PR DESCRIPTION
Refs #1552, #1744

## Which problem is this PR solving?

Adds `maskStatement` and `maskStatementHook` config options to mask sensitive data in `db.query.text` / `db.statement` attributes.

This mirrors the API available in `instrumentation-mysql2` (added in #2732) for consistency across MySQL instrumentations.

### Changes

- Add `maskStatement` boolean option (default: `false`)
- Add `maskStatementHook` for custom masking logic
- Default masking replaces string literals and numeric values with `?`

### Usage

```typescript
new MySQLInstrumentation({
  maskStatement: true,
  // Optional custom hook:
  maskStatementHook: (query) => query.replace(/\d+/g, 'REDACTED'),
})
```

Notes

Unlike mysql2, the mysql instrumentation does not interpolate parameterized query values into `db.query.text`. This means parameterized queries like `query("SELECT * FROM t WHERE id = ?", [123])` are already safe by default. The `maskStatement` option is primarily useful for raw string queries with embedded values.
