### PR TITLE
fix: scripts fix 'occured' -> 'occurred' in check-release-please console.error

### DIFF
--- a/scripts/check-release-please.mjs
+++ b/scripts/check-release-please.mjs
@@ -106,7 +106,7 @@ configPackages.forEach(relativeLocation => {
 });
 
 if (errors.length) {
-  console.error('Errors occured:\n');
+  console.error('Errors occurred:\n');
   console.error(errors.join('\n\n'));
   process.exit(1);
 } else {


### PR DESCRIPTION
`console.error` call in `scripts/check-release-please.mjs:109` read `Errors occured:`. Visible to developers when the release-please audit fails. String-literal-only change.