### PR TITLE
test(sampler-aws-xray): increase wait in tests to 500ms

### DIFF
--- a/packages/sampler-aws-xray/test/remote-sampler.test.ts
+++ b/packages/sampler-aws-xray/test/remote-sampler.test.ts
@@ -188,8 +188,8 @@ describe('AWSXRayRemoteSampler', () => {
         ).toEqual(SamplingDecision.RECORD_AND_SAMPLED);
 
         done();
-      }, 50);
-    }, 50);
+      }, 500);
+    }, 500);
   });
 
   it('testLargeReservoir', done => {
@@ -254,8 +254,8 @@ describe('AWSXRayRemoteSampler', () => {
         ).toEqual(1000);
         expect(sampled).toEqual(1000);
         done();
-      }, 50);
-    }, 50);
+      }, 500);
+    }, 500);
   });
 
   it('testSomeReservoir', done => {
@@ -334,8 +334,8 @@ describe('AWSXRayRemoteSampler', () => {
 
         expect(sampled).toEqual(100);
         done();
-      }, 50);
-    }, 50);
+      }, 500);
+    }, 500);
   });
 
   it('generates valid ClientId', () => {
@@ -389,7 +389,7 @@ describe('AWSXRayRemoteSampler', () => {
         ].SampleCount
       ).toBe(1);
       done();
-    }, 50);
+    }, 500);
   });
 
   it('Non-ParentBased _AWSXRayRemoteSampler creates expected Statistics based on all 3 Spans, disregarding Parent Span Sampling Decision', done => {
@@ -429,7 +429,7 @@ describe('AWSXRayRemoteSampler', () => {
           .SampleCount
       ).toBe(3);
       done();
-    }, 50);
+    }, 500);
   });
 });
 


### PR DESCRIPTION
## Which problem is this PR solving?

See #3394, tests are flaky and are holding back other PRs (including releases and fixes).
This PR bumps the wait to 500ms, which should improve the stability of the test at the cost of time needed to complete. Impact on run-time of the test in CI should be minimal as we only run it once.

I have also queued up a larger change that should improve the overall reliably of the test without increasing the time needed for the test to run.  #3396 

Does not fully fix, but is a workaround for #3394 