### PR TITLE
feat(instrumentation-lru-memoizer): add support for 3.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11891,17 +11891,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/lru-cache": {
-      "version": "7.10.10",
-      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-7.10.10.tgz",
-      "integrity": "sha512-nEpVRPWW9EBmx2SCfNn3ClYxPL7IktPX12HhIoSc/H5mMjdeW3+YsXIpseLQ2xF35+OcpwKQbEUw5VtqE4PDNA==",
-      "deprecated": "This is a stub types definition. lru-cache provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lru-cache": "*"
-      }
-    },
     "node_modules/@types/memcached": {
       "version": "2.2.10",
       "resolved": "https://registry.npmjs.org/@types/memcached/-/memcached-2.2.10.tgz",
@@ -24197,33 +24186,25 @@
       }
     },
     "node_modules/lru-memoizer": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.1.4.tgz",
-      "integrity": "sha512-IXAq50s4qwrOBrXJklY+KhgZF+5y98PDaNo0gi/v2KQBFLyWr+JyFvijZXkGKjQj/h9c0OwoE+JZbwUXce76hQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-3.0.0.tgz",
+      "integrity": "sha512-m83w/cYXLdUIboKSPxzPAGfYnk+vqeDYXuoSrQRw1q+yVEd8IXhvMufN8Q5TIPe7e2jyX4SRNrDJI2Skw1yznQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lodash.clonedeep": "^4.5.0",
-        "lru-cache": "~4.0.0"
+        "lru-cache": "^11.0.1"
       }
     },
     "node_modules/lru-memoizer/node_modules/lru-cache": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-      "integrity": "sha512-uQw9OqphAGiZhkuPlpFGmdTU2tEuhxTourM/19qGJrxBPHAr/f8BT1a0i/lOclESnGatdJG/UCkP9kZB/Lh1iw==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "pseudomap": "^1.0.1",
-        "yallist": "^2.0.0"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
-    },
-    "node_modules/lru-memoizer/node_modules/yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/lru.min": {
       "version": "1.1.4",
@@ -29564,13 +29545,6 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/pump": {
       "version": "3.0.3",
@@ -37760,8 +37734,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/contrib-test-utils": "^0.60.0",
-        "@types/lru-cache": "7.10.10",
-        "lru-memoizer": "2.1.4"
+        "lru-memoizer": "3.0.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"

--- a/packages/instrumentation-lru-memoizer/.tav.yml
+++ b/packages/instrumentation-lru-memoizer/.tav.yml
@@ -1,6 +1,6 @@
 'lru-memoizer':
   versions:
-    include: ">=1.3 <3"
+    include: ">=1.3 <4"
     mode: latest-minors
   commands:
     - npm test

--- a/packages/instrumentation-lru-memoizer/README.md
+++ b/packages/instrumentation-lru-memoizer/README.md
@@ -17,7 +17,7 @@ npm install --save @opentelemetry/instrumentation-lru-memoizer
 
 ## Supported Versions
 
-- [`lru-memoizer`](https://www.npmjs.com/package/lru-memoizer) versions `>=1.3.0 <3`
+- [`lru-memoizer`](https://www.npmjs.com/package/lru-memoizer) versions `>=1.3.0 <4`
 
 ## Usage
 

--- a/packages/instrumentation-lru-memoizer/package.json
+++ b/packages/instrumentation-lru-memoizer/package.json
@@ -46,8 +46,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/contrib-test-utils": "^0.60.0",
-    "@types/lru-cache": "7.10.10",
-    "lru-memoizer": "2.1.4"
+    "lru-memoizer": "3.0.0"
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.213.0"

--- a/packages/instrumentation-lru-memoizer/src/instrumentation.ts
+++ b/packages/instrumentation-lru-memoizer/src/instrumentation.ts
@@ -32,7 +32,7 @@ export class LruMemoizerInstrumentation extends InstrumentationBase {
     return [
       new InstrumentationNodeModuleDefinition(
         'lru-memoizer',
-        ['>=1.3 <3'],
+        ['>=1.3 <4'],
         moduleExports => {
           // moduleExports is a function which receives an options object,
           // and returns a "memoizer" function upon invocation.

--- a/packages/instrumentation-lru-memoizer/test/index.test.ts
+++ b/packages/instrumentation-lru-memoizer/test/index.test.ts
@@ -34,6 +34,7 @@ describe('lru-memoizer instrumentation', () => {
 
       let memoizerLoadCallback: MemoizerTestCallback;
       const memoizedFoo = memoizer({
+        max: 10,
         load: (_param: unknown, callback: MemoizerTestCallback) => {
           memoizerLoadCallback = callback;
         },
@@ -61,6 +62,7 @@ describe('lru-memoizer instrumentation', () => {
       const ongoingMemoizerLoads: Function[] = [];
 
       const memoizedFoo = memoizer({
+        max: 10,
         load: (_param: unknown, callback: MemoizerTestCallback) => {
           // don't call the cb yet, first invoke another call,
           // to let it go into the internal "pendingLoad" queue
@@ -89,6 +91,7 @@ describe('lru-memoizer instrumentation', () => {
 
     it('should not throw when last argument is not callback', () => {
       const memoizedFoo = memoizer({
+        max: 10,
         load: (callback: MemoizerTestCallback) => {
           return 'foo';
         },
@@ -103,6 +106,7 @@ describe('lru-memoizer instrumentation', () => {
   describe('sync', () => {
     it('should not break sync memoizer', () => {
       const memoizedFoo = memoizer.sync({
+        max: 10,
         load: (_params: any) => 'foo',
         hash: () => 'bar',
       } as any);
@@ -117,6 +121,7 @@ describe('lru-memoizer instrumentation', () => {
         .getTracer('lru-memoize-testing');
 
       const memoizedFoo = memoizer.sync({
+        max: 10,
         load: (_params: any) => Promise.resolve('foo'),
         hash: () => 'bar',
       } as any);


### PR DESCRIPTION

## Which problem is this PR solving?

Add support for latest the lru-memoizer.

Note: the new `max` attribute in the tests is one of the now required parameters in 3.x (via https://github.com/isaacs/node-lru-cache/blob/main/src/index.ts#L710-L711) and omitting it will throw an error. Does not affect the tests behaviour.

`@types/lru-cache` dev dep seemed to be unused, removed it.