### PR TITLE
fix(instrumentation-undici)!: fix header capture to match spec

### DIFF
--- a/packages/instrumentation-undici/src/undici.ts
+++ b/packages/instrumentation-undici/src/undici.ts
@@ -384,7 +384,7 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
 
       for (const [name, value] of headersMap.entries()) {
         if (headersToAttribs.has(name)) {
-          const attrValue = Array.isArray(value) ? value.join(', ') : value;
+          const attrValue = Array.isArray(value) ? value : [value];
           spanAttributes[`http.request.header.${name}`] = attrValue;
         }
       }
@@ -420,26 +420,23 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
       true
     );
 
-    const headersToAttribs = new Set();
-
     if (config.headersToSpanAttributes?.responseHeaders) {
+      const headersToAttribs = new Set();
       config.headersToSpanAttributes?.responseHeaders.forEach(name =>
         headersToAttribs.add(name.toLowerCase())
       );
-    }
 
-    for (let idx = 0; idx < response.headers.length; idx = idx + 2) {
-      const name = response.headers[idx].toString().toLowerCase();
-      const value = response.headers[idx + 1];
+      for (let idx = 0; idx < response.headers.length; idx = idx + 2) {
+        const name = response.headers[idx].toString().toLowerCase();
+        const value = response.headers[idx + 1];
 
-      if (headersToAttribs.has(name)) {
-        spanAttributes[`http.response.header.${name}`] = value.toString();
-      }
-
-      if (name === 'content-length') {
-        const contentLength = Number(value.toString());
-        if (!isNaN(contentLength)) {
-          spanAttributes['http.response.header.content-length'] = contentLength;
+        if (headersToAttribs.has(name)) {
+          const attrName = `http.response.header.${name}`;
+          if (!Object.hasOwn(spanAttributes, attrName)) {
+            spanAttributes[attrName] = [value.toString()];
+          } else {
+            (spanAttributes[attrName] as string[]).push(value.toString());
+          }
         }
       }
     }

--- a/packages/instrumentation-undici/test/fetch.test.ts
+++ b/packages/instrumentation-undici/test/fetch.test.ts
@@ -176,7 +176,6 @@ describe('UndiciInstrumentation `fetch` tests', function () {
         httpMethod: 'GET',
         path: '/',
         query: '?query=test',
-        resHeaders: response.headers,
       });
     });
 
@@ -202,7 +201,6 @@ describe('UndiciInstrumentation `fetch` tests', function () {
         httpMethod: 'GET',
         path: '/',
         query: '?query=test',
-        resHeaders: response.headers,
       });
     });
 
@@ -229,7 +227,7 @@ describe('UndiciInstrumentation `fetch` tests', function () {
             response.statusText
           );
         },
-        startSpanHook: request => {
+        startSpanHook: _request => {
           return {
             'test.hook.attribute': 'hook-value',
           };
@@ -275,21 +273,20 @@ describe('UndiciInstrumentation `fetch` tests', function () {
         path: '/',
         query: '?query=test',
         reqHeaders: reqInit.headers,
-        resHeaders: queryResponse.headers,
       });
-      assert.strictEqual(
+      assert.deepStrictEqual(
         span.attributes['http.request.header.foo-client'],
-        'bar',
+        ['bar'],
         'request headers from fetch options are captured'
       );
-      assert.strictEqual(
+      assert.deepStrictEqual(
         span.attributes['http.request.header.x-requested-with'],
-        'undici',
+        ['undici'],
         'request headers from requestHook are captured'
       );
-      assert.strictEqual(
+      assert.deepStrictEqual(
         span.attributes['http.response.header.foo-server'],
-        'bar',
+        ['bar'],
         'response headers from the server are captured'
       );
       assert.strictEqual(

--- a/packages/instrumentation-undici/test/undici.test.ts
+++ b/packages/instrumentation-undici/test/undici.test.ts
@@ -283,7 +283,6 @@ describe('UndiciInstrumentation `undici` tests', function () {
         path: '/',
         query: '?query=test',
         reqHeaders: headers,
-        resHeaders: firstQueryResponse!.headers,
       });
       assert.strictEqual(
         spans[0].attributes['http.request.method_original'],
@@ -299,7 +298,6 @@ describe('UndiciInstrumentation `undici` tests', function () {
         path: '/',
         query: '?query=test',
         reqHeaders: headers,
-        resHeaders: secondQueryResponse!.headers,
       });
       assert.strictEqual(
         spans[1].attributes['http.request.method_original'],
@@ -349,21 +347,20 @@ describe('UndiciInstrumentation `undici` tests', function () {
         path: '/',
         query: '?query=test',
         reqHeaders: headers,
-        resHeaders: queryResponse.headers,
       });
-      assert.strictEqual(
+      assert.deepStrictEqual(
         span.attributes['http.request.header.foo-client'],
-        'bar',
+        ['bar'],
         'request headers from fetch options are captured'
       );
-      assert.strictEqual(
+      assert.deepStrictEqual(
         span.attributes['http.request.header.x-requested-with'],
-        'undici',
+        ['undici'],
         'request headers from requestHook are captured'
       );
-      assert.strictEqual(
+      assert.deepStrictEqual(
         span.attributes['http.response.header.foo-server'],
-        'bar',
+        ['bar'],
         'response headers from the server are captured'
       );
       assert.strictEqual(
@@ -414,21 +411,20 @@ describe('UndiciInstrumentation `undici` tests', function () {
         path: '/',
         query: '?query=test',
         reqHeaders: headers,
-        resHeaders: queryResponse.headers as unknown as Headers,
       });
-      assert.strictEqual(
+      assert.deepStrictEqual(
         span.attributes['http.request.header.foo-client'],
-        'bar',
+        ['bar'],
         'request headers from fetch options are captured'
       );
-      assert.strictEqual(
+      assert.deepStrictEqual(
         span.attributes['http.request.header.x-requested-with'],
-        'undici',
+        ['undici'],
         'request headers from requestHook are captured'
       );
-      assert.strictEqual(
+      assert.deepStrictEqual(
         span.attributes['http.response.header.foo-server'],
-        'bar',
+        ['bar'],
         'response headers from the server are captured'
       );
       assert.strictEqual(
@@ -487,21 +483,20 @@ describe('UndiciInstrumentation `undici` tests', function () {
         path: '/',
         query: '?query=test',
         reqHeaders: headers,
-        resHeaders: queryResponse.headers as unknown as Headers,
       });
-      assert.strictEqual(
+      assert.deepStrictEqual(
         span.attributes['http.request.header.foo-client'],
-        'bar',
+        ['bar'],
         'request headers from fetch options are captured'
       );
-      assert.strictEqual(
+      assert.deepStrictEqual(
         span.attributes['http.request.header.x-requested-with'],
-        'undici',
+        ['undici'],
         'request headers from requestHook are captured'
       );
-      assert.strictEqual(
+      assert.deepStrictEqual(
         span.attributes['http.response.header.foo-server'],
-        'bar',
+        ['bar'],
         'response headers from the server are captured'
       );
       assert.strictEqual(
@@ -568,21 +563,20 @@ describe('UndiciInstrumentation `undici` tests', function () {
         path: '/',
         query: '?query=test',
         reqHeaders: headers,
-        resHeaders: queryResponse.headers as unknown as Headers,
       });
-      assert.strictEqual(
+      assert.deepStrictEqual(
         span.attributes['http.request.header.foo-client'],
-        'bar',
+        ['bar'],
         'request headers from fetch options are captured'
       );
-      assert.strictEqual(
+      assert.deepStrictEqual(
         span.attributes['http.request.header.x-requested-with'],
-        'undici',
+        ['undici'],
         'request headers from requestHook are captured'
       );
-      assert.strictEqual(
+      assert.deepStrictEqual(
         span.attributes['http.response.header.foo-server'],
-        'bar',
+        ['bar'],
         'response headers from the server are captured'
       );
       assert.strictEqual(
@@ -637,7 +631,6 @@ describe('UndiciInstrumentation `undici` tests', function () {
         httpMethod: 'GET',
         path: '/',
         query: '?query=test',
-        resHeaders: headers,
       });
     });
 
@@ -875,7 +868,6 @@ describe('UndiciInstrumentation `undici` tests', function () {
           path: '/',
           query: '?query=test',
           reqHeaders: testCase.headers,
-          resHeaders: queryResponse.headers,
         });
         assert.strictEqual(
           span.attributes['user_agent.original'],
@@ -907,7 +899,6 @@ describe('UndiciInstrumentation `undici` tests', function () {
         httpMethod: 'GET',
         path: '/',
         query: '?query=test',
-        resHeaders: res.headers,
       });
       assert.strictEqual(span.attributes['url.full'], fullUrl);
     });

--- a/packages/instrumentation-undici/test/utils/assertSpan.ts
+++ b/packages/instrumentation-undici/test/utils/assertSpan.ts
@@ -44,7 +44,6 @@ export const assertSpan = (
     httpStatusCode?: number;
     httpMethod: string;
     spanName?: string;
-    resHeaders?: Headers | IncomingHttpHeaders;
     hostname: string;
     reqHeaders?: Headers | IncomingHttpHeaders;
     path?: string | null;
@@ -136,22 +135,6 @@ export const assertSpan = (
     hrTimeToNanoseconds(span.duration) > 0,
     'must have positive duration'
   );
-
-  if (validations.resHeaders) {
-    // Headers were added in v17.5.0, v16.15.0
-    // https://nodejs.org/api/globals.html#class-headers
-    const { resHeaders } = validations;
-    const contentLengthHeader = getHeader(resHeaders, 'content-length');
-
-    if (contentLengthHeader) {
-      const contentLength = Number(contentLengthHeader);
-
-      assert.strictEqual(
-        span.attributes['http.response.header.content-length'],
-        contentLength
-      );
-    }
-  }
 
   assert.strictEqual(
     span.attributes[ATTR_SERVER_ADDRESS],


### PR DESCRIPTION
- When headers are captured (to `http.request.header.<name>` or
  `http.response.header.<name` span attributes) according to the
  `headersToSpanAttributes` option, the value is now an *array of
  string*, rather than a string.
  https://opentelemetry.io/docs/specs/semconv/registry/attributes/http/
- The `http.response.header.content-length` is no longer specially
  handled. Before this change it would (a) always be captured if
  the response included a 'Content-Length' header and (b) would be
  converted to a number. Now, one must use `headersToSpanAttributes`
  to capture this header and it is not converted to a number.

(The spec includes a separate, unstable, `http.response.body.size` that
could be added in a separate PR.)
