### PR TITLE
test(sampler-aws-xray): stabilize flaky setTimeout intervals under CI load

### DIFF
--- a/packages/sampler-aws-xray/test/remote-sampler.test.ts
+++ b/packages/sampler-aws-xray/test/remote-sampler.test.ts
@@ -188,8 +188,8 @@ describe('AWSXRayRemoteSampler', () => {
         ).toEqual(SamplingDecision.RECORD_AND_SAMPLED);
 
         done();
-      }, 500);
-    }, 500);
+      }, 1000);
+    }, 1000);
   });
 
   it('testLargeReservoir', done => {
@@ -254,8 +254,8 @@ describe('AWSXRayRemoteSampler', () => {
         ).toEqual(1000);
         expect(sampled).toEqual(1000);
         done();
-      }, 500);
-    }, 500);
+      }, 1000);
+    }, 1000);
   });
 
   it('testSomeReservoir', done => {
@@ -334,8 +334,8 @@ describe('AWSXRayRemoteSampler', () => {
 
         expect(sampled).toEqual(100);
         done();
-      }, 500);
-    }, 500);
+      }, 1000);
+    }, 1000);
   });
 
   it('generates valid ClientId', () => {
@@ -389,7 +389,7 @@ describe('AWSXRayRemoteSampler', () => {
         ].SampleCount
       ).toBe(1);
       done();
-    }, 500);
+    }, 1000);
   });
 
   it('Non-ParentBased _AWSXRayRemoteSampler creates expected Statistics based on all 3 Spans, disregarding Parent Span Sampling Decision', done => {
@@ -429,7 +429,7 @@ describe('AWSXRayRemoteSampler', () => {
           .SampleCount
       ).toBe(3);
       done();
-    }, 500);
+    }, 1000);
   });
 });
 


### PR DESCRIPTION
Fixes #3394 

## Problem
In recent days, there has been an uptick in flaky tests in `@opentelemetry/sampler-aws-xray`. Specifically, the tests in `remote-sampler.test.ts` depend on `setTimeout` arrays to wait for internal network mocks (`nock`) to resolve and for `sinon` fake timer clocks to cycle. Under heavy CI load, the default 500ms bounds are too tight, causing the `setTimeout` assertion checks to fire before the internal simulated state has fully updated, leading to random test failures.

## Fix
- Increased the terminal `setTimeout` bounds from 500ms to 1000ms within `remote-sampler.test.ts`. 
- This gives the internal `fetchSamplingRules` callback queue sufficient padding to drain across the event loop without artificially slowing down the fast-path passes, effectively stabilizing the test under noisy neighbor CI environments.

I ran the test suite locally multiple times and the sampler suite passes cleanly now.

Thank you!