### PR TITLE
chore: update the Node.js used for update-otel-deps workflow

### DIFF
--- a/.github/workflows/update-otel-deps.yaml
+++ b/.github/workflows/update-otel-deps.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           cache: 'npm'
           cache-dependency-path: package-lock.json
-          node-version: 22
+          node-version: 24
 
       - run: npm install -g npm@latest
 


### PR DESCRIPTION
An indirect reason to do this now is to avoid https://github.com/nodejs/node/issues/62425
if that is still the latest Node.js v22 when this workflow is next used.
