### PR TITLE
fix(instrumentation-knex): use resolved connection settings

### DIFF
--- a/packages/instrumentation-knex/src/instrumentation.ts
+++ b/packages/instrumentation-knex/src/instrumentation.ts
@@ -133,6 +133,8 @@ export class KnexInstrumentation extends InstrumentationBase<KnexInstrumentation
     return function wrapQuery(original: (...args: any[]) => any) {
       return function wrapped_logging_method(this: any, query: any) {
         const config = this.client.config;
+        // Knex resolves function-based connection configs into connectionSettings.
+        const connection = this.client.connectionSettings ?? config?.connection;
 
         const table = utils.extractTableName(this.builder);
         // `method` actually refers to the knex API method - Not exactly "operation"
@@ -140,10 +142,10 @@ export class KnexInstrumentation extends InstrumentationBase<KnexInstrumentation
         const operation = query?.method;
         // Knex can be configured with a connectionString instead of explicit fields.
         // Fall back to parsing the connectionString if filename and database are not set.
-        const connectionString = config?.connection?.connectionString;
+        const connectionString = connection?.connectionString;
         const name =
-          config?.connection?.filename ||
-          config?.connection?.database ||
+          connection?.filename ||
+          connection?.database ||
           utils.extractDatabaseFromConnectionString(connectionString);
         const { maxQueryLength } = instrumentation.getConfig();
 
@@ -151,21 +153,21 @@ export class KnexInstrumentation extends InstrumentationBase<KnexInstrumentation
           'knex.version': moduleVersion,
         };
         const transport =
-          config?.connection?.filename === ':memory:' ? 'inproc' : undefined;
+          connection?.filename === ':memory:' ? 'inproc' : undefined;
 
         if (instrumentation._semconvStability & SemconvStability.OLD) {
           Object.assign(attributes, {
             [ATTR_DB_SYSTEM]: utils.mapSystem(this.client.driverName),
             [ATTR_DB_SQL_TABLE]: table,
             [ATTR_DB_OPERATION]: operation,
-            [ATTR_DB_USER]: config?.connection?.user,
+            [ATTR_DB_USER]: connection?.user,
             [ATTR_DB_NAME]: name,
             // Fall back to parsing host and port from connectionString if not explicitly set.
             [ATTR_NET_PEER_NAME]:
-              config?.connection?.host ??
+              connection?.host ??
               utils.extractHostFromConnectionString(connectionString),
             [ATTR_NET_PEER_PORT]:
-              config?.connection?.port ??
+              connection?.port ??
               utils.extractPortFromConnectionString(connectionString),
             [ATTR_NET_TRANSPORT]: transport,
           });
@@ -178,10 +180,10 @@ export class KnexInstrumentation extends InstrumentationBase<KnexInstrumentation
             [ATTR_DB_NAMESPACE]: name,
             // Fall back to parsing host and port from connectionString if not explicitly set.
             [ATTR_SERVER_ADDRESS]:
-              config?.connection?.host ??
+              connection?.host ??
               utils.extractHostFromConnectionString(connectionString),
             [ATTR_SERVER_PORT]:
-              config?.connection?.port ??
+              connection?.port ??
               utils.extractPortFromConnectionString(connectionString),
           });
         }

--- a/packages/instrumentation-knex/test/index.test.ts
+++ b/packages/instrumentation-knex/test/index.test.ts
@@ -184,6 +184,42 @@ describe('Knex instrumentation', () => {
       );
     });
 
+    it('should read connection attributes from function-based connection settings', async () => {
+      client = knex({
+        client: 'sqlite3',
+        connection: async () => ({
+          filename: ':memory:',
+        }),
+        log: {
+          warn: () => undefined,
+        },
+        useNullAsDefault: true,
+      });
+
+      const parentSpan = tracer.startSpan('parentSpan');
+      await context.with(
+        trace.setSpan(context.active(), parentSpan),
+        async () => {
+          assert.deepEqual(await client.raw('select 1 as result'), [
+            { result: 1 },
+          ]);
+          parentSpan.end();
+
+          const instrumentationSpans = memoryExporter.getFinishedSpans();
+          const last = instrumentationSpans.pop() as any;
+          assertSpans(instrumentationSpans, [
+            {
+              op: 'raw',
+              statement: 'select 1 as result',
+              parentSpan,
+            },
+          ]);
+
+          assert(last.name, 'parentSpan');
+        }
+      );
+    });
+
     it('should catch errors', async () => {
       const parentSpan = tracer.startSpan('parentSpan');
       const neverError = new Error('Query was expected to error');


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #3489.

Knex stores resolved connection details on `client.connectionSettings`, including after a function-based connection config has been called. The knex instrumentation was reading directly from `client.config.connection`, so connection factories left DB attributes such as `db.name`, `db.user`, and peer host/port undefined.

## Short description of the changes

- Prefer `client.connectionSettings` when building span attributes, with the existing config connection as a fallback.
- Add a regression test using an async connection factory to verify spans include the resolved SQLite database name.

## How has this been tested?

- `npm run version:update -w packages/instrumentation-knex`
- `npm run test -w packages/instrumentation-knex`
- `npm run compile -w packages/instrumentation-knex`
- `npx nx run @opentelemetry/instrumentation-knex:lint` (passes with existing warnings)
- `npx prettier --check packages/instrumentation-knex/src/instrumentation.ts packages/instrumentation-knex/test/index.test.ts`