### PR TITLE
feat(pg): add pg-pool.release span

### DIFF
--- a/packages/instrumentation-pg/src/enums/SpanNames.ts
+++ b/packages/instrumentation-pg/src/enums/SpanNames.ts
@@ -18,4 +18,6 @@ export enum SpanNames {
   QUERY_PREFIX = 'pg.query',
   CONNECT = 'pg.connect',
   POOL_CONNECT = 'pg-pool.connect',
+  POOL_RELEASE = 'pg-pool.release',
 }
+

--- a/packages/instrumentation-pg/test/pg-pool.test.ts
+++ b/packages/instrumentation-pg/test/pg-pool.test.ts
@@ -328,6 +328,26 @@ describe('pg-pool', () => {
       assert.strictEqual(spans.length, 0);
     });
 
+    it('should create a span for client.release()', async () => {
+      const newPool = new pgPool(CONFIG);
+      create(); // enable instrumentation
+
+      const client = await newPool.connect();
+      client.release();
+      await newPool.end();
+
+      const spans = memoryExporter.getFinishedSpans();
+      const releaseSpans = spans.filter(
+        span => span.name === 'pg-pool.release'
+      );
+
+      assert.strictEqual(
+        releaseSpans.length,
+        1,
+        'expected one pg-pool.release span'
+      );
+    });
+
     it('should not create connect spans when ignoreConnectSpans=true', async () => {
       const newPool = new pgPool(CONFIG);
       create({
@@ -772,7 +792,7 @@ describe('pg-pool', () => {
           );
           assert.strictEqual(
             metrics[1].dataPoints[0].attributes[
-              ATTR_DB_CLIENT_CONNECTION_STATE
+            ATTR_DB_CLIENT_CONNECTION_STATE
             ],
             'used'
           );
@@ -783,7 +803,7 @@ describe('pg-pool', () => {
           );
           assert.strictEqual(
             metrics[1].dataPoints[1].attributes[
-              ATTR_DB_CLIENT_CONNECTION_STATE
+            ATTR_DB_CLIENT_CONNECTION_STATE
             ],
             'idle'
           );
@@ -1002,7 +1022,7 @@ describe('pg-pool', () => {
           );
           assert.strictEqual(
             metrics[1].dataPoints[0].attributes[
-              ATTR_DB_CLIENT_CONNECTION_STATE
+            ATTR_DB_CLIENT_CONNECTION_STATE
             ],
             'used'
           );


### PR DESCRIPTION
Fixes #1976 

This PR adds a `pg-pool.release` span by instrumenting `client.release()` on the
client returned from `pool.connect()`.

This allows tracing the full PostgreSQL pool lifecycle
(connect → query → release) while keeping existing pool metrics behavior unchanged.
