### PR TITLE
feat(detector-aws): detect Lambda availability zone metadata

### DIFF
--- a/packages/resource-detector-aws/README.md
+++ b/packages/resource-detector-aws/README.md
@@ -107,6 +107,7 @@ Populates `faas` and `cloud` for functions running on [AWS Lambda](https://aws.a
 
 | Resource Attribute | Description                                                         |
 |--------------------|---------------------------------------------------------------------|
+| cloud.availability_zone | Value of `AvailabilityZoneID` from the Lambda metadata endpoint (AZ ID, for example `use1-az1`) |
 | cloud.platform     | The cloud platform. In this context, it's always "aws_lambda"       |
 | cloud.provider     | The cloud provider. In this context, it's always "aws"              |
 | cloud.region       | Value of Process Environment Variable `AWS_REGION`                  |

--- a/packages/resource-detector-aws/README.md
+++ b/packages/resource-detector-aws/README.md
@@ -105,14 +105,29 @@ Populates `container` and `k8s.cluster_name` for containers running on [Amazon E
 Populates `faas` and `cloud` for functions running on [AWS Lambda](https://aws.amazon.com/lambda/).
 `faas.id` is currently not populated as it is not provided by the runtime at startup.
 
-| Resource Attribute | Description                                                         |
-|--------------------|---------------------------------------------------------------------|
-| cloud.availability_zone | Value of `AvailabilityZoneID` from the Lambda metadata endpoint (AZ ID, for example `use1-az1`) |
-| cloud.platform     | The cloud platform. In this context, it's always "aws_lambda"       |
-| cloud.provider     | The cloud provider. In this context, it's always "aws"              |
-| cloud.region       | Value of Process Environment Variable `AWS_REGION`                  |
-| faas.name          | Value of Process Environment Variable `AWS_LAMBDA_FUNCTION_NAME`    |
-| faas.version       | Value of Process Environment Variable `AWS_LAMBDA_FUNCTION_VERSION` |
+| Resource Attribute      | Description                                                                |
+|-------------------------|----------------------------------------------------------------------------|
+| cloud.availability_zone | Value of `AvailabilityZoneID` when `fetchAvailabilityZone` is enabled      |
+| cloud.platform          | The cloud platform. In this context, it's always "aws_lambda"              |
+| cloud.provider          | The cloud provider. In this context, it's always "aws"                     |
+| cloud.region            | Value of Process Environment Variable `AWS_REGION`                         |
+| faas.name               | Value of Process Environment Variable `AWS_LAMBDA_FUNCTION_NAME`           |
+| faas.version            | Value of Process Environment Variable `AWS_LAMBDA_FUNCTION_VERSION`        |
+
+#### Availability zone (opt-in)
+
+By default the Lambda detector only reads attributes from environment variables. Populating `cloud.availability_zone` additionally requires an HTTP request to the [Lambda metadata endpoint](https://docs.aws.amazon.com/lambda/latest/dg/configuration-metadata-endpoint.html) on the initialization (cold-start) path, so it is opt-in and disabled by default. Enable it by constructing the detector with `fetchAvailabilityZone: true`:
+
+```typescript
+import { detectResources } from '@opentelemetry/resources';
+import { AwsLambdaDetector } from '@opentelemetry/resource-detector-aws';
+
+const resource = detectResources({
+  detectors: [new AwsLambdaDetector({ fetchAvailabilityZone: true })],
+});
+```
+
+When enabled, `cloud.availability_zone` is populated with the Lambda metadata endpoint's AZ ID (for example `use1-az1`). The metadata endpoint only exposes the AZ ID, not the AZ name (for example `us-east-1a`). The other AWS detectors in this package (EC2 and ECS) populate `cloud.availability_zone` with the AZ name, so the Lambda value is not directly comparable across detectors.
 
 ## Useful links
 

--- a/packages/resource-detector-aws/src/detectors/AwsLambdaDetector.ts
+++ b/packages/resource-detector-aws/src/detectors/AwsLambdaDetector.ts
@@ -14,13 +14,17 @@
  * limitations under the License.
  */
 
+import { context } from '@opentelemetry/api';
+import { suppressTracing } from '@opentelemetry/core';
 import {
   ResourceDetector,
   DetectedResource,
   DetectedResourceAttributes,
 } from '@opentelemetry/resources';
+import * as http from 'http';
 import {
   ATTR_AWS_LOG_GROUP_NAMES,
+  ATTR_CLOUD_AVAILABILITY_ZONE,
   ATTR_CLOUD_PLATFORM,
   ATTR_CLOUD_PROVIDER,
   ATTR_CLOUD_REGION,
@@ -32,12 +36,21 @@ import {
   CLOUD_PLATFORM_VALUE_AWS_LAMBDA,
 } from '../semconv';
 
+interface LambdaExecutionEnvironmentMetadata {
+  readonly AvailabilityZoneID?: string;
+}
+
 /**
  * The AwsLambdaDetector can be used to detect if a process is running in AWS Lambda
  * and return a {@link Resource} populated with data about the environment.
  * Returns an empty Resource if detection fails.
  */
 export class AwsLambdaDetector implements ResourceDetector {
+  public readonly AWS_LAMBDA_EXECUTION_ENVIRONMENT_METADATA_PATH =
+    '/2026-01-15/metadata/execution-environment';
+  public readonly AWS_LAMBDA_METADATA_AUTH_HEADER = 'Authorization';
+  public readonly MILLISECOND_TIME_OUT = 1000;
+
   public detect(): DetectedResource {
     // Check if running inside AWS Lambda environment
     const executionEnv = process.env.AWS_EXECUTION_ENV;
@@ -72,7 +85,85 @@ export class AwsLambdaDetector implements ResourceDetector {
       attributes[ATTR_FAAS_INSTANCE] = logStreamName;
     }
 
+    const metadataApi = process.env.AWS_LAMBDA_METADATA_API;
+    const metadataToken = process.env.AWS_LAMBDA_METADATA_TOKEN;
+    if (metadataApi && metadataToken) {
+      attributes[ATTR_CLOUD_AVAILABILITY_ZONE] = context.with(
+        suppressTracing(context.active()),
+        () => this._fetchAvailabilityZone(metadataApi, metadataToken)
+      );
+    }
+
     return { attributes };
+  }
+
+  private async _fetchAvailabilityZone(
+    metadataApi: string,
+    metadataToken: string
+  ): Promise<string | undefined> {
+    try {
+      const metadata = await this._fetchExecutionEnvironmentMetadata(
+        metadataApi,
+        metadataToken
+      );
+      return metadata.AvailabilityZoneID;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async _fetchExecutionEnvironmentMetadata(
+    metadataApi: string,
+    metadataToken: string
+  ): Promise<LambdaExecutionEnvironmentMetadata> {
+    const url = new URL(
+      `http://${metadataApi}${this.AWS_LAMBDA_EXECUTION_ENVIRONMENT_METADATA_PATH}`
+    );
+    const metadata = await this._fetchString(url, {
+      method: 'GET',
+      timeout: this.MILLISECOND_TIME_OUT,
+      headers: {
+        [this.AWS_LAMBDA_METADATA_AUTH_HEADER]: `Bearer ${metadataToken}`,
+      },
+    });
+
+    return JSON.parse(metadata);
+  }
+
+  private async _fetchString(
+    url: URL,
+    options: http.RequestOptions
+  ): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        req.abort();
+        reject(new Error('Lambda metadata api request timed out.'));
+      }, this.MILLISECOND_TIME_OUT);
+
+      const req = http.request(url, options, res => {
+        clearTimeout(timeoutId);
+        const { statusCode } = res;
+        res.setEncoding('utf8');
+        let rawData = '';
+        res.on('data', chunk => (rawData += chunk));
+        res.on('end', () => {
+          if (statusCode && statusCode >= 200 && statusCode < 300) {
+            resolve(rawData);
+          } else {
+            reject(
+              new Error('Failed to load page, status code: ' + statusCode)
+            );
+          }
+        });
+      });
+
+      req.on('error', err => {
+        clearTimeout(timeoutId);
+        reject(err);
+      });
+
+      req.end();
+    });
   }
 }
 

--- a/packages/resource-detector-aws/src/detectors/AwsLambdaDetector.ts
+++ b/packages/resource-detector-aws/src/detectors/AwsLambdaDetector.ts
@@ -41,6 +41,24 @@ interface LambdaExecutionEnvironmentMetadata {
 }
 
 /**
+ * Configuration options for {@link AwsLambdaDetector}.
+ */
+export interface AwsLambdaDetectorConfig {
+  /**
+   * Whether to populate `cloud.availability_zone` from the AWS Lambda metadata
+   * endpoint.
+   *
+   * Reading the availability zone requires an HTTP request to the
+   * Lambda-provided metadata endpoint on the initialization (cold-start) path.
+   * To avoid adding that cost for consumers that do not need the attribute, it
+   * is opt-in and disabled by default.
+   *
+   * @default false
+   */
+  fetchAvailabilityZone?: boolean;
+}
+
+/**
  * The AwsLambdaDetector can be used to detect if a process is running in AWS Lambda
  * and return a {@link Resource} populated with data about the environment.
  * Returns an empty Resource if detection fails.
@@ -50,6 +68,12 @@ export class AwsLambdaDetector implements ResourceDetector {
     '/2026-01-15/metadata/execution-environment';
   public readonly AWS_LAMBDA_METADATA_AUTH_HEADER = 'Authorization';
   public readonly MILLISECOND_TIME_OUT = 1000;
+
+  private readonly _shouldFetchAvailabilityZone: boolean;
+
+  constructor(config: AwsLambdaDetectorConfig = {}) {
+    this._shouldFetchAvailabilityZone = config.fetchAvailabilityZone ?? false;
+  }
 
   public detect(): DetectedResource {
     // Check if running inside AWS Lambda environment
@@ -85,13 +109,20 @@ export class AwsLambdaDetector implements ResourceDetector {
       attributes[ATTR_FAAS_INSTANCE] = logStreamName;
     }
 
-    const metadataApi = process.env.AWS_LAMBDA_METADATA_API;
-    const metadataToken = process.env.AWS_LAMBDA_METADATA_TOKEN;
-    if (metadataApi && metadataToken) {
-      attributes[ATTR_CLOUD_AVAILABILITY_ZONE] = context.with(
-        suppressTracing(context.active()),
-        () => this._fetchAvailabilityZone(metadataApi, metadataToken)
-      );
+    // Populating `cloud.availability_zone` requires an HTTP request to the
+    // Lambda metadata endpoint on the cold-start path, so it is opt-in via the
+    // `fetchAvailabilityZone` option. The `AWS_LAMBDA_METADATA_API` and
+    // `AWS_LAMBDA_METADATA_TOKEN` environment variables are set automatically by
+    // Lambda and provide the metadata endpoint address and auth token.
+    if (this._shouldFetchAvailabilityZone) {
+      const metadataApi = process.env.AWS_LAMBDA_METADATA_API;
+      const metadataToken = process.env.AWS_LAMBDA_METADATA_TOKEN;
+      if (metadataApi && metadataToken) {
+        attributes[ATTR_CLOUD_AVAILABILITY_ZONE] = context.with(
+          suppressTracing(context.active()),
+          () => this._fetchAvailabilityZone(metadataApi, metadataToken)
+        );
+      }
     }
 
     return { attributes };
@@ -101,6 +132,11 @@ export class AwsLambdaDetector implements ResourceDetector {
     metadataApi: string,
     metadataToken: string
   ): Promise<string | undefined> {
+    // Lambda's metadata endpoint only exposes the AZ ID (e.g. `use1-az1`), not the AZ name.
+    // This is recorded best-effort. Other AWS resource detectors (EC2 and ECS) in this package
+    // populate `cloud.availability_zone` with the AZ name (e.g. `us-east-1a`), so this value
+    // is not directly comparable across detectors. Translating to a name would require
+    // `ec2:DescribeAvailabilityZones` and is intentionally not done here.
     try {
       const metadata = await this._fetchExecutionEnvironmentMetadata(
         metadataApi,

--- a/packages/resource-detector-aws/src/detectors/index.ts
+++ b/packages/resource-detector-aws/src/detectors/index.ts
@@ -18,4 +18,8 @@ export { awsBeanstalkDetector } from './AwsBeanstalkDetector';
 export { awsEc2Detector } from './AwsEc2Detector';
 export { awsEcsDetector } from './AwsEcsDetector';
 export { awsEksDetector } from './AwsEksDetector';
-export { awsLambdaDetector } from './AwsLambdaDetector';
+export {
+  awsLambdaDetector,
+  AwsLambdaDetector,
+  type AwsLambdaDetectorConfig,
+} from './AwsLambdaDetector';

--- a/packages/resource-detector-aws/src/index.ts
+++ b/packages/resource-detector-aws/src/index.ts
@@ -20,4 +20,6 @@ export {
   awsEcsDetector,
   awsEksDetector,
   awsLambdaDetector,
+  AwsLambdaDetector,
+  type AwsLambdaDetectorConfig,
 } from './detectors';

--- a/packages/resource-detector-aws/test/detectors/AwsLambdaDetector.test.ts
+++ b/packages/resource-detector-aws/test/detectors/AwsLambdaDetector.test.ts
@@ -15,11 +15,13 @@
  */
 
 import * as assert from 'assert';
+import * as nock from 'nock';
 import { detectResources } from '@opentelemetry/resources';
 import { assertEmptyResource } from '@opentelemetry/contrib-test-utils';
 import { awsLambdaDetector } from '../../src';
 import {
   ATTR_AWS_LOG_GROUP_NAMES,
+  ATTR_CLOUD_AVAILABILITY_ZONE,
   ATTR_CLOUD_PLATFORM,
   ATTR_CLOUD_PROVIDER,
   ATTR_CLOUD_REGION,
@@ -31,15 +33,22 @@ import {
   CLOUD_PLATFORM_VALUE_AWS_LAMBDA,
 } from '../../src/semconv';
 
+const AWS_LAMBDA_METADATA_API = '169.254.100.1:9001';
+const AWS_LAMBDA_METADATA_TOKEN = 'test-token';
+const AWS_LAMBDA_METADATA_HOST = `http://${AWS_LAMBDA_METADATA_API}`;
+
 describe('awsLambdaDetector', () => {
   let oldEnv: NodeJS.ProcessEnv;
 
   beforeEach(() => {
     oldEnv = { ...process.env };
+    nock.disableNetConnect();
+    nock.cleanAll();
   });
 
   afterEach(() => {
     process.env = oldEnv;
+    nock.enableNetConnect();
   });
 
   describe('on lambda', () => {
@@ -51,8 +60,23 @@ describe('awsLambdaDetector', () => {
       process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE = '128';
       process.env.AWS_LAMBDA_LOG_GROUP_NAME = '/aws/lambda/name';
       process.env.AWS_LAMBDA_LOG_STREAM_NAME = '2024/03/14/[$LATEST]123456';
+      process.env.AWS_LAMBDA_METADATA_API = AWS_LAMBDA_METADATA_API;
+      process.env.AWS_LAMBDA_METADATA_TOKEN = AWS_LAMBDA_METADATA_TOKEN;
+
+      const scope = nock(AWS_LAMBDA_METADATA_HOST)
+        .get(awsLambdaDetector.AWS_LAMBDA_EXECUTION_ENVIRONMENT_METADATA_PATH)
+        .matchHeader(
+          awsLambdaDetector.AWS_LAMBDA_METADATA_AUTH_HEADER,
+          `Bearer ${AWS_LAMBDA_METADATA_TOKEN}`
+        )
+        .reply(200, {
+          AvailabilityZoneID: 'use1-az1',
+        });
 
       const resource = detectResources({ detectors: [awsLambdaDetector] });
+      await resource.waitForAsyncAttributes?.();
+
+      scope.done();
 
       assert.strictEqual(
         resource.attributes[ATTR_CLOUD_PROVIDER],
@@ -63,6 +87,10 @@ describe('awsLambdaDetector', () => {
         CLOUD_PLATFORM_VALUE_AWS_LAMBDA
       );
       assert.strictEqual(resource.attributes[ATTR_CLOUD_REGION], 'us-east-1');
+      assert.strictEqual(
+        resource.attributes[ATTR_CLOUD_AVAILABILITY_ZONE],
+        'use1-az1'
+      );
       assert.strictEqual(resource.attributes[ATTR_FAAS_NAME], 'name');
       assert.strictEqual(resource.attributes[ATTR_FAAS_VERSION], 'v1');
       assert.strictEqual(
@@ -76,6 +104,49 @@ describe('awsLambdaDetector', () => {
       assert.deepStrictEqual(resource.attributes[ATTR_AWS_LOG_GROUP_NAMES], [
         '/aws/lambda/name',
       ]);
+    });
+
+    it('keeps env-based attributes when metadata endpoint request fails', async () => {
+      process.env.AWS_EXECUTION_ENV = 'AWS_Lambda_nodejs22.x';
+      process.env.AWS_REGION = 'us-east-1';
+      process.env.AWS_LAMBDA_FUNCTION_NAME = 'name';
+      process.env.AWS_LAMBDA_FUNCTION_VERSION = 'v1';
+      process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE = '128';
+      process.env.AWS_LAMBDA_METADATA_API = AWS_LAMBDA_METADATA_API;
+      process.env.AWS_LAMBDA_METADATA_TOKEN = AWS_LAMBDA_METADATA_TOKEN;
+
+      const scope = nock(AWS_LAMBDA_METADATA_HOST)
+        .get(awsLambdaDetector.AWS_LAMBDA_EXECUTION_ENVIRONMENT_METADATA_PATH)
+        .matchHeader(
+          awsLambdaDetector.AWS_LAMBDA_METADATA_AUTH_HEADER,
+          `Bearer ${AWS_LAMBDA_METADATA_TOKEN}`
+        )
+        .reply(500);
+
+      const resource = detectResources({ detectors: [awsLambdaDetector] });
+      await resource.waitForAsyncAttributes?.();
+
+      scope.done();
+
+      assert.strictEqual(
+        resource.attributes[ATTR_CLOUD_PROVIDER],
+        CLOUD_PROVIDER_VALUE_AWS
+      );
+      assert.strictEqual(
+        resource.attributes[ATTR_CLOUD_PLATFORM],
+        CLOUD_PLATFORM_VALUE_AWS_LAMBDA
+      );
+      assert.strictEqual(resource.attributes[ATTR_CLOUD_REGION], 'us-east-1');
+      assert.strictEqual(resource.attributes[ATTR_FAAS_NAME], 'name');
+      assert.strictEqual(resource.attributes[ATTR_FAAS_VERSION], 'v1');
+      assert.strictEqual(
+        resource.attributes[ATTR_FAAS_MAX_MEMORY],
+        128 * 1024 * 1024
+      );
+      assert.strictEqual(
+        resource.attributes[ATTR_CLOUD_AVAILABILITY_ZONE],
+        undefined
+      );
     });
   });
 

--- a/packages/resource-detector-aws/test/detectors/AwsLambdaDetector.test.ts
+++ b/packages/resource-detector-aws/test/detectors/AwsLambdaDetector.test.ts
@@ -18,7 +18,7 @@ import * as assert from 'assert';
 import * as nock from 'nock';
 import { detectResources } from '@opentelemetry/resources';
 import { assertEmptyResource } from '@opentelemetry/contrib-test-utils';
-import { awsLambdaDetector } from '../../src';
+import { awsLambdaDetector, AwsLambdaDetector } from '../../src';
 import {
   ATTR_AWS_LOG_GROUP_NAMES,
   ATTR_CLOUD_AVAILABILITY_ZONE,
@@ -52,7 +52,7 @@ describe('awsLambdaDetector', () => {
   });
 
   describe('on lambda', () => {
-    it('fills resource', async () => {
+    it('fills resource and fetches the availability zone when enabled', async () => {
       process.env.AWS_EXECUTION_ENV = 'AWS_Lambda_nodejs22.x';
       process.env.AWS_REGION = 'us-east-1';
       process.env.AWS_LAMBDA_FUNCTION_NAME = 'name';
@@ -63,17 +63,18 @@ describe('awsLambdaDetector', () => {
       process.env.AWS_LAMBDA_METADATA_API = AWS_LAMBDA_METADATA_API;
       process.env.AWS_LAMBDA_METADATA_TOKEN = AWS_LAMBDA_METADATA_TOKEN;
 
+      const detector = new AwsLambdaDetector({ fetchAvailabilityZone: true });
       const scope = nock(AWS_LAMBDA_METADATA_HOST)
-        .get(awsLambdaDetector.AWS_LAMBDA_EXECUTION_ENVIRONMENT_METADATA_PATH)
+        .get(detector.AWS_LAMBDA_EXECUTION_ENVIRONMENT_METADATA_PATH)
         .matchHeader(
-          awsLambdaDetector.AWS_LAMBDA_METADATA_AUTH_HEADER,
+          detector.AWS_LAMBDA_METADATA_AUTH_HEADER,
           `Bearer ${AWS_LAMBDA_METADATA_TOKEN}`
         )
         .reply(200, {
           AvailabilityZoneID: 'use1-az1',
         });
 
-      const resource = detectResources({ detectors: [awsLambdaDetector] });
+      const resource = detectResources({ detectors: [detector] });
       await resource.waitForAsyncAttributes?.();
 
       scope.done();
@@ -106,6 +107,38 @@ describe('awsLambdaDetector', () => {
       ]);
     });
 
+    it('does not fetch the availability zone by default', async () => {
+      process.env.AWS_EXECUTION_ENV = 'AWS_Lambda_nodejs22.x';
+      process.env.AWS_REGION = 'us-east-1';
+      process.env.AWS_LAMBDA_FUNCTION_NAME = 'name';
+      process.env.AWS_LAMBDA_FUNCTION_VERSION = 'v1';
+      process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE = '128';
+      // Lambda sets these in every execution environment, so their presence must
+      // not be enough to trigger the metadata request on its own.
+      process.env.AWS_LAMBDA_METADATA_API = AWS_LAMBDA_METADATA_API;
+      process.env.AWS_LAMBDA_METADATA_TOKEN = AWS_LAMBDA_METADATA_TOKEN;
+
+      const scope = nock(AWS_LAMBDA_METADATA_HOST)
+        .get(awsLambdaDetector.AWS_LAMBDA_EXECUTION_ENVIRONMENT_METADATA_PATH)
+        .reply(200, {
+          AvailabilityZoneID: 'use1-az1',
+        });
+
+      const resource = detectResources({ detectors: [awsLambdaDetector] });
+      await resource.waitForAsyncAttributes?.();
+
+      assert.ok(
+        !scope.isDone(),
+        'metadata endpoint must not be called when fetchAvailabilityZone is disabled'
+      );
+      assert.strictEqual(
+        resource.attributes[ATTR_CLOUD_AVAILABILITY_ZONE],
+        undefined
+      );
+      assert.strictEqual(resource.attributes[ATTR_CLOUD_REGION], 'us-east-1');
+      assert.strictEqual(resource.attributes[ATTR_FAAS_NAME], 'name');
+    });
+
     it('keeps env-based attributes when metadata endpoint request fails', async () => {
       process.env.AWS_EXECUTION_ENV = 'AWS_Lambda_nodejs22.x';
       process.env.AWS_REGION = 'us-east-1';
@@ -115,15 +148,16 @@ describe('awsLambdaDetector', () => {
       process.env.AWS_LAMBDA_METADATA_API = AWS_LAMBDA_METADATA_API;
       process.env.AWS_LAMBDA_METADATA_TOKEN = AWS_LAMBDA_METADATA_TOKEN;
 
+      const detector = new AwsLambdaDetector({ fetchAvailabilityZone: true });
       const scope = nock(AWS_LAMBDA_METADATA_HOST)
-        .get(awsLambdaDetector.AWS_LAMBDA_EXECUTION_ENVIRONMENT_METADATA_PATH)
+        .get(detector.AWS_LAMBDA_EXECUTION_ENVIRONMENT_METADATA_PATH)
         .matchHeader(
-          awsLambdaDetector.AWS_LAMBDA_METADATA_AUTH_HEADER,
+          detector.AWS_LAMBDA_METADATA_AUTH_HEADER,
           `Bearer ${AWS_LAMBDA_METADATA_TOKEN}`
         )
         .reply(500);
 
-      const resource = detectResources({ detectors: [awsLambdaDetector] });
+      const resource = detectResources({ detectors: [detector] });
       await resource.waitForAsyncAttributes?.();
 
       scope.done();

--- a/packages/resource-detector-aws/test/detectors/AwsSuppressTracing.test.ts
+++ b/packages/resource-detector-aws/test/detectors/AwsSuppressTracing.test.ts
@@ -30,6 +30,13 @@ describe('[Integration] Internal tracing', () => {
     // For ECS detector we setup a mock URL to fetch metadata
     process.env.ECS_CONTAINER_METADATA_URI_V4 =
       'http://169.254.169.254/metadata';
+    process.env.AWS_EXECUTION_ENV = 'AWS_Lambda_nodejs24.x';
+    process.env.AWS_REGION = 'us-east-1';
+    process.env.AWS_LAMBDA_FUNCTION_NAME = 'name';
+    process.env.AWS_LAMBDA_FUNCTION_VERSION = '1';
+    process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE = '128';
+    process.env.AWS_LAMBDA_METADATA_API = '169.254.100.1:9001';
+    process.env.AWS_LAMBDA_METADATA_TOKEN = 'test-token';
 
     const memoryExporter = new InMemorySpanExporter();
     const spanProcessor = new SimpleSpanProcessor(memoryExporter);
@@ -87,5 +94,12 @@ describe('[Integration] Internal tracing', () => {
 
     await sdk.shutdown();
     delete process.env.ECS_CONTAINER_METADATA_URI_V4;
+    delete process.env.AWS_EXECUTION_ENV;
+    delete process.env.AWS_REGION;
+    delete process.env.AWS_LAMBDA_FUNCTION_NAME;
+    delete process.env.AWS_LAMBDA_FUNCTION_VERSION;
+    delete process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE;
+    delete process.env.AWS_LAMBDA_METADATA_API;
+    delete process.env.AWS_LAMBDA_METADATA_TOKEN;
   }).timeout(10000);
 });

--- a/packages/resource-detector-aws/test/detectors/AwsSuppressTracing.test.ts
+++ b/packages/resource-detector-aws/test/detectors/AwsSuppressTracing.test.ts
@@ -61,7 +61,7 @@ describe('[Integration] Internal tracing', () => {
       awsEc2Detector,
       awsEcsDetector,
       awsEksDetector,
-      awsLambdaDetector,
+      AwsLambdaDetector,
     } = require('../../build/src');
 
     // NOTE: the require process makes use of the fs API so spans are being exported.
@@ -74,7 +74,9 @@ describe('[Integration] Internal tracing', () => {
       awsEc2Detector,
       awsEcsDetector,
       awsEksDetector,
-      awsLambdaDetector,
+      // Opt into the availability-zone fetch so the Lambda metadata HTTP path is
+      // exercised here and asserted to not emit internal spans.
+      new AwsLambdaDetector({ fetchAvailabilityZone: true }),
     ] as ResourceDetector[];
 
     for (const d of detectors) {


### PR DESCRIPTION
## Which problem is this PR solving?

- `@opentelemetry/resource-detector-aws` currently detects standard AWS Lambda `cloud` and `faas` attributes, but it does not populate `cloud.availability_zone`.
- AWS Lambda now exposes execution-environment AZ metadata through a local metadata endpoint, which makes this attribute available without requiring an external service call.
- The OpenTelemetry semantic conventions define `cloud.availability_zone`, so the Lambda detector can now populate it consistently with the other AWS resource detectors.

## Short description of the changes

- Add opt-in Lambda metadata endpoint support to the AWS Lambda detector and map `AvailabilityZoneID` to `cloud.availability_zone` when enabled.
- Keep the default detector path environment-variable-only, preserving the previous cold-start behavior unless consumers opt in with `new AwsLambdaDetector({ fetchAvailabilityZone: true })`.
- Suppress internal tracing for the new localhost HTTP request, matching the package’s existing detector behavior.
- Add unit coverage for successful metadata lookup and failure fallback behavior.
- Extend the internal tracing integration test to exercise the Lambda metadata path.
- Document the new attribute in the package README.

## Reasoning

This change stays close to the new Lambda platform feature and the existing detector design. The detector already reads Lambda runtime metadata from environment variables when it is running inside Lambda. The Lambda-provided metadata endpoint is used only when `fetchAvailabilityZone` is enabled, keeping the previous environment-variable-only default while allowing consumers to opt into AZ enrichment.

I chose a direct HTTP call instead of using Powertools. That keeps the detector self-contained and avoids introducing a new runtime dependency on `@aws-lambda-powertools/commons`, or assuming that Powertools is already present through a Lambda layer. For a generic OpenTelemetry detector library, the direct endpoint call is the safer default.

The implementation stores the Lambda-provided AZ identifier as-is. Lambda returns an AZ ID such as `use1-az1`, not an AZ name such as `us-east-1a`. That value is still useful because AZ IDs are consistent across AWS accounts, while AZ names are not.

## Possible optimizations

- Powertools path: if this package ever accepts an explicit Powertools dependency or an optional integration layer, the detector could use the Powertools metadata utility instead of making its own HTTP request. That would delegate response caching and SnapStart-aware refresh behavior to AWS-maintained code.
- Optional translation to AZ name: if a consumer explicitly wants an AZ name instead of the Lambda AZ ID, a separate opt-in path could translate the ID through `DescribeAvailabilityZones`. I did not add that here because it would require additional IAM permissions, another API dependency, and would move the detector away from the value Lambda directly exposes.
- Shared metadata helper: if more Lambda-specific metadata fields are added later, the package could factor the HTTP request code into a reusable helper. Right now that would be premature because only one new field uses the endpoint.

## Testing

- Added unit tests for successful opt-in AZ metadata detection, disabled-by-default behavior, and graceful fallback when the metadata endpoint returns an error.
- Updated the internal tracing integration fixture to opt into the Lambda metadata path and verify it does not emit internal spans.
- Ran `npm run compile --workspace @opentelemetry/resource-detector-aws`.
- Ran `npm test --workspace @opentelemetry/resource-detector-aws` (46 passing).

## References

1. OpenTelemetry semantic conventions, `cloud.availability_zone`: <https://opentelemetry.io/docs/specs/semconv/registry/attributes/cloud/#cloud-availability-zone>
2. AWS Lambda metadata endpoint developer guide: <https://docs.aws.amazon.com/lambda/latest/dg/configuration-metadata-endpoint.html>
3. AWS Lambda availability zone metadata announcement, posted March 19, 2026: <https://aws.amazon.com/about-aws/whats-new/2026/03/lambda-availability-zone-metadata/>
4. Powertools for AWS Lambda (TypeScript) Metadata utility: <https://docs.aws.amazon.com/powertools/typescript/latest/features/metadata/>
