### PR TITLE
fix(instrumentation-router): preserve baggage across next

### DIFF
--- a/packages/instrumentation-router/src/instrumentation.ts
+++ b/packages/instrumentation-router/src/instrumentation.ts
@@ -222,10 +222,13 @@ export class RouterInstrumentation extends InstrumentationBase {
         }
         span.end();
       }
-      if (parent) {
-        return api.context.with(parent, next, undefined, err);
-      }
-      return next(err);
+
+      const activeContext = api.context.active();
+      const nextContext = parentSpan
+        ? api.trace.setSpan(activeContext, parentSpan)
+        : activeContext;
+
+      return api.context.with(nextContext, next, undefined, err);
     };
 
     const ensureFallbackListener = () => {

--- a/packages/instrumentation-router/test/index.test.ts
+++ b/packages/instrumentation-router/test/index.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { context, trace } from '@opentelemetry/api';
+import { context, propagation, trace } from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import {
@@ -244,6 +244,68 @@ describe('Router instrumentation', () => {
         assert.strictEqual(parentSpan.name, 'GET /deep/hello/someone');
       } finally {
         testLocalServer.close();
+      }
+    });
+
+    it('should preserve baggage added before next across middleware and handler boundaries', async () => {
+      const router = new Router();
+      const snapshots: Array<Record<string, string> | null> = [];
+
+      const snapshotBaggage = () => {
+        const baggage = propagation.getBaggage(context.active());
+
+        if (!baggage) {
+          return null;
+        }
+
+        return Object.fromEntries(
+          baggage.getAllEntries().map(([key, entry]) => [key, entry.value])
+        );
+      };
+
+      router.use((_req, _res, next) => {
+        const baggage = (
+          propagation.getBaggage(context.active()) ?? propagation.createBaggage()
+        ).setEntry('foo', { value: 'bar' });
+        const nextContext = propagation.setBaggage(context.active(), baggage);
+
+        context.with(nextContext, next);
+      });
+
+      router.use((_req, _res, next) => {
+        snapshots.push(snapshotBaggage());
+
+        const baggage = (
+          propagation.getBaggage(context.active()) ?? propagation.createBaggage()
+        ).setEntry('baz', { value: 'qux' });
+        const nextContext = propagation.setBaggage(context.active(), baggage);
+
+        context.with(nextContext, next);
+      });
+
+      router.get('/baggage', (_req, res) => {
+        snapshots.push(snapshotBaggage());
+        res.end('ok');
+      });
+
+      const server = http.createServer((req, res) => {
+        router(req, res, () => {
+          if (!res.headersSent) {
+            res.statusCode = 404;
+            res.end('not found');
+          }
+        });
+      });
+      await new Promise<void>(resolve => server.listen(0, resolve));
+
+      try {
+        assert.strictEqual(await request('/baggage', server), 'ok');
+        assert.deepStrictEqual(snapshots, [
+          { foo: 'bar' },
+          { foo: 'bar', baz: 'qux' },
+        ]);
+      } finally {
+        server.close();
       }
     });
   });

--- a/packages/instrumentation-router/test/index.test.ts
+++ b/packages/instrumentation-router/test/index.test.ts
@@ -265,7 +265,8 @@ describe('Router instrumentation', () => {
 
       router.use((_req, _res, next) => {
         const baggage = (
-          propagation.getBaggage(context.active()) ?? propagation.createBaggage()
+          propagation.getBaggage(context.active()) ??
+          propagation.createBaggage()
         ).setEntry('foo', { value: 'bar' });
         const nextContext = propagation.setBaggage(context.active(), baggage);
 
@@ -276,7 +277,8 @@ describe('Router instrumentation', () => {
         snapshots.push(snapshotBaggage());
 
         const baggage = (
-          propagation.getBaggage(context.active()) ?? propagation.createBaggage()
+          propagation.getBaggage(context.active()) ??
+          propagation.createBaggage()
         ).setEntry('baz', { value: 'qux' });
         const nextContext = propagation.setBaggage(context.active(), baggage);
 


### PR DESCRIPTION
## Summary

  Fixes baggage loss across `next()` boundaries in `@opentelemetry/instrumentation-router`.

  This updates `wrappedNext` to preserve the current active context while restoring only the parent span before calling `next()`. That keeps middleware-added baggage intact without causing sibling middleware spans to nest under each
  other.

  Fixes #3527

  ## Problem

  `instrumentation-router` currently captures `parent = api.context.active()` before middleware execution and later calls `next()` with that full parent context.

  That drops baggage added by middleware before `next()`, because the newer active context is replaced with the older pre-middleware context.

  This affects Express 5 because it uses the standalone `router` package, so `@opentelemetry/instrumentation-router` participates in middleware handoff there.

  ## Changes

  - update `wrappedNext` in `packages/instrumentation-router/src/instrumentation.ts`
  - add a regression test covering baggage propagation across middleware and handler boundaries

  ## Notes

  The fix mirrors the baggage-preservation approach already used in @opentelemetry/instrumentation-express, but applies it to the router-layer next() wrapper used by Express 5.