### PR TITLE
fix(instrumentation-mysql): restore 'db.client.connections.usage' when opting-in to stable database semconv

### DIFF
--- a/packages/instrumentation-mysql/README.md
+++ b/packages/instrumentation-mysql/README.md
@@ -76,11 +76,9 @@ Attributes collected:
 
 Metrics collected:
 
-| Old semconv                   | Stable semconv | Description |
-| ----------------------------- | -------------- | ----------- |
-| `db.client.connections.usage` | (removed)      | The number of connections currently in a given state. See note below. |
+- [`db.client.connections.usage`](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/database/database-metrics.md#metric-dbclientconnectionsusage) - The number of connections currently in a given state.
 
-Note: While `db.client.connections.usage` was replaced with `db.client.connection.count` in the [semconv database migration](https://opentelemetry.io/docs/specs/semconv/non-normative/db-migration/#database-client-connection-count), the replacement metric is still unstable, so cannot be enabled via `OTEL_SEMCONV_STABILITY_OPT_IN=database`.
+  Note: While `db.client.connections.usage` has been deprecated in favor of `db.client.connection.count` in the [semconv database migration](https://opentelemetry.io/docs/specs/semconv/non-normative/db-migration/#database-client-connection-count), the new metric is still unstable, so cannot be enabled via `OTEL_SEMCONV_STABILITY_OPT_IN=database`. There is ongoing work to provide an opt-in setting to select the latest experimental semconv.
 
 ## Useful links
 

--- a/packages/instrumentation-mysql/src/instrumentation.ts
+++ b/packages/instrumentation-mysql/src/instrumentation.ts
@@ -89,20 +89,17 @@ export class MySQLInstrumentation extends InstrumentationBase<MySQLInstrumentati
       'database',
       process.env.OTEL_SEMCONV_STABILITY_OPT_IN
     );
-    this._updateMetricInstruments();
   }
 
   protected override _updateMetricInstruments() {
-    if (this._dbSemconvStability & SemconvStability.OLD) {
-      this._connectionsUsageOld = this.meter.createUpDownCounter(
-        METRIC_DB_CLIENT_CONNECTIONS_USAGE,
-        {
-          description:
-            'The number of connections that are currently in state described by the state attribute.',
-          unit: '{connection}',
-        }
-      );
-    }
+    this._connectionsUsageOld = this.meter.createUpDownCounter(
+      METRIC_DB_CLIENT_CONNECTIONS_USAGE,
+      {
+        description:
+          'The number of connections that are currently in state described by the state attribute.',
+        unit: '{connection}',
+      }
+    );
   }
 
   /**


### PR DESCRIPTION
In #3288 support for OTEL_SEMCONV_STABILITY_OPT_IN=database was added
to enable opting-in to stable `db.*` semantic conventions. However, as
part of that change the non-stable but preexisting metric
`db.client.connections.usage` was *removed* when just stable db semconv
was selected.

Per https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3313#discussion_r2632536759
the agreed upon behavior (our understanding of the intent of
https://opentelemetry.io/docs/specs/semconv/non-normative/db-migration/)
is that `OTEL_SEMCONV_STABILITY_OPT_IN` usage should not impact
preexisting attributes/metrics that do not yet have a *stable*
replacement.

Refs: #3288
Refs: https://github.com/open-telemetry/semantic-conventions/issues/3200
