### PR TITLE
chore(socket.io): pin devDependency socket.io@4.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39292,8 +39292,8 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.59.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0",
-        "socket.io": "^4.1.3",
-        "socket.io-client": "^4.1.3"
+        "socket.io": "4.8.1",
+        "socket.io-client": "4.8.1"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"

--- a/packages/instrumentation-socket.io/package.json
+++ b/packages/instrumentation-socket.io/package.json
@@ -47,8 +47,8 @@
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/contrib-test-utils": "^0.59.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
-    "socket.io": "^4.1.3",
-    "socket.io-client": "^4.1.3"
+    "socket.io": "4.8.1",
+    "socket.io-client": "4.8.1"
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.212.0"


### PR DESCRIPTION
## Which problem is this PR solving?

Pins to `socket.io@4.8.1` due to a bug in the latest version which makes the compile step fail in our setup, see #3389 for details.

Unblocks #3261