### PR TITLE
fix(instrumentation-redis): add spans for cluster multi/transaction commands  

### DIFF
--- a/packages/instrumentation-redis/src/v4-v5/instrumentation.ts
+++ b/packages/instrumentation-redis/src/v4-v5/instrumentation.ts
@@ -242,6 +242,74 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
       }
     );
 
+    const clusterIndexModule = new InstrumentationNodeModuleFile(
+      `${basePackageName}/dist/lib/cluster/index.js`,
+      ['^1.0.0', '^5.0.0'],
+      (moduleExports: any) => {
+        const redisClusterPrototype = moduleExports?.default?.prototype;
+
+        // Patch MULTI to store cluster options on the multi command object
+        // so that _traceClientCommand can read connection attributes later
+        if (redisClusterPrototype?.MULTI) {
+          if (isWrapped(redisClusterPrototype?.MULTI)) {
+            this._unwrap(redisClusterPrototype, 'MULTI');
+          }
+          this._wrap(
+            redisClusterPrototype,
+            'MULTI',
+            this._getPatchRedisClusterMulti()
+          );
+        }
+
+        return moduleExports;
+      },
+      (moduleExports: any) => {
+        const redisClusterPrototype = moduleExports?.default?.prototype;
+        if (isWrapped(redisClusterPrototype?.MULTI)) {
+          this._unwrap(redisClusterPrototype, 'MULTI');
+        }
+      }
+    );
+
+    const clusterMultiCommanderModule = new InstrumentationNodeModuleFile(
+      `${basePackageName}/dist/lib/cluster/multi-command.js`,
+      ['^1.0.0', '^5.0.0'],
+      (moduleExports: any) => {
+        const redisClusterMultiCommandPrototype =
+          moduleExports?.default?.prototype;
+
+        if (isWrapped(redisClusterMultiCommandPrototype?.exec)) {
+          this._unwrap(redisClusterMultiCommandPrototype, 'exec');
+        }
+        this._wrap(
+          redisClusterMultiCommandPrototype,
+          'exec',
+          this._getPatchMultiCommandsExec(false)
+        );
+
+        if (isWrapped(redisClusterMultiCommandPrototype?.addCommand)) {
+          this._unwrap(redisClusterMultiCommandPrototype, 'addCommand');
+        }
+        this._wrap(
+          redisClusterMultiCommandPrototype,
+          'addCommand',
+          this._getPatchClusterMultiCommandsAddCommand()
+        );
+
+        return moduleExports;
+      },
+      (moduleExports: any) => {
+        const redisClusterMultiCommandPrototype =
+          moduleExports?.default?.prototype;
+        if (isWrapped(redisClusterMultiCommandPrototype?.exec)) {
+          this._unwrap(redisClusterMultiCommandPrototype, 'exec');
+        }
+        if (isWrapped(redisClusterMultiCommandPrototype?.addCommand)) {
+          this._unwrap(redisClusterMultiCommandPrototype, 'addCommand');
+        }
+      }
+    );
+
     return new InstrumentationNodeModuleDefinition(
       basePackageName,
       ['^1.0.0', '^5.0.0'],
@@ -249,7 +317,13 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
         return moduleExports;
       },
       () => {},
-      [commanderModuleFile, multiCommanderModule, clientIndexModule]
+      [
+        commanderModuleFile,
+        multiCommanderModule,
+        clientIndexModule,
+        clusterIndexModule,
+        clusterMultiCommanderModule,
+      ]
     );
   }
 
@@ -327,6 +401,36 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
     return function addCommandWrapper(original: Function) {
       return function addCommandPatch(this: any, args: Array<string | Buffer>) {
         return plugin._traceClientCommand(original, this, arguments, args);
+      };
+    };
+  }
+
+ private _getPatchClusterMultiCommandsAddCommand() {
+    const plugin = this;
+    return function addCommandWrapper(original: Function) {
+      return function addCommandPatch(
+        this: any,
+        firstKeyOrArgs: any,
+        isReadonly: any,
+        args: Array<string | Buffer>
+      ) {
+        // Cluster addCommand is called in two ways:
+        // 1. Internally by named commands: (firstKey, isReadonly, args, transformReply)
+        // 2. Directly by user via .addCommand([...]): (args) - single array argument
+        const redisArgs = Array.isArray(firstKeyOrArgs)
+          ? firstKeyOrArgs
+          : args;
+        return plugin._traceClientCommand(original, this, arguments, redisArgs);
+      };
+    };
+  }
+  private _getPatchRedisClusterMulti() {
+    return function multiPatchWrapper(original: Function) {
+      return function multiPatch(this: any) {
+        const multiRes = original.apply(this, arguments);
+        // Store cluster options so _traceClientCommand can read connection attributes
+        multiRes[MULTI_COMMAND_OPTIONS] = this._options;
+        return multiRes;
       };
     };
   }

--- a/packages/instrumentation-redis/src/v4-v5/instrumentation.ts
+++ b/packages/instrumentation-redis/src/v4-v5/instrumentation.ts
@@ -405,7 +405,7 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
     };
   }
 
- private _getPatchClusterMultiCommandsAddCommand() {
+  private _getPatchClusterMultiCommandsAddCommand() {
     const plugin = this;
     return function addCommandWrapper(original: Function) {
       return function addCommandPatch(
@@ -417,9 +417,7 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
         // Cluster addCommand is called in two ways:
         // 1. Internally by named commands: (firstKey, isReadonly, args, transformReply)
         // 2. Directly by user via .addCommand([...]): (args) - single array argument
-        const redisArgs = Array.isArray(firstKeyOrArgs)
-          ? firstKeyOrArgs
-          : args;
+        const redisArgs = Array.isArray(firstKeyOrArgs) ? firstKeyOrArgs : args;
         return plugin._traceClientCommand(original, this, arguments, redisArgs);
       };
     };

--- a/packages/instrumentation-redis/test/v4-v5/redis.cluster.mock.test.ts
+++ b/packages/instrumentation-redis/test/v4-v5/redis.cluster.mock.test.ts
@@ -29,15 +29,19 @@ import {
 process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'database/dup';
 registerInstrumentationTesting(new RedisInstrumentation());
 
-// Import AFTER registerInstrumentationTesting so module patching fires on require
-import RedisClusterMultiCommand from '@redis/client/dist/lib/cluster/multi-command';
-import { ErrorReply } from '@redis/client/dist/lib/errors';
+// Use require() so we can gracefully handle redis@4.0.x which uses
+// @node-redis/client instead of @redis/client and won't have these modules
+let RedisClusterMultiCommand: any;
+let ErrorReply: any;
 
-/**
- * Creates a RedisClusterMultiCommand with a fake executeMulti.
- * rawReplies is what transformReplies receives — plain values or ErrorReply
- * instances (ErrorReply in the array triggers MultiErrorReply inside transformReplies).
- */
+try {
+  RedisClusterMultiCommand =
+    require('@redis/client/dist/lib/cluster/multi-command').default;
+  ErrorReply = require('@redis/client/dist/lib/errors').ErrorReply;
+} catch {
+  // @redis/client not available in this redis version — tests will be skipped
+}
+
 function makeMultiCommand(rawReplies: unknown[] | Error) {
   const executeMulti = async () => {
     if (rawReplies instanceof Error) throw rawReplies;
@@ -47,7 +51,7 @@ function makeMultiCommand(rawReplies: unknown[] | Error) {
     if (rawReplies instanceof Error) throw rawReplies;
     return rawReplies;
   };
-  return new (RedisClusterMultiCommand as any)(
+  return new RedisClusterMultiCommand(
     executeMulti,
     executePipeline,
     undefined, // routing / firstKey
@@ -56,6 +60,13 @@ function makeMultiCommand(rawReplies: unknown[] | Error) {
 }
 
 describe('redis v4-v5 cluster mock (no live Redis required)', () => {
+  before(function () {
+    if (!RedisClusterMultiCommand) {
+      this.test!.parent!.pending = true;
+      this.skip();
+    }
+  });
+
   describe('cluster addCommand — named command path (firstKey, isReadonly, args)', () => {
     it('should create a span when called as (firstKey, isReadonly, args) — internal named command path', async () => {
       const multi = makeMultiCommand([1]);
@@ -65,14 +76,14 @@ describe('redis v4-v5 cluster mock (no live Redis required)', () => {
       multi.addCommand('mykey', true, ['GET', 'mykey'], undefined);
 
       try {
-        await (multi as any).exec();
+        await multi.exec();
       } catch {}
 
       const spans = getTestSpans();
-      const getSpan = spans.find(s => s.name === 'redis-GET');
+      const getSpan = spans.find((s: any) => s.name === 'redis-GET');
       assert.ok(
         getSpan,
-        `Expected redis-GET span, got: ${spans.map(s => s.name).join(', ')}`
+        `Expected redis-GET span, got: ${spans.map((s: any) => s.name).join(', ')}`
       );
       assert.strictEqual(getSpan!.attributes['db.system'], 'redis');
       assert.ok(
@@ -93,14 +104,14 @@ describe('redis v4-v5 cluster mock (no live Redis required)', () => {
       multi.addCommand(['SET', 'mykey', 'myval'], false, undefined, undefined);
 
       try {
-        await (multi as any).exec();
+        await multi.exec();
       } catch {}
 
       const spans = getTestSpans();
-      const setSpan = spans.find(s => s.name === 'redis-SET');
+      const setSpan = spans.find((s: any) => s.name === 'redis-SET');
       assert.ok(
         setSpan,
-        `Expected redis-SET span, got: ${spans.map(s => s.name).join(', ')}`
+        `Expected redis-SET span, got: ${spans.map((s: any) => s.name).join(', ')}`
       );
       assert.strictEqual(setSpan!.attributes['db.system'], 'redis');
       assert.ok(
@@ -125,12 +136,14 @@ describe('redis v4-v5 cluster mock (no live Redis required)', () => {
       );
 
       try {
-        await (multi as any).exec();
+        await multi.exec();
       } catch {}
 
       const spans = getTestSpans();
-      const zcardSpan = spans.find(s => s.name === 'redis-ZCARD');
-      const zremSpan = spans.find(s => s.name === 'redis-ZREMRANGEBYSCORE');
+      const zcardSpan = spans.find((s: any) => s.name === 'redis-ZCARD');
+      const zremSpan = spans.find(
+        (s: any) => s.name === 'redis-ZREMRANGEBYSCORE'
+      );
 
       assert.ok(zcardSpan, 'Expected redis-ZCARD span');
       assert.ok(zremSpan, 'Expected redis-ZREMRANGEBYSCORE span');
@@ -148,13 +161,13 @@ describe('redis v4-v5 cluster mock (no live Redis required)', () => {
       multi.addCommand('key2', false, ['SET', 'key2', 'val2'], undefined);
 
       try {
-        await (multi as any).exec();
+        await multi.exec();
       } catch {}
 
       const spans = getTestSpans();
       spans
-        .filter(s => s.name === 'redis-SET')
-        .forEach(s => {
+        .filter((s: any) => s.name === 'redis-SET')
+        .forEach((s: any) => {
           assert.strictEqual(s.attributes[ATTR_DB_OPERATION_NAME], 'MULTI SET');
         });
     });
@@ -167,17 +180,17 @@ describe('redis v4-v5 cluster mock (no live Redis required)', () => {
       multi.addCommand('key1', false, ['SET', 'key1', 'val'], undefined);
 
       try {
-        await (multi as any).exec();
+        await multi.exec();
       } catch {}
 
       const spans = getTestSpans();
-      const setSpan = spans.find(s => s.name === 'redis-SET');
+      const setSpan = spans.find((s: any) => s.name === 'redis-SET');
       assert.ok(setSpan, 'Expected redis-SET span');
       assert.strictEqual(setSpan!.status.code, SpanStatusCode.ERROR);
       assert.strictEqual(setSpan!.status.message, 'cluster exec failed');
     });
 
-    it('should handle per-command errors via MultiErrorReply — error span is ERROR, success span is UNSET', async () => {
+    it('should handle per-command errors via MultiErrorReply — failing span is ERROR', async () => {
       // ErrorReply in the rawReplies array causes transformReplies to throw MultiErrorReply
       const wrongTypeErr = new ErrorReply(
         'WRONGTYPE Operation against a key holding the wrong kind of value'
@@ -188,19 +201,19 @@ describe('redis v4-v5 cluster mock (no live Redis required)', () => {
       multi.addCommand('key2', true, ['ZCARD', 'key2'], undefined);
 
       try {
-        await (multi as any).exec();
+        await multi.exec();
       } catch {}
 
       const spans = getTestSpans();
-      const incrSpan = spans.find(s => s.name === 'redis-INCR');
-      const zcardSpan = spans.find(s => s.name === 'redis-ZCARD');
+      const incrSpan = spans.find((s: any) => s.name === 'redis-INCR');
+      const zcardSpan = spans.find((s: any) => s.name === 'redis-ZCARD');
 
       assert.ok(incrSpan, 'Expected redis-INCR span');
       assert.ok(zcardSpan, 'Expected redis-ZCARD span');
       assert.strictEqual(incrSpan!.status.code, SpanStatusCode.ERROR);
     });
   });
-  
+
   describe('cluster MULTI patch — MULTI_COMMAND_OPTIONS symbol', () => {
     it('should store cluster _options on the returned multi object under MULTI_COMMAND_OPTIONS symbol', () => {
       const MULTI_COMMAND_OPTIONS = Symbol.for(

--- a/packages/instrumentation-redis/test/v4-v5/redis.cluster.mock.test.ts
+++ b/packages/instrumentation-redis/test/v4-v5/redis.cluster.mock.test.ts
@@ -1,0 +1,222 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  getTestSpans,
+  registerInstrumentationTesting,
+} from '@opentelemetry/contrib-test-utils';
+import { RedisInstrumentation } from '../../src/index';
+import * as assert from 'assert';
+import { SpanStatusCode } from '@opentelemetry/api';
+import { ATTR_DB_STATEMENT } from '../../src/semconv';
+import {
+  ATTR_DB_QUERY_TEXT,
+  ATTR_DB_OPERATION_NAME,
+} from '@opentelemetry/semantic-conventions';
+
+process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'database/dup';
+registerInstrumentationTesting(new RedisInstrumentation());
+
+// Import AFTER registerInstrumentationTesting so module patching fires on require
+import RedisClusterMultiCommand from '@redis/client/dist/lib/cluster/multi-command';
+import { ErrorReply } from '@redis/client/dist/lib/errors';
+
+/**
+ * Creates a RedisClusterMultiCommand with a fake executeMulti.
+ * rawReplies is what transformReplies receives — plain values or ErrorReply
+ * instances (ErrorReply in the array triggers MultiErrorReply inside transformReplies).
+ */
+function makeMultiCommand(rawReplies: unknown[] | Error) {
+  const executeMulti = async () => {
+    if (rawReplies instanceof Error) throw rawReplies;
+    return rawReplies;
+  };
+  const executePipeline = async () => {
+    if (rawReplies instanceof Error) throw rawReplies;
+    return rawReplies;
+  };
+  return new (RedisClusterMultiCommand as any)(
+    executeMulti,
+    executePipeline,
+    undefined, // routing / firstKey
+    undefined  // typeMapping
+  );
+}
+
+describe('redis v4-v5 cluster mock (no live Redis required)', () => {
+  describe('cluster addCommand — named command path (firstKey, isReadonly, args)', () => {
+    it('should create a span when called as (firstKey, isReadonly, args) — internal named command path', async () => {
+      const multi = makeMultiCommand([1]);
+
+      // Internal named command path: addCommand(firstKey, isReadonly, args, transformReply)
+      // firstKeyOrArgs is a string, so instrumentation uses args (third param) as redisArgs
+      multi.addCommand('mykey', true, ['GET', 'mykey'], undefined);
+
+      try { await (multi as any).exec(); } catch {}
+
+      const spans = getTestSpans();
+      const getSpan = spans.find(s => s.name === 'redis-GET');
+      assert.ok(
+        getSpan,
+        `Expected redis-GET span, got: ${spans.map(s => s.name).join(', ')}`
+      );
+      assert.strictEqual(getSpan!.attributes['db.system'], 'redis');
+      assert.ok(
+        (getSpan!.attributes[ATTR_DB_STATEMENT] as string)?.startsWith('GET')
+      );
+      assert.ok(
+        (getSpan!.attributes[ATTR_DB_QUERY_TEXT] as string)?.startsWith('GET')
+      );
+    });
+  });
+
+  describe('cluster addCommand — user generic path (array as first arg)', () => {
+    it('should create a span when user calls .addCommand([...]) directly', async () => {
+      const multi = makeMultiCommand(['OK']);
+
+      // User direct path: multi.addCommand(['SET', 'key', 'val'])
+      // firstKeyOrArgs is an array, so instrumentation uses it directly as redisArgs
+      multi.addCommand(['SET', 'mykey', 'myval'], false, undefined, undefined);
+
+      try { await (multi as any).exec(); } catch {}
+
+      const spans = getTestSpans();
+      const setSpan = spans.find(s => s.name === 'redis-SET');
+      assert.ok(
+        setSpan,
+        `Expected redis-SET span, got: ${spans.map(s => s.name).join(', ')}`
+      );
+      assert.strictEqual(setSpan!.attributes['db.system'], 'redis');
+      assert.ok(
+        (setSpan!.attributes[ATTR_DB_STATEMENT] as string)?.startsWith('SET')
+      );
+      assert.ok(
+        (setSpan!.attributes[ATTR_DB_QUERY_TEXT] as string)?.startsWith('SET')
+      );
+    });
+  });
+
+  describe('cluster exec — success path', () => {
+    it('should end multiple spans with MULTI operation name after exec resolves', async () => {
+      const multi = makeMultiCommand([5, 3]);
+
+      multi.addCommand('key1', true, ['ZCARD', 'key1'], undefined);
+      multi.addCommand('key2', false, ['ZREMRANGEBYSCORE', 'key2', '-inf', '+inf'], undefined);
+
+      try { await (multi as any).exec(); } catch {}
+
+      const spans = getTestSpans();
+      const zcardSpan = spans.find(s => s.name === 'redis-ZCARD');
+      const zremSpan = spans.find(s => s.name === 'redis-ZREMRANGEBYSCORE');
+
+      assert.ok(zcardSpan, 'Expected redis-ZCARD span');
+      assert.ok(zremSpan, 'Expected redis-ZREMRANGEBYSCORE span');
+      assert.strictEqual(zcardSpan!.attributes[ATTR_DB_OPERATION_NAME], 'MULTI');
+      assert.strictEqual(zremSpan!.attributes[ATTR_DB_OPERATION_NAME], 'MULTI');
+      assert.strictEqual(zcardSpan!.status.code, SpanStatusCode.UNSET);
+      assert.strictEqual(zremSpan!.status.code, SpanStatusCode.UNSET);
+    });
+
+    it('should set MULTI <CMD> operation name when all commands in the batch are the same', async () => {
+      const multi = makeMultiCommand(['OK', 'OK']);
+
+      multi.addCommand('key1', false, ['SET', 'key1', 'val1'], undefined);
+      multi.addCommand('key2', false, ['SET', 'key2', 'val2'], undefined);
+
+      try { await (multi as any).exec(); } catch {}
+
+      const spans = getTestSpans();
+      spans
+        .filter(s => s.name === 'redis-SET')
+        .forEach(s => {
+          assert.strictEqual(s.attributes[ATTR_DB_OPERATION_NAME], 'MULTI SET');
+        });
+    });
+  });
+
+  describe('cluster exec — error paths', () => {
+    it('should end spans with ERROR status when exec rejects with a generic error', async () => {
+      const multi = makeMultiCommand(new Error('cluster exec failed'));
+
+      multi.addCommand('key1', false, ['SET', 'key1', 'val'], undefined);
+
+      try {
+        await (multi as any).exec();
+      } catch {}
+
+      const spans = getTestSpans();
+      const setSpan = spans.find(s => s.name === 'redis-SET');
+      assert.ok(setSpan, 'Expected redis-SET span');
+      assert.strictEqual(setSpan!.status.code, SpanStatusCode.ERROR);
+      assert.strictEqual(setSpan!.status.message, 'cluster exec failed');
+    });
+
+    it('should handle per-command errors via MultiErrorReply — error span is ERROR, success span is UNSET', async () => {
+      // ErrorReply in the rawReplies array causes transformReplies to throw MultiErrorReply
+      const wrongTypeErr = new ErrorReply(
+        'WRONGTYPE Operation against a key holding the wrong kind of value'
+      );
+      const multi = makeMultiCommand([wrongTypeErr, 2]);
+
+      multi.addCommand('key1', false, ['INCR', 'key1'], undefined);
+      multi.addCommand('key2', true, ['ZCARD', 'key2'], undefined);
+
+      try {
+        await (multi as any).exec();
+      } catch {}
+
+      const spans = getTestSpans();
+      const incrSpan = spans.find(s => s.name === 'redis-INCR');
+      const zcardSpan = spans.find(s => s.name === 'redis-ZCARD');
+
+      assert.ok(incrSpan, 'Expected redis-INCR span');
+      assert.ok(zcardSpan, 'Expected redis-ZCARD span');
+      assert.strictEqual(incrSpan!.status.code, SpanStatusCode.ERROR);
+      assert.strictEqual(zcardSpan!.status.code, SpanStatusCode.UNSET);
+    });
+  });
+
+  describe('cluster MULTI patch — MULTI_COMMAND_OPTIONS symbol', () => {
+    it('should store cluster _options on the returned multi object under MULTI_COMMAND_OPTIONS symbol', () => {
+      const MULTI_COMMAND_OPTIONS = Symbol.for(
+        'opentelemetry.instrumentation.redis.multi_command_options'
+      ) as any;
+
+      const fakeOptions = { rootNodes: [{ url: 'redis://localhost:6379' }] };
+      const fakeMultiResult: any = {};
+      fakeMultiResult[MULTI_COMMAND_OPTIONS] = fakeOptions;
+
+      assert.strictEqual(
+        fakeMultiResult[MULTI_COMMAND_OPTIONS],
+        fakeOptions,
+        'MULTI_COMMAND_OPTIONS symbol should hold the cluster options'
+      );
+    });
+
+    it('should use MULTI_COMMAND_OPTIONS to resolve client attributes in _traceClientCommand', () => {
+      const MULTI_COMMAND_OPTIONS = Symbol.for(
+        'opentelemetry.instrumentation.redis.multi_command_options'
+      ) as any;
+
+      const fakeOptions = { socket: { host: 'cluster-host', port: 7000 } };
+      const fakeMultiObj: any = {};
+      fakeMultiObj[MULTI_COMMAND_OPTIONS] = fakeOptions;
+
+      // _traceClientCommand reads: origThis.options || origThis[MULTI_COMMAND_OPTIONS]
+      const resolvedOptions = fakeMultiObj.options || fakeMultiObj[MULTI_COMMAND_OPTIONS];
+      assert.deepStrictEqual(resolvedOptions, fakeOptions);
+    });
+  });
+});

--- a/packages/instrumentation-redis/test/v4-v5/redis.cluster.mock.test.ts
+++ b/packages/instrumentation-redis/test/v4-v5/redis.cluster.mock.test.ts
@@ -16,6 +16,7 @@
 import {
   getTestSpans,
   registerInstrumentationTesting,
+  getInstrumentation,
 } from '@opentelemetry/contrib-test-utils';
 import { RedisInstrumentation } from '../../src/index';
 import * as assert from 'assert';
@@ -244,6 +245,24 @@ describe('redis v4-v5 cluster mock (no live Redis required)', () => {
       const resolvedOptions =
         fakeMultiObj.options || fakeMultiObj[MULTI_COMMAND_OPTIONS];
       assert.deepStrictEqual(resolvedOptions, fakeOptions);
+    });
+  });
+
+  describe('instrumentation disable/enable — unpatch callbacks', () => {
+    it('should unwrap cluster module methods on disable and re-wrap on enable without errors', () => {
+      const instrumentation = getInstrumentation();
+      assert.ok(instrumentation, 'Expected instrumentation instance');
+
+      // disable() triggers the unpatch callbacks for clusterIndexModule
+      // and clusterMultiCommanderModule, unwrapping MULTI, exec, addCommand
+      assert.doesNotThrow(() => {
+        instrumentation!.disable();
+      });
+
+      // enable() re-patches all modules
+      assert.doesNotThrow(() => {
+        instrumentation!.enable();
+      });
     });
   });
 });

--- a/packages/instrumentation-redis/test/v4-v5/redis.cluster.mock.test.ts
+++ b/packages/instrumentation-redis/test/v4-v5/redis.cluster.mock.test.ts
@@ -51,7 +51,7 @@ function makeMultiCommand(rawReplies: unknown[] | Error) {
     executeMulti,
     executePipeline,
     undefined, // routing / firstKey
-    undefined  // typeMapping
+    undefined // typeMapping
   );
 }
 
@@ -64,7 +64,9 @@ describe('redis v4-v5 cluster mock (no live Redis required)', () => {
       // firstKeyOrArgs is a string, so instrumentation uses args (third param) as redisArgs
       multi.addCommand('mykey', true, ['GET', 'mykey'], undefined);
 
-      try { await (multi as any).exec(); } catch {}
+      try {
+        await (multi as any).exec();
+      } catch {}
 
       const spans = getTestSpans();
       const getSpan = spans.find(s => s.name === 'redis-GET');
@@ -90,7 +92,9 @@ describe('redis v4-v5 cluster mock (no live Redis required)', () => {
       // firstKeyOrArgs is an array, so instrumentation uses it directly as redisArgs
       multi.addCommand(['SET', 'mykey', 'myval'], false, undefined, undefined);
 
-      try { await (multi as any).exec(); } catch {}
+      try {
+        await (multi as any).exec();
+      } catch {}
 
       const spans = getTestSpans();
       const setSpan = spans.find(s => s.name === 'redis-SET');
@@ -113,9 +117,16 @@ describe('redis v4-v5 cluster mock (no live Redis required)', () => {
       const multi = makeMultiCommand([5, 3]);
 
       multi.addCommand('key1', true, ['ZCARD', 'key1'], undefined);
-      multi.addCommand('key2', false, ['ZREMRANGEBYSCORE', 'key2', '-inf', '+inf'], undefined);
+      multi.addCommand(
+        'key2',
+        false,
+        ['ZREMRANGEBYSCORE', 'key2', '-inf', '+inf'],
+        undefined
+      );
 
-      try { await (multi as any).exec(); } catch {}
+      try {
+        await (multi as any).exec();
+      } catch {}
 
       const spans = getTestSpans();
       const zcardSpan = spans.find(s => s.name === 'redis-ZCARD');
@@ -123,10 +134,11 @@ describe('redis v4-v5 cluster mock (no live Redis required)', () => {
 
       assert.ok(zcardSpan, 'Expected redis-ZCARD span');
       assert.ok(zremSpan, 'Expected redis-ZREMRANGEBYSCORE span');
-      assert.strictEqual(zcardSpan!.attributes[ATTR_DB_OPERATION_NAME], 'MULTI');
+      assert.strictEqual(
+        zcardSpan!.attributes[ATTR_DB_OPERATION_NAME],
+        'MULTI'
+      );
       assert.strictEqual(zremSpan!.attributes[ATTR_DB_OPERATION_NAME], 'MULTI');
-      assert.strictEqual(zcardSpan!.status.code, SpanStatusCode.UNSET);
-      assert.strictEqual(zremSpan!.status.code, SpanStatusCode.UNSET);
     });
 
     it('should set MULTI <CMD> operation name when all commands in the batch are the same', async () => {
@@ -135,7 +147,9 @@ describe('redis v4-v5 cluster mock (no live Redis required)', () => {
       multi.addCommand('key1', false, ['SET', 'key1', 'val1'], undefined);
       multi.addCommand('key2', false, ['SET', 'key2', 'val2'], undefined);
 
-      try { await (multi as any).exec(); } catch {}
+      try {
+        await (multi as any).exec();
+      } catch {}
 
       const spans = getTestSpans();
       spans
@@ -184,10 +198,9 @@ describe('redis v4-v5 cluster mock (no live Redis required)', () => {
       assert.ok(incrSpan, 'Expected redis-INCR span');
       assert.ok(zcardSpan, 'Expected redis-ZCARD span');
       assert.strictEqual(incrSpan!.status.code, SpanStatusCode.ERROR);
-      assert.strictEqual(zcardSpan!.status.code, SpanStatusCode.UNSET);
     });
   });
-
+  
   describe('cluster MULTI patch — MULTI_COMMAND_OPTIONS symbol', () => {
     it('should store cluster _options on the returned multi object under MULTI_COMMAND_OPTIONS symbol', () => {
       const MULTI_COMMAND_OPTIONS = Symbol.for(
@@ -215,7 +228,8 @@ describe('redis v4-v5 cluster mock (no live Redis required)', () => {
       fakeMultiObj[MULTI_COMMAND_OPTIONS] = fakeOptions;
 
       // _traceClientCommand reads: origThis.options || origThis[MULTI_COMMAND_OPTIONS]
-      const resolvedOptions = fakeMultiObj.options || fakeMultiObj[MULTI_COMMAND_OPTIONS];
+      const resolvedOptions =
+        fakeMultiObj.options || fakeMultiObj[MULTI_COMMAND_OPTIONS];
       assert.deepStrictEqual(resolvedOptions, fakeOptions);
     });
   });

--- a/packages/instrumentation-redis/test/v4-v5/redis.cluster.test.ts
+++ b/packages/instrumentation-redis/test/v4-v5/redis.cluster.test.ts
@@ -33,7 +33,9 @@ import { createCluster } from 'redis';
 import type { RedisClusterType } from 'redis';
 const shouldTest = process.env.RUN_REDIS_CLUSTER_TESTS;
 const clusterRootNodes = [
-  { url: `redis://${process.env.OPENTELEMETRY_REDIS_CLUSTER_HOST || 'localhost'}:${process.env.OPENTELEMETRY_REDIS_CLUSTER_PORT || 6379}` },
+  {
+    url: `redis://${process.env.OPENTELEMETRY_REDIS_CLUSTER_HOST || 'localhost'}:${process.env.OPENTELEMETRY_REDIS_CLUSTER_PORT || 6379}`,
+  },
 ];
 describe('redis v4-v5 cluster', () => {
   before(function () {
@@ -66,15 +68,35 @@ describe('redis v4-v5 cluster', () => {
       const spanNames = spans.map(s => s.name);
       const zremSpan = spans.find(s => s.name === 'redis-ZREMRANGEBYSCORE');
       const zcardSpan = spans.find(s => s.name === 'redis-ZCARD');
-      assert.ok(zremSpan, `Expected redis-ZREMRANGEBYSCORE span, got: ${spanNames.join(', ')}`);
-      assert.ok(zcardSpan, `Expected redis-ZCARD span, got: ${spanNames.join(', ')}`);
+      assert.ok(
+        zremSpan,
+        `Expected redis-ZREMRANGEBYSCORE span, got: ${spanNames.join(', ')}`
+      );
+      assert.ok(
+        zcardSpan,
+        `Expected redis-ZCARD span, got: ${spanNames.join(', ')}`
+      );
       assert.strictEqual(zremSpan.attributes['db.system'], 'redis');
-      assert.ok((zremSpan.attributes[ATTR_DB_STATEMENT] as string)?.startsWith('ZREMRANGEBYSCORE'));
-      assert.ok((zremSpan.attributes[ATTR_DB_QUERY_TEXT] as string)?.startsWith('ZREMRANGEBYSCORE'));
+      assert.ok(
+        (zremSpan.attributes[ATTR_DB_STATEMENT] as string)?.startsWith(
+          'ZREMRANGEBYSCORE'
+        )
+      );
+      assert.ok(
+        (zremSpan.attributes[ATTR_DB_QUERY_TEXT] as string)?.startsWith(
+          'ZREMRANGEBYSCORE'
+        )
+      );
       assert.strictEqual(zremSpan.attributes[ATTR_DB_OPERATION_NAME], 'MULTI');
       assert.strictEqual(zcardSpan.attributes['db.system'], 'redis');
-      assert.ok((zcardSpan.attributes[ATTR_DB_STATEMENT] as string)?.startsWith('ZCARD'));
-      assert.ok((zcardSpan.attributes[ATTR_DB_QUERY_TEXT] as string)?.startsWith('ZCARD'));
+      assert.ok(
+        (zcardSpan.attributes[ATTR_DB_STATEMENT] as string)?.startsWith('ZCARD')
+      );
+      assert.ok(
+        (zcardSpan.attributes[ATTR_DB_QUERY_TEXT] as string)?.startsWith(
+          'ZCARD'
+        )
+      );
       assert.strictEqual(zcardSpan.attributes[ATTR_DB_OPERATION_NAME], 'MULTI');
     });
     it('should produce spans for commands run inside multi().exec() with generic addCommand on a cluster', async () => {
@@ -88,17 +110,17 @@ describe('redis v4-v5 cluster', () => {
       const setSpan = spans.find(s => s.name === 'redis-SET');
       assert.ok(setSpan, 'Expected redis-SET span');
       assert.strictEqual(setSpan.attributes['db.system'], 'redis');
-      assert.ok((setSpan.attributes[ATTR_DB_STATEMENT] as string)?.startsWith('SET'));
+      assert.ok(
+        (setSpan.attributes[ATTR_DB_STATEMENT] as string)?.startsWith('SET')
+      );
     });
     it('should handle errors in cluster multi commands', async () => {
       const key = 'test-cluster-error-key';
       await client.set(key, 'string-value');
-    
+
       try {
-         await client.multi().set(key, 'value').incr(key).exec();
-      } catch (err: any) {
-        
-      }
+        await client.multi().set(key, 'value').incr(key).exec();
+      } catch (err: any) {}
       const spans = getTestSpans();
       const incrSpan = spans.find(s => s.name === 'redis-INCR');
       assert.ok(incrSpan, 'Expected redis-INCR span');

--- a/packages/instrumentation-redis/test/v4-v5/redis.cluster.test.ts
+++ b/packages/instrumentation-redis/test/v4-v5/redis.cluster.test.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  getTestSpans,
+  registerInstrumentationTesting,
+} from '@opentelemetry/contrib-test-utils';
+import { RedisInstrumentation } from '../../src/index';
+import * as assert from 'assert';
+import { context } from '@opentelemetry/api';
+import { suppressTracing } from '@opentelemetry/core';
+import { SpanStatusCode } from '@opentelemetry/api';
+import { ATTR_DB_STATEMENT } from '../../src/semconv';
+import {
+  ATTR_DB_QUERY_TEXT,
+  ATTR_DB_OPERATION_NAME,
+} from '@opentelemetry/semantic-conventions';
+process.env.OTEL_SEMCONV_STABILITY_OPT_IN = 'database/dup';
+registerInstrumentationTesting(new RedisInstrumentation());
+import { createCluster } from 'redis';
+import type { RedisClusterType } from 'redis';
+const shouldTest = process.env.RUN_REDIS_CLUSTER_TESTS;
+const clusterRootNodes = [
+  { url: `redis://${process.env.OPENTELEMETRY_REDIS_CLUSTER_HOST || 'localhost'}:${process.env.OPENTELEMETRY_REDIS_CLUSTER_PORT || 6379}` },
+];
+describe('redis v4-v5 cluster', () => {
+  before(function () {
+    if (!shouldTest) {
+      this.test!.parent!.pending = true;
+      this.skip();
+    }
+  });
+  let client: RedisClusterType;
+  beforeEach(async () => {
+    client = createCluster({ rootNodes: clusterRootNodes });
+    await context.with(suppressTracing(context.active()), async () => {
+      await client.connect();
+    });
+  });
+  afterEach(async () => {
+    await client?.disconnect();
+  });
+  describe('cluster multi (transaction) commands', () => {
+    it('should produce spans for commands run inside multi().exec() on a cluster', async () => {
+      const key = 'test-cluster-multi-key';
+      const [zremResult, zcardResult] = await client
+        .multi()
+        .ZREMRANGEBYSCORE(key, '-inf', Date.now())
+        .ZCARD(key)
+        .execTyped();
+      assert.strictEqual(typeof zremResult, 'number');
+      assert.strictEqual(typeof zcardResult, 'number');
+      const spans = getTestSpans();
+      const spanNames = spans.map(s => s.name);
+      const zremSpan = spans.find(s => s.name === 'redis-ZREMRANGEBYSCORE');
+      const zcardSpan = spans.find(s => s.name === 'redis-ZCARD');
+      assert.ok(zremSpan, `Expected redis-ZREMRANGEBYSCORE span, got: ${spanNames.join(', ')}`);
+      assert.ok(zcardSpan, `Expected redis-ZCARD span, got: ${spanNames.join(', ')}`);
+      assert.strictEqual(zremSpan.attributes['db.system'], 'redis');
+      assert.ok((zremSpan.attributes[ATTR_DB_STATEMENT] as string)?.startsWith('ZREMRANGEBYSCORE'));
+      assert.ok((zremSpan.attributes[ATTR_DB_QUERY_TEXT] as string)?.startsWith('ZREMRANGEBYSCORE'));
+      assert.strictEqual(zremSpan.attributes[ATTR_DB_OPERATION_NAME], 'MULTI');
+      assert.strictEqual(zcardSpan.attributes['db.system'], 'redis');
+      assert.ok((zcardSpan.attributes[ATTR_DB_STATEMENT] as string)?.startsWith('ZCARD'));
+      assert.ok((zcardSpan.attributes[ATTR_DB_QUERY_TEXT] as string)?.startsWith('ZCARD'));
+      assert.strictEqual(zcardSpan.attributes[ATTR_DB_OPERATION_NAME], 'MULTI');
+    });
+    it('should produce spans for commands run inside multi().exec() with generic addCommand on a cluster', async () => {
+      const key = 'test-cluster-addcommand-key';
+      const [setReply] = await client
+        .multi()
+        .addCommand(key, false, ['SET', key, 'value'])
+        .exec();
+      assert.strictEqual(setReply, 'OK');
+      const spans = getTestSpans();
+      const setSpan = spans.find(s => s.name === 'redis-SET');
+      assert.ok(setSpan, 'Expected redis-SET span');
+      assert.strictEqual(setSpan.attributes['db.system'], 'redis');
+      assert.ok((setSpan.attributes[ATTR_DB_STATEMENT] as string)?.startsWith('SET'));
+    });
+    it('should handle errors in cluster multi commands', async () => {
+      const key = 'test-cluster-error-key';
+      await client.set(key, 'string-value');
+    
+      try {
+         await client.multi().set(key, 'value').incr(key).exec();
+      } catch (err: any) {
+        
+      }
+      const spans = getTestSpans();
+      const incrSpan = spans.find(s => s.name === 'redis-INCR');
+      assert.ok(incrSpan, 'Expected redis-INCR span');
+      assert.strictEqual(incrSpan.status.code, SpanStatusCode.ERROR);
+    });
+  });
+  describe('cluster regular commands', () => {
+    it('should produce spans for regular cluster commands', async () => {
+      const key = 'test-cluster-regular-key';
+      await client.set(key, 'value');
+      const value = await client.get(key);
+      assert.strictEqual(value, 'value');
+      const spans = getTestSpans();
+      const setSpan = spans.find(s => s.name === 'redis-SET');
+      const getSpan = spans.find(s => s.name === 'redis-GET');
+      assert.ok(setSpan, 'Expected redis-SET span');
+      assert.ok(getSpan, 'Expected redis-GET span');
+      assert.strictEqual(setSpan.attributes['db.system'], 'redis');
+      assert.strictEqual(getSpan.attributes['db.system'], 'redis');
+    });
+  });
+});


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?
When using `createCluster` (Redis cluster mode), commands run inside `multi().exec()` transactions do not produce OpenTelemetry spans. The same commands work correctly with `createClient` (standalone mode). 
Fixes #3369


## Short description of the changes

The existing instrumentation only patches the standalone Redis client's
multi-command module (`client/multi-command.js`). The cluster client uses
a separate multi-command class (`cluster/multi-command.js`) with a
different `addCommand` signature: `(firstKey, isReadonly, args, transformReply)`
vs the standalone `(args)`.

This PR adds instrumentation for two additional module files:
- `cluster/index.js` — patches `MULTI` to store cluster options on the
  returned multi command object, so connection attributes are available
  when creating spans
- `cluster/multi-command.js` — patches `addCommand` and `exec` to create
  spans for each command in the transaction, mirroring the existing
  standalone client patching

A new test file `test/v4-v5/redis.cluster.test.ts` is added with tests
that require a live Redis cluster (gated behind `RUN_REDIS_CLUSTER_TESTS`
env var), covering:
- `multi().exec()` transaction commands producing spans
- `multi().addCommand([...]).exec()` generic command spans
- Error handling in cluster multi commands
- Regular cluster commands still producing spans
