### PR TITLE
fix(instr-user-interaction): avoid wrapping/unwrapping browser APIs multiple times

### DIFF
--- a/packages/instrumentation-user-interaction/src/instrumentation.ts
+++ b/packages/instrumentation-user-interaction/src/instrumentation.ts
@@ -398,9 +398,12 @@ export class UserInteractionInstrumentation extends InstrumentationBase<UserInte
    * Patches the certain history api method
    */
   _patchHistoryMethod() {
-  if (!plugin._isEnabled) { return original.apply(this, args); }
+    const plugin = this;
     return (original: any) => {
       return function patchHistoryMethod(this: History, ...args: unknown[]) {
+        if (!plugin._isEnabled) {
+          return original.apply(this, args);
+        }
         const url = `${location.pathname}${location.hash}${location.search}`;
         const result = original.apply(this, args);
         const urlAfter = `${location.pathname}${location.hash}${location.search}`;

--- a/packages/instrumentation-user-interaction/src/instrumentation.ts
+++ b/packages/instrumentation-user-interaction/src/instrumentation.ts
@@ -570,11 +570,11 @@ export class UserInteractionInstrumentation extends InstrumentationBase<UserInte
    * implements enable function
    */
   override enable() {
+    // Early return if already enabled or patched
     if (this._isEnabled) {
       return;
     }
     this._isEnabled = true;
-    // If already patched do nothing
     if (typeof this._zonePatched === 'boolean') {
       return;
     }

--- a/packages/instrumentation-user-interaction/src/instrumentation.ts
+++ b/packages/instrumentation-user-interaction/src/instrumentation.ts
@@ -386,6 +386,7 @@ export class UserInteractionInstrumentation extends InstrumentationBase<UserInte
    * Patches the history api
    */
   _patchHistoryApi() {
+    if (!this._isEnabled) return;
     this._wrap(history, 'replaceState', this._patchHistoryMethod());
     this._wrap(history, 'pushState', this._patchHistoryMethod());
     this._wrap(history, 'back', this._patchHistoryMethod());

--- a/packages/instrumentation-user-interaction/src/instrumentation.ts
+++ b/packages/instrumentation-user-interaction/src/instrumentation.ts
@@ -398,7 +398,7 @@ export class UserInteractionInstrumentation extends InstrumentationBase<UserInte
    * Patches the certain history api method
    */
   _patchHistoryMethod() {
-    const plugin = this;
+  if (!plugin._isEnabled) { return original.apply(this, args); }
     return (original: any) => {
       return function patchHistoryMethod(this: History, ...args: unknown[]) {
         const url = `${location.pathname}${location.hash}${location.search}`;

--- a/packages/instrumentation-user-interaction/src/instrumentation.ts
+++ b/packages/instrumentation-user-interaction/src/instrumentation.ts
@@ -16,7 +16,7 @@
 
 /// <reference types="zone.js" />
 
-import { isWrapped, InstrumentationBase } from '@opentelemetry/instrumentation';
+import { InstrumentationBase } from '@opentelemetry/instrumentation';
 
 import * as api from '@opentelemetry/api';
 import { hrTime } from '@opentelemetry/core';
@@ -57,9 +57,9 @@ export class UserInteractionInstrumentation extends InstrumentationBase<UserInte
   // but not for browser so we cannot access it. TS complains if we use it because
   // we get the types of the nodejs implementation (we cannot override)
   // As a workaround we use a new flag until types are fixed or design is updated
-  private _isEnabled = false;
-  private _spansData = new WeakMap<api.Span, SpanData>();
+  declare private _isEnabled?: boolean;
   declare private _zonePatched?: boolean;
+  private _spansData = new WeakMap<api.Span, SpanData>();
   // for addEventListener/removeEventListener state
   private _wrappedListeners = new WeakMap<
     Function | EventListenerObject,
@@ -578,6 +578,7 @@ export class UserInteractionInstrumentation extends InstrumentationBase<UserInte
     if (typeof this._zonePatched === 'boolean') {
       return;
     }
+
     const ZoneWithPrototype = this._getZoneWithPrototype();
     this._diag.debug(
       'applying patch to',
@@ -587,19 +588,6 @@ export class UserInteractionInstrumentation extends InstrumentationBase<UserInte
       !!ZoneWithPrototype
     );
     if (ZoneWithPrototype) {
-      if (isWrapped(ZoneWithPrototype.prototype.runTask)) {
-        this._unwrap(ZoneWithPrototype.prototype, 'runTask');
-        this._diag.debug('removing previous patch from method runTask');
-      }
-      if (isWrapped(ZoneWithPrototype.prototype.scheduleTask)) {
-        this._unwrap(ZoneWithPrototype.prototype, 'scheduleTask');
-        this._diag.debug('removing previous patch from method scheduleTask');
-      }
-      if (isWrapped(ZoneWithPrototype.prototype.cancelTask)) {
-        this._unwrap(ZoneWithPrototype.prototype, 'cancelTask');
-        this._diag.debug('removing previous patch from method cancelTask');
-      }
-
       this._zonePatched = true;
       this._wrap(
         ZoneWithPrototype.prototype,
@@ -620,18 +608,6 @@ export class UserInteractionInstrumentation extends InstrumentationBase<UserInte
       this._zonePatched = false;
       const targets = this._getPatchableEventTargets();
       targets.forEach(target => {
-        if (isWrapped(target.addEventListener)) {
-          this._unwrap(target, 'addEventListener');
-          this._diag.debug(
-            'removing previous patch from method addEventListener'
-          );
-        }
-        if (isWrapped(target.removeEventListener)) {
-          this._unwrap(target, 'removeEventListener');
-          this._diag.debug(
-            'removing previous patch from method removeEventListener'
-          );
-        }
         this._wrap(target, 'addEventListener', this._patchAddEventListener());
         this._wrap(
           target,

--- a/packages/instrumentation-user-interaction/src/instrumentation.ts
+++ b/packages/instrumentation-user-interaction/src/instrumentation.ts
@@ -53,6 +53,11 @@ function defaultShouldPreventSpanCreation() {
 export class UserInteractionInstrumentation extends InstrumentationBase<UserInteractionInstrumentationConfig> {
   readonly version = PACKAGE_VERSION;
   readonly moduleName: string = 'user-interaction';
+  // NOTE: `_enabled` is a private property of the base class for nodejs platform
+  // but not for browser so we cannot access it. TS complains if we use it because
+  // we get the types of the nodejs implementation (we cannot override)
+  // As a workaround we use a new flag until types are fixed or design is updated
+  private _isEnabled = false;
   private _spansData = new WeakMap<api.Span, SpanData>();
   declare private _zonePatched?: boolean;
   // for addEventListener/removeEventListener state
@@ -119,6 +124,9 @@ export class UserInteractionInstrumentation extends InstrumentationBase<UserInte
     eventName: EventName,
     parentSpan?: api.Span
   ): api.Span | undefined {
+    if (!this._isEnabled) {
+      return undefined;
+    }
     if (!(element instanceof HTMLElement)) {
       return undefined;
     }
@@ -378,8 +386,6 @@ export class UserInteractionInstrumentation extends InstrumentationBase<UserInte
    * Patches the history api
    */
   _patchHistoryApi() {
-    this._unpatchHistoryApi();
-
     this._wrap(history, 'replaceState', this._patchHistoryMethod());
     this._wrap(history, 'pushState', this._patchHistoryMethod());
     this._wrap(history, 'back', this._patchHistoryMethod());
@@ -403,17 +409,6 @@ export class UserInteractionInstrumentation extends InstrumentationBase<UserInte
         return result;
       };
     };
-  }
-
-  /**
-   * unpatch the history api methods
-   */
-  _unpatchHistoryApi() {
-    if (isWrapped(history.replaceState)) this._unwrap(history, 'replaceState');
-    if (isWrapped(history.pushState)) this._unwrap(history, 'pushState');
-    if (isWrapped(history.back)) this._unwrap(history, 'back');
-    if (isWrapped(history.forward)) this._unwrap(history, 'forward');
-    if (isWrapped(history.go)) this._unwrap(history, 'go');
   }
 
   /**
@@ -575,6 +570,14 @@ export class UserInteractionInstrumentation extends InstrumentationBase<UserInte
    * implements enable function
    */
   override enable() {
+    if (this._isEnabled) {
+      return;
+    }
+    this._isEnabled = true;
+    // If already patched do nothing
+    if (typeof this._zonePatched === 'boolean') {
+      return;
+    }
     const ZoneWithPrototype = this._getZoneWithPrototype();
     this._diag.debug(
       'applying patch to',
@@ -645,36 +648,10 @@ export class UserInteractionInstrumentation extends InstrumentationBase<UserInte
    * implements unpatch function
    */
   override disable() {
-    const ZoneWithPrototype = this._getZoneWithPrototype();
-    this._diag.debug(
-      'removing patch from',
-      this.moduleName,
-      this.version,
-      'zone:',
-      !!ZoneWithPrototype
-    );
-    if (ZoneWithPrototype && this._zonePatched) {
-      if (isWrapped(ZoneWithPrototype.prototype.runTask)) {
-        this._unwrap(ZoneWithPrototype.prototype, 'runTask');
-      }
-      if (isWrapped(ZoneWithPrototype.prototype.scheduleTask)) {
-        this._unwrap(ZoneWithPrototype.prototype, 'scheduleTask');
-      }
-      if (isWrapped(ZoneWithPrototype.prototype.cancelTask)) {
-        this._unwrap(ZoneWithPrototype.prototype, 'cancelTask');
-      }
-    } else {
-      const targets = this._getPatchableEventTargets();
-      targets.forEach(target => {
-        if (isWrapped(target.addEventListener)) {
-          this._unwrap(target, 'addEventListener');
-        }
-        if (isWrapped(target.removeEventListener)) {
-          this._unwrap(target, 'removeEventListener');
-        }
-      });
+    if (!this._isEnabled) {
+      return;
     }
-    this._unpatchHistoryApi();
+    this._isEnabled = false;
   }
 
   /**

--- a/packages/instrumentation-user-interaction/test/userInteraction.nozone.test.ts
+++ b/packages/instrumentation-user-interaction/test/userInteraction.nozone.test.ts
@@ -16,10 +16,7 @@
 const originalSetTimeout = window.setTimeout;
 
 import { trace } from '@opentelemetry/api';
-import {
-  registerInstrumentations,
-  isWrapped,
-} from '@opentelemetry/instrumentation';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
 import * as tracing from '@opentelemetry/sdk-trace-base';
 import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
@@ -664,77 +661,13 @@ describe('UserInteractionInstrumentation', () => {
     });
 
     it('should handle disable', () => {
-      assert.strictEqual(
-        isWrapped(HTMLElement.prototype.addEventListener),
-        true,
-        'addEventListener should be wrapped'
-      );
-      assert.strictEqual(
-        isWrapped(HTMLElement.prototype.removeEventListener),
-        true,
-        'removeEventListener should be wrapped'
-      );
-
-      assert.strictEqual(
-        isWrapped(history.replaceState),
-        true,
-        'replaceState should be wrapped'
-      );
-      assert.strictEqual(
-        isWrapped(history.pushState),
-        true,
-        'pushState should be wrapped'
-      );
-      assert.strictEqual(
-        isWrapped(history.back),
-        true,
-        'back should be wrapped'
-      );
-      assert.strictEqual(
-        isWrapped(history.forward),
-        true,
-        'forward should be wrapped'
-      );
-      assert.strictEqual(isWrapped(history.go), true, 'go should be wrapped');
-
+      const element = createButton();
+      element.addEventListener('click', () => {});
+      element.click();
       userInteractionInstrumentation.disable();
+      element.click();
 
-      assert.strictEqual(
-        isWrapped(HTMLElement.prototype.addEventListener),
-        false,
-        'addEventListener should be unwrapped'
-      );
-      assert.strictEqual(
-        isWrapped(HTMLElement.prototype.removeEventListener),
-        false,
-        'removeEventListener should be unwrapped'
-      );
-
-      assert.strictEqual(
-        isWrapped(history.replaceState),
-        false,
-        'replaceState should be unwrapped'
-      );
-      assert.strictEqual(
-        isWrapped(history.pushState),
-        false,
-        'pushState should be unwrapped'
-      );
-      assert.strictEqual(
-        isWrapped(history.back),
-        false,
-        'back should be unwrapped'
-      );
-      assert.strictEqual(
-        isWrapped(history.forward),
-        false,
-        'forward should be unwrapped'
-      );
-      assert.strictEqual(
-        isWrapped(history.go),
-        false,
-        'go should be unwrapped'
-      );
+      assert.strictEqual(exportSpy.args.length, 1, 'should export one span');
     });
 
     describe('simulate IE', () => {

--- a/packages/instrumentation-user-interaction/test/userInteraction.test.ts
+++ b/packages/instrumentation-user-interaction/test/userInteraction.test.ts
@@ -17,7 +17,6 @@ const originalSetTimeout = window.setTimeout;
 import { context, ROOT_CONTEXT, trace } from '@opentelemetry/api';
 import { ZoneContextManager } from '@opentelemetry/context-zone-peer-dep';
 import {
-  isWrapped,
   registerInstrumentations,
 } from '@opentelemetry/instrumentation';
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
@@ -27,7 +26,6 @@ import * as assert from 'assert';
 import * as sinon from 'sinon';
 import 'zone.js';
 import { UserInteractionInstrumentation } from '../src';
-import { WindowWithZone } from '../src/internal-types';
 import { UserInteractionInstrumentationConfig } from '../src/types';
 import {
   assertClickSpan,
@@ -532,92 +530,6 @@ describe('UserInteractionInstrumentation', () => {
 
         done();
       });
-    });
-
-    it('should handle unpatch', () => {
-      const _window: WindowWithZone = window as unknown as WindowWithZone;
-      const ZoneWithPrototype = _window.Zone;
-      assert.strictEqual(
-        isWrapped(ZoneWithPrototype.prototype.runTask),
-        true,
-        'runTask should be wrapped'
-      );
-      assert.strictEqual(
-        isWrapped(ZoneWithPrototype.prototype.scheduleTask),
-        true,
-        'scheduleTask should be wrapped'
-      );
-      assert.strictEqual(
-        isWrapped(ZoneWithPrototype.prototype.cancelTask),
-        true,
-        'cancelTask should be wrapped'
-      );
-
-      assert.strictEqual(
-        isWrapped(history.replaceState),
-        true,
-        'replaceState should be wrapped'
-      );
-      assert.strictEqual(
-        isWrapped(history.pushState),
-        true,
-        'pushState should be wrapped'
-      );
-      assert.strictEqual(
-        isWrapped(history.back),
-        true,
-        'back should be wrapped'
-      );
-      assert.strictEqual(
-        isWrapped(history.forward),
-        true,
-        'forward should be wrapped'
-      );
-      assert.strictEqual(isWrapped(history.go), true, 'go should be wrapped');
-
-      userInteractionInstrumentation.disable();
-
-      assert.strictEqual(
-        isWrapped(ZoneWithPrototype.prototype.runTask),
-        false,
-        'runTask should be unwrapped'
-      );
-      assert.strictEqual(
-        isWrapped(ZoneWithPrototype.prototype.scheduleTask),
-        false,
-        'scheduleTask should be unwrapped'
-      );
-      assert.strictEqual(
-        isWrapped(ZoneWithPrototype.prototype.cancelTask),
-        false,
-        'cancelTask should be unwrapped'
-      );
-
-      assert.strictEqual(
-        isWrapped(history.replaceState),
-        false,
-        'replaceState should be unwrapped'
-      );
-      assert.strictEqual(
-        isWrapped(history.pushState),
-        false,
-        'pushState should be unwrapped'
-      );
-      assert.strictEqual(
-        isWrapped(history.back),
-        false,
-        'back should be unwrapped'
-      );
-      assert.strictEqual(
-        isWrapped(history.forward),
-        false,
-        'forward should be unwrapped'
-      );
-      assert.strictEqual(
-        isWrapped(history.go),
-        false,
-        'go should be unwrapped'
-      );
     });
   });
 });

--- a/packages/instrumentation-user-interaction/test/userInteraction.test.ts
+++ b/packages/instrumentation-user-interaction/test/userInteraction.test.ts
@@ -16,9 +16,7 @@
 const originalSetTimeout = window.setTimeout;
 import { context, ROOT_CONTEXT, trace } from '@opentelemetry/api';
 import { ZoneContextManager } from '@opentelemetry/context-zone-peer-dep';
-import {
-  registerInstrumentations,
-} from '@opentelemetry/instrumentation';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
 import * as tracing from '@opentelemetry/sdk-trace-base';
 import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';


### PR DESCRIPTION
## Which problem is this PR solving?

Unpatching history APIs may lead to breaking other instrumentations like `@opentelemetry/instrumentation-browser-navigation`. Ref: https://github.com/open-telemetry/opentelemetry-browser/issues/204

This was discussed in the Browser SIG and decided that instrumentations should rely on enabled state instead to create telemetry instead of disconnection (unpatching) of the browser APIs.

## Short description of the changes

- instrumentation now patches only once and never unpatches APIs from browser and zone.js is available
- added `_isEnabled` private property to control the creation of spans from the instrumentation
- remove/updates tests that were just checking if patches are applied. Instead in it checks is spans are created or not.
