### PR TITLE
fix(router): reuse response finish listener for layer spans

### DIFF
--- a/packages/instrumentation-router/src/instrumentation.ts
+++ b/packages/instrumentation-router/src/instrumentation.ts
@@ -30,6 +30,13 @@ import AttributeNames from './enums/AttributeNames';
 import LayerType from './enums/LayerType';
 
 const supportedVersions = ['>=1.0.0 <3'];
+const responseFinishSpanEndersKey = Symbol(
+  'opentelemetry.instrumentation-router.finishSpanEnders'
+);
+
+type ResponseWithFinishSpanEnders = http.ServerResponse & {
+  [responseFinishSpanEndersKey]?: Array<() => void>;
+};
 
 export class RouterInstrumentation extends InstrumentationBase {
   constructor(config: InstrumentationConfig = {}) {
@@ -188,8 +195,7 @@ export class RouterInstrumentation extends InstrumentationBase {
     const endSpan = utils.once(span.end.bind(span));
 
     utils.renameHttpSpan(parentSpan, layer.method, route);
-    // make sure spans are ended at least when response is finished
-    res.prependOnceListener('finish', endSpan);
+    this._registerResponseFinishSpanEnder(res, endSpan);
 
     const wrappedNext: Router.NextFunction = err => {
       if (err) {
@@ -206,5 +212,27 @@ export class RouterInstrumentation extends InstrumentationBase {
       context: api.trace.setSpan(parent, span),
       wrappedNext,
     };
+  }
+
+  private _registerResponseFinishSpanEnder(
+    res: http.ServerResponse,
+    endSpan: () => void
+  ) {
+    const response = res as ResponseWithFinishSpanEnders;
+    let finishSpanEnders = response[responseFinishSpanEndersKey];
+    if (finishSpanEnders === undefined) {
+      finishSpanEnders = [];
+      response[responseFinishSpanEndersKey] = finishSpanEnders;
+
+      // Make sure spans are ended at least when response is finished. Use a
+      // single response listener, because a request can pass many router layers.
+      res.prependOnceListener('finish', () => {
+        const pendingEnders = response[responseFinishSpanEndersKey] ?? [];
+        delete response[responseFinishSpanEndersKey];
+        pendingEnders.forEach(pendingEndSpan => pendingEndSpan());
+      });
+    }
+
+    finishSpanEnders.push(endSpan);
   }
 }

--- a/packages/instrumentation-router/test/index.test.ts
+++ b/packages/instrumentation-router/test/index.test.ts
@@ -246,6 +246,59 @@ describe('Router instrumentation', () => {
         testLocalServer.close();
       }
     });
+
+    it('should only add one finish listener for many matched layers', async () => {
+      const router = new Router();
+      const finishListenerCounts: number[] = [];
+      let serverResponse: http.ServerResponse | undefined;
+
+      for (let i = 0; i < 12; i++) {
+        router.use((_req, res, next) => {
+          finishListenerCounts.push(res.listenerCount('finish'));
+          next();
+        });
+      }
+
+      router.get('/many-layers', (_req, res) => {
+        serverResponse = res;
+        finishListenerCounts.push(res.listenerCount('finish'));
+        res.end('ok');
+      });
+
+      const testLocalServer = http.createServer((req, res) => {
+        router(req, res, err => {
+          if (err) {
+            res.statusCode = 500;
+            res.end(err.message);
+          }
+        });
+      });
+
+      await new Promise<void>(resolve => testLocalServer.listen(0, resolve));
+
+      try {
+        assert.strictEqual(
+          await request('/many-layers', testLocalServer),
+          'ok'
+        );
+        const maxFinishListeners = Math.max(...finishListenerCounts);
+        assert.strictEqual(
+          new Set(finishListenerCounts).size,
+          1,
+          'router instrumentation should reuse the same response finish listener'
+        );
+        assert.ok(
+          maxFinishListeners < 10,
+          `expected listener count to stay below the default warning threshold, got ${maxFinishListeners}`
+        );
+        assert.ok(
+          (serverResponse?.listenerCount('finish') ?? 0) < maxFinishListeners
+        );
+        assert.strictEqual(memoryExporter.getFinishedSpans().length, 13);
+      } finally {
+        testLocalServer.close();
+      }
+    });
   });
 
   describe('Disabling instrumentation', () => {


### PR DESCRIPTION
## Summary
- Reuse one `finish` listener per `ServerResponse` for router layer spans instead of attaching one listener for every matched layer.
- Keep each layer span ender registered and drained on response finish, so terminal handlers that do not call `next()` still close their spans.
- Add a regression covering a request crossing 12 router layers, which previously exceeded Node's default listener warning threshold.

Fixes #3458

## Tests
- `npm run compile -w @opentelemetry/instrumentation-router`
- `npm test -w @opentelemetry/instrumentation-router`
- `npx prettier --check packages/instrumentation-router/src/instrumentation.ts packages/instrumentation-router/test/index.test.ts`
- `npx nx run @opentelemetry/instrumentation-router:lint` (passes with existing warnings)