### PR TITLE
fix(instrumentation-pino): Allow control over logged fields

### DIFF
--- a/packages/instrumentation-pino/src/types.ts
+++ b/packages/instrumentation-pino/src/types.ts
@@ -39,6 +39,13 @@ export interface PinoInstrumentationConfig extends InstrumentationConfig {
   disableLogCorrelation?: boolean;
 
   /**
+   * Whether to pass the injected trace-context fields into the
+   * mixin function's context.
+   * @default false
+   */
+  passLogCorrelationToMixin?: boolean;
+
+  /**
    * A function that allows injecting additional fields in log records. It is
    * called, as `logHook(span, record)`, for each log record emitted in a valid
    * span context. It requires `disableLogCorrelation` to be false.
@@ -50,8 +57,8 @@ export interface PinoInstrumentationConfig extends InstrumentationConfig {
    * available.
    */
   logKeys?: {
-    traceId: string;
-    spanId: string;
-    traceFlags: string;
+    traceId?: string;
+    spanId?: string;
+    traceFlags?: string;
   };
 }

--- a/packages/instrumentation-pino/src/types.ts
+++ b/packages/instrumentation-pino/src/types.ts
@@ -57,8 +57,8 @@ export interface PinoInstrumentationConfig extends InstrumentationConfig {
    * available.
    */
   logKeys?: {
-    traceId?: string;
-    spanId?: string;
-    traceFlags?: string;
+    traceId: string | null;
+    spanId: string | null;
+    traceFlags: string | null;
   };
 }


### PR DESCRIPTION
## Which problem is this PR solving?

In some environments, automatic log processing expects certain field names to be present (or absent) in the log record or for the values to have specific complex formats.

## Short description of the changes

The `logKeys` option now accepts partial custom keys to use the default values, and explicitly undefined values to remove the keys from the correlation record.

To prevent any breaking changes from being introduced, a new `passLogCorrelationToMixin` option has been added, which allows total control over the logged values through the mixin function. This option defaults to false.
