### PR TITLE
fix(instr-browser-navigation): do not unpatch history API

### DIFF
--- a/packages/instrumentation-browser-navigation/src/instrumentation.ts
+++ b/packages/instrumentation-browser-navigation/src/instrumentation.ts
@@ -172,7 +172,7 @@ export class BrowserNavigationInstrumentation extends InstrumentationBase<Browse
       ((window as any).navigation as EventTarget);
 
     // Only patch history API if Navigation API is not available
-    if (!navigationApi && ! this._isHistoryPatched) {
+    if (!navigationApi && !this._isHistoryPatched) {
       this._patchHistoryApi();
       this._isHistoryPatched = true;
     }

--- a/packages/instrumentation-browser-navigation/src/instrumentation.ts
+++ b/packages/instrumentation-browser-navigation/src/instrumentation.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { InstrumentationBase, isWrapped } from '@opentelemetry/instrumentation';
+import { InstrumentationBase } from '@opentelemetry/instrumentation';
 import type { LogRecord } from '@opentelemetry/api-logs';
 import { ATTR_URL_FULL } from '@opentelemetry/semantic-conventions';
 /** @knipignore */
@@ -51,6 +51,7 @@ export class BrowserNavigationInstrumentation extends InstrumentationBase<Browse
   // any possible confusion with the `_enabled` field used on the *Node.js*
   // InstrumentationBase class.
   declare private _isEnabled: boolean;
+  declare private _isHistoryPatched: boolean;
 
   /**
    *
@@ -171,8 +172,9 @@ export class BrowserNavigationInstrumentation extends InstrumentationBase<Browse
       ((window as any).navigation as EventTarget);
 
     // Only patch history API if Navigation API is not available
-    if (!navigationApi) {
+    if (!navigationApi && ! this._isHistoryPatched) {
       this._patchHistoryApi();
+      this._isHistoryPatched = true;
     }
 
     // Always listen for page load
@@ -214,7 +216,6 @@ export class BrowserNavigationInstrumentation extends InstrumentationBase<Browse
     }
     this._isEnabled = false;
 
-    this._unpatchHistoryApi();
     if (this._onLoadHandler) {
       document.removeEventListener('DOMContentLoaded', this._onLoadHandler);
       this._onLoadHandler = undefined;
@@ -246,6 +247,9 @@ export class BrowserNavigationInstrumentation extends InstrumentationBase<Browse
     const plugin = this;
     return (original: any) => {
       return function patchHistoryMethod(this: History, ...args: unknown[]) {
+        if (!plugin._isEnabled) {
+          return original.apply(this, args);
+        }
         const result = original.apply(this, args);
         const currentUrl = location.href;
         if (currentUrl !== plugin._lastUrl) {
@@ -267,13 +271,6 @@ export class BrowserNavigationInstrumentation extends InstrumentationBase<Browse
       this._patchHistoryMethod('replaceState')
     );
     this._wrap(history, 'pushState', this._patchHistoryMethod('pushState'));
-  }
-  /**
-   * unpatch the history api methods
-   */
-  _unpatchHistoryApi() {
-    if (isWrapped(history.replaceState)) this._unwrap(history, 'replaceState');
-    if (isWrapped(history.pushState)) this._unwrap(history, 'pushState');
   }
 
   /**


### PR DESCRIPTION
## Which problem is this PR solving?

Follow up of https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3459. This time is for browser navigation instrumentation.

## Short description of the changes

- instrumentation now patches only once and never unpatches APIs from browser
- add/remove event listeners is kept
- add `_isHistoryPatched` private property to avoid multiple patching
