### PR TITLE
refactor(sampler-aws-xray): change internals to be promise-based to improve test stability

### DIFF
--- a/packages/sampler-aws-xray/src/aws-xray-sampling-client.ts
+++ b/packages/sampler-aws-xray/src/aws-xray-sampling-client.ts
@@ -94,7 +94,8 @@ export class AWSXRaySamplingClient {
                     responseObject = JSON.parse(responseData) as T;
                   } catch (error: unknown) {
                     logger(
-                      `Error occurred when parsing responseData from ${url}`, error
+                      `Error occurred when parsing responseData from ${url}`,
+                      error
                     );
                   }
 
@@ -110,16 +111,17 @@ export class AWSXRaySamplingClient {
                   );
                 }
               } catch (error: unknown) {
-                logger(`Error occurred when processing response from ${url}`, error);
+                logger(
+                  `Error occurred when processing response from ${url}`,
+                  error
+                );
               } finally {
                 resolve();
               }
             });
           })
           .on('error', (error: unknown) => {
-            logger(
-              `Error occurred when making an HTTP POST to ${url}`, error
-            );
+            logger(`Error occurred when making an HTTP POST to ${url}`, error);
             resolve();
           });
         if (requestBodyJsonString) {

--- a/packages/sampler-aws-xray/test/remote-sampler.test.ts
+++ b/packages/sampler-aws-xray/test/remote-sampler.test.ts
@@ -416,12 +416,10 @@ describe('AWSXRayRemoteSampler', () => {
     // span1 and span2 are child spans of root span0
     // For _AWSXRayRemoteSampler (Non-ParentBased), expect all 3 spans to update statistics
     expect(
-      internalSampler['ruleCache']['ruleAppliers'][0]['statistics']
-        .RequestCount
+      internalSampler['ruleCache']['ruleAppliers'][0]['statistics'].RequestCount
     ).toBe(3);
     expect(
-      internalSampler['ruleCache']['ruleAppliers'][0]['statistics']
-        .SampleCount
+      internalSampler['ruleCache']['ruleAppliers'][0]['statistics'].SampleCount
     ).toBe(3);
   });
 });

--- a/packages/sampler-aws-xray/test/remote-sampler.test.ts
+++ b/packages/sampler-aws-xray/test/remote-sampler.test.ts
@@ -121,7 +121,7 @@ describe('AWSXRayRemoteSampler', () => {
     expect(sampler['internalXraySampler']['clientId']).toMatch(/[a-f0-9]{24}/);
   });
 
-  it('testUpdateSamplingRulesAndTargetsWithPollersAndShouldSample', done => {
+  it('testUpdateSamplingRulesAndTargetsWithPollersAndShouldSample', async function () {
     nock(TEST_URL)
       .post('/GetSamplingRules')
       .reply(200, require(DATA_DIR_SAMPLING_RULES));
@@ -137,62 +137,63 @@ describe('AWSXRayRemoteSampler', () => {
       resource: resource,
     });
 
-    setTimeout(() => {
-      expect(
-        sampler['internalXraySampler']['ruleCache']['ruleAppliers'][0]
-          .samplingRule.RuleName
-      ).toEqual('test');
-      expect(
-        sampler.shouldSample(
-          context.active(),
-          testTraceId,
-          'name',
-          SpanKind.CLIENT,
-          { abc: '1234' },
-          []
-        ).decision
-      ).toEqual(SamplingDecision.NOT_RECORD);
+    await sampler['internalXraySampler']['initialRulesFetch'];
 
-      sampler['internalXraySampler']['getAndUpdateSamplingTargets']();
+    expect(
+      sampler['internalXraySampler']['ruleCache']['ruleAppliers'][0]
+        .samplingRule.RuleName
+    ).toEqual('test');
+    expect(
+      sampler.shouldSample(
+        context.active(),
+        testTraceId,
+        'name',
+        SpanKind.CLIENT,
+        { abc: '1234' },
+        []
+      ).decision
+    ).toEqual(SamplingDecision.NOT_RECORD);
 
-      setTimeout(() => {
-        expect(
-          sampler.shouldSample(
-            context.active(),
-            testTraceId,
-            'name',
-            SpanKind.CLIENT,
-            { abc: '1234' },
-            []
-          ).decision
-        ).toEqual(SamplingDecision.RECORD_AND_SAMPLED);
-        expect(
-          sampler.shouldSample(
-            context.active(),
-            testTraceId,
-            'name',
-            SpanKind.CLIENT,
-            { abc: '1234' },
-            []
-          ).decision
-        ).toEqual(SamplingDecision.RECORD_AND_SAMPLED);
-        expect(
-          sampler.shouldSample(
-            context.active(),
-            testTraceId,
-            'name',
-            SpanKind.CLIENT,
-            { abc: '1234' },
-            []
-          ).decision
-        ).toEqual(SamplingDecision.RECORD_AND_SAMPLED);
+    await sampler['internalXraySampler']['getAndUpdateSamplingTargets']();
 
-        done();
-      }, 50);
-    }, 50);
+    // Advance time so the rate limiter has accumulated balance
+    const clock = sinon.useFakeTimers(Date.now() + 1000);
+
+    expect(
+      sampler.shouldSample(
+        context.active(),
+        testTraceId,
+        'name',
+        SpanKind.CLIENT,
+        { abc: '1234' },
+        []
+      ).decision
+    ).toEqual(SamplingDecision.RECORD_AND_SAMPLED);
+    expect(
+      sampler.shouldSample(
+        context.active(),
+        testTraceId,
+        'name',
+        SpanKind.CLIENT,
+        { abc: '1234' },
+        []
+      ).decision
+    ).toEqual(SamplingDecision.RECORD_AND_SAMPLED);
+    expect(
+      sampler.shouldSample(
+        context.active(),
+        testTraceId,
+        'name',
+        SpanKind.CLIENT,
+        { abc: '1234' },
+        []
+      ).decision
+    ).toEqual(SamplingDecision.RECORD_AND_SAMPLED);
+
+    clock.restore();
   });
 
-  it('testLargeReservoir', done => {
+  it('testLargeReservoir', async function () {
     nock(TEST_URL)
       .post('/GetSamplingRules')
       .reply(200, require(DATA_DIR_SAMPLING_RULES));
@@ -208,14 +209,31 @@ describe('AWSXRayRemoteSampler', () => {
     sampler = new AWSXRayRemoteSampler({
       resource: resource,
     });
-    sampler['internalXraySampler']['getAndUpdateSamplingRules']();
 
-    setTimeout(() => {
-      expect(
-        sampler['internalXraySampler']['ruleCache']['ruleAppliers'][0]
-          .samplingRule.RuleName
-      ).toEqual('test');
-      expect(
+    await sampler['internalXraySampler']['initialRulesFetch'];
+
+    expect(
+      sampler['internalXraySampler']['ruleCache']['ruleAppliers'][0]
+        .samplingRule.RuleName
+    ).toEqual('test');
+    expect(
+      sampler.shouldSample(
+        context.active(),
+        testTraceId,
+        'name',
+        SpanKind.CLIENT,
+        attributes,
+        []
+      ).decision
+    ).toEqual(SamplingDecision.NOT_RECORD);
+
+    await sampler['internalXraySampler']['getAndUpdateSamplingTargets']();
+
+    const clock = sinon.useFakeTimers(Date.now());
+    clock.tick(1500);
+    let sampled = 0;
+    for (let i = 0; i < 1005; i++) {
+      if (
         sampler.shouldSample(
           context.active(),
           testTraceId,
@@ -223,42 +241,22 @@ describe('AWSXRayRemoteSampler', () => {
           SpanKind.CLIENT,
           attributes,
           []
-        ).decision
-      ).toEqual(SamplingDecision.NOT_RECORD);
-      sampler['internalXraySampler']['getAndUpdateSamplingTargets']();
+        ).decision !== SamplingDecision.NOT_RECORD
+      ) {
+        sampled++;
+      }
+    }
+    clock.restore();
 
-      setTimeout(() => {
-        const clock = sinon.useFakeTimers(Date.now());
-        clock.tick(1500);
-        let sampled = 0;
-        for (let i = 0; i < 1005; i++) {
-          if (
-            sampler.shouldSample(
-              context.active(),
-              testTraceId,
-              'name',
-              SpanKind.CLIENT,
-              attributes,
-              []
-            ).decision !== SamplingDecision.NOT_RECORD
-          ) {
-            sampled++;
-          }
-        }
-        clock.restore();
-
-        expect(
-          sampler['internalXraySampler']['ruleCache']['ruleAppliers'][0][
-            'reservoirSampler'
-          ]['quota']
-        ).toEqual(1000);
-        expect(sampled).toEqual(1000);
-        done();
-      }, 50);
-    }, 50);
+    expect(
+      sampler['internalXraySampler']['ruleCache']['ruleAppliers'][0][
+        'reservoirSampler'
+      ]['quota']
+    ).toEqual(1000);
+    expect(sampled).toEqual(1000);
   });
 
-  it('testSomeReservoir', done => {
+  it('testSomeReservoir', async function () {
     nock(TEST_URL)
       .post('/GetSamplingRules')
       .reply(200, require(DATA_DIR_SAMPLING_RULES));
@@ -293,14 +291,31 @@ describe('AWSXRayRemoteSampler', () => {
           };
         }
       );
-    sampler['internalXraySampler']['getAndUpdateSamplingRules']();
 
-    setTimeout(() => {
-      expect(
-        sampler['internalXraySampler']['ruleCache']['ruleAppliers'][0]
-          .samplingRule.RuleName
-      ).toEqual('test');
-      expect(
+    await sampler['internalXraySampler']['initialRulesFetch'];
+
+    expect(
+      sampler['internalXraySampler']['ruleCache']['ruleAppliers'][0]
+        .samplingRule.RuleName
+    ).toEqual('test');
+    expect(
+      sampler.shouldSample(
+        context.active(),
+        testTraceId,
+        'name',
+        SpanKind.CLIENT,
+        attributes,
+        []
+      ).decision
+    ).toEqual(SamplingDecision.RECORD_AND_SAMPLED);
+
+    await sampler['internalXraySampler']['getAndUpdateSamplingTargets']();
+
+    const clock = sinon.useFakeTimers(Date.now());
+    clock.tick(1000);
+    let sampled = 0;
+    for (let i = 0; i < 1000; i++) {
+      if (
         sampler.shouldSample(
           context.active(),
           testTraceId,
@@ -308,34 +323,14 @@ describe('AWSXRayRemoteSampler', () => {
           SpanKind.CLIENT,
           attributes,
           []
-        ).decision
-      ).toEqual(SamplingDecision.RECORD_AND_SAMPLED);
-      sampler['internalXraySampler']['getAndUpdateSamplingTargets']();
+        ).decision !== SamplingDecision.NOT_RECORD
+      ) {
+        sampled++;
+      }
+    }
+    clock.restore();
 
-      setTimeout(() => {
-        const clock = sinon.useFakeTimers(Date.now());
-        clock.tick(1000);
-        let sampled = 0;
-        for (let i = 0; i < 1000; i++) {
-          if (
-            sampler.shouldSample(
-              context.active(),
-              testTraceId,
-              'name',
-              SpanKind.CLIENT,
-              attributes,
-              []
-            ).decision !== SamplingDecision.NOT_RECORD
-          ) {
-            sampled++;
-          }
-        }
-        clock.restore();
-
-        expect(sampled).toEqual(100);
-        done();
-      }, 50);
-    }, 50);
+    expect(sampled).toEqual(100);
   });
 
   it('generates valid ClientId', () => {
@@ -352,7 +347,7 @@ describe('AWSXRayRemoteSampler', () => {
     );
   });
 
-  it('ParentBased AWSXRayRemoteSampler creates expected Statistics from the 1 Span with no Parent, disregarding 2 Child Spans', done => {
+  it('ParentBased AWSXRayRemoteSampler creates expected Statistics from the 1 Span with no Parent, disregarding 2 Child Spans', async function () {
     const defaultRuleDir =
       __dirname + '/data/get-sampling-rules-response-sample-sample-all.json';
     nock(TEST_URL)
@@ -367,32 +362,31 @@ describe('AWSXRayRemoteSampler', () => {
     });
     const tracer: Tracer = tracerProvider.getTracer('test');
 
-    setTimeout(() => {
-      const span0 = tracer.startSpan('test0');
-      const ctx = trace.setSpan(context.active(), span0);
-      const span1: Span = tracer.startSpan('test1', {}, ctx);
-      const span2: Span = tracer.startSpan('test2', {}, ctx);
-      span2.end();
-      span1.end();
-      span0.end();
+    await sampler['internalXraySampler']['initialRulesFetch'];
 
-      // span1 and span2 are child spans of root span0
-      // For AWSXRayRemoteSampler (ParentBased), expect only span0 to update statistics
-      expect(
-        sampler['internalXraySampler']['ruleCache']['ruleAppliers'][0][
-          'statistics'
-        ].RequestCount
-      ).toBe(1);
-      expect(
-        sampler['internalXraySampler']['ruleCache']['ruleAppliers'][0][
-          'statistics'
-        ].SampleCount
-      ).toBe(1);
-      done();
-    }, 50);
+    const span0 = tracer.startSpan('test0');
+    const ctx = trace.setSpan(context.active(), span0);
+    const span1: Span = tracer.startSpan('test1', {}, ctx);
+    const span2: Span = tracer.startSpan('test2', {}, ctx);
+    span2.end();
+    span1.end();
+    span0.end();
+
+    // span1 and span2 are child spans of root span0
+    // For AWSXRayRemoteSampler (ParentBased), expect only span0 to update statistics
+    expect(
+      sampler['internalXraySampler']['ruleCache']['ruleAppliers'][0][
+        'statistics'
+      ].RequestCount
+    ).toBe(1);
+    expect(
+      sampler['internalXraySampler']['ruleCache']['ruleAppliers'][0][
+        'statistics'
+      ].SampleCount
+    ).toBe(1);
   });
 
-  it('Non-ParentBased _AWSXRayRemoteSampler creates expected Statistics based on all 3 Spans, disregarding Parent Span Sampling Decision', done => {
+  it('Non-ParentBased _AWSXRayRemoteSampler creates expected Statistics based on all 3 Spans, disregarding Parent Span Sampling Decision', async () => {
     const defaultRuleDir =
       __dirname + '/data/get-sampling-rules-response-sample-sample-all.json';
     nock(TEST_URL)
@@ -409,27 +403,26 @@ describe('AWSXRayRemoteSampler', () => {
     });
     const tracer: Tracer = tracerProvider.getTracer('test');
 
-    setTimeout(() => {
-      const span0 = tracer.startSpan('test0');
-      const ctx = trace.setSpan(context.active(), span0);
-      const span1: Span = tracer.startSpan('test1', {}, ctx);
-      const span2: Span = tracer.startSpan('test2', {}, ctx);
-      span2.end();
-      span1.end();
-      span0.end();
+    await sampler['internalXraySampler']['initialRulesFetch'];
 
-      // span1 and span2 are child spans of root span0
-      // For _AWSXRayRemoteSampler (Non-ParentBased), expect all 3 spans to update statistics
-      expect(
-        internalSampler['ruleCache']['ruleAppliers'][0]['statistics']
-          .RequestCount
-      ).toBe(3);
-      expect(
-        internalSampler['ruleCache']['ruleAppliers'][0]['statistics']
-          .SampleCount
-      ).toBe(3);
-      done();
-    }, 50);
+    const span0 = tracer.startSpan('test0');
+    const ctx = trace.setSpan(context.active(), span0);
+    const span1: Span = tracer.startSpan('test1', {}, ctx);
+    const span2: Span = tracer.startSpan('test2', {}, ctx);
+    span2.end();
+    span1.end();
+    span0.end();
+
+    // span1 and span2 are child spans of root span0
+    // For _AWSXRayRemoteSampler (Non-ParentBased), expect all 3 spans to update statistics
+    expect(
+      internalSampler['ruleCache']['ruleAppliers'][0]['statistics']
+        .RequestCount
+    ).toBe(3);
+    expect(
+      internalSampler['ruleCache']['ruleAppliers'][0]['statistics']
+        .SampleCount
+    ).toBe(3);
   });
 });
 


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #3394 (the overkill solution, re-write internals to promise-based, await that promise and then let the test continue).
I'll open a second PR that just increases timeouts.

Note: the diff looks gnarlier than it is - it's mostly just indentation changes due to having async/await over callbacks now.