### PR TITLE
docs(instrumentation-cucumber): correct supported versions note in README

### DIFF
--- a/packages/instrumentation-cucumber/README.md
+++ b/packages/instrumentation-cucumber/README.md
@@ -17,7 +17,7 @@ npm install --save @opentelemetry/instrumentation-cucumber
 
 ## Supported Versions
 
-- [`@cucumber/cucumber`](https://www.npmjs.com/package/@cucumber/cucumber) versions `>=8.0.0 <11`
+- [`@cucumber/cucumber`](https://www.npmjs.com/package/@cucumber/cucumber) versions `>=8.0.0 <13`
 
 ## Usage
 


### PR DESCRIPTION
Refs: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2958 (when cucumber v12 support was added)
