### PR TITLE
feat(profiler-nodejs): add experimental Node.js profiling package

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -69,5 +69,6 @@
   "packages/propagator-ot-trace": "0.29.0",
   "packages/propagator-aws-xray": "2.2.0",
   "packages/propagator-aws-xray-lambda": "0.56.0",
-  "packages/instrumentation-browser-navigation": "0.8.0"
+  "packages/instrumentation-browser-navigation": "0.8.0",
+  "packages/profiler-nodejs": "0.1.0"
 }

--- a/examples/validation-demo/README.md
+++ b/examples/validation-demo/README.md
@@ -1,51 +1,54 @@
 # Validation Demo
 
-这个 demo 用来在当前仓库里快速验证 OpenTelemetry Trace 数据是否已经成功上报。
+This demo provides a quick way to verify that OpenTelemetry trace data can be
+generated and exported from this repository.
 
-默认 Trace 主地址是 `http://localhost:9529/otel`。
-实际 Trace 上报地址会自动拼成 `http://localhost:9529/otel/v1/traces`。
+The default trace base endpoint is `http://localhost:9529/otel`.
+The effective trace export endpoint becomes
+`http://localhost:9529/otel/v1/traces`.
 
-当前版本默认使用 OTLP HTTP/protobuf，更适合直接对接本机 DataKit。
+This demo uses OTLP HTTP/protobuf by default.
 
-## 安装
+## Install
 
 ```bash
 cd examples/validation-demo
 npm install
 ```
 
-## 方式一：直接对接你的接收端
+## Option 1: Send directly to your receiver
 
-如果你的接收端是本机 DataKit，直接运行：
+If your receiver is a local DataKit instance, run:
 
 ```bash
 npm run demo
 ```
 
-这个脚本会：
+The script will:
 
-- 启动一个本地 Express 服务
-- 自动发起一次自调用请求，生成 HTTP client/server span
-- 额外生成一个 `validation.business` 手工 span
-- 同时把 span 打到控制台，便于和接收端结果对照
+- start a local Express service
+- issue a self-request to generate HTTP client/server spans
+- create an additional manual `validation.business` span
+- print spans to the console for side-by-side comparison with receiver output
 
-## 方式二：用本地 receiver 验证请求是否发出
+## Option 2: Verify the outgoing request with a local receiver
 
-先启动本地接收端：
+Start the local receiver first:
 
 ```bash
 npm run receiver
 ```
 
-再执行 demo：
+Then run the demo:
 
 ```bash
 npm run demo
 ```
 
-你会在 receiver 终端看到收到的请求路径、`content-type`、字节长度和前几个字节的十六进制预览。
+The receiver terminal will show the request path, `content-type`, payload
+length, and a hex preview of the first bytes.
 
-## 可选环境变量
+## Optional environment variables
 
 ```bash
 OTEL_SERVICE_NAME=my-validation-demo npm run demo
@@ -55,12 +58,14 @@ DEMO_PORT=8099 npm run demo
 RECEIVER_PORT=9529 npm run receiver
 ```
 
-## 关于 DataKit 路径
+## DataKit path notes
 
-DataKit 的 OTLP Trace HTTP 接收路径应使用 `/otel/v1/traces`。
-如果你希望配置的是主地址而不是完整 signal 路径，请使用 `OTEL_EXPORTER_OTLP_ENDPOINT`，例如 `http://localhost:9529/otel`。
+DataKit's OTLP trace HTTP receiver path should use `/otel/v1/traces`.
+If you want to configure a base endpoint instead of the full signal path, use
+`OTEL_EXPORTER_OTLP_ENDPOINT`, for example `http://localhost:9529/otel`.
 
-如果你要改成其它完整 signal 地址，直接覆盖 `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`：
+To override the full signal endpoint directly, set
+`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`:
 
 ```bash
 OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:9529/otel/v1/traces npm run demo

--- a/examples/validation-demo/README.md
+++ b/examples/validation-demo/README.md
@@ -1,0 +1,67 @@
+# Validation Demo
+
+这个 demo 用来在当前仓库里快速验证 OpenTelemetry Trace 数据是否已经成功上报。
+
+默认 Trace 主地址是 `http://localhost:9529/otel`。
+实际 Trace 上报地址会自动拼成 `http://localhost:9529/otel/v1/traces`。
+
+当前版本默认使用 OTLP HTTP/protobuf，更适合直接对接本机 DataKit。
+
+## 安装
+
+```bash
+cd examples/validation-demo
+npm install
+```
+
+## 方式一：直接对接你的接收端
+
+如果你的接收端是本机 DataKit，直接运行：
+
+```bash
+npm run demo
+```
+
+这个脚本会：
+
+- 启动一个本地 Express 服务
+- 自动发起一次自调用请求，生成 HTTP client/server span
+- 额外生成一个 `validation.business` 手工 span
+- 同时把 span 打到控制台，便于和接收端结果对照
+
+## 方式二：用本地 receiver 验证请求是否发出
+
+先启动本地接收端：
+
+```bash
+npm run receiver
+```
+
+再执行 demo：
+
+```bash
+npm run demo
+```
+
+你会在 receiver 终端看到收到的请求路径、`content-type`、字节长度和前几个字节的十六进制预览。
+
+## 可选环境变量
+
+```bash
+OTEL_SERVICE_NAME=my-validation-demo npm run demo
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:9529/otel npm run demo
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:9529/otel/v1/traces npm run demo
+DEMO_PORT=8099 npm run demo
+RECEIVER_PORT=9529 npm run receiver
+```
+
+## 关于 DataKit 路径
+
+DataKit 的 OTLP Trace HTTP 接收路径应使用 `/otel/v1/traces`。
+如果你希望配置的是主地址而不是完整 signal 路径，请使用 `OTEL_EXPORTER_OTLP_ENDPOINT`，例如 `http://localhost:9529/otel`。
+
+如果你要改成其它完整 signal 地址，直接覆盖 `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`：
+
+```bash
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:9529/otel/v1/traces npm run demo
+```

--- a/examples/validation-demo/demo.js
+++ b/examples/validation-demo/demo.js
@@ -1,0 +1,182 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const { trace, SpanStatusCode } = require('@opentelemetry/api');
+const { registerInstrumentations } = require('@opentelemetry/instrumentation');
+const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-proto');
+const { resourceFromAttributes } = require('@opentelemetry/resources');
+const {
+  ConsoleSpanExporter,
+  SimpleSpanProcessor,
+} = require('@opentelemetry/sdk-trace-base');
+const { NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
+const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
+const { ExpressInstrumentation } = require('@opentelemetry/instrumentation-express');
+const { HttpInstrumentation } = require('@opentelemetry/instrumentation-http');
+
+const serviceName = process.env.OTEL_SERVICE_NAME || 'validation-demo';
+const otlpBaseEndpoint =
+  process.env.OTEL_EXPORTER_OTLP_ENDPOINT || 'http://localhost:9529/otel';
+const otlpTracesEndpoint =
+  process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT ||
+  appendPath(otlpBaseEndpoint, 'v1/traces');
+const port = Number(process.env.DEMO_PORT || 8089);
+
+const provider = new NodeTracerProvider({
+  resource: resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: serviceName,
+  }),
+  spanProcessors: [
+    new SimpleSpanProcessor(
+      new OTLPTraceExporter({
+        url: otlpTracesEndpoint,
+      })
+    ),
+    new SimpleSpanProcessor(new ConsoleSpanExporter()),
+  ],
+});
+
+provider.register();
+
+registerInstrumentations({
+  tracerProvider: provider,
+  instrumentations: [new HttpInstrumentation(), new ExpressInstrumentation()],
+});
+
+const tracer = trace.getTracer(serviceName);
+const express = require('express');
+const axios = require('axios').default;
+const app = express();
+
+app.get('/health', (_req, res) => {
+  res.json({ ok: true });
+});
+
+app.get('/work', async (req, res) => {
+  await tracer.startActiveSpan('validation.business', async span => {
+    try {
+      await sleep(120);
+      span.setAttribute('validation.user', String(req.query.user || 'demo'));
+      span.setAttribute('validation.mode', 'self-check');
+      span.setStatus({ code: SpanStatusCode.OK });
+
+      const context = span.spanContext();
+      res.json({
+        ok: true,
+        message: 'validation data generated',
+        traceId: context.traceId,
+        spanId: context.spanId,
+        exporterEndpoint: otlpTracesEndpoint,
+      });
+    } catch (error) {
+      span.recordException(error);
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: error.message,
+      });
+      res.status(500).json({
+        ok: false,
+        error: error.message,
+      });
+    } finally {
+      span.end();
+    }
+  });
+});
+
+async function main() {
+  const server = await listen(app, port);
+  console.log(`[demo] 服务已启动: http://127.0.0.1:${port}`);
+  console.log(`[demo] Trace 主地址: ${otlpBaseEndpoint}`);
+  console.log(`[demo] Trace 实际上报地址: ${otlpTracesEndpoint}`);
+
+  try {
+    await tracer.startActiveSpan('validation.run', async span => {
+      try {
+        const traceContext = span.spanContext();
+        console.log(
+          `[demo] 发起验证请求，根 span traceId=${traceContext.traceId}`
+        );
+
+        const response = await axios.get(`http://127.0.0.1:${port}/work`, {
+          params: {
+            user: 'otel-demo',
+          },
+        });
+
+        console.log('[demo] 服务响应:');
+        console.log(JSON.stringify(response.data, null, 2));
+        span.setAttribute('validation.response.status', response.status);
+        span.setStatus({ code: SpanStatusCode.OK });
+      } catch (error) {
+        span.recordException(error);
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: error.message,
+        });
+        throw error;
+      } finally {
+        span.end();
+      }
+    });
+  } finally {
+    await provider.forceFlush();
+    await closeServer(server);
+    await provider.shutdown();
+  }
+}
+
+main().catch(error => {
+  console.error('[demo] 执行失败:', error);
+  process.exitCode = 1;
+});
+
+function sleep(ms) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function listen(serverApp, serverPort) {
+  return new Promise((resolve, reject) => {
+    const server = serverApp.listen(serverPort, error => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(server);
+    });
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolve, reject) => {
+    server.close(error => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+function appendPath(baseUrl, path) {
+  const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+  return new URL(path, normalizedBase).toString();
+}

--- a/examples/validation-demo/demo.js
+++ b/examples/validation-demo/demo.js
@@ -101,16 +101,16 @@ app.get('/work', async (req, res) => {
 
 async function main() {
   const server = await listen(app, port);
-  console.log(`[demo] 服务已启动: http://127.0.0.1:${port}`);
-  console.log(`[demo] Trace 主地址: ${otlpBaseEndpoint}`);
-  console.log(`[demo] Trace 实际上报地址: ${otlpTracesEndpoint}`);
+  console.log(`[demo] service started: http://127.0.0.1:${port}`);
+  console.log(`[demo] trace base endpoint: ${otlpBaseEndpoint}`);
+  console.log(`[demo] effective trace export endpoint: ${otlpTracesEndpoint}`);
 
   try {
     await tracer.startActiveSpan('validation.run', async span => {
       try {
         const traceContext = span.spanContext();
         console.log(
-          `[demo] 发起验证请求，根 span traceId=${traceContext.traceId}`
+          `[demo] sending validation request, root span traceId=${traceContext.traceId}`
         );
 
         const response = await axios.get(`http://127.0.0.1:${port}/work`, {
@@ -119,7 +119,7 @@ async function main() {
           },
         });
 
-        console.log('[demo] 服务响应:');
+        console.log('[demo] service response:');
         console.log(JSON.stringify(response.data, null, 2));
         span.setAttribute('validation.response.status', response.status);
         span.setStatus({ code: SpanStatusCode.OK });
@@ -142,7 +142,7 @@ async function main() {
 }
 
 main().catch(error => {
-  console.error('[demo] 执行失败:', error);
+  console.error('[demo] demo failed:', error);
   process.exitCode = 1;
 });
 

--- a/examples/validation-demo/package-lock.json
+++ b/examples/validation-demo/package-lock.json
@@ -1,0 +1,1538 @@
+{
+  "name": "validation-demo",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "validation-demo",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "^0.207.0",
+        "@opentelemetry/instrumentation": "^0.207.0",
+        "@opentelemetry/instrumentation-express": "^0.56.0",
+        "@opentelemetry/instrumentation-http": "^0.207.0",
+        "@opentelemetry/resources": "^2.2.0",
+        "@opentelemetry/sdk-trace-base": "^2.2.0",
+        "@opentelemetry/sdk-trace-node": "^2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.37.0",
+        "axios": "^1.13.1",
+        "express": "^5.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/api-logs/-/api-logs-0.207.0.tgz",
+      "integrity": "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.1.tgz",
+      "integrity": "sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.207.0.tgz",
+      "integrity": "sha512-ruUQB4FkWtxHjNmSXjrhmJZFvyMm+tBzHyMm7YPQshApy4wvZUTcrpPyP/A/rCl/8M4BwoVIZdiwijMdbZaq4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-exporter-base": "0.207.0",
+        "@opentelemetry/otlp-transformer": "0.207.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/sdk-trace-base": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+      "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/instrumentation/-/instrumentation-0.207.0.tgz",
+      "integrity": "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.207.0",
+        "import-in-the-middle": "^2.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-express": {
+      "version": "0.56.0",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/instrumentation-express/-/instrumentation-express-0.56.0.tgz",
+      "integrity": "sha512-rMV0WUTtAGEhHrHl3uDRIO97EkNUp4ewrW2iRVuP7kaV5qRT2b1pPV5PE75oR3GyLLSTooSAzGWl6CTm8eftKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.207.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/instrumentation-http/-/instrumentation-http-0.207.0.tgz",
+      "integrity": "sha512-FC4i5hVixTzuhg4SV2ycTEAYx+0E2hm+GwbdoVPSA6kna0pPVI4etzaA9UkpJ9ussumQheFXP6rkGIaFJjMxsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/instrumentation": "0.207.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0",
+        "forwarded-parse": "2.1.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.207.0.tgz",
+      "integrity": "sha512-4RQluMVVGMrHok/3SVeSJ6EnRNkA2MINcX88sh+d/7DjGUrewW/WT88IsMEci0wUM+5ykTpPPNbEOoW+jwHnbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-transformer": "0.207.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/otlp-transformer/-/otlp-transformer-0.207.0.tgz",
+      "integrity": "sha512-+6DRZLqM02uTIY5GASMZWUwr52sLfNiEe20+OEaZKhztCs3+2LxoTjb6JxFRd9q1qNqckXKYlUKjbH/AhG8/ZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.207.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/sdk-logs": "0.207.0",
+        "@opentelemetry/sdk-metrics": "2.2.0",
+        "@opentelemetry/sdk-trace-base": "2.2.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+      "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/resources/-/resources-2.6.1.tgz",
+      "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.207.0",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/sdk-logs/-/sdk-logs-0.207.0.tgz",
+      "integrity": "sha512-4MEQmn04y+WFe6cyzdrXf58hZxilvY59lzZj2AccuHW/+BxLn/rGVN/Irsi/F0qfBOpMOrrCLKTExoSL2zoQmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.207.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
+      "integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
+      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.6.1.tgz",
+      "integrity": "sha512-Hh2i4FwHWRFhnO2Q/p6svMxy8MPsNCG0uuzUY3glqm0rwM0nQvbTO1dXSp9OqQoTKXcQzaz9q1f65fsurmOhNw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.6.1",
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/sdk-trace-base": "2.6.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmmirror.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.2",
+      "resolved": "https://registry.npmmirror.com/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmmirror.com/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmmirror.com/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmmirror.com/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmmirror.com/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmmirror.com/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmmirror.com/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmmirror.com/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmmirror.com/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmmirror.com/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmmirror.com/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmmirror.com/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmmirror.com/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmmirror.com/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmmirror.com/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmmirror.com/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmmirror.com/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmmirror.com/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/forwarded-parse": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmmirror.com/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+      "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
+      "license": "MIT"
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmmirror.com/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+      "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmmirror.com/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmmirror.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmmirror.com/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmmirror.com/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmmirror.com/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmmirror.com/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmmirror.com/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmmirror.com/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmmirror.com/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmmirror.com/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmmirror.com/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmmirror.com/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmmirror.com/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/examples/validation-demo/package.json
+++ b/examples/validation-demo/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "validation-demo",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Validation demo for sending OpenTelemetry traces to a custom OTLP HTTP endpoint",
+  "scripts": {
+    "demo": "node ./demo.js",
+    "receiver": "node ./receiver.js"
+  },
+  "engines": {
+    "node": "^18.19.0 || >=20.6.0"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.207.0",
+    "@opentelemetry/instrumentation": "^0.207.0",
+    "@opentelemetry/instrumentation-express": "^0.56.0",
+    "@opentelemetry/instrumentation-http": "^0.207.0",
+    "@opentelemetry/resources": "^2.2.0",
+    "@opentelemetry/sdk-trace-base": "^2.2.0",
+    "@opentelemetry/sdk-trace-node": "^2.2.0",
+    "@opentelemetry/semantic-conventions": "^1.37.0",
+    "axios": "^1.13.1",
+    "express": "^5.1.0"
+  }
+}

--- a/examples/validation-demo/receiver.js
+++ b/examples/validation-demo/receiver.js
@@ -45,16 +45,18 @@ const server = http.createServer((req, res) => {
   req.on('end', () => {
     const rawBody = Buffer.concat(chunks);
     const body = rawBody.toString('utf8');
-    console.log(`[receiver] 收到请求: ${req.method} ${requestPath}`);
+    console.log(`[receiver] received request: ${req.method} ${requestPath}`);
     console.log(`[receiver] content-type: ${req.headers['content-type'] || ''}`);
 
     try {
       const payload = JSON.parse(body);
       const summary = summarize(payload);
-      console.log('[receiver] payload 摘要:');
+      console.log('[receiver] payload summary:');
       console.log(JSON.stringify(summary, null, 2));
     } catch (_error) {
-      console.log('[receiver] 无法解析为 JSON，输出原始字节长度和前 48 字节十六进制');
+      console.log(
+        '[receiver] payload is not JSON, showing raw length and the first 48 bytes as hex'
+      );
       console.log(
         JSON.stringify(
           {
@@ -73,9 +75,9 @@ const server = http.createServer((req, res) => {
 });
 
 server.listen(port, () => {
-  console.log(`[receiver] 已监听 http://127.0.0.1:${port}${basePath}`);
+  console.log(`[receiver] listening on http://127.0.0.1:${port}${basePath}`);
   console.log(
-    `[receiver] 同时接受 http://127.0.0.1:${port}${normalizePath(
+    `[receiver] also accepting http://127.0.0.1:${port}${normalizePath(
       `${basePath}/v1/traces`
     )}`
   );

--- a/examples/validation-demo/receiver.js
+++ b/examples/validation-demo/receiver.js
@@ -1,0 +1,116 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const http = require('http');
+
+const port = Number(process.env.RECEIVER_PORT || 9529);
+const basePath = process.env.RECEIVER_PATH || '/otel';
+const acceptedPaths = new Set([
+  normalizePath(basePath),
+  normalizePath(`${basePath}/v1/traces`),
+]);
+
+const server = http.createServer((req, res) => {
+  const requestPath = normalizePath(req.url || '/');
+  if (req.method !== 'POST' || !acceptedPaths.has(requestPath)) {
+    res.writeHead(404, { 'content-type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        ok: false,
+        message: `unsupported route ${req.method} ${requestPath}`,
+      })
+    );
+    return;
+  }
+
+  const chunks = [];
+  req.on('data', chunk => {
+    chunks.push(chunk);
+  });
+  req.on('end', () => {
+    const rawBody = Buffer.concat(chunks);
+    const body = rawBody.toString('utf8');
+    console.log(`[receiver] 收到请求: ${req.method} ${requestPath}`);
+    console.log(`[receiver] content-type: ${req.headers['content-type'] || ''}`);
+
+    try {
+      const payload = JSON.parse(body);
+      const summary = summarize(payload);
+      console.log('[receiver] payload 摘要:');
+      console.log(JSON.stringify(summary, null, 2));
+    } catch (_error) {
+      console.log('[receiver] 无法解析为 JSON，输出原始字节长度和前 48 字节十六进制');
+      console.log(
+        JSON.stringify(
+          {
+            bodyLength: rawBody.length,
+            previewHex: rawBody.subarray(0, 48).toString('hex'),
+          },
+          null,
+          2
+        )
+      );
+    }
+
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+  });
+});
+
+server.listen(port, () => {
+  console.log(`[receiver] 已监听 http://127.0.0.1:${port}${basePath}`);
+  console.log(
+    `[receiver] 同时接受 http://127.0.0.1:${port}${normalizePath(
+      `${basePath}/v1/traces`
+    )}`
+  );
+});
+
+function normalizePath(pathname) {
+  const normalized = pathname.replace(/\/+$/, '');
+  return normalized || '/';
+}
+
+function summarize(payload) {
+  const services = new Set();
+  const spanNames = [];
+  let spanCount = 0;
+
+  for (const resourceSpan of payload.resourceSpans || []) {
+    const attributes = resourceSpan.resource?.attributes || [];
+    for (const attribute of attributes) {
+      if (attribute.key === 'service.name') {
+        services.add(attribute.value?.stringValue || '');
+      }
+    }
+
+    for (const scopeSpan of resourceSpan.scopeSpans || []) {
+      for (const span of scopeSpan.spans || []) {
+        spanCount += 1;
+        spanNames.push(span.name);
+      }
+    }
+  }
+
+  return {
+    resourceSpanCount: (payload.resourceSpans || []).length,
+    spanCount,
+    services: Array.from(services),
+    spanNames,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4290,6 +4290,30 @@
         "kuler": "^2.0.0"
       }
     },
+    "node_modules/@datadog/pprof": {
+      "version": "5.14.1",
+      "resolved": "https://registry.npmmirror.com/@datadog/pprof/-/pprof-5.14.1.tgz",
+      "integrity": "sha512-MlODCE9Gltmx7WChOg1BkIm7W2iE4CDW7K72BMwgzCvxFkG9rFWVsuA7/NEZL1nDvJ0qDe2du7DZZdZHTjcVPw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-gyp-build": "<4.0",
+        "pprof-format": "^2.2.1",
+        "source-map": "^0.7.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@datadog/pprof/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmmirror.com/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
@@ -9474,6 +9498,10 @@
     },
     "node_modules/@opentelemetry/plugin-react-load": {
       "resolved": "packages/plugin-react-load",
+      "link": true
+    },
+    "node_modules/@opentelemetry/profiler-nodejs": {
+      "resolved": "packages/profiler-nodejs",
       "link": true
     },
     "node_modules/@opentelemetry/propagation-utils": {
@@ -26629,6 +26657,17 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/node-gyp-build": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmmirror.com/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
+      "integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/node-gyp/node_modules/abbrev": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
@@ -29177,6 +29216,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/pprof-format": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmmirror.com/pprof-format/-/pprof-format-2.2.1.tgz",
+      "integrity": "sha512-p4tVN7iK19ccDqQv8heyobzUmbHyds4N2FI6aBMcXz6y99MglTWDxIyhFkNaLeEXs6IFUEzT0zya0icbSLLY0g==",
+      "license": "MIT"
     },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
@@ -37778,6 +37823,26 @@
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0",
         "react": "^16.13.1 || ^17.0.0"
+      }
+    },
+    "packages/profiler-nodejs": {
+      "name": "@opentelemetry/profiler-nodejs",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@datadog/pprof": "^5.14.1",
+        "@opentelemetry/resources": "^2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.37.0"
+      },
+      "devDependencies": {
+        "@opentelemetry/api": "^1.3.0",
+        "@types/node": "22.17.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "packages/propagation-utils": {

--- a/packages/profiler-nodejs/CHANGELOG.md
+++ b/packages/profiler-nodejs/CHANGELOG.md
@@ -1,0 +1,6 @@
+<!-- markdownlint-disable MD007 MD034 -->
+# Changelog
+
+## 0.1.0
+
+- Initial release.

--- a/packages/profiler-nodejs/LICENSE
+++ b/packages/profiler-nodejs/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/profiler-nodejs/README.md
+++ b/packages/profiler-nodejs/README.md
@@ -1,0 +1,80 @@
+# `@opentelemetry/profiler-nodejs`
+
+This package provides a practical Node.js profiling bridge for OpenTelemetry
+users. It is not an implementation of the OpenTelemetry Profiles signal.
+
+The package:
+
+- collects Node.js `wall` and `heap` profiles with `@datadog/pprof`
+- reshapes Node.js profiles into the legacy `ddtrace` file layout expected by Guance
+- maps OpenTelemetry resource attributes to profiling tags
+- exports `pprof` payloads to a profiling backend such as DataKit
+
+## Status
+
+This package is experimental.
+
+## Installation
+
+```sh
+npm install @opentelemetry/profiler-nodejs @datadog/pprof
+```
+
+See [USAGE.md](./USAGE.md) for a short module overview, configuration options,
+defaults, and a minimal setup example.
+
+## Usage
+
+```ts
+import { resourceFromAttributes } from '@opentelemetry/resources';
+import {
+  ATTR_SERVICE_NAME,
+  ATTR_SERVICE_VERSION,
+  SEMRESATTRS_DEPLOYMENT_ENVIRONMENT,
+} from '@opentelemetry/semantic-conventions';
+import {
+  DatakitProfilingExporter,
+  NodeProfiling,
+} from '@opentelemetry/profiler-nodejs';
+
+const profiler = new NodeProfiling({
+  resource: resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: 'orders-api',
+    [ATTR_SERVICE_VERSION]: '1.2.3',
+    [SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]: 'dev',
+  }),
+  exporter: new DatakitProfilingExporter({
+    endpoint: 'http://127.0.0.1:9529/profiling/v1/input',
+  }),
+  profileTypes: ['wall', 'heap'],
+  cpuProfilingEnabled: true,
+});
+
+await profiler.start();
+```
+
+## DataKit
+
+DataKit profiling input accepts multipart profile uploads on
+`/profiling/v1/input`.
+
+```ts
+new DatakitProfilingExporter({
+  endpoint: 'http://127.0.0.1:9529/profiling/v1/input',
+});
+```
+
+## Notes
+
+- This package currently focuses on `wall` and `heap` profiles because those
+  are the stable public capabilities exposed by `@datadog/pprof`.
+- The exporter currently emits `wall.pprof` and `space.pprof` so it matches
+  the legacy `ddtrace` Node.js profile layout consumed by Guance's parser.
+- `wall.pprof` contains `sample`, optional `cpu`, and `wall` sample types.
+- `space.pprof` contains `objects` and `space` sample types.
+- This layout is intentional: Guance's current `/home/liurui/code/pprofparser`
+  Node.js parser looks for `wall.pprof` and `space.pprof`, not a single
+  `auto.pprof`.
+- The package is intended as a bridge for practical profiling integration in
+  `opentelemetry-js-contrib`, not as a substitute for a future first-class
+  OpenTelemetry Profiles SDK in `opentelemetry-js`.

--- a/packages/profiler-nodejs/USAGE.md
+++ b/packages/profiler-nodejs/USAGE.md
@@ -1,0 +1,133 @@
+# Node.js Profiler Module
+
+`@opentelemetry/profiler-nodejs` is a practical profiling bridge for Node.js.
+It collects profiles with `@datadog/pprof`, maps OpenTelemetry resource data to
+profiling tags, and uploads profiles to a backend such as DataKit.
+
+This package is not an implementation of the OpenTelemetry Profiles signal. It
+is a compatibility-focused module for real profile delivery.
+
+## What It Exports
+
+The current exporter emits two `pprof` files:
+
+- `wall.pprof`
+- `space.pprof`
+
+This layout is intentional. Guance's current Node.js parser expects the legacy
+`ddtrace` layout rather than a single `auto.pprof` file.
+
+The sample types are:
+
+- `wall.pprof`: `sample/count`, optional `cpu/nanoseconds`, `wall/nanoseconds`
+- `space.pprof`: `objects/count`, `space/bytes`
+
+## Basic Usage
+
+```ts
+import { resourceFromAttributes } from '@opentelemetry/resources';
+import {
+  ATTR_SERVICE_NAME,
+  ATTR_SERVICE_VERSION,
+  SEMRESATTRS_DEPLOYMENT_ENVIRONMENT,
+} from '@opentelemetry/semantic-conventions';
+import {
+  DatakitProfilingExporter,
+  NodeProfiling,
+} from '@opentelemetry/profiler-nodejs';
+
+const profiler = new NodeProfiling({
+  resource: resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: 'orders-api',
+    [ATTR_SERVICE_VERSION]: '1.2.3',
+    [SEMRESATTRS_DEPLOYMENT_ENVIRONMENT]: 'prod',
+  }),
+  exporter: new DatakitProfilingExporter(),
+});
+
+await profiler.start();
+```
+
+## Exporter Options
+
+### `DatakitProfilingExporter`
+
+```ts
+new DatakitProfilingExporter({
+  endpoint: 'http://127.0.0.1:9529/profiling/v1/input',
+  timeoutMillis: 30000,
+  headers: {},
+  fetch: globalThis.fetch,
+});
+```
+
+Parameters:
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `endpoint` | `string` | `http://127.0.0.1:9529/profiling/v1/input` | Profile upload endpoint. |
+| `timeoutMillis` | `number` | `30000` | HTTP timeout for one upload request. |
+| `headers` | `Record<string, string>` | `{}` | Extra request headers. |
+| `fetch` | `typeof fetch` | `globalThis.fetch` | Custom fetch implementation. |
+
+## Profiler Options
+
+### `NodeProfiling`
+
+```ts
+new NodeProfiling({
+  exporter,
+  resource,
+  tags,
+  serviceName,
+  serviceVersion,
+  deploymentEnvironment,
+  hostName,
+  profileTypes,
+  intervalMillis,
+  wallDurationMillis,
+  heapSamplingIntervalBytes,
+  cpuProfilingEnabled,
+});
+```
+
+Parameters:
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `exporter` | `ProfileExporter` | required | Exporter used to send collected profiles. |
+| `resource` | `Resource` | unset | OpenTelemetry resource used to derive tags such as service name and version. |
+| `tags` | `Record<string, string \| number \| boolean>` | unset | Extra profiling tags appended to the exported event. |
+| `serviceName` | `string` | derived from `resource` | Overrides the service name tag. |
+| `serviceVersion` | `string` | derived from `resource` | Overrides the service version tag. |
+| `deploymentEnvironment` | `string` | derived from `resource` | Overrides the environment tag. |
+| `hostName` | `string` | derived from OS hostname | Overrides the host tag. |
+| `profileTypes` | `('wall' \| 'heap')[]` | `['wall', 'heap']` | Profile types collected on each cycle. |
+| `intervalMillis` | `number` | `60000` | Interval between collection cycles. |
+| `wallDurationMillis` | `number` | `10000` | Duration of one wall profile capture. |
+| `heapSamplingIntervalBytes` | `number` | `524288` | Heap sampling interval passed to `@datadog/pprof`. |
+| `cpuProfilingEnabled` | `boolean` | `true` | Enables CPU time data inside `wall.pprof`. |
+| `collectCpuTime` | `boolean` | deprecated | Deprecated alias of `cpuProfilingEnabled`. |
+
+## Default Behavior
+
+By default, the profiler:
+
+- collects both `wall` and `heap` profiles
+- runs one collection cycle every 60 seconds
+- records a 10 second wall profile
+- enables CPU time inside the wall profile
+- uploads to `http://127.0.0.1:9529/profiling/v1/input`
+
+## Lifecycle
+
+- `await profiler.start()`: starts the periodic collection loop
+- `await profiler.collectOnce()`: collects and exports one batch immediately
+- `await profiler.shutdown()`: stops the loop, flushes any in-flight work, and shuts down the exporter
+
+## Notes
+
+- Heap profiling is started lazily and reused between collection cycles.
+- If `profileTypes` is empty, the module skips export.
+- The exporter sends multipart form data with `wall`, `space`, and `event`.
+- The event payload uses `profiler: "ddtrace"` for parser compatibility.

--- a/packages/profiler-nodejs/package.json
+++ b/packages/profiler-nodejs/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@opentelemetry/profiler-nodejs",
+  "version": "0.1.0",
+  "description": "Node.js profiling bridge for OpenTelemetry resource metadata and pprof export",
+  "main": "build/src/index.js",
+  "types": "build/src/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-telemetry/opentelemetry-js-contrib.git",
+    "directory": "packages/profiler-nodejs"
+  },
+  "scripts": {
+    "clean": "rimraf build/*",
+    "compile": "tsc -p .",
+    "compile:with-dependencies": "nx run-many -t compile -p @opentelemetry/profiler-nodejs",
+    "prepublishOnly": "npm run compile",
+    "test": "nyc --no-clean mocha --require ts-node/register/transpile-only 'test/**/*.test.js'",
+    "version:update": "node ../../scripts/version-update.js",
+    "watch": "tsc -w"
+  },
+  "keywords": [
+    "opentelemetry",
+    "profiling",
+    "nodejs",
+    "pprof",
+    "datakit"
+  ],
+  "author": "OpenTelemetry Authors",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": "^18.19.0 || >=20.6.0"
+  },
+  "files": [
+    "build/src/**/*.js",
+    "build/src/**/*.js.map",
+    "build/src/**/*.d.ts"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.3.0"
+  },
+  "devDependencies": {
+    "@opentelemetry/api": "^1.3.0",
+    "@types/node": "22.17.1"
+  },
+  "dependencies": {
+    "@datadog/pprof": "^5.14.1",
+    "@opentelemetry/resources": "^2.2.0",
+    "@opentelemetry/semantic-conventions": "^1.37.0",
+    "pprof-format": "^1.0.0"
+  },
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/profiler-nodejs#readme"
+}

--- a/packages/profiler-nodejs/src/exporter.ts
+++ b/packages/profiler-nodejs/src/exporter.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { diag } from '@opentelemetry/api';
+
+import type {
+  DatakitProfilingExporterOptions,
+  ProfileBatch,
+  ProfileExporter,
+} from './types';
+
+const DEFAULT_ENDPOINT = 'http://127.0.0.1:9529/profiling/v1/input';
+const DEFAULT_TIMEOUT_MILLIS = 30_000;
+
+export class DatakitProfilingExporter implements ProfileExporter {
+  private readonly endpoint: string;
+  private readonly timeoutMillis: number;
+  private readonly headers: Record<string, string>;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: DatakitProfilingExporterOptions = {}) {
+    this.endpoint = options.endpoint ?? DEFAULT_ENDPOINT;
+    this.timeoutMillis = options.timeoutMillis ?? DEFAULT_TIMEOUT_MILLIS;
+    this.headers = options.headers ?? {};
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+
+    if (typeof this.fetchImpl !== 'function') {
+      throw new Error('global fetch is not available');
+    }
+  }
+
+  async export(batch: ProfileBatch): Promise<void> {
+    const form = new FormData();
+
+    for (const profile of batch.profiles) {
+      form.append(
+        profile.type,
+        new Blob([new Uint8Array(profile.data)], {
+          type: 'application/octet-stream',
+        }),
+        profile.filename
+      );
+    }
+
+    form.append(
+      'event',
+      new Blob([JSON.stringify(this.serializeEvent(batch))], {
+        type: 'application/json',
+      }),
+      'event.json'
+    );
+
+    const response = await this.fetchImpl(this.endpoint, {
+      method: 'POST',
+      body: form,
+      headers: this.headers,
+      signal: AbortSignal.timeout(this.timeoutMillis),
+    });
+
+    if (!response.ok) {
+      const body = await safeReadBody(response);
+      throw new Error(
+        `datakit profiling export failed: ${response.status} ${response.statusText}${body}`
+      );
+    }
+
+    diag.debug(
+      `Datakit profiling export succeeded for ${batch.profiles.length} profile(s)`
+    );
+  }
+
+  async shutdown(): Promise<void> {}
+
+  private serializeEvent(batch: ProfileBatch) {
+    return {
+      version: '4',
+      profiler: 'ddtrace',
+      attachments: batch.profiles.map(profile => profile.filename),
+      start: formatDatakitTimestamp(batch.startTime),
+      end: formatDatakitTimestamp(batch.endTime),
+      family: batch.family,
+      format: batch.format,
+      tags_profiler: joinTags(batch.tags),
+    };
+  }
+}
+
+async function safeReadBody(response: Response): Promise<string> {
+  try {
+    const text = await response.text();
+    if (text === '') {
+      return '';
+    }
+    return ` - ${text.slice(0, 300)}`;
+  } catch {
+    return '';
+  }
+}
+
+function joinTags(tags: Record<string, string>): string {
+  return Object.entries(tags)
+    .filter(([, value]) => value !== '')
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}:${value}`)
+    .join(',');
+}
+
+function formatDatakitTimestamp(date: Date): string {
+  return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}

--- a/packages/profiler-nodejs/src/index.ts
+++ b/packages/profiler-nodejs/src/index.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { DatakitProfilingExporter } from './exporter';
+export { NodeProfiling } from './profiler';
+export type {
+  CollectedProfile,
+  DatakitProfilingExporterOptions,
+  NodeProfileType,
+  NodeProfilingOptions,
+  ProfileBatch,
+  ProfileExporter,
+} from './types';

--- a/packages/profiler-nodejs/src/pprof.ts
+++ b/packages/profiler-nodejs/src/pprof.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gzipSync } from 'node:zlib';
+
+import type { Profile, StringTable } from 'pprof-format';
+
+import type { CollectedProfile, NodeProfileType } from './types';
+
+type SourceProfile = {
+  type: NodeProfileType;
+  profile: Profile;
+};
+
+type ExportDefinition = {
+  filename: string;
+  profileType: NodeProfileType;
+  sampleTypes: Array<{ sourceType: string; sourceUnit: string }>;
+};
+
+const EXPORT_DEFINITIONS: ExportDefinition[] = [
+  {
+    filename: 'wall.pprof',
+    profileType: 'wall',
+    sampleTypes: [
+      { sourceType: 'sample', sourceUnit: 'count' },
+      { sourceType: 'cpu', sourceUnit: 'nanoseconds' },
+      { sourceType: 'wall', sourceUnit: 'nanoseconds' },
+    ],
+  },
+  {
+    filename: 'space.pprof',
+    profileType: 'heap',
+    sampleTypes: [
+      { sourceType: 'objects', sourceUnit: 'count' },
+      { sourceType: 'space', sourceUnit: 'bytes' },
+    ],
+  },
+];
+
+export function buildDatakitCompatibleNodeProfiles(
+  profiles: SourceProfile[]
+): CollectedProfile[] {
+  const byType = new Map<NodeProfileType, Profile>();
+  for (const source of profiles) {
+    byType.set(source.type, source.profile);
+  }
+
+  const exported: CollectedProfile[] = [];
+  for (const definition of EXPORT_DEFINITIONS) {
+    const profile = byType.get(definition.profileType);
+    if (profile === undefined) {
+      continue;
+    }
+    exported.push(buildFilteredProfile(profile, definition));
+  }
+
+  if (exported.length === 0) {
+    throw new Error('no compatible Node.js profiles were produced');
+  }
+
+  return exported;
+}
+
+function buildFilteredProfile(
+  profile: Profile,
+  definition: ExportDefinition
+): CollectedProfile {
+  const strings = getStringEntries(profile.stringTable);
+  const sampleTypeIndices = definition.sampleTypes
+    .map(sampleType => findSampleTypeIndex(profile, strings, sampleType))
+    .filter((idx): idx is number => idx !== -1);
+
+  if (sampleTypeIndices.length === 0) {
+    throw new Error(`profile ${definition.profileType} did not contain expected sample types`);
+  }
+
+  const originalSampleType = profile.sampleType;
+  const originalSampleValues = profile.sample.map(sample => sample.value);
+  const originalDefaultSampleType = profile.defaultSampleType;
+
+  try {
+    profile.sampleType = sampleTypeIndices.map(idx => originalSampleType[idx]);
+    for (const sample of profile.sample) {
+      sample.value = sampleTypeIndices.map(idx => sample.value[idx] ?? 0);
+    }
+
+    if (profile.sampleType.length > 0) {
+      profile.defaultSampleType = profile.sampleType[0].type;
+    }
+
+    return {
+      type: definition.filename.replace(/\.pprof$/, ''),
+      filename: definition.filename,
+      data: Buffer.from(gzipSync(profile.encode())),
+    };
+  } finally {
+    profile.sampleType = originalSampleType;
+    for (let idx = 0; idx < profile.sample.length; idx++) {
+      profile.sample[idx].value = originalSampleValues[idx];
+    }
+    profile.defaultSampleType = originalDefaultSampleType;
+  }
+}
+
+function findSampleTypeIndex(
+  profile: Profile,
+  strings: string[],
+  sampleType: { sourceType: string; sourceUnit: string }
+): number {
+  return profile.sampleType.findIndex(
+    valueType =>
+      strings[Number(valueType.type)] === sampleType.sourceType &&
+      strings[Number(valueType.unit)] === sampleType.sourceUnit
+  );
+}
+
+function getStringEntries(table: StringTable): string[] {
+  const withStrings = table as StringTable & { strings?: string[] };
+  if (Array.isArray(withStrings.strings)) {
+    return withStrings.strings;
+  }
+  return table as unknown as string[];
+}

--- a/packages/profiler-nodejs/src/profiler.ts
+++ b/packages/profiler-nodejs/src/profiler.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { diag } from '@opentelemetry/api';
+import { heap, time } from '@datadog/pprof';
+import type { Profile } from 'pprof-format';
+
+import { buildDatakitCompatibleNodeProfiles } from './pprof';
+import { buildProfilerTags } from './resource';
+import type {
+  CollectedProfile,
+  NodeProfileType,
+  NodeProfilingOptions,
+  ProfileBatch,
+  ProfileExporter,
+} from './types';
+
+const DEFAULT_INTERVAL_MILLIS = 60_000;
+const DEFAULT_WALL_DURATION_MILLIS = 10_000;
+const DEFAULT_HEAP_SAMPLING_INTERVAL_BYTES = 512 * 1024;
+const DEFAULT_PROFILE_TYPES: NodeProfileType[] = ['wall', 'heap'];
+const STACK_DEPTH = 64;
+
+export class NodeProfiling {
+  private readonly exporter: ProfileExporter;
+  private readonly tags: Record<string, string>;
+  private readonly profileTypes: NodeProfileType[];
+  private readonly intervalMillis: number;
+  private readonly wallDurationMillis: number;
+  private readonly heapSamplingIntervalBytes: number;
+  private readonly collectCpuTime: boolean;
+
+  private timer?: NodeJS.Timeout;
+  private collecting?: Promise<void>;
+  private heapStarted = false;
+
+  constructor(options: NodeProfilingOptions) {
+    this.exporter = options.exporter;
+    this.tags = buildProfilerTags(options);
+    this.profileTypes = options.profileTypes ?? DEFAULT_PROFILE_TYPES;
+    this.intervalMillis = options.intervalMillis ?? DEFAULT_INTERVAL_MILLIS;
+    this.wallDurationMillis =
+      options.wallDurationMillis ?? DEFAULT_WALL_DURATION_MILLIS;
+    this.heapSamplingIntervalBytes =
+      options.heapSamplingIntervalBytes ?? DEFAULT_HEAP_SAMPLING_INTERVAL_BYTES;
+    this.collectCpuTime =
+      options.cpuProfilingEnabled ?? options.collectCpuTime ?? true;
+  }
+
+  async start(): Promise<void> {
+    if (this.timer !== undefined) {
+      return;
+    }
+
+    this.ensureHeapProfiler();
+    this.timer = setInterval(() => {
+      if (this.collecting === undefined) {
+        this.collecting = this.collectOnce()
+          .catch(error => {
+            diag.error('Node profiling collection failed', error);
+          })
+          .finally(() => {
+            this.collecting = undefined;
+          });
+      }
+    }, this.intervalMillis);
+    this.timer.unref?.();
+  }
+
+  async collectOnce(): Promise<void> {
+    this.ensureHeapProfiler();
+
+    const startTime = new Date();
+    const rawProfiles: Array<{ type: NodeProfileType; profile: Profile }> = [];
+
+    if (this.profileTypes.includes('wall')) {
+      const wallProfile = await time.profile({
+        durationMillis: Math.min(this.wallDurationMillis, this.intervalMillis),
+        collectCpuTime: this.collectCpuTime,
+        useCPED: this.collectCpuTime,
+        withContexts: this.collectCpuTime,
+      });
+      rawProfiles.push({ type: 'wall', profile: wallProfile });
+    }
+
+    if (this.profileTypes.includes('heap')) {
+      rawProfiles.push({ type: 'heap', profile: heap.profile() });
+    }
+
+    const endTime = new Date();
+    if (rawProfiles.length === 0) {
+      diag.debug('No profile types were enabled, skipping export');
+      return;
+    }
+
+    const profiles: CollectedProfile[] =
+      buildDatakitCompatibleNodeProfiles(rawProfiles);
+
+    const batch: ProfileBatch = {
+      startTime,
+      endTime,
+      family: 'nodejs',
+      format: 'pprof',
+      tags: this.tags,
+      profiles,
+    };
+
+    await this.exporter.export(batch);
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.timer !== undefined) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+
+    await this.collecting;
+
+    if (this.heapStarted) {
+      heap.stop();
+      this.heapStarted = false;
+    }
+
+    await this.exporter.shutdown?.();
+  }
+
+  private ensureHeapProfiler(): void {
+    if (!this.profileTypes.includes('heap') || this.heapStarted) {
+      return;
+    }
+
+    heap.start(this.heapSamplingIntervalBytes, STACK_DEPTH);
+    this.heapStarted = true;
+  }
+}

--- a/packages/profiler-nodejs/src/resource.ts
+++ b/packages/profiler-nodejs/src/resource.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as os from 'os';
+import { randomUUID } from 'crypto';
+
+import {
+  ATTR_SERVICE_NAME,
+  ATTR_SERVICE_VERSION,
+  SEMRESATTRS_DEPLOYMENT_ENVIRONMENT,
+  SEMRESATTRS_HOST_NAME,
+} from '@opentelemetry/semantic-conventions';
+
+import type { NodeProfilingOptions } from './types';
+
+const DEFAULT_SERVICE_NAME = 'unknown_service:node';
+const PROFILER_VERSION = '0.1.0';
+const RUNTIME_ID = randomUUID().replace(/-/g, '');
+
+export function buildProfilerTags(
+  options: Pick<
+    NodeProfilingOptions,
+    | 'resource'
+    | 'tags'
+    | 'serviceName'
+    | 'serviceVersion'
+    | 'deploymentEnvironment'
+    | 'hostName'
+  >
+): Record<string, string> {
+  const resourceAttributes = options.resource?.attributes ?? {};
+  const tags: Record<string, string> = {
+    language: 'nodejs',
+    runtime: 'Node.js',
+    runtime_version: process.version,
+    process_id: String(process.pid),
+    'runtime-id': RUNTIME_ID,
+    profiler_version: PROFILER_VERSION,
+    host:
+      firstNonEmpty(
+        options.hostName,
+        attributeString(resourceAttributes[SEMRESATTRS_HOST_NAME]),
+        os.hostname()
+      ) ?? os.hostname(),
+    service:
+      firstNonEmpty(
+        options.serviceName,
+        attributeString(resourceAttributes[ATTR_SERVICE_NAME]),
+        process.env.OTEL_SERVICE_NAME,
+        DEFAULT_SERVICE_NAME
+      ) ?? DEFAULT_SERVICE_NAME,
+  };
+
+  const version = firstNonEmpty(
+    options.serviceVersion,
+    attributeString(resourceAttributes[ATTR_SERVICE_VERSION])
+  );
+  if (version !== undefined) {
+    tags.version = version;
+  }
+
+  const env = firstNonEmpty(
+    options.deploymentEnvironment,
+    attributeString(resourceAttributes[SEMRESATTRS_DEPLOYMENT_ENVIRONMENT])
+  );
+  if (env !== undefined) {
+    tags.env = env;
+  }
+
+  for (const [key, value] of Object.entries(options.tags ?? {})) {
+    tags[key] = String(value);
+  }
+
+  return tags;
+}
+
+function attributeString(value: unknown): string | undefined {
+  if (typeof value === 'string' && value !== '') {
+    return value;
+  }
+  return undefined;
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    if (value !== undefined && value !== '') {
+      return value;
+    }
+  }
+  return undefined;
+}

--- a/packages/profiler-nodejs/src/types.ts
+++ b/packages/profiler-nodejs/src/types.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Resource } from '@opentelemetry/resources';
+
+export type NodeProfileType = 'wall' | 'heap';
+
+export interface CollectedProfile {
+  type: string;
+  filename: string;
+  data: Buffer;
+}
+
+export interface ProfileBatch {
+  startTime: Date;
+  endTime: Date;
+  family: 'nodejs';
+  format: 'pprof';
+  tags: Record<string, string>;
+  profiles: CollectedProfile[];
+}
+
+export interface ProfileExporter {
+  export(batch: ProfileBatch): Promise<void>;
+  shutdown?(): Promise<void>;
+}
+
+export interface DatakitProfilingExporterOptions {
+  endpoint?: string;
+  timeoutMillis?: number;
+  headers?: Record<string, string>;
+  fetch?: typeof fetch;
+}
+
+export interface NodeProfilingOptions {
+  exporter: ProfileExporter;
+  resource?: Resource;
+  tags?: Record<string, string | number | boolean>;
+  serviceName?: string;
+  serviceVersion?: string;
+  deploymentEnvironment?: string;
+  hostName?: string;
+  profileTypes?: NodeProfileType[];
+  intervalMillis?: number;
+  wallDurationMillis?: number;
+  heapSamplingIntervalBytes?: number;
+  /**
+   * Enables CPU time collection inside the wall profile.
+   *
+   * This follows the Node.js profiling model used by Datadog's profiler where
+   * `cpu-time` is emitted as a sample type in the wall profile.
+   */
+  cpuProfilingEnabled?: boolean;
+  /**
+   * @deprecated Use `cpuProfilingEnabled` instead.
+   */
+  collectCpuTime?: boolean;
+}

--- a/packages/profiler-nodejs/test/exporter.test.js
+++ b/packages/profiler-nodejs/test/exporter.test.js
@@ -19,7 +19,7 @@ const assert = require('node:assert/strict');
 const { DatakitProfilingExporter } = require('../src/exporter');
 
 describe('DatakitProfilingExporter', () => {
-  it('会按 ddtrace Node.js 兼容布局发送 multipart 请求', async () => {
+  it('sends a multipart request using the ddtrace-compatible Node.js layout', async () => {
     let captured;
     const exporter = new DatakitProfilingExporter({
       endpoint: 'http://127.0.0.1:9529/profiling/v1/input',
@@ -77,7 +77,7 @@ describe('DatakitProfilingExporter', () => {
     });
   });
 
-  it('非 2xx 响应时会抛出错误', async () => {
+  it('throws when the backend responds with a non-2xx status', async () => {
     const exporter = new DatakitProfilingExporter({
       fetch: async () => new Response('bad request', { status: 400 }),
     });

--- a/packages/profiler-nodejs/test/exporter.test.js
+++ b/packages/profiler-nodejs/test/exporter.test.js
@@ -1,0 +1,103 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const assert = require('node:assert/strict');
+
+const { DatakitProfilingExporter } = require('../src/exporter');
+
+describe('DatakitProfilingExporter', () => {
+  it('会按 ddtrace Node.js 兼容布局发送 multipart 请求', async () => {
+    let captured;
+    const exporter = new DatakitProfilingExporter({
+      endpoint: 'http://127.0.0.1:9529/profiling/v1/input',
+      fetch: async (url, init) => {
+        captured = { url, init };
+        return new Response('', { status: 200 });
+      },
+    });
+
+    await exporter.export({
+      startTime: new Date('2026-04-13T07:40:02.123Z'),
+      endTime: new Date('2026-04-13T07:40:04.456Z'),
+      family: 'nodejs',
+      format: 'pprof',
+      tags: {
+        service: 'svc-js',
+        env: 'dev',
+        version: '1.2.3',
+        runtime: 'Node.js',
+      },
+      profiles: [
+        {
+          type: 'wall',
+          filename: 'wall.pprof',
+          data: Buffer.from([1, 2, 3]),
+        },
+        {
+          type: 'space',
+          filename: 'space.pprof',
+          data: Buffer.from([4, 5, 6]),
+        },
+      ],
+    });
+
+    assert.equal(captured.url, 'http://127.0.0.1:9529/profiling/v1/input');
+    assert.equal(captured.init.method, 'POST');
+
+    const req = new Request(captured.url, captured.init);
+    const form = await req.formData();
+
+    assert.equal(form.get('wall').name, 'wall.pprof');
+    assert.equal(form.get('space').name, 'space.pprof');
+
+    const event = JSON.parse(await form.get('event').text());
+    assert.deepEqual(event, {
+      version: '4',
+      profiler: 'ddtrace',
+      attachments: ['wall.pprof', 'space.pprof'],
+      start: '2026-04-13T07:40:02Z',
+      end: '2026-04-13T07:40:04Z',
+      family: 'nodejs',
+      format: 'pprof',
+      tags_profiler:
+        'env:dev,runtime:Node.js,service:svc-js,version:1.2.3',
+    });
+  });
+
+  it('非 2xx 响应时会抛出错误', async () => {
+    const exporter = new DatakitProfilingExporter({
+      fetch: async () => new Response('bad request', { status: 400 }),
+    });
+
+    await assert.rejects(
+      exporter.export({
+        startTime: new Date('2026-04-13T07:40:02.123Z'),
+        endTime: new Date('2026-04-13T07:40:04.456Z'),
+        family: 'nodejs',
+        format: 'pprof',
+        tags: {},
+        profiles: [
+          {
+            type: 'wall',
+            filename: 'wall.pprof',
+            data: Buffer.from([1]),
+          },
+        ],
+      }),
+      /datakit profiling export failed: 400/
+    );
+  });
+});

--- a/packages/profiler-nodejs/test/profiler.test.js
+++ b/packages/profiler-nodejs/test/profiler.test.js
@@ -107,7 +107,7 @@ describe('NodeProfiling', () => {
     return exportedBatches[0];
   }
 
-  it('默认会在 wall profile 中启用 cpu time 采集', async () => {
+  it('enables CPU time collection for wall profiles by default', async () => {
     const batch = await collectWith();
     const decoded = batch.profiles.map(profile => [
       profile.filename,
@@ -136,7 +136,7 @@ describe('NodeProfiling', () => {
     ]);
   });
 
-  it('cpuProfilingEnabled=false 时会关闭 cpu time 采集', async () => {
+  it('disables CPU time collection when cpuProfilingEnabled=false', async () => {
     const batch = await collectWith({
       cpuProfilingEnabled: false,
     });
@@ -157,7 +157,7 @@ describe('NodeProfiling', () => {
     ]);
   });
 
-  it('仍兼容已废弃的 collectCpuTime 配置', async () => {
+  it('remains compatible with the deprecated collectCpuTime option', async () => {
     await collectWith({
       collectCpuTime: false,
     });
@@ -170,7 +170,7 @@ describe('NodeProfiling', () => {
     });
   });
 
-  it('cpuProfilingEnabled 的优先级高于 collectCpuTime', async () => {
+  it('gives cpuProfilingEnabled precedence over collectCpuTime', async () => {
     await collectWith({
       cpuProfilingEnabled: true,
       collectCpuTime: false,

--- a/packages/profiler-nodejs/test/profiler.test.js
+++ b/packages/profiler-nodejs/test/profiler.test.js
@@ -1,0 +1,251 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const assert = require('node:assert/strict');
+const { gunzipSync } = require('node:zlib');
+const pprof = require('@datadog/pprof');
+const {
+  Function: PprofFunction,
+  Line,
+  Location,
+  Mapping,
+  Profile,
+  Sample,
+  StringTable,
+  ValueType,
+} = require('pprof-format');
+
+describe('NodeProfiling', () => {
+  let exporter;
+  let exportedBatches;
+  let originals;
+  let timeProfileCalls;
+
+  beforeEach(() => {
+    exportedBatches = [];
+    timeProfileCalls = [];
+    exporter = {
+      export: async batch => {
+        exportedBatches.push(batch);
+      },
+    };
+
+    originals = {
+      heapProfile: pprof.heap.profile,
+      heapStart: pprof.heap.start,
+      heapStop: pprof.heap.stop,
+      timeProfile: pprof.time.profile,
+    };
+
+    pprof.time.profile = async options => {
+      timeProfileCalls.push(options);
+      return makeProfile({
+        sampleTypes: options.collectCpuTime
+          ? [
+              ['sample', 'count', 3],
+              ['wall', 'nanoseconds', 30],
+              ['cpu', 'nanoseconds', 20],
+            ]
+          : [
+              ['sample', 'count', 3],
+              ['wall', 'nanoseconds', 30],
+            ],
+      });
+    };
+    pprof.heap.start = () => {};
+    pprof.heap.profile = () =>
+      makeProfile({
+        sampleTypes: [
+          ['objects', 'count', 7],
+          ['space', 'bytes', 70],
+        ],
+      });
+    pprof.heap.stop = () => {};
+  });
+
+  afterEach(() => {
+    pprof.heap.profile = originals.heapProfile;
+    pprof.heap.start = originals.heapStart;
+    pprof.heap.stop = originals.heapStop;
+    pprof.time.profile = originals.timeProfile;
+  });
+
+  function loadNodeProfiling() {
+    const profilerModulePath = require.resolve('../src/profiler');
+    delete require.cache[profilerModulePath];
+    return require('../src/profiler').NodeProfiling;
+  }
+
+  async function collectWith(options = {}) {
+    const NodeProfiling = loadNodeProfiling();
+    const profiler = new NodeProfiling({
+      exporter,
+      intervalMillis: 10_000,
+      wallDurationMillis: 1_000,
+      profileTypes: ['wall', 'heap'],
+      ...options,
+    });
+
+    await profiler.collectOnce();
+
+    assert.equal(timeProfileCalls.length, 1);
+    assert.equal(exportedBatches.length, 1);
+
+    return exportedBatches[0];
+  }
+
+  it('默认会在 wall profile 中启用 cpu time 采集', async () => {
+    const batch = await collectWith();
+    const decoded = batch.profiles.map(profile => [
+      profile.filename,
+      readSampleTypes(decodeProfile(profile.data)),
+    ]);
+
+    assert.deepEqual(timeProfileCalls[0], {
+      durationMillis: 1_000,
+      collectCpuTime: true,
+      useCPED: true,
+      withContexts: true,
+    });
+    assert.deepEqual(
+      batch.profiles.map(profile => [profile.type, profile.filename]),
+      [
+        ['wall', 'wall.pprof'],
+        ['space', 'space.pprof'],
+      ]
+    );
+    assert.deepEqual(decoded, [
+      [
+        'wall.pprof',
+        ['sample/count', 'cpu/nanoseconds', 'wall/nanoseconds'],
+      ],
+      ['space.pprof', ['objects/count', 'space/bytes']],
+    ]);
+  });
+
+  it('cpuProfilingEnabled=false 时会关闭 cpu time 采集', async () => {
+    const batch = await collectWith({
+      cpuProfilingEnabled: false,
+    });
+    const decoded = batch.profiles.map(profile => [
+      profile.filename,
+      readSampleTypes(decodeProfile(profile.data)),
+    ]);
+
+    assert.deepEqual(timeProfileCalls[0], {
+      durationMillis: 1_000,
+      collectCpuTime: false,
+      useCPED: false,
+      withContexts: false,
+    });
+    assert.deepEqual(decoded, [
+      ['wall.pprof', ['sample/count', 'wall/nanoseconds']],
+      ['space.pprof', ['objects/count', 'space/bytes']],
+    ]);
+  });
+
+  it('仍兼容已废弃的 collectCpuTime 配置', async () => {
+    await collectWith({
+      collectCpuTime: false,
+    });
+
+    assert.deepEqual(timeProfileCalls[0], {
+      durationMillis: 1_000,
+      collectCpuTime: false,
+      useCPED: false,
+      withContexts: false,
+    });
+  });
+
+  it('cpuProfilingEnabled 的优先级高于 collectCpuTime', async () => {
+    await collectWith({
+      cpuProfilingEnabled: true,
+      collectCpuTime: false,
+    });
+
+    assert.deepEqual(timeProfileCalls[0], {
+      durationMillis: 1_000,
+      collectCpuTime: true,
+      useCPED: true,
+      withContexts: true,
+    });
+  });
+});
+
+function makeProfile({ sampleTypes }) {
+  const strings = new StringTable();
+  const fn = new PprofFunction({
+    id: 1,
+    name: strings.dedup('handler'),
+    systemName: strings.dedup('handler'),
+    filename: strings.dedup('app.js'),
+    startLine: 1,
+  });
+  const mapping = new Mapping({
+    id: 1,
+    hasFunctions: true,
+    hasFilenames: true,
+    hasLineNumbers: true,
+    hasInlineFrames: true,
+  });
+  const location = new Location({
+    id: 1,
+    mappingId: 1,
+    address: 1,
+    line: [
+      new Line({
+        functionId: 1,
+        line: 1,
+      }),
+    ],
+  });
+
+  return new Profile({
+    sampleType: sampleTypes.map(
+      ([type, unit]) =>
+        new ValueType({
+          type: strings.dedup(type),
+          unit: strings.dedup(unit),
+        })
+    ),
+    sample: [
+      new Sample({
+        locationId: [1],
+        value: sampleTypes.map(([, , value]) => value),
+      }),
+    ],
+    mapping: [mapping],
+    location: [location],
+    function: [fn],
+    stringTable: strings,
+    timeNanos: 1n,
+    durationNanos: 10n,
+  });
+}
+
+function decodeProfile(buffer) {
+  return Profile.decode(gunzipSync(buffer));
+}
+
+function readSampleTypes(profile) {
+  const strings = Array.isArray(profile.stringTable.strings)
+    ? profile.stringTable.strings
+    : profile.stringTable;
+  return profile.sampleType.map(
+    valueType =>
+      `${strings[Number(valueType.type)]}/${strings[Number(valueType.unit)]}`
+  );
+}

--- a/packages/profiler-nodejs/tsconfig.json
+++ b/packages/profiler-nodejs/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build",
+    "skipLibCheck": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -78,6 +78,7 @@
     "packages/propagator-ot-trace": {},
     "packages/propagator-aws-xray": {},
     "packages/propagator-aws-xray-lambda": {},
-    "packages/instrumentation-browser-navigation": {}
+    "packages/instrumentation-browser-navigation": {},
+    "packages/profiler-nodejs": {}
   }
 }


### PR DESCRIPTION
## Summary

This PR adds an experimental `@opentelemetry/profiler-nodejs` package to the
repository together with tests, docs, and a small validation demo.

The package is intended as a practical bridge for Node.js profiling workflows
that need:

- profile collection with `@datadog/pprof`
- resource-to-tag mapping from OpenTelemetry resource attributes
- multipart `pprof` export through `DatakitProfilingExporter`

## Changes

- add `packages/profiler-nodejs`
- add exporter / profiler / pprof / resource / types modules
- add package docs:
  - `README.md`
  - `USAGE.md`
  - `CHANGELOG.md`
  - `LICENSE`
- add exporter and profiler tests
- add `examples/validation-demo` for trace export validation
- add `packages/profiler-nodejs` to release metadata

## Validation

- `npm run compile -w packages/profiler-nodejs`
- `npm test -w packages/profiler-nodejs`

## Notes

- this package is not presented as an implementation of the OpenTelemetry
  Profiles signal
- the current implementation focuses on practical Node.js profiling export
  based on `pprof`
- the exporter implementation is currently tailored to DataKit-compatible
  profiling ingestion
