### PR TITLE
chore(renovate): add minimumReleaseAge to config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -63,5 +63,6 @@
   "semanticCommitType": "feat",
   "constraints": {
     "npm": ">=11.6.3"
-  }
+  },
+  "minimumReleaseAge": "1 week"
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Adds `minimumReleaseAge` to the renovate config.

See https://github.com/open-telemetry/opentelemetry-js/issues/6696