### PR TITLE
test(instrumentation-undici): fix a mismerge that results in breaking the build in the undici test files

### DIFF
--- a/packages/instrumentation-undici/test/undici.test.ts
+++ b/packages/instrumentation-undici/test/undici.test.ts
@@ -321,7 +321,6 @@ describe('UndiciInstrumentation `undici` tests', function () {
         path: '/',
         query: '?query=test',
         reqHeaders: headers,
-        resHeaders: thirdQueryResponse!.headers,
       });
       assert.strictEqual(
         spans[2].attributes['http.request.method_original'],


### PR DESCRIPTION
Fixes this compilation error in instrumentation-undici:

```
   ✖  nx run @opentelemetry/instrumentation-undici:compile
      > @opentelemetry/instrumentation-undici@0.21.0 compile
      > tsc -p .

      test/undici.test.ts:324:9 - error TS2345: Argument of type '{ hostname: string; httpStatusCode: number; spanName: string; httpMethod: string; path: string; query: string; reqHeaders: { 'user-agent': string; 'foo-client': string; }; resHeaders: IncomingHttpHeaders; }' is not assignable to parameter of type '{ httpStatusCode?: number | undefined; httpMethod: string; spanName?: string | undefined; hostname: string; reqHeaders?: IncomingHttpHeaders | Headers | undefined; ... 4 more ...; error?: Exception | undefined; }'.
        Object literal may only specify known properties, but 'resHeaders' does not exist in type '{ httpStatusCode?: number | undefined; httpMethod: string; spanName?: string | undefined; hostname: string; reqHeaders?: IncomingHttpHeaders | Headers | undefined; ... 4 more ...; error?: Exception | undefined; }'. Did you mean to write 'reqHeaders'?

      324         resHeaders: thirdQueryResponse!.headers,
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


      Found 1 error in test/undici.test.ts:324
```