### PR TITLE
fix(instrumentation-pg): correct `db.client.connection.count` metric counting to handle multiple pg pools

### DIFF
--- a/packages/instrumentation-pg/src/instrumentation.ts
+++ b/packages/instrumentation-pg/src/instrumentation.ts
@@ -87,7 +87,9 @@ export class PgInstrumentation extends InstrumentationBase<PgInstrumentationConf
   // connections. The `_connCountsFromPoolName` is used to keep track of latest
   // values (per pool) and only update the metrics (_connectionsCount and
   // _connectionPendingRequests) when the values change.
-  private _connCountsFromPoolName: {[name: string]: utils.poolConnectionsCounter} = {};
+  private _connCountsFromPoolName: {
+    [name: string]: utils.poolConnectionsCounter;
+  } = {};
   private _semconvStability: SemconvStability;
 
   constructor(config: PgInstrumentationConfig = {}) {
@@ -529,7 +531,7 @@ export class PgInstrumentation extends InstrumentationBase<PgInstrumentationConf
         pgPool,
         this._connectionsCount,
         this._connectionPendingRequests,
-        this._connCountsFromPoolName,
+        this._connCountsFromPoolName
       );
     });
 
@@ -539,7 +541,7 @@ export class PgInstrumentation extends InstrumentationBase<PgInstrumentationConf
         pgPool,
         this._connectionsCount,
         this._connectionPendingRequests,
-        this._connCountsFromPoolName,
+        this._connCountsFromPoolName
       );
     });
 
@@ -549,7 +551,7 @@ export class PgInstrumentation extends InstrumentationBase<PgInstrumentationConf
         pgPool,
         this._connectionsCount,
         this._connectionPendingRequests,
-        this._connCountsFromPoolName,
+        this._connCountsFromPoolName
       );
     });
 
@@ -559,7 +561,7 @@ export class PgInstrumentation extends InstrumentationBase<PgInstrumentationConf
         pgPool,
         this._connectionsCount,
         this._connectionPendingRequests,
-        this._connCountsFromPoolName,
+        this._connCountsFromPoolName
       );
     });
     pgPool[EVENT_LISTENERS_SET] = true;

--- a/packages/instrumentation-pg/src/instrumentation.ts
+++ b/packages/instrumentation-pg/src/instrumentation.ts
@@ -81,16 +81,13 @@ export class PgInstrumentation extends InstrumentationBase<PgInstrumentationConf
   declare private _operationDuration: Histogram;
   declare private _connectionsCount: UpDownCounter;
   declare private _connectionPendingRequests: UpDownCounter;
+  // `_connCountsFromPoolName` is used to keep track of
   // Pool events connect, acquire, release and remove can be called
   // multiple times without changing the values of total, idle and waiting
-  // connections. The _connectionsCounter is used to keep track of latest
-  // values and only update the metrics _connectionsCount and _connectionPendingRequests
-  // when the value change.
-  private _connectionsCounter: utils.poolConnectionsCounter = {
-    used: 0,
-    idle: 0,
-    pending: 0,
-  };
+  // connections. The `_connCountsFromPoolName` is used to keep track of latest
+  // values (per pool) and only update the metrics (_connectionsCount and
+  // _connectionPendingRequests) when the values change.
+  private _connCountsFromPoolName: {[name: string]: utils.poolConnectionsCounter} = {};
   private _semconvStability: SemconvStability;
 
   constructor(config: PgInstrumentationConfig = {}) {
@@ -116,11 +113,7 @@ export class PgInstrumentation extends InstrumentationBase<PgInstrumentationConf
       }
     );
 
-    this._connectionsCounter = {
-      idle: 0,
-      pending: 0,
-      used: 0,
-    };
+    this._connCountsFromPoolName = {};
     this._connectionsCount = this.meter.createUpDownCounter(
       METRIC_DB_CLIENT_CONNECTION_COUNT,
       {
@@ -531,42 +524,42 @@ export class PgInstrumentation extends InstrumentationBase<PgInstrumentationConf
     const poolName = utils.getPoolName(pgPool.options);
 
     pgPool.on('connect', () => {
-      this._connectionsCounter = utils.updateCounter(
+      utils.updateCounter(
         poolName,
         pgPool,
         this._connectionsCount,
         this._connectionPendingRequests,
-        this._connectionsCounter
+        this._connCountsFromPoolName,
       );
     });
 
     pgPool.on('acquire', () => {
-      this._connectionsCounter = utils.updateCounter(
+      utils.updateCounter(
         poolName,
         pgPool,
         this._connectionsCount,
         this._connectionPendingRequests,
-        this._connectionsCounter
+        this._connCountsFromPoolName,
       );
     });
 
     pgPool.on('remove', () => {
-      this._connectionsCounter = utils.updateCounter(
+      utils.updateCounter(
         poolName,
         pgPool,
         this._connectionsCount,
         this._connectionPendingRequests,
-        this._connectionsCounter
+        this._connCountsFromPoolName,
       );
     });
 
     pgPool.on('release' as any, () => {
-      this._connectionsCounter = utils.updateCounter(
+      utils.updateCounter(
         poolName,
         pgPool,
         this._connectionsCount,
         this._connectionPendingRequests,
-        this._connectionsCounter
+        this._connCountsFromPoolName,
       );
     });
     pgPool[EVENT_LISTENERS_SET] = true;

--- a/packages/instrumentation-pg/src/utils.ts
+++ b/packages/instrumentation-pg/src/utils.ts
@@ -381,7 +381,7 @@ export function updateCounter(
   pool: PgPoolExtended,
   connectionCount: UpDownCounter,
   connectionPendingRequests: UpDownCounter,
-  connCountFromPoolName: {[name: string]: poolConnectionsCounter},
+  connCountFromPoolName: { [name: string]: poolConnectionsCounter }
 ) {
   const all = pool.totalCount;
   const pending = pool.waitingCount;
@@ -390,7 +390,7 @@ export function updateCounter(
 
   let connCount = connCountFromPoolName[poolName];
   if (!connCount) {
-    connCount = {used: 0, idle: 0, pending: 0};
+    connCount = { used: 0, idle: 0, pending: 0 };
     connCountFromPoolName[poolName] = connCount;
   }
 

--- a/packages/instrumentation-pg/src/utils.ts
+++ b/packages/instrumentation-pg/src/utils.ts
@@ -381,28 +381,36 @@ export function updateCounter(
   pool: PgPoolExtended,
   connectionCount: UpDownCounter,
   connectionPendingRequests: UpDownCounter,
-  latestCounter: poolConnectionsCounter
-): poolConnectionsCounter {
+  connCountFromPoolName: {[name: string]: poolConnectionsCounter},
+) {
   const all = pool.totalCount;
   const pending = pool.waitingCount;
   const idle = pool.idleCount;
   const used = all - idle;
 
-  connectionCount.add(used - latestCounter.used, {
+  let connCount = connCountFromPoolName[poolName];
+  if (!connCount) {
+    connCount = {used: 0, idle: 0, pending: 0};
+    connCountFromPoolName[poolName] = connCount;
+  }
+
+  connectionCount.add(used - connCount.used, {
     [ATTR_DB_CLIENT_CONNECTION_STATE]: DB_CLIENT_CONNECTION_STATE_VALUE_USED,
     [ATTR_DB_CLIENT_CONNECTION_POOL_NAME]: poolName,
   });
 
-  connectionCount.add(idle - latestCounter.idle, {
+  connectionCount.add(idle - connCount.idle, {
     [ATTR_DB_CLIENT_CONNECTION_STATE]: DB_CLIENT_CONNECTION_STATE_VALUE_IDLE,
     [ATTR_DB_CLIENT_CONNECTION_POOL_NAME]: poolName,
   });
 
-  connectionPendingRequests.add(pending - latestCounter.pending, {
+  connectionPendingRequests.add(pending - connCount.pending, {
     [ATTR_DB_CLIENT_CONNECTION_POOL_NAME]: poolName,
   });
 
-  return { used: used, idle: idle, pending: pending };
+  connCount.used = used;
+  connCount.idle = idle;
+  connCount.pending = pending;
 }
 
 export function patchCallbackPGPool(


### PR DESCRIPTION
Before this change the instrumentation was assuming there was only ever
one active PG pool.

Fixes: https://github.com/open-telemetry/opentelemetry-js-contrib/issues/3354


# Checklist

- [ ] Add tests
- [ ] Discuss whether getPoolName and `db.namespace` could include the PG schema, if any. Though really this would be a separate PR.
