### PR TITLE
refactor(instrumentation-redis): rename MutliCommandInfo to MultiComm…

### DIFF
--- a/packages/instrumentation-redis/src/v4-v5/instrumentation.ts
+++ b/packages/instrumentation-redis/src/v4-v5/instrumentation.ts
@@ -37,7 +37,7 @@ const MULTI_COMMAND_OPTIONS = Symbol(
   'opentelemetry.instrumentation.redis.multi_command_options'
 );
 
-interface MutliCommandInfo {
+interface MultiCommandInfo {
   span: Span;
   commandName: string;
   commandArgs: Array<string | Buffer>;
@@ -454,7 +454,7 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
       );
     } else {
       const redisClientMultiCommand = res as {
-        [OTEL_OPEN_SPANS]?: Array<MutliCommandInfo>;
+        [OTEL_OPEN_SPANS]?: Array<MultiCommandInfo>;
       };
       redisClientMultiCommand[OTEL_OPEN_SPANS] =
         redisClientMultiCommand[OTEL_OPEN_SPANS] || [];
@@ -468,7 +468,7 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
   }
 
   private _endSpansWithRedisReplies(
-    openSpans: Array<MutliCommandInfo>,
+    openSpans: Array<MultiCommandInfo>,
     replies: unknown[],
     isPipeline = false
   ) {


### PR DESCRIPTION
## Which problem is this PR solving?

While I looked over the redis instrumentation, I found a typo. The interface `MutliCommandInfo` in `instrumentation-redis/src/v4-v5/instrumentation.ts` has a typo, it should be `MultiCommandInfo`.

## Short description of the changes

Rename `MutliCommandInfo` to `MultiCommandInfo`.
