### PR TITLE
test(instrumentation-undici): stabilize flaky fetch abort and cancel tests

### DIFF
--- a/packages/instrumentation-undici/test/fetch.test.ts
+++ b/packages/instrumentation-undici/test/fetch.test.ts
@@ -35,6 +35,16 @@ describe('UndiciInstrumentation `fetch` tests', function () {
     spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
   });
 
+  async function waitForSpans(count: number, timeoutMs = 1000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (
+      memoryExporter.getFinishedSpans().length < count &&
+      Date.now() < deadline
+    ) {
+      await new Promise(r => setTimeout(r, 5));
+    }
+  }
+
   before(function (done) {
     // Do not test if the `fetch` global API is not available
     // This applies to nodejs < v18 or nodejs < v16.15 wihtout the flag
@@ -386,6 +396,8 @@ describe('UndiciInstrumentation `fetch` tests', function () {
       const controller = new AbortController();
       const fetchUrl = `${protocol}://${hostname}:${mockServer.port}/?query=test`;
       const fetchPromise = fetch(fetchUrl, { signal: controller.signal });
+      // Make sure the span is started before we abort
+      await Promise.resolve();
       controller.abort();
       try {
         await fetchPromise;
@@ -393,8 +405,7 @@ describe('UndiciInstrumentation `fetch` tests', function () {
         // Expected - fetch throws on abort, but we don't need the error
       }
 
-      // Let the error be published to diagnostics channel
-      await new Promise(r => setTimeout(r, 50));
+      await waitForSpans(1);
 
       spans = memoryExporter.getFinishedSpans();
       const span = spans[0];
@@ -429,17 +440,11 @@ describe('UndiciInstrumentation `fetch` tests', function () {
       // Cancel the response body instead of consuming it
       await response.body?.cancel();
 
-      // Let the error be published to diagnostics channel
-      await new Promise(r => setTimeout(r, 50));
+      await waitForSpans(1);
 
       spans = memoryExporter.getFinishedSpans();
-
-      // If cancelled before span was recorded, no span is expected
-      if (spans.length === 0) {
-        return;
-      }
-
       const span = spans[0];
+      assert.ok(span, 'a span is present');
       assert.strictEqual(spans.length, 1);
 
       // Per OTel HTTP spec: intentional cancellation SHOULD NOT be an error


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Noticed in the unit tests on my unrelated PR #2981 that an undici instrumentation test was failing somehow. Looks like the test is quite flaky and relies on a 50ms sleep to make sure that the diagnostics channel emits have fired (`undici:request:create` followed by `undici:request:error` once the abort has propagated) and the resulting span is in the in-memory exporter before the assertions. Seems like this is not deterministic enough since I saw the following error on my unrelated PR:
```
  1) UndiciInstrumentation `fetch` tests
       enable()
         should not record abort as an error if fetch request is aborted:
     AssertionError [ERR_ASSERTION]: a span is present
      at Context.<anonymous> (test/fetch.test.ts:401:14)

  2) UndiciInstrumentation `fetch` tests
       enable()
         should not record error if fetch response body is cancelled:

      AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:

2 !== 1

      + expected - actual

      -2
      +1

      at Context.<anonymous> (test/fetch.test.ts:443:14)
```
The first test fails because no span is present in the inmemory exporter (the error message "a span is present" is confusing though). And the following test fails because 2 spans are present where it expects just 1. So this is caused by that same root cause in both cases, the synchronous `controller.abort()` in the first test beats undici's deferred `request:create` publish, so no span is created. The request completes async after the 50ms sleep, and its span that is eventually exported leaks into the next test's exporter which thus gets 2 spans instead of 1.

## Short description of the changes

My proposed fix is to do 2 things:
1. The span in the first test is made sure to have been started by adding `await Promise.resolve()` right after the fetch call. This way we know, by FIFO ordering of the microtask queue, that undici's dispatch microtask will always run before we reach `controller.abort()`. `fetch()` enqueues its dispatch first, our await enqueues the continuation second, so dispatch drains first and `undici:request:create` is published (and the span started) before the abort fires. see also: https://github.com/open-telemetry/opentelemetry-js-contrib/blob/9a0bf882bfdf3087a0cb71f6b2f407da6a7d9d0a/packages/instrumentation-undici/src/undici.ts#L111-L114
2. Deterministically wait for the expected span to have been exported before trying to continue on to the assertions on that span. I did this with a simple function that polls until either a desired count of spans are in the memory exporter, or a timeout is reached.