### PR TITLE
chore: when updating otel deps, ensure release-please will consider the update significant

### DIFF
--- a/scripts/update-otel-deps.js
+++ b/scripts/update-otel-deps.js
@@ -333,7 +333,10 @@ function updateNpmWorkspacesDeps({ patterns, allowRangeBumpFor0x, dryRun }) {
   }
 
   // Summary/commit message.
-  let commitMsg = `chore(deps): update deps${matchStr}\n\n`;
+  // Note: using `feat` rather than `chore`, because if release-please is
+  // being used, it ignores `chore` conventional-commits when determining if
+  // a package needs a new release.
+  let commitMsg = `feat(deps): update deps${matchStr}\n\n`;
   commitMsg +=
     '    ' +
     Array.from(summaryStrs)


### PR DESCRIPTION
Change the update-otel-deps.js script to suggest 'feat' rather than
'chore' for the commit title. The release-please release process will
ignore 'chore' commits when determining if a new release is needed:
https://github.com/googleapis/release-please#step-1-ensure-releasable-units-are-merged

Refs: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3383
