### PR TITLE
feat(deps): update deps matching "@opentelemetry/*"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -964,6 +964,7 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -1016,6 +1017,7 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
         "@smithy/types": "^4.12.0",
@@ -1253,6 +1255,7 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -9117,9 +9120,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.212.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.212.0.tgz",
-      "integrity": "sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==",
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.213.0.tgz",
+      "integrity": "sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -9149,12 +9152,12 @@
       "link": true
     },
     "node_modules/@opentelemetry/configuration": {
-      "version": "0.212.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/configuration/-/configuration-0.212.0.tgz",
-      "integrity": "sha512-D8sAY6RbqMa1W8lCeiaSL2eMCW2MF87QI3y+I6DQE1j+5GrDMwiKPLdzpa/2/+Zl9v1//74LmooCTCJBvWR8Iw==",
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/configuration/-/configuration-0.213.0.tgz",
+      "integrity": "sha512-MfVgZiUuwL1d3bPPvXcEkVHGTGNUGoqGK97lfwBuRoKttcVGGqDyxTCCVa5MGbirtBQkUTysXMBUVWPaq7zbWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/core": "2.6.0",
         "yaml": "^2.0.0"
       },
       "engines": {
@@ -9180,9 +9183,9 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.5.1.tgz",
-      "integrity": "sha512-MHbu8XxCHcBn6RwvCt2Vpn1WnLMNECfNKYB14LI5XypcgH4IE0/DiVifVR9tAkwPMyLXN8dOoPJfya3IryLQVw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.0.tgz",
+      "integrity": "sha512-L8UyDwqpTcbkIK5cgwDRDYDoEhQoj8wp8BwsO19w3LB1Z41yEQm2VJyNfAi9DrLP/YTqXqWpKHyZfR9/tFYo1Q==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -9192,9 +9195,9 @@
       }
     },
     "node_modules/@opentelemetry/context-zone-peer-dep": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-2.5.1.tgz",
-      "integrity": "sha512-xyBDA9BIjlAeawNawFZtwJp4BUznGrR5Sm7ldK/94qWtYde9+1y61tAqBep0/5B46WpbEadZGbpa2MCKAZwvxA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-2.6.0.tgz",
+      "integrity": "sha512-cFSbc+3Osyo3nBmdteNarJaI3GqTRn0YgcEJWt/PkgazLqfwMifPIoSBLpLCZQzGtkTbdef2htgE7Tw6qe/bkw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -9210,9 +9213,9 @@
       "link": true
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.1.tgz",
-      "integrity": "sha512-Dwlc+3HAZqpgTYq0MUyZABjFkcrKTePwuiFVLjahGD8cx3enqihmpAmdgNFO1R4m/sIe5afjJrA25Prqy4NXlA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz",
+      "integrity": "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -9225,13 +9228,13 @@
       }
     },
     "node_modules/@opentelemetry/exporter-jaeger": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-2.5.1.tgz",
-      "integrity": "sha512-U97uyVcWGaXlbsB2v7K3ljg8AeE3jaBRqUp5+/pYReZsK2V4sPfZu4iXeO1vLK1ZIXEdghg5RgWXAB7Uj6ubog==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-jaeger/-/exporter-jaeger-2.6.0.tgz",
+      "integrity": "sha512-KzyYCSKg4OpXaczS5+abChe8hnTGJhgXyi9O0HQ6TNcyB/R+Rr7Vslneb9RvpirmsWXZvORhzei3Ed91hPSWHA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/sdk-trace-base": "2.5.1",
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/sdk-trace-base": "2.6.0",
         "@opentelemetry/semantic-conventions": "^1.29.0",
         "jaeger-client": "^3.15.0"
       },
@@ -9243,17 +9246,17 @@
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
-      "version": "0.212.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.212.0.tgz",
-      "integrity": "sha512-/0bk6fQG+eSFZ4L6NlckGTgUous/ib5+OVdg0x4OdwYeHzV3lTEo3it1HgnPY6UKpmX7ki+hJvxjsOql8rCeZA==",
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.213.0.tgz",
+      "integrity": "sha512-QiRZzvayEOFnenSXi85Eorgy5WTqyNQ+E7gjl6P6r+W3IUIwAIH8A9/BgMWfP056LwmdrBL6+qvnwaIEmug6Yg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.3",
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/otlp-exporter-base": "0.212.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.212.0",
-        "@opentelemetry/otlp-transformer": "0.212.0",
-        "@opentelemetry/sdk-logs": "0.212.0"
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/otlp-exporter-base": "0.213.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.213.0",
+        "@opentelemetry/otlp-transformer": "0.213.0",
+        "@opentelemetry/sdk-logs": "0.213.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -9263,16 +9266,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-http": {
-      "version": "0.212.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.212.0.tgz",
-      "integrity": "sha512-JidJasLwG/7M9RTxV/64xotDKmFAUSBc9SNlxI32QYuUMK5rVKhHNWMPDzC7E0pCAL3cu+FyiKvsTwLi2KqPYw==",
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.213.0.tgz",
+      "integrity": "sha512-vqDVSpLp09ZzcFIdb7QZrEFPxUlO3GzdhBKLstq3jhYB5ow3+ZtV5V0ngSdi/0BZs+J5WPiN1+UDV4X5zD/GzA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.212.0",
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/otlp-exporter-base": "0.212.0",
-        "@opentelemetry/otlp-transformer": "0.212.0",
-        "@opentelemetry/sdk-logs": "0.212.0"
+        "@opentelemetry/api-logs": "0.213.0",
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/otlp-exporter-base": "0.213.0",
+        "@opentelemetry/otlp-transformer": "0.213.0",
+        "@opentelemetry/sdk-logs": "0.213.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -9282,18 +9285,18 @@
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
-      "version": "0.212.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.212.0.tgz",
-      "integrity": "sha512-RpKB5UVfxc7c6Ta1UaCrxXDTQ0OD7BCGT66a97Q5zR1x3+9fw4dSaiqMXT/6FAWj2HyFbem6Rcu1UzPZikGTWQ==",
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.213.0.tgz",
+      "integrity": "sha512-gQk41nqfK3KhDk8jbSo3LR/fQBlV7f6Q5xRcfDmL1hZlbgXQPdVFV9/rIfYUrCoq1OM+2NnKnFfGjBt6QpLSsA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.212.0",
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/otlp-exporter-base": "0.212.0",
-        "@opentelemetry/otlp-transformer": "0.212.0",
-        "@opentelemetry/resources": "2.5.1",
-        "@opentelemetry/sdk-logs": "0.212.0",
-        "@opentelemetry/sdk-trace-base": "2.5.1"
+        "@opentelemetry/api-logs": "0.213.0",
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/otlp-exporter-base": "0.213.0",
+        "@opentelemetry/otlp-transformer": "0.213.0",
+        "@opentelemetry/resources": "2.6.0",
+        "@opentelemetry/sdk-logs": "0.213.0",
+        "@opentelemetry/sdk-trace-base": "2.6.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -9303,19 +9306,19 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
-      "version": "0.212.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.212.0.tgz",
-      "integrity": "sha512-/6Gqf9wpBq22XsomR1i0iPGnbQtCq2Vwnrq5oiDPjYSqveBdK1jtQbhGfmpK2mLLxk4cPDtD1ZEYdIou5K8EaA==",
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.213.0.tgz",
+      "integrity": "sha512-Z8gYKUAU48qwm+a1tjnGv9xbE7a5lukVIwgF6Z5i3VPXPVMe4Sjra0nN3zU7m277h+V+ZpsPGZJ2Xf0OTkL7/w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.3",
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.212.0",
-        "@opentelemetry/otlp-exporter-base": "0.212.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.212.0",
-        "@opentelemetry/otlp-transformer": "0.212.0",
-        "@opentelemetry/resources": "2.5.1",
-        "@opentelemetry/sdk-metrics": "2.5.1"
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.213.0",
+        "@opentelemetry/otlp-exporter-base": "0.213.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.213.0",
+        "@opentelemetry/otlp-transformer": "0.213.0",
+        "@opentelemetry/resources": "2.6.0",
+        "@opentelemetry/sdk-metrics": "2.6.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -9325,16 +9328,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
-      "version": "0.212.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.212.0.tgz",
-      "integrity": "sha512-8hgBw3aTTRpSTkU4b9MLf/2YVLnfWp+hfnLq/1Fa2cky+vx6HqTodo+Zv1GTIrAKMOOwgysOjufy0gTxngqeBg==",
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.213.0.tgz",
+      "integrity": "sha512-yw3fTIw4KQIRXC/ZyYQq5gtA3Ogfdfz/g5HVgleobQAcjUUE8Nj3spGMx8iQPp+S+u6/js7BixufRkXhzLmpJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/otlp-exporter-base": "0.212.0",
-        "@opentelemetry/otlp-transformer": "0.212.0",
-        "@opentelemetry/resources": "2.5.1",
-        "@opentelemetry/sdk-metrics": "2.5.1"
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/otlp-exporter-base": "0.213.0",
+        "@opentelemetry/otlp-transformer": "0.213.0",
+        "@opentelemetry/resources": "2.6.0",
+        "@opentelemetry/sdk-metrics": "2.6.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -9344,17 +9347,17 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
-      "version": "0.212.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.212.0.tgz",
-      "integrity": "sha512-C7I4WN+ghn3g7SnxXm2RK3/sRD0k/BYcXaK6lGU3yPjiM7a1M25MLuM6zY3PeVPPzzTZPfuS7+wgn/tHk768Xw==",
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.213.0.tgz",
+      "integrity": "sha512-geHF+zZaDb0/WRkJTxR8o8dG4fCWT/Wq7HBdNZCxwH5mxhwRi/5f37IDYH7nvU+dwU6IeY4Pg8TPI435JCiNkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.212.0",
-        "@opentelemetry/otlp-exporter-base": "0.212.0",
-        "@opentelemetry/otlp-transformer": "0.212.0",
-        "@opentelemetry/resources": "2.5.1",
-        "@opentelemetry/sdk-metrics": "2.5.1"
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.213.0",
+        "@opentelemetry/otlp-exporter-base": "0.213.0",
+        "@opentelemetry/otlp-transformer": "0.213.0",
+        "@opentelemetry/resources": "2.6.0",
+        "@opentelemetry/sdk-metrics": "2.6.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -9364,14 +9367,14 @@
       }
     },
     "node_modules/@opentelemetry/exporter-prometheus": {
-      "version": "0.212.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.212.0.tgz",
-      "integrity": "sha512-hJFLhCJba5MW5QHexZMHZdMhBfNqNItxOsN0AZojwD1W2kU9xM+BEICowFGJFo/vNV+I2BJvTtmuKafeDSAo7Q==",
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.213.0.tgz",
+      "integrity": "sha512-FyV3/JfKGAgx+zJUwCHdjQHbs+YeGd2fOWvBHYrW6dmfv/w89lb8WhJTSZEoWgP525jwv/gFeBttlGu1flebdA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/resources": "2.5.1",
-        "@opentelemetry/sdk-metrics": "2.5.1",
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/resources": "2.6.0",
+        "@opentelemetry/sdk-metrics": "2.6.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -9382,18 +9385,18 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.212.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.212.0.tgz",
-      "integrity": "sha512-9xTuYWp8ClBhljDGAoa0NSsJcsxJsC9zCFKMSZJp1Osb9pjXCMRdA6fwXtlubyqe7w8FH16EWtQNKx/FWi+Ghw==",
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.213.0.tgz",
+      "integrity": "sha512-L8y6piP4jBIIx1Nv7/9hkx25ql6/Cro/kQrs+f9e8bPF0Ar5Dm991v7PnbtubKz6Q4fT872H56QXUWVnz/Cs4Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.3",
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/otlp-exporter-base": "0.212.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.212.0",
-        "@opentelemetry/otlp-transformer": "0.212.0",
-        "@opentelemetry/resources": "2.5.1",
-        "@opentelemetry/sdk-trace-base": "2.5.1"
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/otlp-exporter-base": "0.213.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.213.0",
+        "@opentelemetry/otlp-transformer": "0.213.0",
+        "@opentelemetry/resources": "2.6.0",
+        "@opentelemetry/sdk-trace-base": "2.6.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -9403,16 +9406,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http": {
-      "version": "0.212.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.212.0.tgz",
-      "integrity": "sha512-v/0wMozNoiEPRolzC4YoPo4rAT0q8r7aqdnRw3Nu7IDN0CGFzNQazkfAlBJ6N5y0FYJkban7Aw5WnN73//6YlA==",
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.213.0.tgz",
+      "integrity": "sha512-tnRmJD39aWrE/Sp7F6AbRNAjKHToDkAqBi6i0lESpGWz3G+f4bhVAV6mgSXH2o18lrDVJXo6jf9bAywQw43wRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/otlp-exporter-base": "0.212.0",
-        "@opentelemetry/otlp-transformer": "0.212.0",
-        "@opentelemetry/resources": "2.5.1",
-        "@opentelemetry/sdk-trace-base": "2.5.1"
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/otlp-exporter-base": "0.213.0",
+        "@opentelemetry/otlp-transformer": "0.213.0",
+        "@opentelemetry/resources": "2.6.0",
+        "@opentelemetry/sdk-trace-base": "2.6.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -9422,16 +9425,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.212.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.212.0.tgz",
-      "integrity": "sha512-d1ivqPT0V+i0IVOOdzGaLqonjtlk5jYrW7ItutWzXL/Mk+PiYb59dymy/i2reot9dDnBFWfrsvxyqdutGF5Vig==",
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.213.0.tgz",
+      "integrity": "sha512-six3vPq3sL+ge1iZOfKEg+RHuFQhGb8ZTdlvD234w/0gi8ty/qKD46qoGpKvM3amy5yYunWBKiFBW47WaVS26w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/otlp-exporter-base": "0.212.0",
-        "@opentelemetry/otlp-transformer": "0.212.0",
-        "@opentelemetry/resources": "2.5.1",
-        "@opentelemetry/sdk-trace-base": "2.5.1"
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/otlp-exporter-base": "0.213.0",
+        "@opentelemetry/otlp-transformer": "0.213.0",
+        "@opentelemetry/resources": "2.6.0",
+        "@opentelemetry/sdk-trace-base": "2.6.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -9441,14 +9444,14 @@
       }
     },
     "node_modules/@opentelemetry/exporter-zipkin": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.5.1.tgz",
-      "integrity": "sha512-Me6JVO7WqXGXsgr4+7o+B7qwKJQbt0c8WamFnxpkR43avgG9k/niTntwCaXiXUTjonWy0+61ZuX6CGzj9nn8CQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.6.0.tgz",
+      "integrity": "sha512-AFP77OQMLfw/Jzh6WT2PtrywstNjdoyT9t9lYrYdk1s4igsvnMZ8DkZKCwxsItC01D+4Lydgrb+Wy0bAvpp8xg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/resources": "2.5.1",
-        "@opentelemetry/sdk-trace-base": "2.5.1",
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/resources": "2.6.0",
+        "@opentelemetry/sdk-trace-base": "2.6.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -9467,13 +9470,13 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.212.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.212.0.tgz",
-      "integrity": "sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==",
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.213.0.tgz",
+      "integrity": "sha512-3i9NdkET/KvQomeh7UaR/F4r9P25Rx6ooALlWXPIjypcEOUxksCmVu0zA70NBJWlrMW1rPr/LRidFAflLI+s/w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.212.0",
-        "import-in-the-middle": "^2.0.6",
+        "@opentelemetry/api-logs": "0.213.0",
+        "import-in-the-middle": "^3.0.0",
         "require-in-the-middle": "^8.0.0"
       },
       "engines": {
@@ -9536,14 +9539,14 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-fetch": {
-      "version": "0.212.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.212.0.tgz",
-      "integrity": "sha512-qHcv+4fVvT1PGSLLiwK4UjfXlbpg1KDVZWJyle3VoH6uMfyeQSirS23u4WewwNdRPorfDX8bhQ7RCWItwWvZtA==",
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.213.0.tgz",
+      "integrity": "sha512-A9Gr/iQ4bjQ4m6FOKierMOmI1/MGcRetmG7Y+/SrgV9aefT9/Fn4hFWHwbgZ4dATkEJQ5DIBXVn1sENOe/uQyg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/instrumentation": "0.212.0",
-        "@opentelemetry/sdk-trace-web": "2.5.1",
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/instrumentation": "0.213.0",
+        "@opentelemetry/sdk-trace-web": "2.6.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -9566,12 +9569,12 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-grpc": {
-      "version": "0.212.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.212.0.tgz",
-      "integrity": "sha512-r1t7LNKWVhSQMUrBdDJtooFmmLZ93kGuFixqeXPoUP8W+chJCxhey9l0c0+L3xriNdyB7TzvkKHhPXUDevgVEA==",
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.213.0.tgz",
+      "integrity": "sha512-GT53wIJnEffHcWlDUXRodTSUUspy57PNBZXc46z9rfy3Ee+VeM5XqWnieF1yefCd01QTaISYB49LXNc2SayIBQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "0.212.0",
+        "@opentelemetry/instrumentation": "0.213.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -9586,13 +9589,13 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.212.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.212.0.tgz",
-      "integrity": "sha512-t2nt16Uyv9irgR+tqnX96YeToOStc3X5js7Ljn3EKlI2b4Fe76VhMkTXtsTQ0aId6AsYgefrCRnXSCo/Fn/vww==",
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.213.0.tgz",
+      "integrity": "sha512-B978Xsm5XEPGhm1P07grDoaOFLHapJPkOG9h016cJsyWWxmiLnPu2M/4Nrm7UCkHSiLnkXgC+zVGUAIahy8EEA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/instrumentation": "0.212.0",
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/instrumentation": "0.213.0",
         "@opentelemetry/semantic-conventions": "^1.29.0",
         "forwarded-parse": "2.1.2"
       },
@@ -9720,14 +9723,14 @@
       "link": true
     },
     "node_modules/@opentelemetry/instrumentation-xml-http-request": {
-      "version": "0.212.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.212.0.tgz",
-      "integrity": "sha512-MkBZ2/7iup+rrKB5pzVDAjGKGpnr8pHWmRv02hJPkD/nX2HBSV6WQ2oXrXedDgeTKdOs6bthpNj+2yzfLRrlHA==",
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-xml-http-request/-/instrumentation-xml-http-request-0.213.0.tgz",
+      "integrity": "sha512-Swuigd0YX5zQANch6lC0vSx63Z9ilB8/fJPn9iYBSif/SwPGmecHLawXpMM78PuxO/hIn8rSWP1gSWhBthLTKw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/instrumentation": "0.212.0",
-        "@opentelemetry/sdk-trace-web": "2.5.1",
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/instrumentation": "0.213.0",
+        "@opentelemetry/sdk-trace-web": "2.6.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -9738,13 +9741,13 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.212.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.212.0.tgz",
-      "integrity": "sha512-HoMv5pQlzbuxiMS0hN7oiUtg8RsJR5T7EhZccumIWxYfNo/f4wFc7LPDfFK6oHdG2JF/+qTocfqIHoom+7kLpw==",
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.213.0.tgz",
+      "integrity": "sha512-MegxAP1/n09Ob2dQvY5NBDVjAFkZRuKtWKxYev1R2M8hrsgXzQGkaMgoEKeUOyQ0FUyYcO29UOnYdQWmWa0PXg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/otlp-transformer": "0.212.0"
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/otlp-transformer": "0.213.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -9754,15 +9757,15 @@
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.212.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.212.0.tgz",
-      "integrity": "sha512-YidOSlzpsun9uw0iyIWrQp6HxpMtBlECE3tiHGAsnpEqJWbAUWcMnIffvIuvTtTQ1OyRtwwaE79dWSQ8+eiB7g==",
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.213.0.tgz",
+      "integrity": "sha512-XgRGuLE9usFNlnw2lgMIM4HTwpcIyjdU/xPoJ8v3LbBLBfjaDkIugjc9HoWa7ZSJ/9Bhzgvm/aD0bGdYUFgnTw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.3",
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/otlp-exporter-base": "0.212.0",
-        "@opentelemetry/otlp-transformer": "0.212.0"
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/otlp-exporter-base": "0.213.0",
+        "@opentelemetry/otlp-transformer": "0.213.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -9772,48 +9775,24 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.212.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.212.0.tgz",
-      "integrity": "sha512-bj7zYFOg6Db7NUwsRZQ/WoVXpAf41WY2gsd3kShSfdpZQDRKHWJiRZIg7A8HvWsf97wb05rMFzPbmSHyjEl9tw==",
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.213.0.tgz",
+      "integrity": "sha512-RSuAlxFFPjeK4d5Y6ps8L2WhaQI6CXWllIjvo5nkAlBpmq2XdYWEBGiAbOF4nDs8CX4QblJDv5BbMUft3sEfDw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.212.0",
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/resources": "2.5.1",
-        "@opentelemetry/sdk-logs": "0.212.0",
-        "@opentelemetry/sdk-metrics": "2.5.1",
-        "@opentelemetry/sdk-trace-base": "2.5.1",
-        "protobufjs": "8.0.0"
+        "@opentelemetry/api-logs": "0.213.0",
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/resources": "2.6.0",
+        "@opentelemetry/sdk-logs": "0.213.0",
+        "@opentelemetry/sdk-metrics": "2.6.0",
+        "@opentelemetry/sdk-trace-base": "2.6.0",
+        "protobufjs": "^7.0.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/protobufjs": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.0.tgz",
-      "integrity": "sha512-jx6+sE9h/UryaCZhsJWbJtTEy47yXoGNYI4z8ZaRncM0zBKeRqjO2JEcOUYwrYGb1WLhXM1FfMzW3annvFv0rw==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/@opentelemetry/plugin-react-load": {
@@ -9833,12 +9812,12 @@
       "link": true
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.5.1.tgz",
-      "integrity": "sha512-AU6sZgunZrZv/LTeHP+9IQsSSH5p3PtOfDPe8VTdwYH69nZCfvvvXehhzu+9fMW2mgJMh5RVpiH8M9xuYOu5Dg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.6.0.tgz",
+      "integrity": "sha512-SguK4jMmRvQ0c0dxAMl6K+Eu1+01X0OP7RLiIuHFjOS8hlB23ZYNnhnbAdSQEh5xVXQmH0OAS0TnmVI+6vB2Kg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.5.1"
+        "@opentelemetry/core": "2.6.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -9852,12 +9831,12 @@
       "link": true
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.5.1.tgz",
-      "integrity": "sha512-8+SB94/aSIOVGDUPRFSBRHVUm2A8ye1vC6/qcf/D+TF4qat7PC6rbJhRxiUGDXZtMtKEPM/glgv5cBGSJQymSg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.6.0.tgz",
+      "integrity": "sha512-KGWJuvp9X8X36bhHgIhWEnHAzXDInFr+Fvo9IQhhuu6pXLT8mF7HzFyx/X+auZUITvPaZhM39Phj3vK12MbhwA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.5.1"
+        "@opentelemetry/core": "2.6.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -9903,12 +9882,12 @@
       "link": true
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.1.tgz",
-      "integrity": "sha512-BViBCdE/GuXRlp9k7nS1w6wJvY5fnFX5XvuEtWsTAOQFIO89Eru7lGW3WbfbxtCuZ/GbrJfAziXG0w0dpxL7eQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.0.tgz",
+      "integrity": "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.5.1",
+        "@opentelemetry/core": "2.6.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -9923,14 +9902,15 @@
       "link": true
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.212.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.212.0.tgz",
-      "integrity": "sha512-qglb5cqTf0mOC1sDdZ7nfrPjgmAqs2OxkzOPIf2+Rqx8yKBK0pS7wRtB1xH30rqahBIut9QJDbDePyvtyqvH/Q==",
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.213.0.tgz",
+      "integrity": "sha512-00xlU3GZXo3kXKve4DLdrAL0NAFUaZ9appU/mn00S/5kSUdAvyYsORaDUfR04Mp2CLagAOhrzfUvYozY/EZX2g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.212.0",
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/resources": "2.5.1"
+        "@opentelemetry/api-logs": "0.213.0",
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/resources": "2.6.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -9940,13 +9920,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.5.1.tgz",
-      "integrity": "sha512-RKMn3QKi8nE71ULUo0g/MBvq1N4icEBo7cQSKnL3URZT16/YH3nSVgWegOjwx7FRBTrjOIkMJkCUn/ZFIEfn4A==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.6.0.tgz",
+      "integrity": "sha512-CicxWZxX6z35HR83jl+PLgtFgUrKRQ9LCXyxgenMnz5A1lgYWfAog7VtdOvGkJYyQgMNPhXQwkYrDLujk7z1Iw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/resources": "2.5.1"
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/resources": "2.6.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -9956,34 +9936,34 @@
       }
     },
     "node_modules/@opentelemetry/sdk-node": {
-      "version": "0.212.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.212.0.tgz",
-      "integrity": "sha512-tJzVDk4Lo44MdgJLlP+gdYdMnjxSNsjC/IiTxj5CFSnsjzpHXwifgl3BpUX67Ty3KcdubNVfedeBc/TlqHXwwg==",
+      "version": "0.213.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.213.0.tgz",
+      "integrity": "sha512-8s7SQtY8DIAjraXFrUf0+I90SBAUQbsMWMtUGKmusswRHWXtKJx42aJQMoxEtC82Csqj+IlBH6FoP8XmmUDSrQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.212.0",
-        "@opentelemetry/configuration": "0.212.0",
-        "@opentelemetry/context-async-hooks": "2.5.1",
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/exporter-logs-otlp-grpc": "0.212.0",
-        "@opentelemetry/exporter-logs-otlp-http": "0.212.0",
-        "@opentelemetry/exporter-logs-otlp-proto": "0.212.0",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "0.212.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.212.0",
-        "@opentelemetry/exporter-metrics-otlp-proto": "0.212.0",
-        "@opentelemetry/exporter-prometheus": "0.212.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.212.0",
-        "@opentelemetry/exporter-trace-otlp-http": "0.212.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.212.0",
-        "@opentelemetry/exporter-zipkin": "2.5.1",
-        "@opentelemetry/instrumentation": "0.212.0",
-        "@opentelemetry/propagator-b3": "2.5.1",
-        "@opentelemetry/propagator-jaeger": "2.5.1",
-        "@opentelemetry/resources": "2.5.1",
-        "@opentelemetry/sdk-logs": "0.212.0",
-        "@opentelemetry/sdk-metrics": "2.5.1",
-        "@opentelemetry/sdk-trace-base": "2.5.1",
-        "@opentelemetry/sdk-trace-node": "2.5.1",
+        "@opentelemetry/api-logs": "0.213.0",
+        "@opentelemetry/configuration": "0.213.0",
+        "@opentelemetry/context-async-hooks": "2.6.0",
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.213.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.213.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.213.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.213.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.213.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.213.0",
+        "@opentelemetry/exporter-prometheus": "0.213.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.213.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.213.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.213.0",
+        "@opentelemetry/exporter-zipkin": "2.6.0",
+        "@opentelemetry/instrumentation": "0.213.0",
+        "@opentelemetry/propagator-b3": "2.6.0",
+        "@opentelemetry/propagator-jaeger": "2.6.0",
+        "@opentelemetry/resources": "2.6.0",
+        "@opentelemetry/sdk-logs": "0.213.0",
+        "@opentelemetry/sdk-metrics": "2.6.0",
+        "@opentelemetry/sdk-trace-base": "2.6.0",
+        "@opentelemetry/sdk-trace-node": "2.6.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -9994,13 +9974,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.5.1.tgz",
-      "integrity": "sha512-iZH3Gw8cxQn0gjpOjJMmKLd9GIaNh/E3v3ST67vyzLSxHBs14HsG4dy7jMYyC5WXGdBVEcM7U/XTF5hCQxjDMw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.0.tgz",
+      "integrity": "sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/resources": "2.5.1",
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/resources": "2.6.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -10011,14 +9991,14 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.5.1.tgz",
-      "integrity": "sha512-9lopQ6ZoElETOEN0csgmtEV5/9C7BMfA7VtF4Jape3i954b6sTY2k3Xw3CxUTKreDck/vpAuJM+EDo4zheUw+A==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.6.0.tgz",
+      "integrity": "sha512-YhswtasmsbIGEFvLGvR9p/y3PVRTfFf+mgY8van4Ygpnv4sA3vooAjvh+qAn9PNWxs4/IwGGqiQS0PPsaRJ0vQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "2.5.1",
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/sdk-trace-base": "2.5.1"
+        "@opentelemetry/context-async-hooks": "2.6.0",
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/sdk-trace-base": "2.6.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -10028,13 +10008,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-web": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.5.1.tgz",
-      "integrity": "sha512-4PWFtMJ5nqWMP2YqgKjcMlQlUeN1imUYSXdhy6Xl/3bnO0/Ryo5Y3/kWG8T66uMHo2RpTQLloZjoQACKdbHbxg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.6.0.tgz",
+      "integrity": "sha512-xyYmLFatwUeYnB7NtQ2Ydl9Y8uiblN+EDo5YEjnk7ZRMhGFyt1wgPqb8EYvATLuDiRVtxid1fJsL6RH1fCQMIA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.5.1",
-        "@opentelemetry/sdk-trace-base": "2.5.1"
+        "@opentelemetry/core": "2.6.0",
+        "@opentelemetry/sdk-trace-base": "2.6.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -10044,9 +10024,9 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.39.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz",
-      "integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -20888,15 +20868,18 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
-      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.0.tgz",
+      "integrity": "sha512-OnGy+eYT7wVejH2XWgLRgbmzujhhVIATQH0ztIeRilwHBjTeG3pD+XnH3PKX0r9gJ0BuJmJ68q/oh9qgXnNDQg==",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.15.0",
         "acorn-import-attributes": "^1.9.5",
         "cjs-module-lexer": "^2.2.0",
         "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/import-local": {
@@ -36641,7 +36624,7 @@
       "version": "0.70.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/instrumentation-amqplib": "^0.59.0",
         "@opentelemetry/instrumentation-aws-lambda": "^0.64.0",
         "@opentelemetry/instrumentation-aws-sdk": "^0.67.0",
@@ -36656,9 +36639,9 @@
         "@opentelemetry/instrumentation-fs": "^0.31.0",
         "@opentelemetry/instrumentation-generic-pool": "^0.55.0",
         "@opentelemetry/instrumentation-graphql": "^0.60.0",
-        "@opentelemetry/instrumentation-grpc": "^0.212.0",
+        "@opentelemetry/instrumentation-grpc": "^0.213.0",
         "@opentelemetry/instrumentation-hapi": "^0.58.0",
-        "@opentelemetry/instrumentation-http": "^0.212.0",
+        "@opentelemetry/instrumentation-http": "^0.213.0",
         "@opentelemetry/instrumentation-ioredis": "^0.60.0",
         "@opentelemetry/instrumentation-kafkajs": "^0.21.0",
         "@opentelemetry/instrumentation-knex": "^0.56.0",
@@ -36689,7 +36672,7 @@
         "@opentelemetry/resource-detector-container": "^0.8.3",
         "@opentelemetry/resource-detector-gcp": "^0.47.0",
         "@opentelemetry/resources": "^2.0.0",
-        "@opentelemetry/sdk-node": "^0.212.0"
+        "@opentelemetry/sdk-node": "^0.213.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.4.1",
@@ -36708,11 +36691,11 @@
       "version": "0.57.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/instrumentation-document-load": "^0.57.0",
-        "@opentelemetry/instrumentation-fetch": "^0.212.0",
+        "@opentelemetry/instrumentation-fetch": "^0.213.0",
         "@opentelemetry/instrumentation-user-interaction": "^0.56.0",
-        "@opentelemetry/instrumentation-xml-http-request": "^0.212.0"
+        "@opentelemetry/instrumentation-xml-http-request": "^0.213.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.9.0"
@@ -36730,7 +36713,7 @@
       "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/sdk-logs": "^0.212.0"
+        "@opentelemetry/sdk-logs": "^0.213.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0"
@@ -36766,10 +36749,10 @@
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/exporter-jaeger": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/resources": "^2.0.0",
         "@opentelemetry/sdk-metrics": "^2.0.0",
-        "@opentelemetry/sdk-node": "^0.212.0",
+        "@opentelemetry/sdk-node": "^0.213.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0",
         "@opentelemetry/sdk-trace-node": "^2.0.0",
         "@opentelemetry/semantic-conventions": "^1.37.0"
@@ -36825,7 +36808,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.33.0"
       },
       "devDependencies": {
@@ -36848,7 +36831,7 @@
       "version": "0.64.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/aws-lambda": "^8.10.155"
       },
@@ -36874,7 +36857,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.34.0"
       },
       "devDependencies": {
@@ -36905,13 +36888,13 @@
       "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/api-logs": "^0.212.0",
-        "@opentelemetry/sdk-logs": "^0.212.0",
+        "@opentelemetry/api-logs": "^0.213.0",
+        "@opentelemetry/sdk-logs": "^0.213.0",
         "@rollup/plugin-commonjs": "^29.0.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@types/chai": "^5.2.2",
@@ -36932,14 +36915,14 @@
       "version": "0.57.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.212.0",
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/api-logs": "^0.213.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@types/bunyan": "1.8.11"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/resources": "^2.0.0",
-        "@opentelemetry/sdk-logs": "^0.212.0",
+        "@opentelemetry/sdk-logs": "^0.213.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0",
         "@opentelemetry/sdk-trace-node": "^2.0.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -36957,7 +36940,7 @@
       "version": "0.57.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.37.0"
       },
       "devDependencies": {
@@ -36981,7 +36964,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/connect": "3.4.38"
       },
@@ -37004,7 +36987,7 @@
       "version": "0.28.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37027,7 +37010,7 @@
       "version": "0.29.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0"
+        "@opentelemetry/instrumentation": "^0.213.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37049,7 +37032,7 @@
       "version": "0.55.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0"
+        "@opentelemetry/instrumentation": "^0.213.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37070,7 +37053,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/sdk-trace-web": "^2.0.0",
         "@opentelemetry/semantic-conventions": "^1.23.0"
       },
@@ -37099,7 +37082,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37124,7 +37107,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37132,7 +37115,7 @@
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^2.0.0",
         "@opentelemetry/contrib-test-utils": "^0.59.0",
-        "@opentelemetry/instrumentation-http": "^0.212.0",
+        "@opentelemetry/instrumentation-http": "^0.213.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0",
         "@opentelemetry/sdk-trace-node": "^2.0.0",
         "fastify": "4.18.0"
@@ -37150,7 +37133,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.212.0"
+        "@opentelemetry/instrumentation": "^0.213.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37171,7 +37154,7 @@
       "version": "0.55.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0"
+        "@opentelemetry/instrumentation": "^0.213.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37193,7 +37176,7 @@
       "version": "0.60.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0"
+        "@opentelemetry/instrumentation": "^0.213.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37214,7 +37197,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37238,7 +37221,7 @@
       "version": "0.60.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/redis-common": "^0.38.2",
         "@opentelemetry/semantic-conventions": "^1.33.0"
       },
@@ -37263,7 +37246,7 @@
       "version": "0.21.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.30.0"
       },
       "devDependencies": {
@@ -37284,7 +37267,7 @@
       "version": "0.56.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.33.1"
       },
       "devDependencies": {
@@ -37309,7 +37292,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.36.0"
       },
       "devDependencies": {
@@ -37317,7 +37300,7 @@
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/context-async-hooks": "^2.0.0",
         "@opentelemetry/contrib-test-utils": "^0.59.0",
-        "@opentelemetry/instrumentation-http": "^0.212.0",
+        "@opentelemetry/instrumentation-http": "^0.213.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0",
         "@opentelemetry/sdk-trace-node": "^2.0.0",
         "@types/koa": "3.0.1",
@@ -37337,7 +37320,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.212.0"
+        "@opentelemetry/instrumentation": "^0.213.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37357,7 +37340,7 @@
       "version": "0.56.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0"
+        "@opentelemetry/instrumentation": "^0.213.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37377,7 +37360,7 @@
       "version": "0.55.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.33.0",
         "@types/memcached": "^2.2.6"
       },
@@ -37401,7 +37384,7 @@
       "version": "0.65.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.33.0"
       },
       "devDependencies": {
@@ -37427,7 +37410,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.33.0"
       },
       "devDependencies": {
@@ -37448,7 +37431,7 @@
       "version": "0.58.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.33.0",
         "@types/mysql": "2.15.27"
       },
@@ -37472,7 +37455,7 @@
       "version": "0.58.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.33.0",
         "@opentelemetry/sql-common": "^0.41.2"
       },
@@ -37495,7 +37478,7 @@
       "version": "0.58.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.30.0"
       },
       "devDependencies": {
@@ -37522,7 +37505,7 @@
       "version": "0.56.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.33.0"
       },
       "devDependencies": {
@@ -37543,14 +37526,14 @@
       "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.212.0",
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/api-logs": "^0.213.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.36.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.59.0",
-        "@opentelemetry/sdk-logs": "^0.212.0",
+        "@opentelemetry/sdk-logs": "^0.213.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0",
         "@opentelemetry/sdk-trace-node": "^2.0.0",
         "openai": "^6.2.0"
@@ -37567,7 +37550,7 @@
       "version": "0.37.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.34.0",
         "@types/oracledb": "6.5.2"
       },
@@ -37592,7 +37575,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.34.0",
         "@opentelemetry/sql-common": "^0.41.2",
         "@types/pg": "8.15.6",
@@ -37619,14 +37602,14 @@
       "version": "0.58.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.212.0",
+        "@opentelemetry/api-logs": "^0.213.0",
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.212.0"
+        "@opentelemetry/instrumentation": "^0.213.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.59.0",
-        "@opentelemetry/sdk-logs": "^0.212.0",
+        "@opentelemetry/sdk-logs": "^0.213.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0",
         "@opentelemetry/sdk-trace-node": "^2.0.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -37644,7 +37627,7 @@
       "version": "0.60.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/redis-common": "^0.38.2",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
@@ -37669,7 +37652,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37692,7 +37675,7 @@
       "version": "0.56.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37714,7 +37697,7 @@
       "version": "0.25.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0"
+        "@opentelemetry/instrumentation": "^0.213.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37733,7 +37716,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
@@ -37775,7 +37758,7 @@
       "version": "0.59.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0"
+        "@opentelemetry/instrumentation": "^0.213.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37796,7 +37779,7 @@
       "version": "0.31.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.33.0",
         "@types/tedious": "^4.0.14"
       },
@@ -37820,7 +37803,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.212.0"
+        "@opentelemetry/instrumentation": "^0.213.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37842,7 +37825,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.24.0"
       },
       "devDependencies": {
@@ -37865,13 +37848,13 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/sdk-trace-web": "^2.0.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-zone-peer-dep": "^2.0.0",
-        "@opentelemetry/instrumentation-xml-http-request": "^0.212.0",
+        "@opentelemetry/instrumentation-xml-http-request": "^0.213.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0",
         "zone.js": "^0.11.4 || ^0.13.0 || ^0.14.0 || ^0.15.0 || ^0.16.0"
       },
@@ -37888,15 +37871,15 @@
       "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.212.0",
+        "@opentelemetry/api-logs": "^0.213.0",
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       },
       "devDependencies": {
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/sdk-logs": "^0.212.0",
+        "@opentelemetry/sdk-logs": "^0.213.0",
         "@rollup/plugin-commonjs": "^26.0.0",
         "@rollup/plugin-node-resolve": "^16.0.0",
         "@web/dev-server-esbuild": "^1.0.1",
@@ -38162,13 +38145,13 @@
       "version": "0.56.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.212.0",
-        "@opentelemetry/instrumentation": "^0.212.0"
+        "@opentelemetry/api-logs": "^0.213.0",
+        "@opentelemetry/instrumentation": "^0.213.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^2.0.0",
-        "@opentelemetry/sdk-logs": "^0.212.0",
+        "@opentelemetry/sdk-logs": "^0.213.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0",
         "@opentelemetry/sdk-trace-node": "^2.0.0",
         "@opentelemetry/winston-transport": "^0.22.0",
@@ -38188,7 +38171,7 @@
       "version": "0.44.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0",
+        "@opentelemetry/instrumentation": "^0.213.0",
         "shimmer": "^1.2.1"
       },
       "devDependencies": {
@@ -38326,7 +38309,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.59.0",
         "@opentelemetry/instrumentation-fs": "^0.31.0",
-        "@opentelemetry/instrumentation-http": "^0.212.0",
+        "@opentelemetry/instrumentation-http": "^0.213.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0"
       },
       "engines": {
@@ -38348,7 +38331,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.59.0",
-        "@opentelemetry/instrumentation-http": "^0.212.0",
+        "@opentelemetry/instrumentation-http": "^0.213.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0"
       },
       "engines": {
@@ -38391,7 +38374,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.59.0",
-        "@opentelemetry/instrumentation-http": "^0.212.0",
+        "@opentelemetry/instrumentation-http": "^0.213.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0",
         "bignumber.js": "9.3.1"
       },
@@ -38486,7 +38469,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.59.0",
-        "@opentelemetry/sdk-node": "^0.212.0"
+        "@opentelemetry/sdk-node": "^0.213.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -38538,11 +38521,11 @@
       "version": "0.22.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "^0.212.0",
+        "@opentelemetry/api-logs": "^0.213.0",
         "winston-transport": "4.*"
       },
       "devDependencies": {
-        "@opentelemetry/sdk-logs": "^0.212.0",
+        "@opentelemetry/sdk-logs": "^0.213.0",
         "@types/triple-beam": "1.3.5"
       },
       "engines": {

--- a/packages/auto-instrumentations-node/package.json
+++ b/packages/auto-instrumentations-node/package.json
@@ -43,7 +43,7 @@
     "@opentelemetry/core": "^2.0.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/instrumentation-amqplib": "^0.59.0",
     "@opentelemetry/instrumentation-aws-lambda": "^0.64.0",
     "@opentelemetry/instrumentation-aws-sdk": "^0.67.0",
@@ -58,9 +58,9 @@
     "@opentelemetry/instrumentation-fs": "^0.31.0",
     "@opentelemetry/instrumentation-generic-pool": "^0.55.0",
     "@opentelemetry/instrumentation-graphql": "^0.60.0",
-    "@opentelemetry/instrumentation-grpc": "^0.212.0",
+    "@opentelemetry/instrumentation-grpc": "^0.213.0",
     "@opentelemetry/instrumentation-hapi": "^0.58.0",
-    "@opentelemetry/instrumentation-http": "^0.212.0",
+    "@opentelemetry/instrumentation-http": "^0.213.0",
     "@opentelemetry/instrumentation-ioredis": "^0.60.0",
     "@opentelemetry/instrumentation-kafkajs": "^0.21.0",
     "@opentelemetry/instrumentation-knex": "^0.56.0",
@@ -91,7 +91,7 @@
     "@opentelemetry/resource-detector-container": "^0.8.3",
     "@opentelemetry/resource-detector-gcp": "^0.47.0",
     "@opentelemetry/resources": "^2.0.0",
-    "@opentelemetry/sdk-node": "^0.212.0"
+    "@opentelemetry/sdk-node": "^0.213.0"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/auto-instrumentations-web/package.json
+++ b/packages/auto-instrumentations-web/package.json
@@ -39,11 +39,11 @@
     "@opentelemetry/api": "^1.9.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/instrumentation-document-load": "^0.57.0",
-    "@opentelemetry/instrumentation-fetch": "^0.212.0",
+    "@opentelemetry/instrumentation-fetch": "^0.213.0",
     "@opentelemetry/instrumentation-user-interaction": "^0.56.0",
-    "@opentelemetry/instrumentation-xml-http-request": "^0.212.0"
+    "@opentelemetry/instrumentation-xml-http-request": "^0.213.0"
   },
   "files": [
     "build/src/**/*.js",

--- a/packages/baggage-log-record-processor/package.json
+++ b/packages/baggage-log-record-processor/package.json
@@ -44,7 +44,7 @@
     "@opentelemetry/api": "^1.0.0"
   },
   "dependencies": {
-    "@opentelemetry/sdk-logs": "^0.212.0"
+    "@opentelemetry/sdk-logs": "^0.213.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0"

--- a/packages/contrib-test-utils/package.json
+++ b/packages/contrib-test-utils/package.json
@@ -45,10 +45,10 @@
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",
     "@opentelemetry/exporter-jaeger": "^2.0.0",
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/resources": "^2.0.0",
     "@opentelemetry/sdk-metrics": "^2.0.0",
-    "@opentelemetry/sdk-node": "^0.212.0",
+    "@opentelemetry/sdk-node": "^0.213.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "@opentelemetry/sdk-trace-node": "^2.0.0",
     "@opentelemetry/semantic-conventions": "^1.37.0"

--- a/packages/instrumentation-amqplib/package.json
+++ b/packages/instrumentation-amqplib/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.33.0"
   },
   "devDependencies": {

--- a/packages/instrumentation-aws-lambda/package.json
+++ b/packages/instrumentation-aws-lambda/package.json
@@ -53,7 +53,7 @@
     "@opentelemetry/sdk-trace-node": "^2.0.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
     "@types/aws-lambda": "^8.10.155"
   },

--- a/packages/instrumentation-aws-sdk/package.json
+++ b/packages/instrumentation-aws-sdk/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.34.0"
   },
   "devDependencies": {

--- a/packages/instrumentation-browser-navigation/package.json
+++ b/packages/instrumentation-browser-navigation/package.json
@@ -49,8 +49,8 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/api-logs": "^0.212.0",
-    "@opentelemetry/sdk-logs": "^0.212.0",
+    "@opentelemetry/api-logs": "^0.213.0",
+    "@opentelemetry/sdk-logs": "^0.213.0",
     "@rollup/plugin-commonjs": "^29.0.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@types/chai": "^5.2.2",
@@ -60,7 +60,7 @@
     "chai": "^6.2.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-browser-navigation#readme"

--- a/packages/instrumentation-bunyan/package.json
+++ b/packages/instrumentation-bunyan/package.json
@@ -47,15 +47,15 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/resources": "^2.0.0",
-    "@opentelemetry/sdk-logs": "^0.212.0",
+    "@opentelemetry/sdk-logs": "^0.213.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "@opentelemetry/sdk-trace-node": "^2.0.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
     "bunyan": "1.8.15"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "^0.212.0",
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/api-logs": "^0.213.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@types/bunyan": "1.8.11"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-bunyan#readme"

--- a/packages/instrumentation-cassandra-driver/package.json
+++ b/packages/instrumentation-cassandra-driver/package.json
@@ -59,7 +59,7 @@
     "cassandra-driver": "4.6.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.37.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-cassandra-driver#readme"

--- a/packages/instrumentation-connect/package.json
+++ b/packages/instrumentation-connect/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
     "@types/connect": "3.4.38"
   },

--- a/packages/instrumentation-cucumber/package.json
+++ b/packages/instrumentation-cucumber/package.json
@@ -53,7 +53,7 @@
     "@opentelemetry/sdk-trace-node": "^2.0.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-cucumber#readme"

--- a/packages/instrumentation-dataloader/package.json
+++ b/packages/instrumentation-dataloader/package.json
@@ -52,7 +52,7 @@
     "dataloader": "2.2.3"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0"
+    "@opentelemetry/instrumentation": "^0.213.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-dataloader#readme"
 }

--- a/packages/instrumentation-dns/package.json
+++ b/packages/instrumentation-dns/package.json
@@ -50,7 +50,7 @@
     "@opentelemetry/sdk-trace-node": "^2.0.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0"
+    "@opentelemetry/instrumentation": "^0.213.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-dns#readme"
 }

--- a/packages/instrumentation-document-load/package.json
+++ b/packages/instrumentation-document-load/package.json
@@ -66,7 +66,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/sdk-trace-web": "^2.0.0",
     "@opentelemetry/semantic-conventions": "^1.23.0"
   },

--- a/packages/instrumentation-express/package.json
+++ b/packages/instrumentation-express/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-express#readme"

--- a/packages/instrumentation-fastify/package.json
+++ b/packages/instrumentation-fastify/package.json
@@ -49,14 +49,14 @@
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/context-async-hooks": "^2.0.0",
     "@opentelemetry/contrib-test-utils": "^0.59.0",
-    "@opentelemetry/instrumentation-http": "^0.212.0",
+    "@opentelemetry/instrumentation-http": "^0.213.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "@opentelemetry/sdk-trace-node": "^2.0.0",
     "fastify": "4.18.0"
   },
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-fastify#readme"

--- a/packages/instrumentation-fs/package.json
+++ b/packages/instrumentation-fs/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",
-    "@opentelemetry/instrumentation": "^0.212.0"
+    "@opentelemetry/instrumentation": "^0.213.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-fs#readme"
 }

--- a/packages/instrumentation-generic-pool/package.json
+++ b/packages/instrumentation-generic-pool/package.json
@@ -52,7 +52,7 @@
     "generic-pool": "3.8.2"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0"
+    "@opentelemetry/instrumentation": "^0.213.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-generic-pool#readme"
 }

--- a/packages/instrumentation-graphql/package.json
+++ b/packages/instrumentation-graphql/package.json
@@ -52,7 +52,7 @@
     "graphql": "^16.5.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0"
+    "@opentelemetry/instrumentation": "^0.213.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-graphql#readme"
 }

--- a/packages/instrumentation-hapi/package.json
+++ b/packages/instrumentation-hapi/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-hapi#readme"

--- a/packages/instrumentation-ioredis/package.json
+++ b/packages/instrumentation-ioredis/package.json
@@ -61,7 +61,7 @@
     "ioredis": "5.8.2"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/redis-common": "^0.38.2",
     "@opentelemetry/semantic-conventions": "^1.33.0"
   },

--- a/packages/instrumentation-kafkajs/package.json
+++ b/packages/instrumentation-kafkajs/package.json
@@ -51,7 +51,7 @@
     "kafkajs": "^2.2.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.30.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-kafkajs#readme"

--- a/packages/instrumentation-knex/package.json
+++ b/packages/instrumentation-knex/package.json
@@ -54,7 +54,7 @@
     "sqlite3": "5.1.7"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.33.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-knex#readme"

--- a/packages/instrumentation-koa/package.json
+++ b/packages/instrumentation-koa/package.json
@@ -51,7 +51,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/context-async-hooks": "^2.0.0",
     "@opentelemetry/contrib-test-utils": "^0.59.0",
-    "@opentelemetry/instrumentation-http": "^0.212.0",
+    "@opentelemetry/instrumentation-http": "^0.213.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "@opentelemetry/sdk-trace-node": "^2.0.0",
     "@types/koa": "3.0.1",
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.36.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-koa#readme"

--- a/packages/instrumentation-long-task/package.json
+++ b/packages/instrumentation-long-task/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",
-    "@opentelemetry/instrumentation": "^0.212.0"
+    "@opentelemetry/instrumentation": "^0.213.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.3.0"

--- a/packages/instrumentation-lru-memoizer/package.json
+++ b/packages/instrumentation-lru-memoizer/package.json
@@ -50,7 +50,7 @@
     "lru-memoizer": "2.1.4"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0"
+    "@opentelemetry/instrumentation": "^0.213.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-lru-memoizer#readme"
 }

--- a/packages/instrumentation-memcached/package.json
+++ b/packages/instrumentation-memcached/package.json
@@ -57,7 +57,7 @@
     "memcached": "2.2.2"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.33.0",
     "@types/memcached": "^2.2.6"
   },

--- a/packages/instrumentation-mongodb/package.json
+++ b/packages/instrumentation-mongodb/package.json
@@ -66,7 +66,7 @@
     "mongodb": "6.19.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.33.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-mongodb#readme"

--- a/packages/instrumentation-mongoose/package.json
+++ b/packages/instrumentation-mongoose/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.33.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-mongoose#readme"

--- a/packages/instrumentation-mysql/package.json
+++ b/packages/instrumentation-mysql/package.json
@@ -56,7 +56,7 @@
     "mysql": "2.18.1"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.33.0",
     "@types/mysql": "2.15.27"
   },

--- a/packages/instrumentation-mysql2/package.json
+++ b/packages/instrumentation-mysql2/package.json
@@ -57,7 +57,7 @@
     "mysql2": "3.11.5"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.33.0",
     "@opentelemetry/sql-common": "^0.41.2"
   },

--- a/packages/instrumentation-nestjs-core/package.json
+++ b/packages/instrumentation-nestjs-core/package.json
@@ -59,7 +59,7 @@
     "rxjs-compat": "6.6.7"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.30.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-nestjs-core#readme"

--- a/packages/instrumentation-net/package.json
+++ b/packages/instrumentation-net/package.json
@@ -51,7 +51,7 @@
     "@opentelemetry/sdk-trace-node": "^2.0.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.33.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-net#readme"

--- a/packages/instrumentation-openai/package.json
+++ b/packages/instrumentation-openai/package.json
@@ -48,14 +48,14 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/contrib-test-utils": "^0.59.0",
-    "@opentelemetry/sdk-logs": "^0.212.0",
+    "@opentelemetry/sdk-logs": "^0.213.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "@opentelemetry/sdk-trace-node": "^2.0.0",
     "openai": "^6.2.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "^0.212.0",
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/api-logs": "^0.213.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.36.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-openai#readme"

--- a/packages/instrumentation-oracledb/package.json
+++ b/packages/instrumentation-oracledb/package.json
@@ -62,7 +62,7 @@
     "oracledb": "^6.7.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.34.0",
     "@types/oracledb": "6.5.2"
   },

--- a/packages/instrumentation-pg/package.json
+++ b/packages/instrumentation-pg/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.34.0",
     "@opentelemetry/sql-common": "^0.41.2",
     "@types/pg": "8.15.6",

--- a/packages/instrumentation-pino/package.json
+++ b/packages/instrumentation-pino/package.json
@@ -48,16 +48,16 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/contrib-test-utils": "^0.59.0",
-    "@opentelemetry/sdk-logs": "^0.212.0",
+    "@opentelemetry/sdk-logs": "^0.213.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "@opentelemetry/sdk-trace-node": "^2.0.0",
     "@opentelemetry/semantic-conventions": "^1.27.0",
     "pino": "^8.21.0"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "^0.212.0",
+    "@opentelemetry/api-logs": "^0.213.0",
     "@opentelemetry/core": "^2.0.0",
-    "@opentelemetry/instrumentation": "^0.212.0"
+    "@opentelemetry/instrumentation": "^0.213.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-pino#readme"
 }

--- a/packages/instrumentation-redis/package.json
+++ b/packages/instrumentation-redis/package.json
@@ -60,7 +60,7 @@
     "redis": "^5.6.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/redis-common": "^0.38.2",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },

--- a/packages/instrumentation-restify/package.json
+++ b/packages/instrumentation-restify/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-restify#readme"

--- a/packages/instrumentation-router/package.json
+++ b/packages/instrumentation-router/package.json
@@ -51,7 +51,7 @@
     "router": "1.3.8"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-router#readme"

--- a/packages/instrumentation-runtime-node/package.json
+++ b/packages/instrumentation-runtime-node/package.json
@@ -40,7 +40,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0"
+    "@opentelemetry/instrumentation": "^0.213.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",

--- a/packages/instrumentation-sequelize/package.json
+++ b/packages/instrumentation-sequelize/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-sequelize#readme"

--- a/packages/instrumentation-socket.io/package.json
+++ b/packages/instrumentation-socket.io/package.json
@@ -51,7 +51,7 @@
     "socket.io-client": "^4.1.3"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0"
+    "@opentelemetry/instrumentation": "^0.213.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-socket.io#readme"
 }

--- a/packages/instrumentation-tedious/package.json
+++ b/packages/instrumentation-tedious/package.json
@@ -60,7 +60,7 @@
     "tedious": "17.0.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.33.0",
     "@types/tedious": "^4.0.14"
   },

--- a/packages/instrumentation-typeorm/package.json
+++ b/packages/instrumentation-typeorm/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",
-    "@opentelemetry/instrumentation": "^0.212.0"
+    "@opentelemetry/instrumentation": "^0.213.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-typeorm#readme"
 }

--- a/packages/instrumentation-undici/package.json
+++ b/packages/instrumentation-undici/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.24.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-undici#readme",

--- a/packages/instrumentation-user-interaction/package.json
+++ b/packages/instrumentation-user-interaction/package.json
@@ -53,13 +53,13 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/context-zone-peer-dep": "^2.0.0",
-    "@opentelemetry/instrumentation-xml-http-request": "^0.212.0",
+    "@opentelemetry/instrumentation-xml-http-request": "^0.213.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "zone.js": "^0.11.4 || ^0.13.0 || ^0.14.0 || ^0.15.0 || ^0.16.0"
   },
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/sdk-trace-web": "^2.0.0"
   },
   "peerDependencies": {

--- a/packages/instrumentation-web-exception/package.json
+++ b/packages/instrumentation-web-exception/package.json
@@ -53,7 +53,7 @@
   "devDependencies": {
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
     "@opentelemetry/api": "^1.3.0",
-    "@opentelemetry/sdk-logs": "^0.212.0",
+    "@opentelemetry/sdk-logs": "^0.213.0",
     "@rollup/plugin-commonjs": "^26.0.0",
     "@rollup/plugin-node-resolve": "^16.0.0",
     "@web/dev-server-esbuild": "^1.0.1",
@@ -62,9 +62,9 @@
     "chai": "^4.3.10"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "^0.212.0",
+    "@opentelemetry/api-logs": "^0.213.0",
     "@opentelemetry/core": "^2.0.0",
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/semantic-conventions": "^1.27.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/web/opentelemetry-instrumentation-web-exception#readme"

--- a/packages/instrumentation-winston/package.json
+++ b/packages/instrumentation-winston/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/context-async-hooks": "^2.0.0",
-    "@opentelemetry/sdk-logs": "^0.212.0",
+    "@opentelemetry/sdk-logs": "^0.213.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "@opentelemetry/sdk-trace-node": "^2.0.0",
     "@opentelemetry/winston-transport": "^0.22.0",
@@ -56,8 +56,8 @@
     "winston2": "npm:winston@2.4.7"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "^0.212.0",
-    "@opentelemetry/instrumentation": "^0.212.0"
+    "@opentelemetry/api-logs": "^0.213.0",
+    "@opentelemetry/instrumentation": "^0.213.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-winston#readme"
 }

--- a/packages/plugin-react-load/package.json
+++ b/packages/plugin-react-load/package.json
@@ -65,7 +65,7 @@
     "react": "^16.13.1 || ^17.0.0"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation": "^0.212.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "shimmer": "^1.2.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/plugin-react-load#readme"

--- a/packages/resource-detector-aws/package.json
+++ b/packages/resource-detector-aws/package.json
@@ -46,7 +46,7 @@
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/contrib-test-utils": "^0.59.0",
     "@opentelemetry/instrumentation-fs": "^0.31.0",
-    "@opentelemetry/instrumentation-http": "^0.212.0",
+    "@opentelemetry/instrumentation-http": "^0.213.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0"
   },
   "peerDependencies": {

--- a/packages/resource-detector-azure/package.json
+++ b/packages/resource-detector-azure/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/contrib-test-utils": "^0.59.0",
-    "@opentelemetry/instrumentation-http": "^0.212.0",
+    "@opentelemetry/instrumentation-http": "^0.213.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0"
   },
   "peerDependencies": {

--- a/packages/resource-detector-gcp/package.json
+++ b/packages/resource-detector-gcp/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/contrib-test-utils": "^0.59.0",
-    "@opentelemetry/instrumentation-http": "^0.212.0",
+    "@opentelemetry/instrumentation-http": "^0.213.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0",
     "bignumber.js": "9.3.1"
   },

--- a/packages/resource-detector-instana/package.json
+++ b/packages/resource-detector-instana/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/contrib-test-utils": "^0.59.0",
-    "@opentelemetry/sdk-node": "^0.212.0"
+    "@opentelemetry/sdk-node": "^0.213.0"
   },
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",

--- a/packages/winston-transport/package.json
+++ b/packages/winston-transport/package.json
@@ -39,11 +39,11 @@
     "access": "public"
   },
   "devDependencies": {
-    "@opentelemetry/sdk-logs": "^0.212.0",
+    "@opentelemetry/sdk-logs": "^0.213.0",
     "@types/triple-beam": "1.3.5"
   },
   "dependencies": {
-    "@opentelemetry/api-logs": "^0.212.0",
+    "@opentelemetry/api-logs": "^0.213.0",
     "winston-transport": "4.*"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/winston-transport#readme"


### PR DESCRIPTION
Update to the 2.6.0 / 0.213.0 release from opentelemetry-js.git.

    0.212.0 -> 0.213.0 @opentelemetry/api-logs (range-bump)
    0.212.0 -> 0.213.0 @opentelemetry/instrumentation (range-bump)
    0.212.0 -> 0.213.0 @opentelemetry/instrumentation-fetch (range-bump)
    0.212.0 -> 0.213.0 @opentelemetry/instrumentation-grpc (range-bump)
    0.212.0 -> 0.213.0 @opentelemetry/instrumentation-http (range-bump)
    0.212.0 -> 0.213.0 @opentelemetry/instrumentation-xml-http-request (range-bump)
    0.212.0 -> 0.213.0 @opentelemetry/sdk-logs (range-bump)
    0.212.0 -> 0.213.0 @opentelemetry/sdk-node (range-bump)
    1.39.0 -> 1.40.0 @opentelemetry/semantic-conventions
    2.5.1 -> 2.6.0 @opentelemetry/context-async-hooks
    2.5.1 -> 2.6.0 @opentelemetry/context-zone-peer-dep
    2.5.1 -> 2.6.0 @opentelemetry/core
    2.5.1 -> 2.6.0 @opentelemetry/exporter-jaeger
    2.5.1 -> 2.6.0 @opentelemetry/propagator-b3
    2.5.1 -> 2.6.0 @opentelemetry/propagator-jaeger
    2.5.1 -> 2.6.0 @opentelemetry/resources
    2.5.1 -> 2.6.0 @opentelemetry/sdk-metrics
    2.5.1 -> 2.6.0 @opentelemetry/sdk-trace-base
    2.5.1 -> 2.6.0 @opentelemetry/sdk-trace-node
    2.5.1 -> 2.6.0 @opentelemetry/sdk-trace-web
