### PR TITLE
fix(redis-common): expand redaction to include ACL, CONFIG, PSETEX, GETSET

### DIFF
--- a/packages/instrumentation-ioredis/test/ioredis.test.ts
+++ b/packages/instrumentation-ioredis/test/ioredis.test.ts
@@ -663,6 +663,82 @@ describe('ioredis', () => {
           });
         });
       });
+
+      describe('sensitive command sanitization', function () {
+        after(async () => {
+          // cleanup added user
+          client.acl('DELUSER', 'testuser');
+        })
+
+        it('should redact CONFIG SET arguments in db.statement', async function () {
+          const span = provider.getTracer('ioredis-test').startSpan('test span');
+          await context.with(trace.setSpan(context.active(), span), async function () {
+            await client.config('SET', 'hz', '15');
+            span.end();
+            const endedSpans = memoryExporter.getFinishedSpans();
+            assert.strictEqual(
+              endedSpans[0].attributes[ATTR_DB_STATEMENT],
+              'config SET [2 other arguments]'
+            );
+            assert.strictEqual(
+              endedSpans[0].attributes[ATTR_DB_QUERY_TEXT],
+              'config SET [2 other arguments]'
+            );
+          });
+        });
+
+        it('should redact ACL SETUSER arguments in db.statement', async function () {
+          const span = provider.getTracer('ioredis-test').startSpan('test span');
+          await context.with(trace.setSpan(context.active(), span), async function () {
+            await (client as any).acl('setuser', 'testuser');
+            span.end();
+            const endedSpans = memoryExporter.getFinishedSpans();
+            assert.strictEqual(
+              endedSpans[0].attributes[ATTR_DB_STATEMENT],
+              'acl setuser [1 other arguments]'
+            );
+            assert.strictEqual(
+              endedSpans[0].attributes[ATTR_DB_QUERY_TEXT],
+              'acl setuser [1 other arguments]'
+            );
+          });
+          await (client as any).acl('deluser', 'testuser'); // cleanup
+        });
+
+        it('should redact GETSET value in db.statement', async function () {
+          const span = provider.getTracer('ioredis-test').startSpan('test span');
+          await context.with(trace.setSpan(context.active(), span), async function () {
+            await client.getset(testKeyName, 'secret-value');
+            span.end();
+            const endedSpans = memoryExporter.getFinishedSpans();
+            assert.strictEqual(
+              endedSpans[0].attributes[ATTR_DB_STATEMENT],
+              `getset ${testKeyName} [1 other arguments]`
+            );
+            assert.strictEqual(
+              endedSpans[0].attributes[ATTR_DB_QUERY_TEXT],
+              `getset ${testKeyName} [1 other arguments]`
+            );
+          });
+        });
+
+        it('should redact PSETEX value in db.statement', async function () {
+          const span = provider.getTracer('ioredis-test').startSpan('test span');
+          await context.with(trace.setSpan(context.active(), span), async function () {
+            await client.psetex(testKeyName, 60000, 'secret-value');
+            span.end();
+            const endedSpans = memoryExporter.getFinishedSpans();
+            assert.strictEqual(
+              endedSpans[0].attributes[ATTR_DB_STATEMENT],
+              `psetex ${testKeyName} [2 other arguments]`
+            );
+            assert.strictEqual(
+              endedSpans[0].attributes[ATTR_DB_QUERY_TEXT],
+              `psetex ${testKeyName} [2 other arguments]`
+            );
+          });
+        });
+      });
     });
 
     describe('Instrumenting without parent span', () => {

--- a/packages/instrumentation-ioredis/test/ioredis.test.ts
+++ b/packages/instrumentation-ioredis/test/ioredis.test.ts
@@ -668,75 +668,95 @@ describe('ioredis', () => {
         after(async () => {
           // cleanup added user
           client.acl('DELUSER', 'testuser');
-        })
+        });
 
         it('should redact CONFIG SET arguments in db.statement', async function () {
-          const span = provider.getTracer('ioredis-test').startSpan('test span');
-          await context.with(trace.setSpan(context.active(), span), async function () {
-            await client.config('SET', 'hz', '15');
-            span.end();
-            const endedSpans = memoryExporter.getFinishedSpans();
-            assert.strictEqual(
-              endedSpans[0].attributes[ATTR_DB_STATEMENT],
-              'config SET [2 other arguments]'
-            );
-            assert.strictEqual(
-              endedSpans[0].attributes[ATTR_DB_QUERY_TEXT],
-              'config SET [2 other arguments]'
-            );
-          });
+          const span = provider
+            .getTracer('ioredis-test')
+            .startSpan('test span');
+          await context.with(
+            trace.setSpan(context.active(), span),
+            async function () {
+              await client.config('SET', 'hz', '15');
+              span.end();
+              const endedSpans = memoryExporter.getFinishedSpans();
+              assert.strictEqual(
+                endedSpans[0].attributes[ATTR_DB_STATEMENT],
+                'config SET [2 other arguments]'
+              );
+              assert.strictEqual(
+                endedSpans[0].attributes[ATTR_DB_QUERY_TEXT],
+                'config SET [2 other arguments]'
+              );
+            }
+          );
         });
 
         it('should redact ACL SETUSER arguments in db.statement', async function () {
-          const span = provider.getTracer('ioredis-test').startSpan('test span');
-          await context.with(trace.setSpan(context.active(), span), async function () {
-            await (client as any).acl('setuser', 'testuser');
-            span.end();
-            const endedSpans = memoryExporter.getFinishedSpans();
-            assert.strictEqual(
-              endedSpans[0].attributes[ATTR_DB_STATEMENT],
-              'acl setuser [1 other arguments]'
-            );
-            assert.strictEqual(
-              endedSpans[0].attributes[ATTR_DB_QUERY_TEXT],
-              'acl setuser [1 other arguments]'
-            );
-          });
+          const span = provider
+            .getTracer('ioredis-test')
+            .startSpan('test span');
+          await context.with(
+            trace.setSpan(context.active(), span),
+            async function () {
+              await (client as any).acl('setuser', 'testuser');
+              span.end();
+              const endedSpans = memoryExporter.getFinishedSpans();
+              assert.strictEqual(
+                endedSpans[0].attributes[ATTR_DB_STATEMENT],
+                'acl setuser [1 other arguments]'
+              );
+              assert.strictEqual(
+                endedSpans[0].attributes[ATTR_DB_QUERY_TEXT],
+                'acl setuser [1 other arguments]'
+              );
+            }
+          );
           await (client as any).acl('deluser', 'testuser'); // cleanup
         });
 
         it('should redact GETSET value in db.statement', async function () {
-          const span = provider.getTracer('ioredis-test').startSpan('test span');
-          await context.with(trace.setSpan(context.active(), span), async function () {
-            await client.getset(testKeyName, 'secret-value');
-            span.end();
-            const endedSpans = memoryExporter.getFinishedSpans();
-            assert.strictEqual(
-              endedSpans[0].attributes[ATTR_DB_STATEMENT],
-              `getset ${testKeyName} [1 other arguments]`
-            );
-            assert.strictEqual(
-              endedSpans[0].attributes[ATTR_DB_QUERY_TEXT],
-              `getset ${testKeyName} [1 other arguments]`
-            );
-          });
+          const span = provider
+            .getTracer('ioredis-test')
+            .startSpan('test span');
+          await context.with(
+            trace.setSpan(context.active(), span),
+            async function () {
+              await client.getset(testKeyName, 'secret-value');
+              span.end();
+              const endedSpans = memoryExporter.getFinishedSpans();
+              assert.strictEqual(
+                endedSpans[0].attributes[ATTR_DB_STATEMENT],
+                `getset ${testKeyName} [1 other arguments]`
+              );
+              assert.strictEqual(
+                endedSpans[0].attributes[ATTR_DB_QUERY_TEXT],
+                `getset ${testKeyName} [1 other arguments]`
+              );
+            }
+          );
         });
 
         it('should redact PSETEX value in db.statement', async function () {
-          const span = provider.getTracer('ioredis-test').startSpan('test span');
-          await context.with(trace.setSpan(context.active(), span), async function () {
-            await client.psetex(testKeyName, 60000, 'secret-value');
-            span.end();
-            const endedSpans = memoryExporter.getFinishedSpans();
-            assert.strictEqual(
-              endedSpans[0].attributes[ATTR_DB_STATEMENT],
-              `psetex ${testKeyName} [2 other arguments]`
-            );
-            assert.strictEqual(
-              endedSpans[0].attributes[ATTR_DB_QUERY_TEXT],
-              `psetex ${testKeyName} [2 other arguments]`
-            );
-          });
+          const span = provider
+            .getTracer('ioredis-test')
+            .startSpan('test span');
+          await context.with(
+            trace.setSpan(context.active(), span),
+            async function () {
+              await client.psetex(testKeyName, 60000, 'secret-value');
+              span.end();
+              const endedSpans = memoryExporter.getFinishedSpans();
+              assert.strictEqual(
+                endedSpans[0].attributes[ATTR_DB_STATEMENT],
+                `psetex ${testKeyName} [2 other arguments]`
+              );
+              assert.strictEqual(
+                endedSpans[0].attributes[ATTR_DB_QUERY_TEXT],
+                `psetex ${testKeyName} [2 other arguments]`
+              );
+            }
+          );
         });
       });
     });

--- a/packages/instrumentation-redis/test/v2-v3/redis.test.ts
+++ b/packages/instrumentation-redis/test/v2-v3/redis.test.ts
@@ -335,6 +335,80 @@ describe('redis v2-v3', () => {
       });
     });
 
+    describe('sensitive command sanitization', () => {
+      it('should redact CONFIG SET arguments in db.statement', function (done) {
+        const span = tracer.startSpan('test span');
+        context.with(trace.setSpan(context.active(), span), () => {
+          client.config('set', 'hz', '15', (err: unknown) => {
+            try {
+              assert.ifError(err);
+              span.end();
+              const endedSpans = testUtils.getTestSpans();
+              assert.strictEqual(
+                endedSpans[0].attributes[ATTR_DB_STATEMENT],
+                'config set [2 other arguments]'
+              );
+              assert.strictEqual(
+                endedSpans[0].attributes[ATTR_DB_QUERY_TEXT],
+                'config set [2 other arguments]'
+              );
+              done();
+            } catch (error) {
+              done(error);
+            }
+          });
+        });
+      });
+
+      it('should redact GETSET value in db.statement', function (done) {
+        const span = tracer.startSpan('test span');
+        context.with(trace.setSpan(context.active(), span), () => {
+          client.getset('test', 'secret-value', (err: unknown) => {
+            try {
+              assert.ifError(err);
+              span.end();
+              const endedSpans = testUtils.getTestSpans();
+              assert.strictEqual(
+                endedSpans[0].attributes[ATTR_DB_STATEMENT],
+                'getset test [1 other arguments]'
+              );
+              assert.strictEqual(
+                endedSpans[0].attributes[ATTR_DB_QUERY_TEXT],
+                'getset test [1 other arguments]'
+              );
+              done();
+            } catch (err) {
+              done(err)
+            }
+          });
+        });
+      });
+
+      it('should redact PSETEX value in db.statement', function (done) {
+        const span = tracer.startSpan('test span');
+        context.with(trace.setSpan(context.active(), span), () => {
+          client.psetex('test', 60000, 'secret-value', (err: unknown) => {
+            try {
+              assert.ifError(err);
+              span.end();
+              const endedSpans = testUtils.getTestSpans();
+              assert.strictEqual(
+                endedSpans[0].attributes[ATTR_DB_STATEMENT],
+                'psetex test [2 other arguments]'
+              );
+              assert.strictEqual(
+                endedSpans[0].attributes[ATTR_DB_QUERY_TEXT],
+                'psetex test [2 other arguments]'
+              );
+              done();
+            } catch (err) {
+              done(err);
+            }
+          });
+        });
+      });
+    });
+
     describe('dbStatementSerializer config', () => {
       const dbStatementSerializer = (
         cmdName: string,

--- a/packages/instrumentation-redis/test/v2-v3/redis.test.ts
+++ b/packages/instrumentation-redis/test/v2-v3/redis.test.ts
@@ -378,7 +378,7 @@ describe('redis v2-v3', () => {
               );
               done();
             } catch (err) {
-              done(err)
+              done(err);
             }
           });
         });

--- a/packages/instrumentation-redis/test/v4-v5/redis.test.ts
+++ b/packages/instrumentation-redis/test/v4-v5/redis.test.ts
@@ -241,15 +241,21 @@ describe('redis v4-v5', () => {
           span?.attributes[ATTR_DB_QUERY_TEXT],
           'ACL SETUSER [1 other arguments]'
         );
-        await context.with(suppressTracing(context.active()), async function () {
-          await client.sendCommand(['ACL', 'DELUSER', 'testuser']);
-        });
+        await context.with(
+          suppressTracing(context.active()),
+          async function () {
+            await client.sendCommand(['ACL', 'DELUSER', 'testuser']);
+          }
+        );
       });
 
       it('redacts GETSET value in db.statement', async function () {
-        await context.with(suppressTracing(context.active()), async function () {
-          await client.set('key', 'initial');
-        });
+        await context.with(
+          suppressTracing(context.active()),
+          async function () {
+            await client.set('key', 'initial');
+          }
+        );
         await client.sendCommand(['GETSET', 'key', 'secret-value']);
         const [span] = getTestSpans();
         assert.strictEqual(

--- a/packages/instrumentation-redis/test/v4-v5/redis.test.ts
+++ b/packages/instrumentation-redis/test/v4-v5/redis.test.ts
@@ -215,6 +215,66 @@ describe('redis v4-v5', () => {
         'ERR value is not an integer or out of range'
       );
     });
+
+    describe('sensitive command sanitization', function () {
+      it('redacts CONFIG SET arguments in db.statement', async function () {
+        await client.sendCommand(['CONFIG', 'SET', 'hz', '15']);
+        const [span] = getTestSpans();
+        assert.strictEqual(
+          span?.attributes[ATTR_DB_STATEMENT],
+          'CONFIG SET [2 other arguments]'
+        );
+        assert.strictEqual(
+          span?.attributes[ATTR_DB_QUERY_TEXT],
+          'CONFIG SET [2 other arguments]'
+        );
+      });
+
+      it('redacts ACL SETUSER arguments in db.statement', async function () {
+        await client.sendCommand(['ACL', 'SETUSER', 'testuser']);
+        const [span] = getTestSpans();
+        assert.strictEqual(
+          span?.attributes[ATTR_DB_STATEMENT],
+          'ACL SETUSER [1 other arguments]'
+        );
+        assert.strictEqual(
+          span?.attributes[ATTR_DB_QUERY_TEXT],
+          'ACL SETUSER [1 other arguments]'
+        );
+        await context.with(suppressTracing(context.active()), async function () {
+          await client.sendCommand(['ACL', 'DELUSER', 'testuser']);
+        });
+      });
+
+      it('redacts GETSET value in db.statement', async function () {
+        await context.with(suppressTracing(context.active()), async function () {
+          await client.set('key', 'initial');
+        });
+        await client.sendCommand(['GETSET', 'key', 'secret-value']);
+        const [span] = getTestSpans();
+        assert.strictEqual(
+          span?.attributes[ATTR_DB_STATEMENT],
+          'GETSET key [1 other arguments]'
+        );
+        assert.strictEqual(
+          span?.attributes[ATTR_DB_QUERY_TEXT],
+          'GETSET key [1 other arguments]'
+        );
+      });
+
+      it('redacts PSETEX value in db.statement', async function () {
+        await client.sendCommand(['PSETEX', 'key', '60000', 'secret-value']);
+        const [span] = getTestSpans();
+        assert.strictEqual(
+          span?.attributes[ATTR_DB_STATEMENT],
+          'PSETEX key [2 other arguments]'
+        );
+        assert.strictEqual(
+          span?.attributes[ATTR_DB_QUERY_TEXT],
+          'PSETEX key [2 other arguments]'
+        );
+      });
+    });
   });
 
   describe('client connect', () => {

--- a/packages/redis-common/src/index.ts
+++ b/packages/redis-common/src/index.ts
@@ -28,7 +28,8 @@ const serializationSubsets = [
     args: 0,
   },
   {
-    regex: /^(GETSET|LPUSH|MSET|PFA|PSETEX|PUBLISH|RPUSH|SADD|SET|SPUBLISH|XADD|ZADD)/i,
+    regex:
+      /^(GETSET|LPUSH|MSET|PFA|PSETEX|PUBLISH|RPUSH|SADD|SET|SPUBLISH|XADD|ZADD)/i,
     args: 1,
   },
   {

--- a/packages/redis-common/src/index.ts
+++ b/packages/redis-common/src/index.ts
@@ -28,7 +28,7 @@ const serializationSubsets = [
     args: 0,
   },
   {
-    regex: /^(LPUSH|MSET|PFA|PUBLISH|RPUSH|SADD|SET|SPUBLISH|XADD|ZADD)/i,
+    regex: /^(GETSET|LPUSH|MSET|PFA|PSETEX|PUBLISH|RPUSH|SADD|SET|SPUBLISH|XADD|ZADD)/i,
     args: 1,
   },
   {

--- a/packages/redis-common/src/index.ts
+++ b/packages/redis-common/src/index.ts
@@ -35,9 +35,15 @@ const serializationSubsets = [
     regex: /^(HSET|HMSET|LSET|LINSERT)/i,
     args: 2,
   },
+  // ACL and CONFIG subcommands may contain sensitive data (e.g. passwords),
+  // so only serialize the subcommand name (first argument).
+  {
+    regex: /^(ACL|CONFIG)/i,
+    args: 1,
+  },
   {
     regex:
-      /^(ACL|BIT|B[LRZ]|CLIENT|CLUSTER|CONFIG|COMMAND|DECR|DEL|EVAL|EX|FUNCTION|GEO|GET|HINCR|HMGET|HSCAN|INCR|L[TRLM]|MEMORY|P[EFISTU]|RPOP|S[CDIMORSU]|XACK|X[CDGILPRT]|Z[CDILMPRS])/i,
+      /^(BIT|B[LRZ]|CLIENT|CLUSTER|COMMAND|DECR|DEL|EVAL|EX|FUNCTION|GEO|GET|HINCR|HMGET|HSCAN|INCR|L[TRLM]|MEMORY|P[EFISTU]|RPOP|S[CDIMORSU]|XACK|X[CDGILPRT]|Z[CDILMPRS])/i,
     args: -1,
   },
 ];

--- a/packages/redis-common/test/redis-common.test.ts
+++ b/packages/redis-common/test/redis-common.test.ts
@@ -43,6 +43,33 @@ describe('#defaultDbStatementSerializer()', () => {
       cmdArgs: ['key', 5],
       expected: 'INCRBY key 5',
     },
+    // ACL subcommands with sensitive data should be redacted
+    {
+      cmdName: 'ACL',
+      cmdArgs: ['SETUSER', 'alice', 'on', '>MySecretPass', '~user:alice:*', '+@read', '+@write'],
+      expected: 'ACL SETUSER [6 other arguments]',
+    },
+    {
+      cmdName: 'ACL',
+      cmdArgs: ['WHOAMI'],
+      expected: 'ACL WHOAMI',
+    },
+    {
+      cmdName: 'ACL',
+      cmdArgs: ['LIST'],
+      expected: 'ACL LIST',
+    },
+    // CONFIG subcommands with sensitive data should be redacted
+    {
+      cmdName: 'CONFIG',
+      cmdArgs: ['SET', 'requirepass', 'MyNewPassword123'],
+      expected: 'CONFIG SET [2 other arguments]',
+    },
+    {
+      cmdName: 'CONFIG',
+      cmdArgs: ['GET', 'maxmemory'],
+      expected: 'CONFIG GET [1 other arguments]',
+    },
   ].forEach(({ cmdName, cmdArgs, expected }) => {
     it(`should serialize the correct number of arguments for ${cmdName}`, () => {
       assert.strictEqual(

--- a/packages/redis-common/test/redis-common.test.ts
+++ b/packages/redis-common/test/redis-common.test.ts
@@ -46,7 +46,15 @@ describe('#defaultDbStatementSerializer()', () => {
     // ACL subcommands with sensitive data should be redacted
     {
       cmdName: 'ACL',
-      cmdArgs: ['SETUSER', 'alice', 'on', '>MySecretPass', '~user:alice:*', '+@read', '+@write'],
+      cmdArgs: [
+        'SETUSER',
+        'alice',
+        'on',
+        '>MySecretPass',
+        '~user:alice:*',
+        '+@read',
+        '+@write',
+      ],
       expected: 'ACL SETUSER [6 other arguments]',
     },
     {
@@ -69,6 +77,18 @@ describe('#defaultDbStatementSerializer()', () => {
       cmdName: 'CONFIG',
       cmdArgs: ['GET', 'maxmemory'],
       expected: 'CONFIG GET [1 other arguments]',
+    },
+    // GETSET (deprecated) args should be redacted since it can contain sensitive data
+    {
+      cmdName: 'GETSET',
+      cmdArgs: ['key', 'secret_value'],
+      expected: 'GETSET key [1 other arguments]',
+    },
+    // PSETEX (deprecated) can also contain sensitive data
+    {
+      cmdName: 'PSETEX',
+      cmdArgs: ['key', '100000', 'secret_value'],
+      expected: 'PSETEX key [2 other arguments]',
     },
   ].forEach(({ cmdName, cmdArgs, expected }) => {
     it(`should serialize the correct number of arguments for ${cmdName}`, () => {


### PR DESCRIPTION
## Which problem is this PR solving?

We don't sanitize quite some commands that can contain sensitive data, as described in #3469.
In addition to `ACL` and `CONFIG`, there's also `PSETEX` (set something for some time) and `GETSET` (atomic get + set) that we should redact in the same way as `SET`

## Short description of the changes

- add `ACL`, `CONFIG`, `PSETEX` and `GETSET` to the list of redacted things (all should only include the first arg)