### PR TITLE
chore: Adding hectorhdzg as component owner for GenAI instrumentations

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -116,6 +116,7 @@ components:
   packages/instrumentation-koa: []
     # Unmaintained
   packages/instrumentation-langchain:
+    - hectorhdzg
     - yiyuan-he
     - mxiamxia
   packages/instrumentation-memcached: []
@@ -136,6 +137,7 @@ components:
   packages/instrumentation-runtime-node:
     - d4nyll
   packages/instrumentation-openai:
+    - hectorhdzg
     - trentm
     - seemk
   packages/instrumentation-pg:


### PR DESCRIPTION
I'm interested in becoming component owner for existing GenAI instrumentations and willing to contribute and help review as much as possible to get this into very good shape