### PR TITLE
chore(instrumentation-web-exception): clean up otel dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40304,11 +40304,11 @@
     },
     "packages/instrumentation-web-exception": {
       "name": "@opentelemetry/instrumentation-web-exception",
-      "version": "0.3.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "^0.210.0",
-        "@opentelemetry/core": "^1.30.1",
+        "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/instrumentation": "^0.210.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
@@ -40316,7 +40316,6 @@
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/sdk-logs": "^0.210.0",
-        "@opentelemetry/sdk-trace-base": "^1.0.0",
         "@rollup/plugin-commonjs": "^26.0.0",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@web/dev-server-esbuild": "^1.0.1",
@@ -40329,65 +40328,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "packages/instrumentation-web-exception/node_modules/@opentelemetry/core": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.28.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "packages/instrumentation-web-exception/node_modules/@opentelemetry/resources": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
-      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/semantic-conventions": "1.28.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "packages/instrumentation-web-exception/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
-      "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/resources": "1.30.1",
-        "@opentelemetry/semantic-conventions": "1.28.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "packages/instrumentation-web-exception/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "packages/instrumentation-web-exception/node_modules/@rollup/plugin-commonjs": {

--- a/packages/instrumentation-web-exception/package.json
+++ b/packages/instrumentation-web-exception/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentelemetry/instrumentation-web-exception",
-  "version": "0.3.0",
+  "version": "0.2.1",
   "description": "OpenTelemetry instrumentation for web exceptions",
   "main": "build/src/index.js",
   "module": "build/esm/index.js",
@@ -54,7 +54,6 @@
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/sdk-logs": "^0.210.0",
-    "@opentelemetry/sdk-trace-base": "^1.0.0",
     "@rollup/plugin-commonjs": "^26.0.0",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@web/dev-server-esbuild": "^1.0.1",
@@ -64,7 +63,7 @@
   },
   "dependencies": {
     "@opentelemetry/api-logs": "^0.210.0",
-    "@opentelemetry/core": "^1.30.1",
+    "@opentelemetry/core": "^2.0.0",
     "@opentelemetry/instrumentation": "^0.210.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },


### PR DESCRIPTION
## Which problem is this PR solving?

See #3333 

Old versions of OTel JS are used in the web-exception instrumentation. It also depends on `@opentelemetry/sdk-trace-base`, but it's not using it. This PR fixes both. 🙂 