### PR TITLE
fix(instrumentation-host-metrics): unpin and update to systeminformation@^5.31.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34421,9 +34421,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.30.3",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.30.3.tgz",
-      "integrity": "sha512-NgHJUpA+y7j4asLQa9jgBt+Eb2piyQIXQ+YjOyd2K0cHNwbNJ6I06F5afOqOiaCuV/wrEyGrb0olg4aFLlJD+A==",
+      "version": "5.31.1",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.1.tgz",
+      "integrity": "sha512-6pRwxoGeV/roJYpsfcP6tN9mep6pPeCtXbUOCdVa0nme05Brwcwdge/fVNhIZn2wuUitAKZm4IYa7QjnRIa9zA==",
       "license": "MIT",
       "os": [
         "darwin",
@@ -37788,7 +37788,7 @@
       "version": "0.38.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "systeminformation": "5.30.3"
+        "systeminformation": "^5.31.1"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",

--- a/packages/host-metrics/package.json
+++ b/packages/host-metrics/package.json
@@ -48,7 +48,7 @@
     "@opentelemetry/sdk-metrics": "^2.0.0"
   },
   "dependencies": {
-    "systeminformation": "5.30.3"
+    "systeminformation": "^5.31.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/host-metrics#readme"
 }


### PR DESCRIPTION
## Which problem is this PR solving?

See #3391, a vulnerability in an unused code-path is triggering alerts for end-users. This also unpins the package, so that future patches are pulled in without us needing to publish a new version.