### PR TITLE
chore(bitrot): update bitrot script, add 'configuration' package to renovate group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,7 @@
       "groupName": "OTel Core experimental",
       "matchPackageNames": [
         "@opentelemetry/api-logs",
+        "@opentelemetry/configuration",
         "@opentelemetry/exporter-logs-otlp-grpc",
         "@opentelemetry/exporter-logs-otlp-http",
         "@opentelemetry/exporter-logs-otlp-proto",

--- a/scripts/bitrot.mjs
+++ b/scripts/bitrot.mjs
@@ -157,7 +157,7 @@ function getNpmInfo(name) {
     );
   }
 
-  const stdout = execSync(`npm info -j "${name}"`);
+  const stdout = execSync(`npm info --json "${name}"`);
   const npmInfo = JSON.parse(stdout);
 
   cache[name] = {
@@ -195,6 +195,8 @@ function bitrotInstrumentations() {
     'user-interaction',
     'long-task',
     'document-load',
+    'browser-navigation',
+    'web-exception',
     'runtime-node',
     'dns',
     'net',


### PR DESCRIPTION
- A couple new browser-related packages for the bitrot script to ignore.
- Switch to '--json' option to 'npm info' because recent npm warns
  about '-j' being deprecated.
