### PR TITLE
test(instrumentation-runtime-node): increase wait before metric collection

### DIFF
--- a/packages/instrumentation-runtime-node/test/event_loop_delay.test.ts
+++ b/packages/instrumentation-runtime-node/test/event_loop_delay.test.ts
@@ -43,7 +43,7 @@ describe('nodejs.eventloop.delay.*', function () {
       instrumentation.setMeterProvider(meterProvider);
 
       // act
-      await new Promise(resolve => setTimeout(resolve, 100));
+      await new Promise(resolve => setTimeout(resolve, 1000));
       const { resourceMetrics, errors } = await metricReader.collect();
 
       // assert


### PR DESCRIPTION
## Which problem is this PR solving?

This test has to depend on timing since we're measuring event loop delay. It seems that the current wait of 100ms is not enough for a reliable test, so this bumps it to 1s. This has the side-effect of taking longer, but since this is not running in TAV, impact should be negligible compared to having to re-run all tests.

ref https://github.com/open-telemetry/opentelemetry-js-contrib/actions/runs/22086572767/job/63822870530#step:10:1623