### PR TITLE
fix(instrumentation-sequelize): do not include 'server.address' for SQLite DB spans

### DIFF
--- a/packages/instrumentation-sequelize/src/instrumentation.ts
+++ b/packages/instrumentation-sequelize/src/instrumentation.ts
@@ -163,16 +163,20 @@ export class SequelizeInstrumentation extends InstrumentationBase<SequelizeInstr
           else tableName = extractTableFromQuery(statement);
         }
 
+        const dialect = sequelizeInstance.getDialect();
         const attributes: Attributes = {
-          [ATTR_DB_SYSTEM_NAME]: sequelizeInstance.getDialect(),
+          [ATTR_DB_SYSTEM_NAME]: dialect,
           [ATTR_DB_NAMESPACE]: config?.database,
           [ATTR_DB_OPERATION_NAME]: operation,
           [ATTR_DB_QUERY_TEXT]: statement,
           [ATTR_DB_COLLECTION_NAME]: tableName,
-          [ATTR_SERVER_ADDRESS]: config?.host,
-          [ATTR_SERVER_PORT]: config?.port ? Number(config?.port) : undefined,
           [ATTR_NETWORK_TRANSPORT]: self._getNetTransport(config?.protocol),
         };
+        if (dialect !== 'sqlite') {
+          // Server address and port don't make sense for SQLite DBs.
+          attributes[ATTR_SERVER_ADDRESS] = config?.host;
+          attributes[ATTR_SERVER_PORT] = config?.port ? Number(config?.port) : undefined;
+        }
 
         const newSpan: Span = self.tracer.startSpan(`Sequelize ${operation}`, {
           kind: SpanKind.CLIENT,

--- a/packages/instrumentation-sequelize/src/instrumentation.ts
+++ b/packages/instrumentation-sequelize/src/instrumentation.ts
@@ -175,7 +175,9 @@ export class SequelizeInstrumentation extends InstrumentationBase<SequelizeInstr
         if (dialect !== 'sqlite') {
           // Server address and port don't make sense for SQLite DBs.
           attributes[ATTR_SERVER_ADDRESS] = config?.host;
-          attributes[ATTR_SERVER_PORT] = config?.port ? Number(config?.port) : undefined;
+          attributes[ATTR_SERVER_PORT] = config?.port
+            ? Number(config?.port)
+            : undefined;
         }
 
         const newSpan: Span = self.tracer.startSpan(`Sequelize ${operation}`, {

--- a/packages/instrumentation-sequelize/test/sequelize.test.ts
+++ b/packages/instrumentation-sequelize/test/sequelize.test.ts
@@ -326,7 +326,8 @@ describe('instrumentation-sequelize', () => {
   });
 
   describe('sqlite', () => {
-    const instance = new sequelize.Sequelize('sqlite:memory', {
+    // https://sequelize.org/docs/v6/getting-started/#connecting-to-a-database
+    const instance = new sequelize.Sequelize('sqlite::memory:', {
       logging: false,
     });
     instance.define('User', {
@@ -341,7 +342,10 @@ describe('instrumentation-sequelize', () => {
       assert.strictEqual(spans.length, 1);
       const attributes = spans[0].attributes;
       assert.strictEqual(attributes[ATTR_DB_SYSTEM_NAME], 'sqlite');
-      assert.strictEqual(attributes[ATTR_SERVER_ADDRESS], 'memory');
+      // db.namespace: I think we'd expect ":memory:" here, with the trailing
+      // colon as at https://www.sqlite.org/inmemorydb.html. However sequelize
+      // Sequelize#config.database drops the trailing ':'.
+      assert.strictEqual(attributes[ATTR_DB_NAMESPACE], ':memory');
       assert.strictEqual(attributes[ATTR_DB_OPERATION_NAME], 'INSERT');
       assert.strictEqual(attributes[ATTR_DB_COLLECTION_NAME], 'Users');
       assert.strictEqual(


### PR DESCRIPTION
I've tweaked the instr to not include server.address / server.port
for SQLite spans, because it doesn't make sense. Before this change
it was using the SQLite *filename* as the `server.address`.
This is not discussed in DB semantic conventions.
I've asked about this in semconv Slack.

I've also corrected the connection string for a SQLite in-memory
database in the tests. The previous usage was creating an actual local
*file* named 'memory'.
