### PR TITLE
chore: add component owner for instrumentation-nestjs-core

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -127,8 +127,8 @@ components:
     # Unmaintained
   packages/instrumentation-mysql2:
     - raphael-theriault-swi
-  packages/instrumentation-nestjs-core: []
-    # Unmaintained
+  packages/instrumentation-nestjs-core:
+    - neilime
   packages/instrumentation-net:
     - seemk
   packages/instrumentation-oracledb:


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- instrumentation-nestjs-core is unmaintained, I can be a maintainer

## Short description of the changes

- Adding myself as instrumentation-nestjs-core maintainer
