### PR TITLE
test(instrumentation-express): add missing test coverage

### DIFF
--- a/packages/instrumentation-express/test/express.test.ts
+++ b/packages/instrumentation-express/test/express.test.ts
@@ -601,7 +601,33 @@ describe('ExpressInstrumentation', () => {
         }
       );
     });
+    it('should allow setting properties on patched layer handle', async () => {
+      const rootSpan = tracer.startSpan('rootSpan');
+      let handlerRef: express.RequestHandler;
 
+      const httpServer = await serverWithMiddleware(tracer, rootSpan, app => {
+        handlerRef = (req: express.Request, res: express.Response) => {
+          res.status(200).end('ok');
+        };
+        (handlerRef as any).customProp = 'initial';
+          app.get('/test', handlerRef);
+      });
+      server = httpServer.server;
+      port = httpServer.port;
+
+      await context.with(
+        trace.setSpan(context.active(), rootSpan),
+        async () => {
+          await httpRequest.get(`http://localhost:${port}/test`);
+          
+          // set property AFTER request — handler is now patched by OTel
+          (handlerRef as any).customProp = 'updated';
+          assert.strictEqual((handlerRef as any).customProp, 'updated');
+          
+          rootSpan.end();
+        }
+      );
+    });
     it('should end spans when the client aborts the request', async () => {
       const rootSpan = tracer.startSpan('rootSpan');
       let requestReceived: () => void;

--- a/packages/instrumentation-express/test/express.test.ts
+++ b/packages/instrumentation-express/test/express.test.ts
@@ -610,7 +610,7 @@ describe('ExpressInstrumentation', () => {
           res.status(200).end('ok');
         };
         (handlerRef as any).customProp = 'initial';
-          app.get('/test', handlerRef);
+        app.get('/test', handlerRef);
       });
       server = httpServer.server;
       port = httpServer.port;
@@ -619,11 +619,11 @@ describe('ExpressInstrumentation', () => {
         trace.setSpan(context.active(), rootSpan),
         async () => {
           await httpRequest.get(`http://localhost:${port}/test`);
-          
+
           // set property AFTER request — handler is now patched by OTel
           (handlerRef as any).customProp = 'updated';
           assert.strictEqual((handlerRef as any).customProp, 'updated');
-          
+
           rootSpan.end();
         }
       );

--- a/packages/instrumentation-express/test/utils.test.ts
+++ b/packages/instrumentation-express/test/utils.test.ts
@@ -81,14 +81,13 @@ describe('Utils', () => {
         false
       );
     });
-      it('should not throw when pattern is unsupported datatype', () => {
-    assert.doesNotThrow(() =>
-      utils.isLayerIgnored('test', ExpressLayerType.MIDDLEWARE, {
-        ignoreLayers: [123 as any],
-      })
-    );
-  });
-    
+    it('should not throw when pattern is unsupported datatype', () => {
+      assert.doesNotThrow(() =>
+        utils.isLayerIgnored('test', ExpressLayerType.MIDDLEWARE, {
+          ignoreLayers: [123 as any],
+        })
+      );
+    });
   });
 
   describe('getLayerMetadata()', () => {

--- a/packages/instrumentation-express/test/utils.test.ts
+++ b/packages/instrumentation-express/test/utils.test.ts
@@ -81,6 +81,14 @@ describe('Utils', () => {
         false
       );
     });
+      it('should not throw when pattern is unsupported datatype', () => {
+    assert.doesNotThrow(() =>
+      utils.isLayerIgnored('test', ExpressLayerType.MIDDLEWARE, {
+        ignoreLayers: [123 as any],
+      })
+    );
+  });
+    
   });
 
   describe('getLayerMetadata()', () => {


### PR DESCRIPTION

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

One code path in instrumentation-express had no test coverage:
- The unsupported datatype branch in satisfiesPattern (utils.ts line 126)

Also added a test to verify properties can be set on patched layer handles.
-

## Short description of the changes

-- Added test to verify isLayerIgnored handles unsupported pattern datatypes gracefully
- Added test to verify properties can be set on patched layer handles after OTel patches them
