### PR TITLE
feat(resource-detector-aws): read cloud.account.id from symlink in Lambda detector

### DIFF
--- a/packages/resource-detector-aws/src/detectors/AwsLambdaDetector.ts
+++ b/packages/resource-detector-aws/src/detectors/AwsLambdaDetector.ts
@@ -15,6 +15,7 @@
  */
 
 import * as fs from 'fs';
+import { diag } from '@opentelemetry/api';
 import {
   ResourceDetector,
   DetectedResource,
@@ -79,8 +80,8 @@ export class AwsLambdaDetector implements ResourceDetector {
     try {
       const accountId = fs.readlinkSync(ACCOUNT_ID_SYMLINK_PATH);
       attributes[ATTR_CLOUD_ACCOUNT_ID] = accountId;
-    } catch {
-      // Symlink doesn't exist or readlink failed — silently skip
+    } catch (e) {
+      diag.debug('AwsLambdaDetector: cloud.account.id not available via symlink', e);
     }
 
     return { attributes };

--- a/packages/resource-detector-aws/src/detectors/AwsLambdaDetector.ts
+++ b/packages/resource-detector-aws/src/detectors/AwsLambdaDetector.ts
@@ -34,7 +34,7 @@ import {
   CLOUD_PLATFORM_VALUE_AWS_LAMBDA,
 } from '../semconv';
 
-const ACCOUNT_ID_SYMLINK_PATH = '/tmp/.otel-account-id';
+const ACCOUNT_ID_SYMLINK_PATH = '/tmp/.otel-aws-account-id';
 
 /**
  * The AwsLambdaDetector can be used to detect if a process is running in AWS Lambda

--- a/packages/resource-detector-aws/src/detectors/AwsLambdaDetector.ts
+++ b/packages/resource-detector-aws/src/detectors/AwsLambdaDetector.ts
@@ -81,7 +81,10 @@ export class AwsLambdaDetector implements ResourceDetector {
       const accountId = fs.readlinkSync(ACCOUNT_ID_SYMLINK_PATH);
       attributes[ATTR_CLOUD_ACCOUNT_ID] = accountId;
     } catch (e) {
-      diag.debug('AwsLambdaDetector: cloud.account.id not available via symlink', e);
+      diag.debug(
+        'AwsLambdaDetector: cloud.account.id not available via symlink',
+        e
+      );
     }
 
     return { attributes };

--- a/packages/resource-detector-aws/src/detectors/AwsLambdaDetector.ts
+++ b/packages/resource-detector-aws/src/detectors/AwsLambdaDetector.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import * as fs from 'fs';
 import {
   ResourceDetector,
   DetectedResource,
@@ -21,6 +22,7 @@ import {
 } from '@opentelemetry/resources';
 import {
   ATTR_AWS_LOG_GROUP_NAMES,
+  ATTR_CLOUD_ACCOUNT_ID,
   ATTR_CLOUD_PLATFORM,
   ATTR_CLOUD_PROVIDER,
   ATTR_CLOUD_REGION,
@@ -31,6 +33,8 @@ import {
   CLOUD_PROVIDER_VALUE_AWS,
   CLOUD_PLATFORM_VALUE_AWS_LAMBDA,
 } from '../semconv';
+
+const ACCOUNT_ID_SYMLINK_PATH = '/tmp/.otel-account-id';
 
 /**
  * The AwsLambdaDetector can be used to detect if a process is running in AWS Lambda
@@ -70,6 +74,13 @@ export class AwsLambdaDetector implements ResourceDetector {
     }
     if (logStreamName) {
       attributes[ATTR_FAAS_INSTANCE] = logStreamName;
+    }
+
+    try {
+      const accountId = fs.readlinkSync(ACCOUNT_ID_SYMLINK_PATH);
+      attributes[ATTR_CLOUD_ACCOUNT_ID] = accountId;
+    } catch {
+      // Symlink doesn't exist or readlink failed — silently skip
     }
 
     return { attributes };

--- a/packages/resource-detector-aws/test/detectors/AwsLambdaDetector.test.ts
+++ b/packages/resource-detector-aws/test/detectors/AwsLambdaDetector.test.ts
@@ -15,11 +15,13 @@
  */
 
 import * as assert from 'assert';
+import * as fs from 'fs';
 import { detectResources } from '@opentelemetry/resources';
 import { assertEmptyResource } from '@opentelemetry/contrib-test-utils';
 import { awsLambdaDetector } from '../../src';
 import {
   ATTR_AWS_LOG_GROUP_NAMES,
+  ATTR_CLOUD_ACCOUNT_ID,
   ATTR_CLOUD_PLATFORM,
   ATTR_CLOUD_PROVIDER,
   ATTR_CLOUD_REGION,
@@ -76,6 +78,58 @@ describe('awsLambdaDetector', () => {
       assert.deepStrictEqual(resource.attributes[ATTR_AWS_LOG_GROUP_NAMES], [
         '/aws/lambda/name',
       ]);
+    });
+  });
+
+  describe('cloud.account.id from symlink', () => {
+    const symlinkPath = '/tmp/.otel-account-id';
+
+    function setLambdaEnv() {
+      process.env.AWS_EXECUTION_ENV = 'AWS_Lambda_nodejs22.x';
+      process.env.AWS_REGION = 'us-east-1';
+      process.env.AWS_LAMBDA_FUNCTION_NAME = 'name';
+      process.env.AWS_LAMBDA_FUNCTION_VERSION = 'v1';
+      process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE = '128';
+    }
+
+    afterEach(() => {
+      try {
+        fs.unlinkSync(symlinkPath);
+      } catch {
+        // ignore if not present
+      }
+    });
+
+    it('sets cloud.account.id when symlink exists', () => {
+      setLambdaEnv();
+      fs.symlinkSync('123456789012', symlinkPath);
+
+      const resource = detectResources({ detectors: [awsLambdaDetector] });
+
+      assert.strictEqual(
+        resource.attributes[ATTR_CLOUD_ACCOUNT_ID],
+        '123456789012'
+      );
+    });
+
+    it('preserves leading zeros in account ID', () => {
+      setLambdaEnv();
+      fs.symlinkSync('000123456789', symlinkPath);
+
+      const resource = detectResources({ detectors: [awsLambdaDetector] });
+
+      assert.strictEqual(
+        resource.attributes[ATTR_CLOUD_ACCOUNT_ID],
+        '000123456789'
+      );
+    });
+
+    it('does not set cloud.account.id when symlink is missing', () => {
+      setLambdaEnv();
+
+      const resource = detectResources({ detectors: [awsLambdaDetector] });
+
+      assert.strictEqual(resource.attributes[ATTR_CLOUD_ACCOUNT_ID], undefined);
     });
   });
 

--- a/packages/resource-detector-aws/test/detectors/AwsLambdaDetector.test.ts
+++ b/packages/resource-detector-aws/test/detectors/AwsLambdaDetector.test.ts
@@ -82,7 +82,7 @@ describe('awsLambdaDetector', () => {
   });
 
   describe('cloud.account.id from symlink', () => {
-    const symlinkPath = '/tmp/.otel-account-id';
+    const symlinkPath = '/tmp/.otel-aws-account-id';
 
     function setLambdaEnv() {
       process.env.AWS_EXECUTION_ENV = 'AWS_Lambda_nodejs22.x';


### PR DESCRIPTION
## Summary

- Reads `cloud.account.id` from the symlink at `/tmp/.otel-aws-account-id` created by the OTel Lambda Extension
- Uses `fs.readlinkSync()` to read the symlink target (the AWS account ID)
- Logs at debug level if the symlink doesn't exist — no impact on other resource detection

## Depends on

- open-telemetry/opentelemetry-lambda#2127 (extension creates the symlink)

## Changes

- `AwsLambdaDetector.ts` — Added readlink logic with `ACCOUNT_ID_SYMLINK_PATH` constant
- Tests: happy path, leading zeros preserved, missing symlink handled gracefully

## Test plan

- [x] Unit test: symlink exists → `cloud.account.id` set correctly
- [x] Unit test: leading zeros preserved as string
- [x] Unit test: missing symlink → attribute absent, no error