### PR TITLE
fix(instrumentation-aws-lambda): handle non-configurable exports from esbuild CJS bundles

### DIFF
--- a/packages/instrumentation-aws-lambda/src/instrumentation.ts
+++ b/packages/instrumentation-aws-lambda/src/instrumentation.ts
@@ -91,6 +91,34 @@ function isSupportingCallbacks(): boolean {
   return false;
 }
 
+// When esbuild bundles ESM to CJS format, it defines exports using non-configurable
+// accessor descriptors. OpenTelemetry's shimmer then fails with "Cannot redefine property"
+// when trying to wrap the handler. This replaces such exports with a new object that has
+// configurable data descriptors so shimmer can wrap them.
+// See: https://github.com/evanw/esbuild/issues/2199
+function makeExportsConfigurable<T>(moduleExports: T): T {
+  if (typeof moduleExports !== 'object' || moduleExports === null) {
+    return moduleExports;
+  }
+  const keys = Object.getOwnPropertyNames(moduleExports);
+  const descriptors = Object.getOwnPropertyDescriptors(moduleExports);
+  if (keys.every(key => descriptors[key].configurable)) {
+    return moduleExports;
+  }
+  const fixed = Object.create(
+    Object.getPrototypeOf(moduleExports)
+  ) as T;
+  for (const key of keys) {
+    Object.defineProperty(fixed, key, {
+      value: (moduleExports as Record<string, unknown>)[key],
+      writable: true,
+      enumerable: descriptors[key].enumerable,
+      configurable: true,
+    });
+  }
+  return fixed;
+}
+
 export class AwsLambdaInstrumentation extends InstrumentationBase<AwsLambdaInstrumentationConfig> {
   declare private _traceForceFlusher?: () => Promise<void>;
   declare private _metricForceFlusher?: () => Promise<void>;
@@ -175,6 +203,7 @@ export class AwsLambdaInstrumentation extends InstrumentationBase<AwsLambdaInstr
             module,
             ['*'],
             (moduleExports: LambdaModule) => {
+              moduleExports = makeExportsConfigurable(moduleExports);
               if (isWrapped(moduleExports[functionName])) {
                 this._unwrap(moduleExports, functionName);
               }

--- a/packages/instrumentation-aws-lambda/src/instrumentation.ts
+++ b/packages/instrumentation-aws-lambda/src/instrumentation.ts
@@ -105,9 +105,7 @@ function makeExportsConfigurable<T>(moduleExports: T): T {
   if (keys.every(key => descriptors[key].configurable)) {
     return moduleExports;
   }
-  const fixed = Object.create(
-    Object.getPrototypeOf(moduleExports)
-  ) as T;
+  const fixed = Object.create(Object.getPrototypeOf(moduleExports)) as T;
   for (const key of keys) {
     Object.defineProperty(fixed, key, {
       value: (moduleExports as Record<string, unknown>)[key],

--- a/packages/instrumentation-aws-lambda/test/integrations/lambda-handler.test.ts
+++ b/packages/instrumentation-aws-lambda/test/integrations/lambda-handler.test.ts
@@ -736,6 +736,38 @@ describe('lambda handler', () => {
     });
   });
 
+  describe('esbuild CJS bundle with non-configurable exports', () => {
+    it('should export a valid span', async () => {
+      initializeHandler('lambda-test/esbuild-cjs.handler');
+
+      const result = await lambdaRequire('lambda-test/esbuild-cjs').handler(
+        'arg',
+        ctx
+      );
+      assert.strictEqual(result, 'ok');
+      const spans = memoryExporter.getFinishedSpans();
+      const [span] = spans;
+      assert.strictEqual(spans.length, 1);
+      assertSpanSuccess(span);
+    });
+
+    it('should record error', async () => {
+      initializeHandler('lambda-test/esbuild-cjs.error');
+
+      let err: Error;
+      try {
+        await lambdaRequire('lambda-test/esbuild-cjs').error('arg', ctx);
+      } catch (e: any) {
+        err = e;
+      }
+      assert.strictEqual(err!.message, 'handler error');
+      const spans = memoryExporter.getFinishedSpans();
+      const [span] = spans;
+      assert.strictEqual(spans.length, 1);
+      assertSpanFailure(span);
+    });
+  });
+
   describe('custom handler', () => {
     it('prioritizes instrumenting the handler specified on the config over the handler implied from the _HANDLER env var', async () => {
       initializeHandler('not-a-real-handler', {

--- a/packages/instrumentation-aws-lambda/test/lambda-test/esbuild-cjs.js
+++ b/packages/instrumentation-aws-lambda/test/lambda-test/esbuild-cjs.js
@@ -19,8 +19,8 @@
 // property" unless the instrumentation handles it.
 // See: https://github.com/evanw/esbuild/issues/2199
 
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
 
 async function handler(event, context) {
   return 'ok';
@@ -30,13 +30,13 @@ async function error(event, context) {
   throw new Error('handler error');
 }
 
-Object.defineProperty(exports, "handler", {
+Object.defineProperty(exports, 'handler', {
   enumerable: true,
   get: function () { return handler; },
   // intentionally no configurable: true — this is what esbuild produces
 });
 
-Object.defineProperty(exports, "error", {
+Object.defineProperty(exports, 'error', {
   enumerable: true,
   get: function () { return error; },
 });

--- a/packages/instrumentation-aws-lambda/test/lambda-test/esbuild-cjs.js
+++ b/packages/instrumentation-aws-lambda/test/lambda-test/esbuild-cjs.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Simulates esbuild's ESM-to-CJS output which uses non-configurable accessor
+// descriptors on exports. This causes shimmer to fail with "Cannot redefine
+// property" unless the instrumentation handles it.
+// See: https://github.com/evanw/esbuild/issues/2199
+
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+
+async function handler(event, context) {
+  return 'ok';
+}
+
+async function error(event, context) {
+  throw new Error('handler error');
+}
+
+Object.defineProperty(exports, "handler", {
+  enumerable: true,
+  get: function () { return handler; },
+  // intentionally no configurable: true — this is what esbuild produces
+});
+
+Object.defineProperty(exports, "error", {
+  enumerable: true,
+  get: function () { return error; },
+});

--- a/packages/instrumentation-aws-lambda/test/lambda-test/esbuild-cjs.js
+++ b/packages/instrumentation-aws-lambda/test/lambda-test/esbuild-cjs.js
@@ -32,11 +32,15 @@ async function error(event, context) {
 
 Object.defineProperty(exports, 'handler', {
   enumerable: true,
-  get: function () { return handler; },
+  get: function () {
+    return handler;
+  },
   // intentionally no configurable: true — this is what esbuild produces
 });
 
 Object.defineProperty(exports, 'error', {
   enumerable: true,
-  get: function () { return error; },
+  get: function () {
+    return error;
+  },
 });


### PR DESCRIPTION
## Summary
- When esbuild bundles ESM to CJS format, it defines exports using non-configurable accessor descriptors. OpenTelemetry's shimmer then fails with `Cannot redefine property` when trying to wrap the handler.
- Adds a `makeExportsConfigurable()` helper in the Lambda instrumentation's patch callback that replaces such exports with a new object having configurable data descriptors before shimmer attempts patching.

Fixes: open-telemetry/opentelemetry-lambda#1781
See: https://github.com/evanw/esbuild/issues/2199

## Steps to reproduce

Create a handler that uses the same non-configurable export pattern that esbuild emits when bundling ESM to CJS:

```js
// index.js
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
Object.defineProperty(exports, "handler", {
  enumerable: true,
  get: function () { return handler; }
  // intentionally no configurable: true — this is what esbuild produces
});

async function handler(event) {
  return { statusCode: 200, body: JSON.stringify({ message: "OK" }) };
}
```

Deploy as a Lambda with the OTel layer and `AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler`:

```sh
zip handler.zip index.js

aws lambda create-function \
  --function-name otel-cjs-repro \
  --runtime nodejs20.x \
  --role <execution-role-arn> \
  --handler index.handler \
  --zip-file fileb://handler.zip \
  --layers arn:aws:lambda:<region>:184161586896:layer:opentelemetry-nodejs-0_20_0:1 \
  --environment "Variables={AWS_LAMBDA_EXEC_WRAPPER=/opt/otel-handler}"

aws lambda invoke --function-name otel-cjs-repro \
  --cli-binary-format raw-in-base64-out \
  --payload '{}' response.json && cat response.json
```

**Error (before fix):**
```json
{
  "errorType": "TypeError",
  "errorMessage": "Cannot redefine property: handler",
  "trace": [
    "TypeError: Cannot redefine property: handler",
    "    at Function.defineProperty (<anonymous>)",
    "    at T._wrap (...)",
    "    at Z.patch (...)",
    "    at T._onRequire (...)"
  ]
}
```

**Root cause:** esbuild emits exports as non-configurable accessor descriptors (see [esbuild#2199](https://github.com/evanw/esbuild/issues/2199)), so `Object.defineProperty` in shimmer fails when trying to wrap the handler.

## Test plan
- [x] Added `test/lambda-test/esbuild-cjs.js` simulating esbuild's non-configurable export pattern
- [x] Added integration tests verifying both success and error spans work with esbuild-style exports
- [x] Verified tests fail without the fix (`TypeError: Cannot redefine property: handler`)
- [x] Verified all 55 existing tests continue to pass
- [x] Normal CJS exports (already configurable) return the same object without creating a copy