### PR TITLE
ci(instrumentation-mongoose): increase minimum node version to match what mongoose 9 requires

### DIFF
--- a/packages/instrumentation-mongoose/.tav.yml
+++ b/packages/instrumentation-mongoose/.tav.yml
@@ -16,5 +16,5 @@ mongoose:
   - versions:
       include: ">=9 <10"
       mode: max-7
-    node: '>=18.0.0'
+    node: '>=20.19.0'
     commands: npm run test-v7-v9


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

The mongoose instrumentation causes the `test-all-versions` job for node 18 to hang until github default timeout (6h). The mongodb driver that is bundled by mongoose calls `crypto.randomUUID()` to create lsids. `crypto` however is marked unstable and behind an experimental feature flag for node 18: https://nodejs.org/docs/latest-v18.x/api/globals.html#crypto_1

Run that's hanging on a PR of mine that is completely unrelated to mongoose: https://github.com/open-telemetry/opentelemetry-js-contrib/actions/runs/25541671848/job/74969459010?pr=2981
You can see a bunch of "...Error: crypto is not defined" errors at the end there. I think it's hanging indefinitely due to the cleanup hooks throwing before they can close the underlying mongo client, like this one: https://github.com/open-telemetry/opentelemetry-js-contrib/blob/051a93abfdefd2d2530dfe9df11418ccffa906b7/packages/instrumentation-mongoose/test/mongoose-v7-v9.test.ts#L53-L57
Tries to call `mongoose.connection.close()` which underneath tries to use the `crypto` global as described above. So the call throws and the underlying mongo driver doesn't get torn down. Making it so the process doesn't exit and runs until the timeout.

## Short description of the changes

Increased required node version for mongoose 9 tests.