### PR TITLE
chore(deps): update glob

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "eslint-plugin-n": "17.21.3",
         "eslint-plugin-yet-another-license-header": "0.2.0",
         "expect": "29.7.0",
-        "glob": "13.0.0",
+        "glob": "13.0.5",
         "globals": "^16.3.0",
         "karma": "6.4.4",
         "karma-chrome-launcher": "3.2.0",
@@ -20597,13 +20597,13 @@
       "license": "MIT"
     },
     "node_modules/glob": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
-      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.5.tgz",
+      "integrity": "sha512-BzXxZg24Ibra1pbQ/zE7Kys4Ua1ks7Bn6pKLkVPZ9FZe4JQS6/Q7ef3LG1H+k7lUf5l4T3PLSyYyYJVYUvfgTw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minimatch": "^10.1.1",
+        "minimatch": "^10.2.1",
         "minipass": "^7.1.2",
         "path-scurry": "^2.0.0"
       },
@@ -20634,14 +20634,37 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
+      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.1.tgz",
+      "integrity": "sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": "20 || >=22"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "eslint-plugin-n": "17.21.3",
     "eslint-plugin-yet-another-license-header": "0.2.0",
     "expect": "29.7.0",
-    "glob": "13.0.0",
+    "glob": "13.0.5",
     "globals": "^16.3.0",
     "karma": "6.4.4",
     "karma-chrome-launcher": "3.2.0",


### PR DESCRIPTION
## Which problem is this PR solving?

On updating @opentelemetry/auto-instrumentations-node to 0.70.0 just now, we got a dependabot security alert in the repository using it:

<img width="1222" height="693" alt="image" src="https://github.com/user-attachments/assets/102e6c1e-f702-4cc9-ba6b-702b9cbcd5c1" />

## Short description of the changes

- Update glob to 13.0.5 to resolve GHSA-3ppc-4f35-3m26 from its dependency minimatch.
