### PR TITLE
feat(auto-instrumentations-node): opt-in crash flush via OTEL_NODE_FLUSH_ON_CRASH

### DIFF
--- a/packages/auto-instrumentations-node/README.md
+++ b/packages/auto-instrumentations-node/README.md
@@ -124,6 +124,20 @@ Notes:
 - Logs are always sent to console, no matter the environment, or debug level.
 - Debug logs are extremely verbose. Enable debug logging only when needed. Debug logging negatively impacts the performance of your application.
 
+### Flush telemetry on crash
+
+By default, the SDK only shuts down on `SIGTERM` or normal `beforeExit`. Uncaught exceptions, unhandled promise rejections, and `SIGINT` bypass `beforeExit`, so any spans/metrics/logs still buffered in a Batch processor are dropped — this is the typical "logs visible in stdout but never reach the collector" symptom.
+
+Set `OTEL_NODE_FLUSH_ON_CRASH=true` to register handlers for `uncaughtException`, `unhandledRejection`, and `SIGINT` that race `sdk.shutdown()` against a bounded timeout before exiting. The original error is written to `stderr` first, and the process still exits non-zero so the crash semantics are preserved.
+
+```shell
+export OTEL_NODE_FLUSH_ON_CRASH=true
+# Optional, defaults to 5000ms:
+export OTEL_NODE_FLUSH_ON_CRASH_TIMEOUT_MS=3000
+```
+
+Caveat: registering an `uncaughtException` handler suppresses Node's default behavior of terminating on unhandled errors. The handler always calls `process.exit(1)` after flushing to keep that semantics — but if you also register your own `uncaughtException` handler that swallows errors, the process can be left in an undefined state. Don't enable this flag unless you're comfortable with that trade-off.
+
 ## Usage: Instrumentation Initialization
 
 OpenTelemetry Meta Packages for Node automatically loads instrumentations for Node builtin modules and common packages.

--- a/packages/auto-instrumentations-node/src/register.ts
+++ b/packages/auto-instrumentations-node/src/register.ts
@@ -45,3 +45,60 @@ async function shutdown(): Promise<void> {
 process.on('SIGTERM', shutdown);
 // Gracefully shutdown SDK if Node.js is exiting normally
 process.once('beforeExit', shutdown);
+
+// Opt-in: flush telemetry before the process dies on a crash signal.
+// `beforeExit` does not fire on uncaught exceptions, unhandled rejections,
+// or process.exit(), so batched logs/spans/metrics in the BatchProcessor
+// queues are lost. When OTEL_NODE_FLUSH_ON_CRASH=true, register handlers
+// that race sdk.shutdown() against a bounded timeout, then re-raise the
+// original termination semantics by exiting non-zero.
+const flushOnCrash =
+  getStringFromEnv('OTEL_NODE_FLUSH_ON_CRASH')?.toLowerCase() === 'true';
+
+if (flushOnCrash) {
+  const timeoutEnv = getStringFromEnv('OTEL_NODE_FLUSH_ON_CRASH_TIMEOUT_MS');
+  const parsedTimeout = timeoutEnv != null ? Number(timeoutEnv) : NaN;
+  const timeoutMs =
+    Number.isFinite(parsedTimeout) && parsedTimeout > 0 ? parsedTimeout : 5000;
+
+  const shutdownWithTimeout = (): Promise<void> => {
+    return Promise.race([
+      shutdown(),
+      new Promise<void>(resolve => {
+        // unref() so a wedged exporter doesn't keep the process alive
+        // longer than the user's timeout budget.
+        setTimeout(resolve, timeoutMs).unref();
+      }),
+    ]);
+  };
+
+  let crashing = false;
+  const handleFatal = async (
+    label: 'uncaughtException' | 'unhandledRejection',
+    err: unknown
+  ): Promise<void> => {
+    // Re-entrancy guard: if shutdown itself throws, don't recurse forever.
+    if (crashing) {
+      process.exit(1);
+    }
+    crashing = true;
+
+    // Preserve the original crash output — users still need to see the error.
+    // eslint-disable-next-line no-console
+    console.error(`[otel] flushing telemetry before exit (${label}):`, err);
+
+    await shutdownWithTimeout();
+    process.exit(1);
+  };
+
+  process.on('uncaughtException', err => {
+    void handleFatal('uncaughtException', err);
+  });
+  process.on('unhandledRejection', reason => {
+    void handleFatal('unhandledRejection', reason);
+  });
+  process.on('SIGINT', async () => {
+    await shutdownWithTimeout();
+    process.exit(130); // 128 + SIGINT(2)
+  });
+}


### PR DESCRIPTION
## Summary

- Adds opt-in handlers in `packages/auto-instrumentations-node/src/register.ts` that flush the SDK on `uncaughtException`, `unhandledRejection`, and `SIGINT` before exiting.
- Gated behind `OTEL_NODE_FLUSH_ON_CRASH=true`; default behavior is unchanged.
- Optional `OTEL_NODE_FLUSH_ON_CRASH_TIMEOUT_MS` (default 5000ms) bounds shutdown so a wedged exporter cannot keep the process alive.

## Motivation

`register.ts` currently wires `SIGTERM` and `beforeExit` to `sdk.shutdown()`. Per the [Node.js docs](https://nodejs.org/api/process.html#event-beforeexit), `beforeExit` does **not** fire for `process.exit()`, uncaught exceptions, or unhandled promise rejections. With the default `BatchLogRecordProcessor` / `BatchSpanProcessor` (queue-and-flush every N ms), any records still in the buffer when the process is killed by a crash are dropped — this is the well-known "logs are in stdout but never reach the collector" symptom around crash timestamps.

In a real incident this looked like:

- An uncaught `KafkaJSProtocolError` (TOPIC_AUTHORIZATION_FAILED) propagated from a producer.
- The error log emitted ~milliseconds before termination was visible in stdout but never arrived in the OTEL backend.
- `BatchLogRecordProcessor.scheduledDelayMillis` (default 1000ms) is the worst-case loss window.

## Behavior

When `OTEL_NODE_FLUSH_ON_CRASH=true`:

1. The original error is written to stderr (preserving the existing crash output for humans/log scrapers).
2. `sdk.shutdown()` is raced against a bounded timer; whichever finishes first wins.
3. The process exits with the canonical Node status code (`1` for crashes, `130` for `SIGINT` per `128 + signum`) so shells, supervisors, and CI see the same status they would have without the handler.
4. A re-entrancy guard protects against `shutdown()` itself throwing.

The flag is opt-in because registering an `uncaughtException` handler suppresses Node's default termination — users should make that trade-off consciously, and existing applications that rely on the current behavior are unaffected.

## Test plan

- [ ] `npm run compile` in `packages/auto-instrumentations-node` (TypeScript)
- [ ] Existing `register.test.ts` cases still pass (no behavior change with the flag unset)
- [ ] Manual: run a script that throws after emitting a log; with `OTEL_NODE_FLUSH_ON_CRASH=true` and a console exporter, confirm the trailing record is exported before exit
- [ ] Manual: confirm process exits with 1 on uncaught exception, 130 on SIGINT
- [ ] Manual: with a deliberately broken exporter endpoint, confirm the timeout fires and the process still exits within `OTEL_NODE_FLUSH_ON_CRASH_TIMEOUT_MS`

Happy to add an automated test for the crash-flush path if maintainers want it — it would mirror the existing SIGTERM test in `register.test.ts` (spawn child, send signal / cause throw, assert shutdown message in stdout).