### PR TITLE
feat(ci): allow manual re-runs of release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,6 +2,9 @@ on:
   push:
     branches:
       - main
+  # If tweaking release notes (https://github.com/googleapis/release-please#how-can-i-fix-release-notes),
+  # it can be helpful to be able to manually re-run release-please.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
This is helpful if one is tweaking PR descriptions to impact
release-please's generated changelog.
