### PR TITLE
feat(instrumentation-winston): use Logs API exception field when translating winston error records

### DIFF
--- a/packages/instrumentation-winston/test/winston.test.ts
+++ b/packages/instrumentation-winston/test/winston.test.ts
@@ -80,6 +80,12 @@ describe('WinstonInstrumentation', () => {
       case 'colorize':
         format = winston.format.colorize();
         break;
+      case 'errors':
+        format = winston.format.combine(
+          winston.format.errors({ stack: true }),
+          winston.format.json()
+        );
+        break;
       case 'none':
       case undefined:
         format = undefined;
@@ -252,6 +258,31 @@ describe('WinstonInstrumentation', () => {
           logRecords[0].attributes['extraAttribute2'],
           'attributeValue2'
         );
+      }
+    });
+
+    it('emit LogRecord with exception attributes', () => {
+      if (!isWinston2) {
+        instrumentation.setConfig({
+          disableLogSending: false,
+        });
+        initLogger(undefined, 'errors');
+
+        (logger as any).error(new Error('boom'));
+        const logRecords = memoryLogExporter.getFinishedLogRecords();
+        assert.strictEqual(logRecords.length, 1);
+        assert.strictEqual(logRecords[0].body, 'boom');
+        assert.strictEqual(
+          logRecords[0].attributes['exception.message'],
+          'boom'
+        );
+        assert.strictEqual(logRecords[0].attributes['exception.type'], 'Error');
+        assert.ok(
+          typeof logRecords[0].attributes['exception.stacktrace'] === 'string'
+        );
+        assert.strictEqual(logRecords[0].attributes['stack'], undefined);
+
+        initLogger();
       }
     });
 

--- a/packages/winston-transport/src/utils.ts
+++ b/packages/winston-transport/src/utils.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  AnyValue,
   LogAttributes,
   LogRecord,
   Logger,
@@ -59,7 +60,11 @@ function getSeverityNumber(level: string): SeverityNumber | undefined {
   return npmLevels[level] ?? sysLoglevels[level] ?? cliLevels[level];
 }
 
-function isExceptionCandidate(value: unknown): boolean {
+/**
+ * Mirrors the exception shapes handled by sdk-logs `LogRecordImpl._setException`.
+ * We cannot reuse that internal method directly from this package.
+ */
+function isSdkLogsExceptionCandidate(value: unknown): boolean {
   if (typeof value === 'string' || typeof value === 'number') {
     return true;
   }
@@ -76,31 +81,100 @@ function isExceptionCandidate(value: unknown): boolean {
   };
 
   return (
-    typeof exception.code === 'string' ||
-    typeof exception.code === 'number' ||
-    typeof exception.name === 'string' ||
-    typeof exception.message === 'string' ||
-    typeof exception.stack === 'string'
+    exception.code != null ||
+    exception.name != null ||
+    exception.message != null ||
+    exception.stack != null
   );
 }
 
+function extractCauseAttributes(
+  key: 'err' | 'error',
+  value: unknown
+): LogAttributes {
+  if (value == null || typeof value !== 'object' || !('cause' in value)) {
+    return {};
+  }
+
+  const cause = (value as { cause: unknown }).cause;
+  if (cause == null) {
+    return {};
+  }
+
+  const attributes: LogAttributes = {};
+  if (typeof cause === 'string' || typeof cause === 'number') {
+    attributes[`${key}.cause`] = cause as AnyValue;
+    return attributes;
+  }
+
+  if (typeof cause !== 'object') {
+    attributes[`${key}.cause`] = String(cause);
+    return attributes;
+  }
+
+  const exceptionCause = cause as {
+    code?: unknown;
+    name?: unknown;
+    message?: unknown;
+    stack?: unknown;
+  };
+  if (
+    typeof exceptionCause.code === 'string' ||
+    typeof exceptionCause.code === 'number'
+  ) {
+    attributes[`${key}.cause.code`] = exceptionCause.code;
+  }
+  if (typeof exceptionCause.name === 'string') {
+    attributes[`${key}.cause.type`] = exceptionCause.name;
+  }
+  if (typeof exceptionCause.message === 'string') {
+    attributes[`${key}.cause.message`] = exceptionCause.message;
+  }
+  if (typeof exceptionCause.stack === 'string') {
+    attributes[`${key}.cause.stacktrace`] = exceptionCause.stack;
+  }
+
+  if (Object.keys(attributes).length === 0) {
+    attributes[`${key}.cause`] = String(cause);
+  }
+  return attributes;
+}
+
+/**
+ * Attempts to extract an exception/error from a Winston log record.
+ *
+ * Winston records can carry error information in several ways depending on
+ * how the user logged and which formats are configured. This function checks
+ * three sources in priority order:
+ *
+ * 1. Named fields ('err', 'error') used by user code and Winston internals.
+ * 2. Splat args (Symbol.for('splat')) used for extra positional log args.
+ * 3. Flattened stack fields produced by format.errors({ stack: true }).
+ *
+ * @returns The extracted exception, record keys that should be excluded from
+ *          OTel attributes to avoid duplication, and optional extra attributes
+ *          derived from the source error (for example `error.cause.*`).
+ *          Returns null if no error was found.
+ */
 function getExceptionPayload(record: Record<string | symbol, any>): {
   exception: unknown;
   excludedAttributes: string[];
+  additionalAttributes?: LogAttributes;
 } | null {
   for (const key of ['err', 'error'] as const) {
     const value = record[key];
-    if (isExceptionCandidate(value)) {
+    if (isSdkLogsExceptionCandidate(value)) {
       return {
         exception: value,
         excludedAttributes: [key],
+        additionalAttributes: extractCauseAttributes(key, value),
       };
     }
   }
 
   const splat = record[Symbol.for('splat')];
   if (Array.isArray(splat)) {
-    const splatException = splat.find(isExceptionCandidate);
+    const splatException = splat.find(isSdkLogsExceptionCandidate);
     if (splatException !== undefined) {
       return {
         exception: splatException,
@@ -159,6 +233,18 @@ export function emitLogRecord(
       !excludedAttributes.has(key)
     ) {
       attributes[key] = splat[key];
+    }
+  }
+  if (exceptionPayload?.additionalAttributes) {
+    for (const key in exceptionPayload.additionalAttributes) {
+      if (
+        Object.prototype.hasOwnProperty.call(
+          exceptionPayload.additionalAttributes,
+          key
+        )
+      ) {
+        attributes[key] = exceptionPayload.additionalAttributes[key];
+      }
     }
   }
   const logRecord: LogRecord = {

--- a/packages/winston-transport/src/utils.ts
+++ b/packages/winston-transport/src/utils.ts
@@ -59,6 +59,86 @@ function getSeverityNumber(level: string): SeverityNumber | undefined {
   return npmLevels[level] ?? sysLoglevels[level] ?? cliLevels[level];
 }
 
+function isExceptionCandidate(value: unknown): boolean {
+  if (typeof value === 'string' || typeof value === 'number') {
+    return true;
+  }
+
+  if (value == null || typeof value !== 'object') {
+    return false;
+  }
+
+  const exception = value as {
+    code?: unknown;
+    name?: unknown;
+    message?: unknown;
+    stack?: unknown;
+  };
+
+  return (
+    typeof exception.code === 'string' ||
+    typeof exception.code === 'number' ||
+    typeof exception.name === 'string' ||
+    typeof exception.message === 'string' ||
+    typeof exception.stack === 'string'
+  );
+}
+
+function getExceptionPayload(record: Record<string | symbol, any>): {
+  exception: unknown;
+  excludedAttributes: string[];
+} | null {
+  for (const key of ['err', 'error'] as const) {
+    const value = record[key];
+    if (isExceptionCandidate(value)) {
+      return {
+        exception: value,
+        excludedAttributes: [key],
+      };
+    }
+  }
+
+  const splat = record[Symbol.for('splat')];
+  if (Array.isArray(splat)) {
+    const splatException = splat.find(isExceptionCandidate);
+    if (splatException !== undefined) {
+      return {
+        exception: splatException,
+        excludedAttributes: [],
+      };
+    }
+  }
+
+  if (typeof record.stack === 'string') {
+    const stackTypeMatch = /^([^:\n]+):/.exec(record.stack);
+    const exception: {
+      code?: string | number;
+      name?: string;
+      message?: string;
+      stack: string;
+    } = {
+      stack: record.stack,
+    };
+    if (typeof record.code === 'string' || typeof record.code === 'number') {
+      exception.code = record.code;
+    }
+    if (typeof record.name === 'string') {
+      exception.name = record.name;
+    } else if (stackTypeMatch) {
+      exception.name = stackTypeMatch[1];
+    }
+    if (typeof record.message === 'string') {
+      exception.message = record.message;
+    }
+    return {
+      exception,
+      excludedAttributes: ['code', 'name', 'stack'],
+    };
+  }
+
+  return null;
+}
+
 export function emitLogRecord(
   record: Record<string | symbol, any>,
   logger: Logger
@@ -69,8 +149,15 @@ export function emitLogRecord(
   // accidental inclusion of ANSI color codes that may be present in the string
   // property.
   const levelSym = record[Symbol.for('level')];
+  const exceptionPayload = getExceptionPayload(record);
+  const excludedAttributes = new Set(
+    exceptionPayload?.excludedAttributes ?? []
+  );
   for (const key in splat) {
-    if (Object.prototype.hasOwnProperty.call(splat, key)) {
+    if (
+      Object.prototype.hasOwnProperty.call(splat, key) &&
+      !excludedAttributes.has(key)
+    ) {
       attributes[key] = splat[key];
     }
   }
@@ -79,6 +166,7 @@ export function emitLogRecord(
     severityText: levelSym,
     body: message,
     attributes: attributes,
+    ...(exceptionPayload ? { exception: exceptionPayload.exception } : {}),
   };
   logger.emit(logRecord);
 }

--- a/packages/winston-transport/test/openTelemetryTransport.test.ts
+++ b/packages/winston-transport/test/openTelemetryTransport.test.ts
@@ -85,6 +85,177 @@ describe('OpenTelemetryTransportV3', () => {
     assert.strictEqual(logRecords[0].attributes['err'], undefined);
   });
 
+  it('emit LogRecord with exception from string error field', () => {
+    const transport = new OpenTelemetryTransportV3();
+    transport.log({ message: kMessage, error: 'boom' }, () => {});
+
+    const logRecords = memoryLogExporter.getFinishedLogRecords();
+    assert.strictEqual(logRecords.length, 1);
+    assert.strictEqual(logRecords[0].body, kMessage);
+    assert.strictEqual(logRecords[0].attributes['exception.message'], 'boom');
+    assert.strictEqual(logRecords[0].attributes['error'], undefined);
+  });
+
+  it('emit LogRecord with exception from coded error object', () => {
+    const transport = new OpenTelemetryTransportV3();
+    transport.log({ message: kMessage, error: { code: 500 } }, () => {});
+
+    const logRecords = memoryLogExporter.getFinishedLogRecords();
+    assert.strictEqual(logRecords.length, 1);
+    assert.strictEqual(logRecords[0].body, kMessage);
+    assert.strictEqual(logRecords[0].attributes['exception.type'], '500');
+    assert.strictEqual(logRecords[0].attributes['error'], undefined);
+  });
+
+  it('keeps winston exception-handler metadata attributes', () => {
+    const transport = new OpenTelemetryTransportV3();
+    const err = new Error('boom');
+    transport.log(
+      {
+        message: 'uncaughtException: boom',
+        error: err,
+        stack: err.stack,
+        exception: true,
+        date: 'Thu Jan 01 1970 00:00:00 GMT+0000 (UTC)',
+        process: { pid: 1234 },
+        os: { uptime: 10 },
+        trace: [{ file: 'app.js', line: 1 }],
+        [Symbol.for('level')]: 'error',
+      },
+      () => {}
+    );
+
+    const logRecords = memoryLogExporter.getFinishedLogRecords();
+    assert.strictEqual(logRecords.length, 1);
+    assert.strictEqual(logRecords[0].attributes['exception.message'], 'boom');
+    assert.strictEqual(logRecords[0].attributes['exception.type'], 'Error');
+    assert.deepStrictEqual(logRecords[0].attributes['process'], { pid: 1234 });
+    assert.deepStrictEqual(logRecords[0].attributes['os'], { uptime: 10 });
+    assert.deepStrictEqual(logRecords[0].attributes['trace'], [
+      { file: 'app.js', line: 1 },
+    ]);
+    assert.strictEqual(logRecords[0].attributes['exception'], true);
+    assert.strictEqual(
+      logRecords[0].attributes['date'],
+      'Thu Jan 01 1970 00:00:00 GMT+0000 (UTC)'
+    );
+    assert.strictEqual(logRecords[0].attributes['error'], undefined);
+  });
+
+  it('keeps error.cause as attribute when error is promoted to exception', () => {
+    const transport = new OpenTelemetryTransportV3();
+    const cause = new Error('root cause');
+    const error = new Error('boom') as Error & { cause?: Error };
+    error.cause = cause;
+
+    transport.log({ message: kMessage, error }, () => {});
+
+    const logRecords = memoryLogExporter.getFinishedLogRecords();
+    assert.strictEqual(logRecords.length, 1);
+    assert.strictEqual(logRecords[0].attributes['exception.message'], 'boom');
+    assert.strictEqual(logRecords[0].attributes['exception.type'], 'Error');
+    assert.strictEqual(logRecords[0].attributes['error'], undefined);
+    assert.strictEqual(
+      logRecords[0].attributes['error.cause.message'],
+      'root cause'
+    );
+    assert.strictEqual(logRecords[0].attributes['error.cause.type'], 'Error');
+    assert.ok(
+      typeof logRecords[0].attributes['error.cause.stacktrace'] === 'string'
+    );
+  });
+
+  it('keeps error.cause.code when cause has only code', () => {
+    const transport = new OpenTelemetryTransportV3();
+    const error = new Error('boom') as Error & { cause?: unknown };
+    error.cause = { code: 'ECONNRESET' };
+
+    transport.log({ message: kMessage, error }, () => {});
+
+    const logRecords = memoryLogExporter.getFinishedLogRecords();
+    assert.strictEqual(logRecords.length, 1);
+    assert.strictEqual(
+      logRecords[0].attributes['error.cause.code'],
+      'ECONNRESET'
+    );
+  });
+
+  it('stringifies non-object, non-string/number error.cause values', () => {
+    const transport = new OpenTelemetryTransportV3();
+    const error = new Error('boom') as Error & { cause?: unknown };
+    error.cause = true;
+
+    transport.log({ message: kMessage, error }, () => {});
+
+    const logRecords = memoryLogExporter.getFinishedLogRecords();
+    assert.strictEqual(logRecords.length, 1);
+    assert.strictEqual(logRecords[0].attributes['error.cause'], 'true');
+  });
+
+  it('keeps primitive string error.cause', () => {
+    const transport = new OpenTelemetryTransportV3();
+    const error = new Error('boom') as Error & { cause?: unknown };
+    error.cause = 'network timeout';
+
+    transport.log({ message: kMessage, error }, () => {});
+
+    const logRecords = memoryLogExporter.getFinishedLogRecords();
+    assert.strictEqual(logRecords.length, 1);
+    assert.strictEqual(
+      logRecords[0].attributes['error.cause'],
+      'network timeout'
+    );
+  });
+
+  it('does not set cause attributes when error.cause is null', () => {
+    const transport = new OpenTelemetryTransportV3();
+    const error = new Error('boom') as Error & { cause?: unknown };
+    error.cause = null;
+
+    transport.log({ message: kMessage, error }, () => {});
+
+    const logRecords = memoryLogExporter.getFinishedLogRecords();
+    assert.strictEqual(logRecords.length, 1);
+    assert.strictEqual(logRecords[0].attributes['error.cause'], undefined);
+    assert.strictEqual(
+      logRecords[0].attributes['error.cause.message'],
+      undefined
+    );
+  });
+
+  it('stringifies object cause when no supported cause fields exist', () => {
+    const transport = new OpenTelemetryTransportV3();
+    const error = new Error('boom') as Error & { cause?: unknown };
+    error.cause = {};
+
+    transport.log({ message: kMessage, error }, () => {});
+
+    const logRecords = memoryLogExporter.getFinishedLogRecords();
+    assert.strictEqual(logRecords.length, 1);
+    assert.strictEqual(
+      logRecords[0].attributes['error.cause'],
+      '[object Object]'
+    );
+  });
+
+  it('emit LogRecord with exception from splat args', () => {
+    const transport = new OpenTelemetryTransportV3();
+    const err = new Error('boom');
+    transport.log(
+      {
+        message: kMessage,
+        [Symbol.for('splat')]: [err, 'ignored'],
+        [Symbol.for('level')]: 'error',
+      },
+      () => {}
+    );
+
+    const logRecords = memoryLogExporter.getFinishedLogRecords();
+    assert.strictEqual(logRecords.length, 1);
+    assert.strictEqual(logRecords[0].attributes['exception.message'], 'boom');
+    assert.strictEqual(logRecords[0].attributes['exception.type'], 'Error');
+  });
+
   it('emit LogRecord with exception from stack field', () => {
     const transport = new OpenTelemetryTransportV3();
     transport.log(
@@ -104,6 +275,29 @@ describe('OpenTelemetryTransportV3', () => {
       logRecords[0].attributes['exception.stacktrace'],
       'Error: boom\n    at test'
     );
+    assert.strictEqual(logRecords[0].attributes['stack'], undefined);
+  });
+
+  it('emit LogRecord with exception from stack field and explicit code/name', () => {
+    const transport = new OpenTelemetryTransportV3();
+    transport.log(
+      {
+        message: 'boom',
+        stack: 'TypeError: boom\n    at test',
+        name: 'CustomErrorName',
+        code: 'E_CUSTOM',
+        [Symbol.for('level')]: 'error',
+      },
+      () => {}
+    );
+
+    const logRecords = memoryLogExporter.getFinishedLogRecords();
+    assert.strictEqual(logRecords.length, 1);
+    assert.strictEqual(logRecords[0].body, 'boom');
+    assert.strictEqual(logRecords[0].attributes['exception.type'], 'E_CUSTOM');
+    assert.strictEqual(logRecords[0].attributes['exception.message'], 'boom');
+    assert.strictEqual(logRecords[0].attributes['name'], undefined);
+    assert.strictEqual(logRecords[0].attributes['code'], undefined);
     assert.strictEqual(logRecords[0].attributes['stack'], undefined);
   });
 

--- a/packages/winston-transport/test/openTelemetryTransport.test.ts
+++ b/packages/winston-transport/test/openTelemetryTransport.test.ts
@@ -70,6 +70,43 @@ describe('OpenTelemetryTransportV3', () => {
     );
   });
 
+  it('emit LogRecord with exception from err field', () => {
+    const transport = new OpenTelemetryTransportV3();
+    transport.log({ message: kMessage, err: new Error('boom') }, () => {});
+
+    const logRecords = memoryLogExporter.getFinishedLogRecords();
+    assert.strictEqual(logRecords.length, 1);
+    assert.strictEqual(logRecords[0].body, kMessage);
+    assert.strictEqual(logRecords[0].attributes['exception.message'], 'boom');
+    assert.strictEqual(logRecords[0].attributes['exception.type'], 'Error');
+    assert.ok(
+      typeof logRecords[0].attributes['exception.stacktrace'] === 'string'
+    );
+    assert.strictEqual(logRecords[0].attributes['err'], undefined);
+  });
+
+  it('emit LogRecord with exception from stack field', () => {
+    const transport = new OpenTelemetryTransportV3();
+    transport.log(
+      {
+        message: 'boom',
+        stack: 'Error: boom\n    at test',
+        [Symbol.for('level')]: 'error',
+      },
+      () => {}
+    );
+
+    const logRecords = memoryLogExporter.getFinishedLogRecords();
+    assert.strictEqual(logRecords.length, 1);
+    assert.strictEqual(logRecords[0].body, 'boom');
+    assert.strictEqual(logRecords[0].attributes['exception.message'], 'boom');
+    assert.strictEqual(
+      logRecords[0].attributes['exception.stacktrace'],
+      'Error: boom\n    at test'
+    );
+    assert.strictEqual(logRecords[0].attributes['stack'], undefined);
+  });
+
   describe('emit logRecord severity', () => {
     it('npm levels', () => {
       const callback = () => {};


### PR DESCRIPTION
## Which problem is this PR solving?

- https://github.com/open-telemetry/opentelemetry-js-contrib/issues/3440

## Short description of the changes

- Call the exceptions API added in https://github.com/open-telemetry/opentelemetry-js/pull/6385 from `bunyan` auto instrumentation.
