### PR TITLE
feat(instrumentation-runtime-node): add active resource gauge

### DIFF
--- a/packages/instrumentation-runtime-node/src/instrumentation.ts
+++ b/packages/instrumentation-runtime-node/src/instrumentation.ts
@@ -11,6 +11,7 @@ import { EventLoopDelayCollector } from './metrics/eventLoopDelayCollector';
 import { GCCollector } from './metrics/gcCollector';
 import { HeapSpacesSizeAndUsedCollector } from './metrics/heapSpacesSizeAndUsedCollector';
 import { EventLoopTimeCollector } from './metrics/eventLoopTimeCollector';
+import { ActiveResourcesCollector } from './metrics/activeResourcesCollector';
 /** @knipignore */
 import { PACKAGE_VERSION, PACKAGE_NAME } from './version';
 
@@ -33,6 +34,7 @@ export class RuntimeNodeInstrumentation extends InstrumentationBase<RuntimeNodeI
       new EventLoopDelayCollector(this._config),
       new GCCollector(this._config),
       new HeapSpacesSizeAndUsedCollector(this._config),
+      new ActiveResourcesCollector(this._config),
     ];
     if (this._config.enabled) {
       for (const collector of this._collectors) {

--- a/packages/instrumentation-runtime-node/src/metrics/activeResourcesCollector.ts
+++ b/packages/instrumentation-runtime-node/src/metrics/activeResourcesCollector.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meter } from '@opentelemetry/api';
+
+import { BaseCollector } from './baseCollector';
+import {
+  ATTR_V8JS_RESOURCE_TYPE,
+  METRIC_V8JS_RESOURCE_ACTIVE,
+} from '../semconv';
+
+type DataMap = {
+  [key: string]: number;
+};
+
+export class ActiveResourcesCollector extends BaseCollector {
+  updateMetricInstruments(meter: Meter): void {
+    const activeResources = meter.createObservableGauge(
+      METRIC_V8JS_RESOURCE_ACTIVE,
+      {
+        description:
+          'Count of the active resources that are currently keeping the event loop alive.',
+        unit: '{resource_type}',
+      }
+    );
+
+    meter.addBatchObservableCallback(
+      observableResult => {
+        if (!this._config.enabled) return;
+
+        const data = this.scrape();
+        if (data === undefined) return;
+
+        // STore the procssed data
+        const pdata: DataMap = {};
+
+        // Convert String to string and count
+        for (const t of data) {
+          const type: string = t.toString();
+          if (Object.hasOwn(pdata, type)) {
+            pdata[type] += 1;
+          } else {
+            pdata[type] = 1;
+          }
+        }
+
+        for (const [key, value] of Object.entries(pdata)) {
+          observableResult.observe(activeResources, value, {
+            [ATTR_V8JS_RESOURCE_TYPE]: key,
+          });
+        }
+      },
+      [activeResources]
+    );
+  }
+
+  internalEnable(): void {}
+
+  internalDisable(): void {}
+
+  private scrape(): String[] {
+    return process.getActiveResourcesInfo();
+  }
+}

--- a/packages/instrumentation-runtime-node/src/metrics/activeResourcesCollector.ts
+++ b/packages/instrumentation-runtime-node/src/metrics/activeResourcesCollector.ts
@@ -33,7 +33,7 @@ export class ActiveResourcesCollector extends BaseCollector {
       {
         description:
           'Count of the active resources that are currently keeping the event loop alive.',
-        unit: '{resource_type}',
+        unit: '{resource}',
       }
     );
 
@@ -44,12 +44,12 @@ export class ActiveResourcesCollector extends BaseCollector {
         const data = this.scrape();
         if (data === undefined) return;
 
-        // STore the procssed data
+        // Store the procssed data
         const pdata: DataMap = {};
 
-        // Convert String to string and count
+        // Count each type
         for (const t of data) {
-          const type: string = t.toString();
+          const type: string = t;
           if (Object.hasOwn(pdata, type)) {
             pdata[type] += 1;
           } else {
@@ -71,7 +71,7 @@ export class ActiveResourcesCollector extends BaseCollector {
 
   internalDisable(): void {}
 
-  private scrape(): String[] {
+  private scrape(): string[] {
     return process.getActiveResourcesInfo();
   }
 }

--- a/packages/instrumentation-runtime-node/src/metrics/activeResourcesCollector.ts
+++ b/packages/instrumentation-runtime-node/src/metrics/activeResourcesCollector.ts
@@ -11,11 +11,11 @@ import {
   METRIC_V8JS_RESOURCE_ACTIVE,
 } from '../semconv';
 
-type DataMap = {
-  [key: string]: number;
-};
+type DataMap = Record<string, number>;
 
 export class ActiveResourcesCollector extends BaseCollector {
+  private _knownTypes: Set<string> = new Set();
+
   updateMetricInstruments(meter: Meter): void {
     const activeResources = meter.createObservableGauge(
       METRIC_V8JS_RESOURCE_ACTIVE,
@@ -40,12 +40,15 @@ export class ActiveResourcesCollector extends BaseCollector {
           } else {
             pdata[type] = 1;
           }
+          this._knownTypes.add(type);
         }
 
-        for (const [key, value] of Object.entries(pdata)) {
-          observableResult.observe(activeResources, value, {
-            [ATTR_V8JS_RESOURCE_TYPE]: key,
-          });
+        for (const key of this._knownTypes) {
+          observableResult.observe(
+            activeResources,
+            Object.hasOwn(pdata, key) ? pdata[key] : 0,
+            { [ATTR_V8JS_RESOURCE_TYPE]: key }
+          );
         }
       },
       [activeResources]

--- a/packages/instrumentation-runtime-node/src/metrics/activeResourcesCollector.ts
+++ b/packages/instrumentation-runtime-node/src/metrics/activeResourcesCollector.ts
@@ -42,14 +42,10 @@ export class ActiveResourcesCollector extends BaseCollector {
         if (!this._config.enabled) return;
 
         const data = this.scrape();
-        if (data === undefined) return;
 
-        // Store the procssed data
         const pdata: DataMap = {};
 
-        // Count each type
-        for (const t of data) {
-          const type: string = t;
+        for (const type of data) {
           if (Object.hasOwn(pdata, type)) {
             pdata[type] += 1;
           } else {

--- a/packages/instrumentation-runtime-node/src/metrics/activeResourcesCollector.ts
+++ b/packages/instrumentation-runtime-node/src/metrics/activeResourcesCollector.ts
@@ -1,17 +1,6 @@
 /*
  * Copyright The OpenTelemetry Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 import { Meter } from '@opentelemetry/api';

--- a/packages/instrumentation-runtime-node/src/semconv.ts
+++ b/packages/instrumentation-runtime-node/src/semconv.ts
@@ -33,6 +33,13 @@ export const ATTR_V8JS_GC_TYPE = 'v8js.gc.type' as const;
 export const ATTR_V8JS_HEAP_SPACE_NAME = 'v8js.heap.space.name' as const;
 
 /**
+ * The type of Active Resource.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_V8JS_RESOURCE_TYPE = 'v8js.resource.type' as const;
+
+/**
  * Event loop maximum delay.
  *
  * @note Value can be retrieved from value `histogram.max` of [`perf_hooks.monitorEventLoopDelay([options])`](https://nodejs.org/api/perf_hooks.html#perf_hooksmonitoreventloopdelayoptions)
@@ -167,6 +174,15 @@ export const METRIC_V8JS_MEMORY_HEAP_SPACE_PHYSICAL_SIZE =
  * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const METRIC_V8JS_MEMORY_HEAP_USED = 'v8js.memory.heap.used' as const;
+
+/**
+ * Types of the active resources that are currently keeping the event loop alive.
+ *
+ * @note The value can be retrieved from [`process.getActiveResourcesInfo()`](https://nodejs.org/api/process.html#processgetactiveresourcesinfo)
+ *
+ * @experimental This metric is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const METRIC_V8JS_RESOURCE_ACTIVE = 'v8js.resource.active' as const;
 
 /**
  * Enum value "active" for attribute {@link ATTR_NODEJS_EVENTLOOP_STATE}.

--- a/packages/instrumentation-runtime-node/src/semconv.ts
+++ b/packages/instrumentation-runtime-node/src/semconv.ts
@@ -33,7 +33,7 @@ export const ATTR_V8JS_GC_TYPE = 'v8js.gc.type' as const;
 export const ATTR_V8JS_HEAP_SPACE_NAME = 'v8js.heap.space.name' as const;
 
 /**
- * The type of Active Resource.
+ * The type of active resource.
  *
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */

--- a/packages/instrumentation-runtime-node/test/resource_active.test.ts
+++ b/packages/instrumentation-runtime-node/test/resource_active.test.ts
@@ -159,6 +159,6 @@ describe('v8js.resource.active', function () {
       undefined,
       `${METRIC_V8JS_RESOURCE_ACTIVE} space "${ATTR_V8JS_RESOURCE_TYPE}" not found`
     );
-    assert.ok(typeAttribute!.value == 0);
+    assert.ok(typeAttribute!.value === 0);
   });
 });

--- a/packages/instrumentation-runtime-node/test/resource_active.test.ts
+++ b/packages/instrumentation-runtime-node/test/resource_active.test.ts
@@ -122,13 +122,13 @@ describe('v8js.resource.active', function () {
       socket.on('error', () => {});
     });
 
-    server.listen(4000, '127.0.0.1', () => {});
+    server.listen(0, '127.0.0.1', () => {});
 
     await new Promise(resolve => setTimeout(resolve, 100));
 
     await metricReader.collect();
 
-    server.close();
+    await new Promise(resolve => server.close(resolve));
 
     await new Promise(resolve => setTimeout(resolve, 100));
 

--- a/packages/instrumentation-runtime-node/test/resource_active.test.ts
+++ b/packages/instrumentation-runtime-node/test/resource_active.test.ts
@@ -72,34 +72,41 @@ describe('v8js.resource.active', function () {
       monitoringPrecision: MEASUREMENT_INTERVAL,
     });
     instrumentation.setMeterProvider(meterProvider);
-    const map = [...Array(10).keys()].map(x => x + 10);
-    map.indexOf(1);
-    // act
-    await new Promise(resolve => setTimeout(resolve, MEASUREMENT_INTERVAL * 5));
-    const { resourceMetrics, errors } = await metricReader.collect();
 
-    // assert
-    assert.deepEqual(
-      errors,
-      [],
-      'expected no errors from the callback during collection'
-    );
-    const scopeMetrics = resourceMetrics.scopeMetrics;
-    let metric: GaugeMetricData | undefined = undefined;
-    const foundMetric = scopeMetrics[0].metrics.find(
-      x => x.descriptor.name === METRIC_V8JS_RESOURCE_ACTIVE
-    );
-    if (foundMetric?.dataPointType === DataPointType.GAUGE) {
-      metric = foundMetric;
+    // We need a Timout to really exist for this test.
+    const keepAlive = setTimeout(() => {}, 60_000);
+    try {
+      await new Promise(resolve =>
+        setTimeout(resolve, MEASUREMENT_INTERVAL * 5)
+      );
+      const { resourceMetrics, errors } = await metricReader.collect();
+
+      assert.deepEqual(
+        errors,
+        [],
+        'expected no errors from the callback during collection'
+      );
+      const scopeMetrics = resourceMetrics.scopeMetrics;
+      let metric: GaugeMetricData | undefined = undefined;
+      const foundMetric = scopeMetrics[0].metrics.find(
+        x => x.descriptor.name === METRIC_V8JS_RESOURCE_ACTIVE
+      );
+      if (foundMetric?.dataPointType === DataPointType.GAUGE) {
+        metric = foundMetric;
+      }
+      const typeAttribute = metric?.dataPoints.find(
+        x => x.attributes[ATTR_V8JS_RESOURCE_TYPE] === 'Timeout'
+      );
+
+      assert.notEqual(
+        typeAttribute,
+        undefined,
+        `${METRIC_V8JS_RESOURCE_ACTIVE} space "${ATTR_V8JS_RESOURCE_TYPE}" not found`
+      );
+
+      assert.ok(typeAttribute!.value >= 1);
+    } finally {
+      clearTimeout(keepAlive);
     }
-    const spaceAttribute = metric?.dataPoints.find(
-      x => x.attributes[ATTR_V8JS_RESOURCE_TYPE] === 'Timeout'
-    );
-
-    assert.notEqual(
-      spaceAttribute,
-      undefined,
-      `${METRIC_V8JS_RESOURCE_ACTIVE} space "${ATTR_V8JS_RESOURCE_TYPE}" not found`
-    );
   });
 });

--- a/packages/instrumentation-runtime-node/test/resource_active.test.ts
+++ b/packages/instrumentation-runtime-node/test/resource_active.test.ts
@@ -13,6 +13,8 @@ import {
   METRIC_V8JS_RESOURCE_ACTIVE,
 } from '../src/semconv';
 
+import * as net from 'node:net';
+
 const MEASUREMENT_INTERVAL = 10;
 
 describe('v8js.resource.active', function () {
@@ -108,5 +110,55 @@ describe('v8js.resource.active', function () {
     } finally {
       clearTimeout(keepAlive);
     }
+  });
+
+  it(`should write set ${ATTR_V8JS_RESOURCE_TYPE} attribute to zero`, async function () {
+    const instrumentation = new RuntimeNodeInstrumentation({
+      monitoringPrecision: MEASUREMENT_INTERVAL,
+    });
+    instrumentation.setMeterProvider(meterProvider);
+
+    const server = net.createServer((socket: net.Socket) => {
+      socket.on('error', () => {});
+    });
+
+    server.listen(4000, '127.0.0.1', () => {});
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    await metricReader.collect();
+
+    server.close();
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    const { resourceMetrics, errors } = await metricReader.collect();
+
+    assert.deepEqual(
+      errors,
+      [],
+      'expected no errors from the callback during collection'
+    );
+    const scopeMetrics = resourceMetrics.scopeMetrics;
+
+    let metric: GaugeMetricData | undefined = undefined;
+
+    const foundMetric = scopeMetrics[0].metrics.find(
+      x => x.descriptor.name === METRIC_V8JS_RESOURCE_ACTIVE
+    );
+
+    if (foundMetric?.dataPointType === DataPointType.GAUGE) {
+      metric = foundMetric;
+    }
+    const typeAttribute = metric?.dataPoints.find(
+      x => x.attributes[ATTR_V8JS_RESOURCE_TYPE] === 'TCPServerWrap'
+    );
+
+    assert.notEqual(
+      typeAttribute,
+      undefined,
+      `${METRIC_V8JS_RESOURCE_ACTIVE} space "${ATTR_V8JS_RESOURCE_TYPE}" not found`
+    );
+    assert.ok(typeAttribute!.value == 0);
   });
 });

--- a/packages/instrumentation-runtime-node/test/resource_active.test.ts
+++ b/packages/instrumentation-runtime-node/test/resource_active.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert';
+import { DataPointType, MeterProvider } from '@opentelemetry/sdk-metrics';
+import { GaugeMetricData } from '@opentelemetry/sdk-metrics/build/src/export/MetricData';
+import { RuntimeNodeInstrumentation } from '../src';
+import { TestMetricReader } from './testMetricsReader';
+import {
+  ATTR_V8JS_RESOURCE_TYPE,
+  METRIC_V8JS_RESOURCE_ACTIVE,
+} from '../src/semconv';
+
+const MEASUREMENT_INTERVAL = 10;
+
+describe('v8js.resource.active', function () {
+  let metricReader: TestMetricReader;
+  let meterProvider: MeterProvider;
+
+  beforeEach(() => {
+    metricReader = new TestMetricReader();
+    meterProvider = new MeterProvider({
+      readers: [metricReader],
+    });
+  });
+
+  it(`should write ${METRIC_V8JS_RESOURCE_ACTIVE} after monitoringPrecision`, async function () {
+    // arrange
+    const instrumentation = new RuntimeNodeInstrumentation({
+      monitoringPrecision: MEASUREMENT_INTERVAL,
+    });
+    instrumentation.setMeterProvider(meterProvider);
+
+    // act
+    await new Promise(resolve => setTimeout(resolve, MEASUREMENT_INTERVAL * 5));
+    const { resourceMetrics, errors } = await metricReader.collect();
+
+    // assert
+    assert.deepEqual(
+      errors,
+      [],
+      'expected no errors from the callback during collection'
+    );
+    const scopeMetrics = resourceMetrics.scopeMetrics;
+    const metric = scopeMetrics[0].metrics.find(
+      x => x.descriptor.name === METRIC_V8JS_RESOURCE_ACTIVE
+    );
+
+    assert.notEqual(
+      metric,
+      undefined,
+      `${METRIC_V8JS_RESOURCE_ACTIVE} not found`
+    );
+
+    assert.strictEqual(
+      metric!.dataPointType,
+      DataPointType.GAUGE,
+      'expected gauge'
+    );
+
+    assert.strictEqual(
+      metric!.descriptor.name,
+      METRIC_V8JS_RESOURCE_ACTIVE,
+      'descriptor.name'
+    );
+  });
+
+  it(`should write ${METRIC_V8JS_RESOURCE_ACTIVE} ${ATTR_V8JS_RESOURCE_TYPE} attribute`, async function () {
+    // We are only looking for the presence of 'TTYWrap' in this test.
+    // Because at this point it is the only option.
+    const instrumentation = new RuntimeNodeInstrumentation({
+      monitoringPrecision: MEASUREMENT_INTERVAL,
+    });
+    instrumentation.setMeterProvider(meterProvider);
+    const map = [...Array(10).keys()].map(x => x + 10);
+    map.indexOf(1);
+    // act
+    await new Promise(resolve => setTimeout(resolve, MEASUREMENT_INTERVAL * 5));
+    const { resourceMetrics, errors } = await metricReader.collect();
+
+    // assert
+    assert.deepEqual(
+      errors,
+      [],
+      'expected no errors from the callback during collection'
+    );
+    const scopeMetrics = resourceMetrics.scopeMetrics;
+    let metric: GaugeMetricData | undefined = undefined;
+    const foundMetric = scopeMetrics[0].metrics.find(
+      x => x.descriptor.name === METRIC_V8JS_RESOURCE_ACTIVE
+    );
+    if (foundMetric?.dataPointType === DataPointType.GAUGE) {
+      metric = foundMetric;
+    }
+    const spaceAttribute = metric?.dataPoints.find(
+      x => x.attributes[ATTR_V8JS_RESOURCE_TYPE] === 'TTYWrap'
+    );
+
+    assert.notEqual(
+      spaceAttribute,
+      undefined,
+      `${METRIC_V8JS_RESOURCE_ACTIVE} space "${ATTR_V8JS_RESOURCE_TYPE}" not found`
+    );
+  });
+});

--- a/packages/instrumentation-runtime-node/test/resource_active.test.ts
+++ b/packages/instrumentation-runtime-node/test/resource_active.test.ts
@@ -68,8 +68,6 @@ describe('v8js.resource.active', function () {
   });
 
   it(`should write ${METRIC_V8JS_RESOURCE_ACTIVE} ${ATTR_V8JS_RESOURCE_TYPE} attribute`, async function () {
-    // We are only looking for the presence of 'TTYWrap' in this test.
-    // Because at this point it is the only option.
     const instrumentation = new RuntimeNodeInstrumentation({
       monitoringPrecision: MEASUREMENT_INTERVAL,
     });
@@ -95,7 +93,7 @@ describe('v8js.resource.active', function () {
       metric = foundMetric;
     }
     const spaceAttribute = metric?.dataPoints.find(
-      x => x.attributes[ATTR_V8JS_RESOURCE_TYPE] === 'TTYWrap'
+      x => x.attributes[ATTR_V8JS_RESOURCE_TYPE] === 'Timeout'
     );
 
     assert.notEqual(


### PR DESCRIPTION
## Which problem is this PR solving?

Add a gauge to monitor the Active Resources that are keeping the event loop alive. This metric is recommended to be monitored to avoid saturation and starvation issues.

- allows detection of resource leaks (sockets and file descriptors for example)

## Short description of the changes

- Add gauge metric `v8js.resource.active`
- Add metric attribute `v8js.resource.type` 

## Reference

- https://nodejs.org/api/process.html#processgetactiveresourcesinfo

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->
