### PR TITLE
test(ioredis): fix tests running on older versions

### DIFF
--- a/packages/instrumentation-ioredis/test/ioredis.test.ts
+++ b/packages/instrumentation-ioredis/test/ioredis.test.ts
@@ -655,8 +655,10 @@ describe('ioredis', () => {
 
       describe('sensitive command sanitization', function () {
         after(async () => {
-          // cleanup added user
-          client.acl('DELUSER', 'testuser');
+          // cleanup added user (ACL not available in older ioredis versions)
+          if (typeof (client as any).acl === 'function') {
+            await (client as any).acl('DELUSER', 'testuser');
+          }
         });
 
         it('should redact CONFIG SET arguments in db.statement', async function () {
@@ -682,6 +684,9 @@ describe('ioredis', () => {
         });
 
         it('should redact ACL SETUSER arguments in db.statement', async function () {
+          if (typeof (client as any).acl !== 'function') {
+            this.skip();
+          }
           const span = provider
             .getTracer('ioredis-test')
             .startSpan('test span');


### PR DESCRIPTION
## Which problem is this PR solving?

TAV is failing for instrumentaton-ioredis@4.13.1 because the acl function was not available yet in that version.
This fixes that by skipping the test when that's the case.

ref (failing test run) https://github.com/open-telemetry/opentelemetry-js-contrib/actions/runs/25439110941/job/74626687225

This failed with:

```
2026-05-06T14:16:34.3125889Z   1) ioredis
2026-05-06T14:16:34.3126520Z        #send_internal_message()
2026-05-06T14:16:34.3127150Z          Instrumenting query operations
2026-05-06T14:16:34.3137922Z            sensitive command sanitization
2026-05-06T14:16:34.3138696Z              should redact ACL SETUSER arguments in db.statement:
2026-05-06T14:16:34.3139500Z      TypeError: client.acl is not a function
2026-05-06T14:16:34.3140822Z       at /home/runner/work/opentelemetry-js-contrib/opentelemetry-js-contrib/packages/instrumentation-ioredis/test/ioredis.test.ts:691:37
2026-05-06T14:16:34.3142300Z       at AsyncLocalStorage.run (node:internal/async_local_storage/async_context_frame:63:14)
2026-05-06T14:16:34.3144641Z       at AsyncLocalStorageContextManager.with (/home/runner/work/opentelemetry-js-contrib/opentelemetry-js-contrib/node_modules/@opentelemetry/context-async-hooks/src/AsyncLocalStorageContextManager.ts:30:36)
2026-05-06T14:16:34.3146803Z       at ContextAPI.with (/home/runner/work/opentelemetry-js-contrib/opentelemetry-js-contrib/node_modules/@opentelemetry/api/src/api/context.ts:77:42)
2026-05-06T14:16:34.3148031Z       at Context.<anonymous> (test/ioredis.test.ts:688:29)
2026-05-06T14:16:34.3148708Z       at processImmediate (node:internal/timers:504:21)
2026-05-06T14:16:34.3149199Z 
2026-05-06T14:16:34.3149475Z   2) ioredis
2026-05-06T14:16:34.3149937Z        #send_internal_message()
2026-05-06T14:16:34.3150505Z          Instrumenting query operations
2026-05-06T14:16:34.3151110Z            sensitive command sanitization
2026-05-06T14:16:34.3151874Z              "after all" hook for "should redact PSETEX value in db.statement":
2026-05-06T14:16:34.3152641Z      TypeError: client.acl is not a function
2026-05-06T14:16:34.3153382Z       at Context.<anonymous> (test/ioredis.test.ts:659:18)
2026-05-06T14:16:34.3154425Z       at processImmediate (node:internal/timers:504:21)
```

The feature must've been added somewhere from ioredis@4.13.1 - ioredis@4.24.3, very likely in this release: https://github.com/redis/ioredis/releases/tag/v4.17.0