### PR TITLE
feat(instrumentation-bunyan): use Logs API exception field when translating bunyan error records

### DIFF
--- a/packages/instrumentation-bunyan/README.md
+++ b/packages/instrumentation-bunyan/README.md
@@ -59,6 +59,11 @@ If the OpenTelemetry SDK is not configured with a Logger provider, then this add
 
 Log sending can be disabled with the `disableLogSending: true` option.
 
+When Bunyan emits a top-level `err` field, for example via
+`logger.error(err, 'msg')`, this instrumentation forwards it through the Logs
+API `exception` field so the SDK can populate standard `exception.*`
+attributes.
+
 ### Log correlation
 
 Bunyan logger calls in the context of a tracing span will have fields
@@ -120,7 +125,8 @@ const logger = bunyan.createLogger({
 
 ## Semantic Conventions
 
-This package does not currently generate any attributes from semantic conventions.
+This package forwards Bunyan `err` fields through the Logs API `exception`
+field, allowing the SDK to populate standard `exception.*` attributes.
 
 ## Useful links
 

--- a/packages/instrumentation-bunyan/src/OpenTelemetryBunyanStream.ts
+++ b/packages/instrumentation-bunyan/src/OpenTelemetryBunyanStream.ts
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import { logs, SeverityNumber, Logger } from '@opentelemetry/api-logs';
+import {
+  logs,
+  SeverityNumber,
+  Logger,
+  type LogRecord,
+} from '@opentelemetry/api-logs';
 import type { LogLevelString } from 'bunyan';
 /** @knipignore */
 import { PACKAGE_NAME, PACKAGE_VERSION } from './version';
@@ -135,6 +140,7 @@ export class OpenTelemetryBunyanStream {
       time,
       level,
       msg,
+      err,
       v, // eslint-disable-line @typescript-eslint/no-unused-vars
       hostname, // eslint-disable-line @typescript-eslint/no-unused-vars
       pid, // eslint-disable-line @typescript-eslint/no-unused-vars
@@ -149,7 +155,7 @@ export class OpenTelemetryBunyanStream {
     } else {
       fields.time = time; // Expose non-Date "time" field on attributes.
     }
-    const otelRec = {
+    const otelRec: LogRecord = {
       timestamp,
       observedTimestamp: timestamp,
       severityNumber: severityNumberFromBunyanLevel(level),
@@ -157,6 +163,9 @@ export class OpenTelemetryBunyanStream {
       body: msg,
       attributes: fields,
     };
+    if (err !== undefined) {
+      otelRec.exception = err;
+    }
     this._otelLogger.emit(otelRec);
   }
 }

--- a/packages/instrumentation-bunyan/test/bunyan.test.ts
+++ b/packages/instrumentation-bunyan/test/bunyan.test.ts
@@ -28,7 +28,12 @@ import {
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { isWrapped } from '@opentelemetry/instrumentation';
 import { resourceFromAttributes } from '@opentelemetry/resources';
-import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import {
+  ATTR_EXCEPTION_MESSAGE,
+  ATTR_EXCEPTION_STACKTRACE,
+  ATTR_EXCEPTION_TYPE,
+  ATTR_SERVICE_NAME,
+} from '@opentelemetry/semantic-conventions';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import { Writable } from 'stream';
@@ -264,6 +269,25 @@ describe('BunyanInstrumentation', () => {
       rec = logRecords[logRecords.length - 1];
       assert.strictEqual(rec.severityNumber, SeverityNumber.FATAL4);
       assert.strictEqual(rec.severityText, undefined);
+    });
+
+    it('maps Bunyan err fields to exception attributes', () => {
+      const error = new Error('boom');
+
+      log.error(error, 'with exception');
+
+      const logRecords = memExporter.getFinishedLogRecords();
+      const rec = logRecords[logRecords.length - 1];
+      assert.strictEqual(rec.body, 'with exception');
+      assert.strictEqual(rec.attributes.err, undefined);
+      assert.strictEqual(rec.attributes[ATTR_EXCEPTION_MESSAGE], error.message);
+      assert.strictEqual(rec.attributes[ATTR_EXCEPTION_TYPE], error.name);
+      if (error.stack) {
+        assert.strictEqual(
+          rec.attributes[ATTR_EXCEPTION_STACKTRACE],
+          error.stack
+        );
+      }
     });
 
     it('does not emit to the Logs SDK if disableLogSending=true', () => {


### PR DESCRIPTION
## Which problem is this PR solving?

- https://github.com/open-telemetry/opentelemetry-js-contrib/issues/3430

## Short description of the changes

- Call the exceptions API added in https://github.com/open-telemetry/opentelemetry-js/pull/6385 from `bunyan` auto instrumentation.
