### PR TITLE
chore(instrumentation-redis): fix lint

### DIFF
--- a/packages/instrumentation-redis/test/v4-v5/redis.cluster.mock.test.ts
+++ b/packages/instrumentation-redis/test/v4-v5/redis.cluster.mock.test.ts
@@ -1,17 +1,6 @@
 /*
  * Copyright The OpenTelemetry Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 import {
   getTestSpans,

--- a/packages/instrumentation-redis/test/v4-v5/redis.cluster.test.ts
+++ b/packages/instrumentation-redis/test/v4-v5/redis.cluster.test.ts
@@ -1,17 +1,6 @@
 /*
  * Copyright The OpenTelemetry Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * SPDX-License-Identifier: Apache-2.0
  */
 import {
   getTestSpans,


### PR DESCRIPTION
## Which problem is this PR solving?

I merged a PR (#3427) that broke the lint step as it was using the long-form license header. This PR fixes that by changing to short-form again.