### PR TITLE
fix(instrumentation-router): fix MaxListenersExceededWarning

### DIFF
--- a/packages/instrumentation-router/src/instrumentation.ts
+++ b/packages/instrumentation-router/src/instrumentation.ts
@@ -108,13 +108,13 @@ export class RouterInstrumentation extends InstrumentationBase {
       ) {
         return original.call(this, req, res, next);
       }
-      const { context, wrappedNext } = instrumentation._setupSpan(
-        this,
-        req,
-        res,
-        next
-      );
-      return api.context.with(context, original, this, req, res, wrappedNext);
+      const { context, wrappedNext, ensureFallbackListener } =
+        instrumentation._setupSpan(this, req, res, next);
+      try {
+        return api.context.with(context, original, this, req, res, wrappedNext);
+      } finally {
+        ensureFallbackListener();
+      }
     };
   }
 
@@ -136,21 +136,21 @@ export class RouterInstrumentation extends InstrumentationBase {
       ) {
         return original.call(this, error, req, res, next);
       }
-      const { context, wrappedNext } = instrumentation._setupSpan(
-        this,
-        req,
-        res,
-        next
-      );
-      return api.context.with(
-        context,
-        original,
-        this,
-        error,
-        req,
-        res,
-        wrappedNext
-      );
+      const { context, wrappedNext, ensureFallbackListener } =
+        instrumentation._setupSpan(this, req, res, next);
+      try {
+        return api.context.with(
+          context,
+          original,
+          this,
+          error,
+          req,
+          res,
+          wrappedNext
+        );
+      } finally {
+        ensureFallbackListener();
+      }
     };
   }
 
@@ -185,26 +185,60 @@ export class RouterInstrumentation extends InstrumentationBase {
       },
       parent
     ) as types.InstrumentationSpan;
-    const endSpan = utils.once(span.end.bind(span));
 
     utils.renameHttpSpan(parentSpan, layer.method, route);
-    // make sure spans are ended at least when response is finished
-    res.prependOnceListener('finish', endSpan);
+
+    // Span lifecycle:
+    //   - Normal path: the layer calls `next(err?)`, which runs `wrappedNext`,
+    //     ending the span and removing the fallback `close` listener (if one
+    //     was attached).
+    //   - Layer ends the response itself (e.g. `res.send(...)` and never
+    //     calls `next`): the `close` listener fires when the underlying
+    //     connection closes and ends the span.
+    //
+    // The fallback listener is only attached AFTER the original handler
+    // returns, and only if `next` wasn't already called synchronously. For
+    // the overwhelmingly common case (synchronous `next()`) NO listener is
+    // registered at all, so listener count never approaches Node's default
+    // MaxListeners=10 even with dozens of middleware (issue #3458). This
+    // mirrors the pattern adopted by `instrumentation-express` in #3462.
+    let spanEnded = false;
+    let listenerAttached = false;
+    const onClose = () => {
+      if (!spanEnded) {
+        spanEnded = true;
+        span.end();
+      }
+    };
 
     const wrappedNext: Router.NextFunction = err => {
       if (err) {
         span.recordException(err);
       }
-      endSpan();
+      if (!spanEnded) {
+        spanEnded = true;
+        if (listenerAttached) {
+          res.removeListener('close', onClose);
+        }
+        span.end();
+      }
       if (parent) {
         return api.context.with(parent, next, undefined, err);
       }
       return next(err);
     };
 
+    const ensureFallbackListener = () => {
+      if (!spanEnded && !listenerAttached) {
+        listenerAttached = true;
+        res.once('close', onClose);
+      }
+    };
+
     return {
       context: api.trace.setSpan(parent, span),
       wrappedNext,
+      ensureFallbackListener,
     };
   }
 }

--- a/packages/instrumentation-router/src/utils.ts
+++ b/packages/instrumentation-router/src/utils.ts
@@ -31,13 +31,3 @@ export const renameHttpSpan = (
     span.updateName(`${method.toUpperCase()} ${route}`);
   }
 };
-
-export const once = (fn: Function) => {
-  let run = true;
-  return () => {
-    if (run) {
-      run = false;
-      fn();
-    }
-  };
-};

--- a/packages/instrumentation-router/test/index.test.ts
+++ b/packages/instrumentation-router/test/index.test.ts
@@ -255,4 +255,197 @@ describe('Router instrumentation', () => {
       assert.strictEqual(memoryExporter.getFinishedSpans().length, 0);
     });
   });
+
+  describe('Response listener management (issue #3458)', () => {
+    // Builds a server with `count` trivial middleware on a single Router and
+    // captures res.listenerCount('close') as observed *during* the response's
+    // own 'close' event. The test installs its own 'close' listener first so
+    // that, at the moment of capture, any not-yet-removed instrumentation
+    // listeners are still present.
+    const createLeakServer = async (
+      count: number,
+      mw: Router.RequestHandler
+    ) => {
+      const router = new Router();
+      let observedCloseListeners: number | undefined;
+      let observedListenersAtRequestStart: number | undefined;
+
+      router.use((_req, res, next) => {
+        observedListenersAtRequestStart = res.listenerCount('close');
+        res.on('close', () => {
+          observedCloseListeners = res.listenerCount('close');
+        });
+        next();
+      });
+      for (let i = 0; i < count; i++) {
+        router.use(mw);
+      }
+      router.get('/ping', (_req, res) => {
+        res.end('pong');
+      });
+
+      const server = http.createServer((req, res) => {
+        router(req, res, () => {
+          if (!res.headersSent) {
+            res.statusCode = 404;
+            res.end('not found');
+          }
+        });
+      });
+      await new Promise<void>(resolve => server.listen(0, resolve));
+      return {
+        server,
+        getCloseListeners: () => observedCloseListeners,
+        getInitialListeners: () => observedListenersAtRequestStart,
+      };
+    };
+
+    // Captures any process warnings emitted during `fn`. Used to assert that
+    // no MaxListenersExceededWarning fires while a request is in flight.
+    const collectWarnings = async <T>(fn: () => Promise<T>) => {
+      const warnings: Error[] = [];
+      const onWarning = (w: Error) => warnings.push(w);
+      process.on('warning', onWarning);
+      try {
+        const result = await fn();
+        return { result, warnings };
+      } finally {
+        process.removeListener('warning', onWarning);
+      }
+    };
+
+    it('does not emit MaxListenersExceededWarning with many sync middleware', async () => {
+      const leakServer = await createLeakServer(20, (_req, _res, next) =>
+        next()
+      );
+      try {
+        const { warnings } = await collectWarnings(async () => {
+          assert.strictEqual(
+            await request('/ping', leakServer.server),
+            'pong'
+          );
+        });
+        const maxListenersWarn = warnings.find(
+          w => w.name === 'MaxListenersExceededWarning'
+        );
+        assert.strictEqual(
+          maxListenersWarn,
+          undefined,
+          `unexpected warning: ${maxListenersWarn?.message}`
+        );
+        // For synchronous next() the fallback listener is never attached, so
+        // the only 'close' listeners at the time of close are http.Server's
+        // built-in one plus the one our probe registered. Without the fix
+        // this would scale with the middleware count (~22).
+        assert.strictEqual(leakServer.getCloseListeners(), 2);
+      } finally {
+        leakServer.server.close();
+      }
+    });
+
+    it('does not leak close listeners with many async middleware', async () => {
+      const asyncMw: Router.RequestHandler = (_req, _res, next) => {
+        setImmediate(next);
+      };
+      const leakServer = await createLeakServer(20, asyncMw);
+      try {
+        const { warnings } = await collectWarnings(async () => {
+          assert.strictEqual(
+            await request('/ping', leakServer.server),
+            'pong'
+          );
+        });
+        const maxListenersWarn = warnings.find(
+          w => w.name === 'MaxListenersExceededWarning'
+        );
+        assert.strictEqual(
+          maxListenersWarn,
+          undefined,
+          `unexpected warning: ${maxListenersWarn?.message}`
+        );
+        // Each async layer's fallback listener is removed when its `next()`
+        // eventually fires, so by the time the response closes the only
+        // remaining 'close' listeners are http.Server's built-in one plus
+        // our probe.
+        assert.strictEqual(leakServer.getCloseListeners(), 2);
+      } finally {
+        leakServer.server.close();
+      }
+    });
+
+    it('still ends the span when a layer ends the response without calling next()', async () => {
+      const router = new Router();
+      router.use((_req, _res, next) => next());
+      router.get('/ping', function selfEndingHandler(_req, res) {
+        // Intentionally never calls next(); the fallback 'close' listener is
+        // what must end the span here.
+        res.end('pong');
+      });
+      const server = http.createServer((req, res) => router(req, res, () => {}));
+      await new Promise<void>(resolve => server.listen(0, resolve));
+      try {
+        assert.strictEqual(await request('/ping', server), 'pong');
+        const finished = memoryExporter.getFinishedSpans();
+        const handlerSpan = finished.find(
+          s => s.attributes['router.name'] === 'selfEndingHandler'
+        );
+        assert.notStrictEqual(
+          handlerSpan,
+          undefined,
+          'expected a span for selfEndingHandler to be ended'
+        );
+        assert.notStrictEqual(
+          handlerSpan?.endTime,
+          undefined,
+          'expected handlerSpan to have an end time'
+        );
+      } finally {
+        server.close();
+      }
+    });
+
+    it('ends the span when the client aborts before the layer responds', async () => {
+      const router = new Router();
+      let serverResponse: http.ServerResponse | undefined;
+      router.get('/hang', function hangingHandler(_req, res) {
+        // Hold the response open; rely on the client abort -> 'close' to end
+        // the span.
+        serverResponse = res;
+      });
+      const server = http.createServer((req, res) => router(req, res, () => {}));
+      await new Promise<void>(resolve => server.listen(0, resolve));
+      const port = (server.address() as AddressInfo).port;
+
+      try {
+        await new Promise<void>((resolve, reject) => {
+          const req = http.get(`http://localhost:${port}/hang`, () => {
+            // unexpected; the server never replies
+            reject(new Error('unexpected response'));
+          });
+          req.on('error', () => resolve()); // expected: aborted
+          // Wait for the request to actually reach the handler, then abort.
+          const wait = setInterval(() => {
+            if (serverResponse) {
+              clearInterval(wait);
+              req.destroy();
+            }
+          }, 5);
+        });
+
+        // 'close' fires asynchronously after destroy; give the loop a tick.
+        await new Promise(r => setTimeout(r, 20));
+
+        const handlerSpan = memoryExporter
+          .getFinishedSpans()
+          .find(s => s.attributes['router.name'] === 'hangingHandler');
+        assert.notStrictEqual(
+          handlerSpan,
+          undefined,
+          'expected hangingHandler span to be ended on client abort'
+        );
+      } finally {
+        server.close();
+      }
+    });
+  });
 });

--- a/packages/instrumentation-router/test/index.test.ts
+++ b/packages/instrumentation-router/test/index.test.ts
@@ -257,29 +257,13 @@ describe('Router instrumentation', () => {
   });
 
   describe('Response listener management (issue #3458)', () => {
-    // Builds a server with `count` trivial middleware on a single Router and
-    // captures res.listenerCount('close') as observed *during* the response's
-    // own 'close' event. The test installs its own 'close' listener first so
-    // that, at the moment of capture, any not-yet-removed instrumentation
-    // listeners are still present.
-    const createLeakServer = async (
-      count: number,
-      mw: Router.RequestHandler
-    ) => {
+    it('does not emit MaxListenersExceededWarning with many sync middleware', async () => {
       const router = new Router();
-      let observedCloseListeners: number | undefined;
-      let observedListenersAtRequestStart: number | undefined;
 
-      router.use((_req, res, next) => {
-        observedListenersAtRequestStart = res.listenerCount('close');
-        res.on('close', () => {
-          observedCloseListeners = res.listenerCount('close');
-        });
-        next();
-      });
-      for (let i = 0; i < count; i++) {
-        router.use(mw);
+      for (let i = 0; i < 20; i++) {
+        router.use((_req, _res, next) => next());
       }
+
       router.get('/ping', (_req, res) => {
         res.end('pong');
       });
@@ -293,157 +277,23 @@ describe('Router instrumentation', () => {
         });
       });
       await new Promise<void>(resolve => server.listen(0, resolve));
-      return {
-        server,
-        getCloseListeners: () => observedCloseListeners,
-        getInitialListeners: () => observedListenersAtRequestStart,
-      };
-    };
 
-    // Captures any process warnings emitted during `fn`. Used to assert that
-    // no MaxListenersExceededWarning fires while a request is in flight.
-    const collectWarnings = async <T>(fn: () => Promise<T>) => {
       const warnings: Error[] = [];
       const onWarning = (w: Error) => warnings.push(w);
       process.on('warning', onWarning);
-      try {
-        const result = await fn();
-        return { result, warnings };
-      } finally {
-        process.removeListener('warning', onWarning);
-      }
-    };
 
-    it('does not emit MaxListenersExceededWarning with many sync middleware', async () => {
-      const leakServer = await createLeakServer(20, (_req, _res, next) =>
-        next()
-      );
-      try {
-        const { warnings } = await collectWarnings(async () => {
-          assert.strictEqual(
-            await request('/ping', leakServer.server),
-            'pong'
-          );
-        });
-        const maxListenersWarn = warnings.find(
-          w => w.name === 'MaxListenersExceededWarning'
-        );
-        assert.strictEqual(
-          maxListenersWarn,
-          undefined,
-          `unexpected warning: ${maxListenersWarn?.message}`
-        );
-        // For synchronous next() the fallback listener is never attached, so
-        // the only 'close' listeners at the time of close are http.Server's
-        // built-in one plus the one our probe registered. Without the fix
-        // this would scale with the middleware count (~22).
-        assert.strictEqual(leakServer.getCloseListeners(), 2);
-      } finally {
-        leakServer.server.close();
-      }
-    });
-
-    it('does not leak close listeners with many async middleware', async () => {
-      const asyncMw: Router.RequestHandler = (_req, _res, next) => {
-        setImmediate(next);
-      };
-      const leakServer = await createLeakServer(20, asyncMw);
-      try {
-        const { warnings } = await collectWarnings(async () => {
-          assert.strictEqual(
-            await request('/ping', leakServer.server),
-            'pong'
-          );
-        });
-        const maxListenersWarn = warnings.find(
-          w => w.name === 'MaxListenersExceededWarning'
-        );
-        assert.strictEqual(
-          maxListenersWarn,
-          undefined,
-          `unexpected warning: ${maxListenersWarn?.message}`
-        );
-        // Each async layer's fallback listener is removed when its `next()`
-        // eventually fires, so by the time the response closes the only
-        // remaining 'close' listeners are http.Server's built-in one plus
-        // our probe.
-        assert.strictEqual(leakServer.getCloseListeners(), 2);
-      } finally {
-        leakServer.server.close();
-      }
-    });
-
-    it('still ends the span when a layer ends the response without calling next()', async () => {
-      const router = new Router();
-      router.use((_req, _res, next) => next());
-      router.get('/ping', function selfEndingHandler(_req, res) {
-        // Intentionally never calls next(); the fallback 'close' listener is
-        // what must end the span here.
-        res.end('pong');
-      });
-      const server = http.createServer((req, res) => router(req, res, () => {}));
-      await new Promise<void>(resolve => server.listen(0, resolve));
       try {
         assert.strictEqual(await request('/ping', server), 'pong');
-        const finished = memoryExporter.getFinishedSpans();
-        const handlerSpan = finished.find(
-          s => s.attributes['router.name'] === 'selfEndingHandler'
+        const maxListenersWarn = warnings.find(
+          w => w.name === 'MaxListenersExceededWarning'
         );
-        assert.notStrictEqual(
-          handlerSpan,
+        assert.strictEqual(
+          maxListenersWarn,
           undefined,
-          'expected a span for selfEndingHandler to be ended'
-        );
-        assert.notStrictEqual(
-          handlerSpan?.endTime,
-          undefined,
-          'expected handlerSpan to have an end time'
+          `unexpected warning: ${maxListenersWarn?.message}`
         );
       } finally {
-        server.close();
-      }
-    });
-
-    it('ends the span when the client aborts before the layer responds', async () => {
-      const router = new Router();
-      let serverResponse: http.ServerResponse | undefined;
-      router.get('/hang', function hangingHandler(_req, res) {
-        // Hold the response open; rely on the client abort -> 'close' to end
-        // the span.
-        serverResponse = res;
-      });
-      const server = http.createServer((req, res) => router(req, res, () => {}));
-      await new Promise<void>(resolve => server.listen(0, resolve));
-      const port = (server.address() as AddressInfo).port;
-
-      try {
-        await new Promise<void>((resolve, reject) => {
-          const req = http.get(`http://localhost:${port}/hang`, () => {
-            // unexpected; the server never replies
-            reject(new Error('unexpected response'));
-          });
-          req.on('error', () => resolve()); // expected: aborted
-          // Wait for the request to actually reach the handler, then abort.
-          const wait = setInterval(() => {
-            if (serverResponse) {
-              clearInterval(wait);
-              req.destroy();
-            }
-          }, 5);
-        });
-
-        // 'close' fires asynchronously after destroy; give the loop a tick.
-        await new Promise(r => setTimeout(r, 20));
-
-        const handlerSpan = memoryExporter
-          .getFinishedSpans()
-          .find(s => s.attributes['router.name'] === 'hangingHandler');
-        assert.notStrictEqual(
-          handlerSpan,
-          undefined,
-          'expected hangingHandler span to be ended on client abort'
-        );
-      } finally {
+        process.removeListener('warning', onWarning);
         server.close();
       }
     });


### PR DESCRIPTION
Fixes router instrumentation span cleanup to avoid MaxListenersExceededWarning for the common case where many synchronous middleware call next() in a single request. #3458 

The instrumentation now delays attaching the response close fallback listener until after the router layer returns, and skips attaching it entirely when synchronous next() already ended the span. If a layer is async or ends the response itself, the fallback still ensures the span is closed.

Note: requests with a large number of concurrently pending async middleware can still temporarily attach many response close listeners before those middleware call next() but this shouldn't be a common case. Also this somewhat matches what express instrumentation is doing.