### PR TITLE
fix(pino): avoid mutating user options when reused

### DIFF
--- a/packages/instrumentation-pino/src/instrumentation.ts
+++ b/packages/instrumentation-pino/src/instrumentation.ts
@@ -55,7 +55,12 @@ export class PinoInstrumentation extends InstrumentationBase<PinoInstrumentation
           const config = instrumentation.getConfig();
           const isEnabled = instrumentation.isEnabled();
 
-          const logger = moduleExports(...args);
+         const patchedArgs = [...args];
+
+          if (patchedArgs.length > 0 && typeof patchedArgs[0] === 'object') {
+           patchedArgs[0] = { ...(patchedArgs[0] as object) };
+           }
+           const logger = moduleExports(...patchedArgs);
 
           // Setup "log correlation" -- injection of `trace_id` et al fields.
           // Note: If the Pino logger is configured with `nestedKey`, then

--- a/packages/instrumentation-pino/src/instrumentation.ts
+++ b/packages/instrumentation-pino/src/instrumentation.ts
@@ -55,12 +55,12 @@ export class PinoInstrumentation extends InstrumentationBase<PinoInstrumentation
           const config = instrumentation.getConfig();
           const isEnabled = instrumentation.isEnabled();
 
-         const patchedArgs = [...args];
+          const patchedArgs = [...args];
 
           if (patchedArgs.length > 0 && typeof patchedArgs[0] === 'object') {
-           patchedArgs[0] = { ...(patchedArgs[0] as object) };
-           }
-           const logger = moduleExports(...patchedArgs);
+            patchedArgs[0] = { ...(patchedArgs[0] as object) };
+          }
+          const logger = moduleExports(...patchedArgs);
 
           // Setup "log correlation" -- injection of `trace_id` et al fields.
           // Note: If the Pino logger is configured with `nestedKey`, then

--- a/packages/instrumentation-pino/test/pino.test.ts
+++ b/packages/instrumentation-pino/test/pino.test.ts
@@ -321,16 +321,16 @@ describe('PinoInstrumentation', () => {
     });
 
     it('does not stack mixins when reusing the same options object', () => {
-  const options: any = {};
+      const options: any = {};
 
-  const logger1 = pino(options);
-  const logger2 = pino(options);
-  const logger3 = pino(options);
+      pino(options);
+      pino(options);
+      const logger3 = pino(options);
 
-  assert.doesNotThrow(() => {
-    logger3.info('test message');
+      assert.doesNotThrow(() => {
+        logger3.info('test message');
+      });
     });
-  });
 
     it('`pino()` with no args works', () => {
       const logger = pino();

--- a/packages/instrumentation-pino/test/pino.test.ts
+++ b/packages/instrumentation-pino/test/pino.test.ts
@@ -320,6 +320,18 @@ describe('PinoInstrumentation', () => {
       stdoutSpy.restore();
     });
 
+    it('does not stack mixins when reusing the same options object', () => {
+  const options: any = {};
+
+  const logger1 = pino(options);
+  const logger2 = pino(options);
+  const logger3 = pino(options);
+
+  assert.doesNotThrow(() => {
+    logger3.info('test message');
+    });
+  });
+
     it('`pino()` with no args works', () => {
       const logger = pino();
       tracer.startActiveSpan('abc', span => {


### PR DESCRIPTION
This change avoids mutating user-provided options when creating multiple Pino
logger instances with the same configuration object.

Previously, reusing the same options object across multiple `pino(options)`
calls could lead to mixin wrappers being stacked, since the options reference
was shared. This patch defensively clones the options argument before passing
it to `pino()`, preventing unintended side effects.

A regression test has been added to ensure that reusing the same options object
does not cause errors or recursive mixin behavior.

Fixes #2024 

Note: On Windows, `nx test instrumentation-pino` fails locally due to Mocha glob
quoting (`'test/**/*.test.ts'`). Tests pass in CI (Linux), which is the supported
environment for this repository.
