### PR TITLE
feat(auto-instrumentations-node): add opt-in host metrics via OTEL_NODE_HOST_METRICS_ENABLED

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36310,6 +36310,7 @@
       "version": "0.73.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@opentelemetry/host-metrics": "^0.38.0",
         "@opentelemetry/instrumentation": "^0.215.0",
         "@opentelemetry/instrumentation-amqplib": "^0.62.0",
         "@opentelemetry/instrumentation-aws-lambda": "^0.67.0",

--- a/packages/auto-instrumentations-node/README.md
+++ b/packages/auto-instrumentations-node/README.md
@@ -124,6 +124,16 @@ Notes:
 - Logs are always sent to console, no matter the environment, or debug level.
 - Debug logs are extremely verbose. Enable debug logging only when needed. Debug logging negatively impacts the performance of your application.
 
+### Host Metrics
+
+Host metrics (CPU, memory, network) are not collected by default. To enable them, set `OTEL_NODE_HOST_METRICS_ENABLED=true`:
+
+```shell
+export OTEL_NODE_HOST_METRICS_ENABLED="true"
+```
+
+This uses [`@opentelemetry/host-metrics`](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/host-metrics) and automatically exports to the same metrics pipeline configured for your application.
+
 ## Usage: Instrumentation Initialization
 
 OpenTelemetry Meta Packages for Node automatically loads instrumentations for Node builtin modules and common packages.

--- a/packages/auto-instrumentations-node/package.json
+++ b/packages/auto-instrumentations-node/package.json
@@ -43,6 +43,7 @@
     "@opentelemetry/core": "^2.0.0"
   },
   "dependencies": {
+    "@opentelemetry/host-metrics": "^0.38.0",
     "@opentelemetry/instrumentation": "^0.215.0",
     "@opentelemetry/instrumentation-amqplib": "^0.62.0",
     "@opentelemetry/instrumentation-aws-lambda": "^0.67.0",

--- a/packages/auto-instrumentations-node/src/register.ts
+++ b/packages/auto-instrumentations-node/src/register.ts
@@ -32,6 +32,12 @@ try {
   );
 }
 
+if (process.env.OTEL_NODE_HOST_METRICS_ENABLED === 'true') {
+  void import('@opentelemetry/host-metrics').then(({ HostMetrics }) => {
+    new HostMetrics().start();
+  });
+}
+
 async function shutdown(): Promise<void> {
   try {
     await sdk.shutdown();


### PR DESCRIPTION
## Summary

Adds opt-in host metrics (CPU, memory, network) to the `register` entry point,
enabled by setting `OTEL_NODE_HOST_METRICS_ENABLED=true`.

- `@opentelemetry/host-metrics` is added as a runtime dependency
- The env var is checked at startup; if unset (the default) nothing changes
- `HostMetrics` is started after `sdk.start()` so it picks up the global
  MeterProvider automatically — no explicit wiring needed

## Motivation

The OpenTelemetry Operator's `autoinstrumentation-nodejs` image uses this
package as its `--require` script. Getting host metrics today requires
manually adding a second init container. This makes it available opt-in
with a single env var.

Validated end-to-end on GKE: `system.cpu.time`, `system.memory.usage`,
`process.cpu.time`, and network metrics all flowing correctly.

Closes #3483