### PR TITLE
chore: fix codeowners order

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,18 +12,19 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
+# Default: all files (this is overridden by more specific rules below)
+* @open-telemetry/javascript-approvers
+
 # Only maintainers can approve changes in .github/ - including this file here, workflows and issue templates
 .github/ @open-telemetry/javascript-maintainers
 
 # Any browser-specific code is co-owned by Browser SIG and JS SIG (list more packages here as needed):
 examples/web/ @open-telemetry/browser-maintainers @open-telemetry/javascript-approvers
-packages/auto-instrumentations-web @open-telemetry/browser-maintainers @open-telemetry/javascript-approvers
-packages/instrumentation-browser-navigation @open-telemetry/browser-maintainers @open-telemetry/javascript-approvers
+packages/auto-instrumentations-web/ @open-telemetry/browser-maintainers @open-telemetry/javascript-approvers
+packages/instrumentation-browser-navigation/ @open-telemetry/browser-maintainers @open-telemetry/javascript-approvers
 packages/instrumentation-document-load/ @open-telemetry/browser-maintainers @open-telemetry/javascript-approvers
 packages/instrumentation-long-task/ @open-telemetry/browser-maintainers @open-telemetry/javascript-approvers
 packages/instrumentation-user-interaction/ @open-telemetry/browser-maintainers @open-telemetry/javascript-approvers
 packages/instrumentation-web-exception/ @open-telemetry/browser-maintainers @open-telemetry/javascript-approvers
 packages/plugin-react-load/ @open-telemetry/browser-maintainers @open-telemetry/javascript-approvers
 
-# All other files
-* @open-telemetry/javascript-approvers


### PR DESCRIPTION
## Which problem is this PR solving?

I messed up bad with the code-owners files when I added them and got the order wrong.
This applies the same changes here that Jared made over at https://github.com/open-telemetry/opentelemetry-js/pull/6297