### PR TITLE
docs(resource-detector-container): fix SDK compatibility statement

### DIFF
--- a/packages/resource-detector-container/README.md
+++ b/packages/resource-detector-container/README.md
@@ -6,7 +6,7 @@
 [component owners](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/.github/component_owners.yml): @abhee11
 
 Resource detector for container id.
-Compatible with OpenTelemetry JS API and SDK `1.0+`.
+Compatible with OpenTelemetry JS SDK `2.0+`.
 
 ## Installation
 


### PR DESCRIPTION
When this package was updated to SDK 2 in #2738, the mention of SDK 1.0 was missed.

Plus: Remove API from compatibility statement, since no specific API version is required.
