### PR TITLE
feat(instrumentation-undici): support "QUERY" as a known HTTP method

### DIFF
--- a/packages/instrumentation-undici/src/undici.ts
+++ b/packages/instrumentation-undici/src/undici.ts
@@ -544,6 +544,8 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
       PATCH: true,
       DELETE: true,
       TRACE: true,
+      // QUERY from https://datatracker.ietf.org/doc/draft-ietf-httpbis-safe-method-w-body/
+      QUERY: true,
     };
 
     if (original.toUpperCase() in knownMethods) {


### PR DESCRIPTION
QUERY is (or soon will be, I'm not sure what is "authoritative" here) an
accepted HTTP request method. See https://datatracker.ietf.org/doc/draft-ietf-httpbis-safe-method-w-body/

FWIW, "QUERY" was added to the set of values for the
`http.request.method` enum in semconv v1.38.0.

Refs: https://github.com/open-telemetry/semantic-conventions/issues/2642
Refs: https://github.com/open-telemetry/opentelemetry-js/pull/6160 (same change for instrs in core repo)

---

This is a follow-up of the same change made to instr-http et al in the core repo in November.