### PR TITLE
test(instrumentation-knex): fix instr-knex tests to work with knex@3.2.0 and later

### DIFF
--- a/packages/instrumentation-knex/test/index.test.ts
+++ b/packages/instrumentation-knex/test/index.test.ts
@@ -35,7 +35,7 @@ const plugin = new KnexInstrumentation({
 
 import knex from 'knex';
 // @ts-ignore
-import * as BetterSqlite3Dialect from 'knex/lib/dialects/better-sqlite3';
+import * as BetterSqlite3Dialect from 'knex/lib/dialects/better-sqlite3/index.js';
 
 describe('Knex instrumentation', () => {
   const memoryExporter = new InMemorySpanExporter();


### PR DESCRIPTION
knex@3.2.0 added 'exports' to its package.json. The wildcard mapping
added broke the deep-import used in the instr-knex imports. Using
`import ... from 'knex/lib/dialects/better-sqlite3/index.js'`
works for all tested knex versions.

Refs: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3206 (where this test case was added)
