### PR TITLE
fix(instrumentation-express): prevent post-handler middleware from overwriting rpcMetadata.route

### DIFF
--- a/packages/instrumentation-express/src/instrumentation.ts
+++ b/packages/instrumentation-express/src/instrumentation.ts
@@ -193,7 +193,12 @@ export class ExpressInstrumentation extends InstrumentationBase<ExpressInstrumen
 
         const rpcMetadata = getRPCMetadata(context.active());
         if (rpcMetadata?.type === RPCType.HTTP) {
-          rpcMetadata.route = actualMatchedRoute;
+          if (
+            (actualMatchedRoute?.length || 0) >=
+            (rpcMetadata.route?.length || 0)
+          ) {
+            rpcMetadata.route = actualMatchedRoute;
+          }
         }
 
         // verify against the config if the layer should be ignored

--- a/packages/instrumentation-express/test/express.test.ts
+++ b/packages/instrumentation-express/test/express.test.ts
@@ -498,7 +498,32 @@ describe('ExpressInstrumentation', () => {
         }
       );
     });
-
+    it('should not overwrite rpcMetadata.route when middleware runs after request handler', async () => {
+      const rootSpan = tracer.startSpan('rootSpan');
+      let capturedRoute: string | undefined;
+      const httpServer = await serverWithMiddleware(tracer, rootSpan, app => {
+        app.use(express.json());
+        app.get('/users', (req, res) => {
+          // capture INSIDE the request handler, where context is active
+          capturedRoute = getRPCMetadata(context.active())?.route;
+          res.status(200).end('ok');
+        });
+        // middleware running AFTER request handler - should not overwrite route
+        app.use((req, res, next) => {
+          next();
+        });
+      });
+      server = httpServer.server;
+      port = httpServer.port;
+      await context.with(
+        trace.setSpan(context.active(), rootSpan),
+        async () => {
+          await httpRequest.get(`http://localhost:${port}/users`);
+          rootSpan.end();
+          assert.strictEqual(capturedRoute, '/users');
+        }
+      );
+    });
     it('should ignore double slashes in routes', async () => {
       const rootSpan = tracer.startSpan('rootSpan');
       let rpcMetadata: RPCMetadata | undefined;
@@ -631,12 +656,22 @@ describe('ExpressInstrumentation', () => {
         async () => {
           let clientError: Error | undefined;
           const clientReq = httpGet(`http://localhost:${port}/slow`);
+
           clientReq.on('error', err => {
             clientError = err;
           });
+
+          clientReq.on('close', () => {
+            if (!clientError) {
+              clientError = new Error('connection closed');
+            }
+          });
+
           await requestReceivedPromise;
           clientReq.destroy();
           await responseClosedPromise;
+          // wait for client events to fire (needed on Windows)
+          await new Promise(resolve => setTimeout(resolve, 100));
           assert.ok(
             clientError,
             'client should have received an error from the aborted request'

--- a/packages/instrumentation-express/test/express.test.ts
+++ b/packages/instrumentation-express/test/express.test.ts
@@ -656,22 +656,12 @@ describe('ExpressInstrumentation', () => {
         async () => {
           let clientError: Error | undefined;
           const clientReq = httpGet(`http://localhost:${port}/slow`);
-
           clientReq.on('error', err => {
             clientError = err;
           });
-
-          clientReq.on('close', () => {
-            if (!clientError) {
-              clientError = new Error('connection closed');
-            }
-          });
-
           await requestReceivedPromise;
           clientReq.destroy();
           await responseClosedPromise;
-          // wait for client events to fire (needed on Windows)
-          await new Promise(resolve => setTimeout(resolve, 100));
           assert.ok(
             clientError,
             'client should have received an error from the aborted request'


### PR DESCRIPTION


<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

When a middleware runs after the request handler, it resets `rpcMetadata.route` back to `/`, overwriting the correct route already set by the request handler


## Short description of the changes

Only update `rpcMetadata.route` if the new route is longer than or equal to the current one. This ensures that once a specific route like `/users` is set, a generic catch-all middleware with route `/` cannot overwrite it.
A regression test was added to verify that post-handler middlewares do not overwrite the correctly matched route.

