### PR TITLE
fix(instrumentation-aws-sdk): patch middlewareStack via Client.send for @smithy/core>=3.24.0

### DIFF
--- a/packages/instrumentation-aws-sdk/src/aws-sdk.ts
+++ b/packages/instrumentation-aws-sdk/src/aws-sdk.ts
@@ -123,6 +123,21 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
       }
     );
 
+    // Patch for @smithy/core >= 3.24.0: Client class moved from @smithy/smithy-client
+    // into @smithy/core/client bundle. We need to patch Client.prototype.send there too.
+    const v3SmithyCoreClientFile = new InstrumentationNodeModuleFile(
+      '@smithy/core/dist-cjs/submodules/client/index.js',
+      ['>=3.24.0'],
+      this.patchV3SmithyClient.bind(this),
+      this.unpatchV3SmithyClient.bind(this)
+    );
+    const v3SmithyCore = new InstrumentationNodeModuleDefinition(
+      '@smithy/core',
+      ['>=3.24.0'],
+      undefined,
+      undefined,
+      [v3SmithyCoreClientFile]
+    );
     const v3SmithyClient = new InstrumentationNodeModuleDefinition(
       '@aws-sdk/smithy-client',
       ['^3.1.0'],
@@ -141,6 +156,7 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
     return [
       v3MiddlewareStack,
       v3SmithyMiddlewareStack,
+      v3SmithyCore,
       v3SmithyClient,
       v3NewSmithyClient,
     ];

--- a/packages/instrumentation-aws-sdk/src/aws-sdk.ts
+++ b/packages/instrumentation-aws-sdk/src/aws-sdk.ts
@@ -106,6 +106,7 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
     // As of @smithy/middleware-stack@2.1.0 `constructStack` is only available
     // as a getter, so we cannot use `this._wrap()`.
     const self = this;
+    
     const v3SmithyMiddlewareStack = new InstrumentationNodeModuleDefinition(
       '@smithy/middleware-stack',
       ['>=2.0.0'],
@@ -120,6 +121,36 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
         );
         return newExports;
       }
+    );
+
+    // Patch for @smithy/core >= 3.24.0, which moved constructStack out of
+    // @smithy/middleware-stack and into @smithy/core/client (see smithy-lang/smithy-typescript#1991).
+    // AWS SDK v3 clients now require constructStack directly from @smithy/core/client,
+    // so the @smithy/middleware-stack hook no longer fires for these versions.
+  const v3SmithyCoreClientFile = new InstrumentationNodeModuleFile(
+      '@smithy/core/dist-cjs/submodules/client/index.js',
+      ['>=3.24.0'],
+      (moduleExports: any, moduleVersion?: string) => {
+        const newExports = propwrap(
+          moduleExports,
+          'constructStack',
+          (orig: any) => {
+            self._diag.debug(
+              'propwrapping aws-sdk v3 constructStack (@smithy/core/client)'
+            );
+            return self._getV3ConstructStackPatch(moduleVersion, orig);
+          }
+        );
+        return newExports;
+      },
+      (moduleExports: any) => moduleExports
+    );
+    const v3SmithyCore = new InstrumentationNodeModuleDefinition(
+      '@smithy/core',
+      ['>=3.24.0'],
+      undefined,
+      undefined,
+      [v3SmithyCoreClientFile]
     );
 
     const v3SmithyClient = new InstrumentationNodeModuleDefinition(
@@ -140,6 +171,7 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
     return [
       v3MiddlewareStack,
       v3SmithyMiddlewareStack,
+      v3SmithyCore,
       v3SmithyClient,
       v3NewSmithyClient,
     ];

--- a/packages/instrumentation-aws-sdk/src/aws-sdk.ts
+++ b/packages/instrumentation-aws-sdk/src/aws-sdk.ts
@@ -106,7 +106,7 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
     // As of @smithy/middleware-stack@2.1.0 `constructStack` is only available
     // as a getter, so we cannot use `this._wrap()`.
     const self = this;
-    
+
     const v3SmithyMiddlewareStack = new InstrumentationNodeModuleDefinition(
       '@smithy/middleware-stack',
       ['>=2.0.0'],
@@ -121,36 +121,6 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
         );
         return newExports;
       }
-    );
-
-    // Patch for @smithy/core >= 3.24.0, which moved constructStack out of
-    // @smithy/middleware-stack and into @smithy/core/client (see smithy-lang/smithy-typescript#1991).
-    // AWS SDK v3 clients now require constructStack directly from @smithy/core/client,
-    // so the @smithy/middleware-stack hook no longer fires for these versions.
-  const v3SmithyCoreClientFile = new InstrumentationNodeModuleFile(
-      '@smithy/core/dist-cjs/submodules/client/index.js',
-      ['>=3.24.0'],
-      (moduleExports: any, moduleVersion?: string) => {
-        const newExports = propwrap(
-          moduleExports,
-          'constructStack',
-          (orig: any) => {
-            self._diag.debug(
-              'propwrapping aws-sdk v3 constructStack (@smithy/core/client)'
-            );
-            return self._getV3ConstructStackPatch(moduleVersion, orig);
-          }
-        );
-        return newExports;
-      },
-      (moduleExports: any) => moduleExports
-    );
-    const v3SmithyCore = new InstrumentationNodeModuleDefinition(
-      '@smithy/core',
-      ['>=3.24.0'],
-      undefined,
-      undefined,
-      [v3SmithyCoreClientFile]
     );
 
     const v3SmithyClient = new InstrumentationNodeModuleDefinition(
@@ -171,7 +141,6 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
     return [
       v3MiddlewareStack,
       v3SmithyMiddlewareStack,
-      v3SmithyCore,
       v3SmithyClient,
       v3NewSmithyClient,
     ];
@@ -191,11 +160,11 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
     return moduleExports;
   }
 
-  protected patchV3SmithyClient(moduleExports: any) {
+  protected patchV3SmithyClient(moduleExports: any, moduleVersion?: string) {
     this._wrap(
       moduleExports.Client.prototype,
       'send',
-      this._getV3SmithyClientSendPatch.bind(this)
+      this._getV3SmithyClientSendPatch.bind(this, moduleVersion)
     );
     return moduleExports;
   }
@@ -308,14 +277,17 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
   }
 
   private _getV3SmithyClientSendPatch(
+    moduleVersion: string | undefined,
     original: (...args: unknown[]) => Promise<any>
   ) {
+    const self = this;
     return function send(
       this: any,
       command: V3PluginCommand,
       ...args: unknown[]
     ): Promise<any> {
       command[V3_CLIENT_CONFIG_KEY] = this.config;
+      self.patchV3MiddlewareStack(moduleVersion, this.middlewareStack);
       return original.apply(this, [command, ...args]);
     };
   }
@@ -334,16 +306,20 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
 
     // 'clone' and 'concat' functions are internally calling 'constructStack' which is in same
     // module, thus not patched, and we need to take care of it specifically.
-    this._wrap(
-      middlewareStackToPatch,
-      'clone',
-      this._getV3MiddlewareStackClonePatch.bind(this, moduleVersion)
-    );
-    this._wrap(
-      middlewareStackToPatch,
-      'concat',
-      this._getV3MiddlewareStackClonePatch.bind(this, moduleVersion)
-    );
+    if (!isWrapped(middlewareStackToPatch.clone)) {
+      this._wrap(
+        middlewareStackToPatch,
+        'clone',
+        this._getV3MiddlewareStackClonePatch.bind(this, moduleVersion)
+      );
+    }
+    if (!isWrapped(middlewareStackToPatch.concat)) {
+      this._wrap(
+        middlewareStackToPatch,
+        'concat',
+        this._getV3MiddlewareStackClonePatch.bind(this, moduleVersion)
+      );
+    }
   }
 
   private _getV3MiddlewareStackClonePatch(


### PR DESCRIPTION
## Summary

Fixes #3514

`@smithy/core@3.24.0` moved `constructStack` into a CJS bundle
(`dist-cjs/submodules/client/index.js`) where `Client` and `Command`
classes call it as a closed-over local reference, not through the module
export. Patching `exports.constructStack` via `propwrap` has no effect
on these internal usages — and as noted by @trentm, could cause
instrumentation headers to leak into SigV4 signed headers, breaking
AWS request signing (see aws/aws-sdk-js-v3#8019).

Additionally, in `@smithy/core>=3.24.0` the `Client` class itself moved
from `@smithy/smithy-client` into the `@smithy/core/client` bundle, so
the existing `Client.prototype.send` patch via `@smithy/smithy-client`
no longer fires for AWS SDK v3 clients using the new bundle.

## Fix

Two changes:

1. Added an `InstrumentationNodeModuleFile` targeting
`@smithy/core/dist-cjs/submodules/client/index.js` for `>=3.24.0` to
patch `Client.prototype.send` there, reusing the existing
`patchV3SmithyClient`/`unpatchV3SmithyClient` methods.

2. Inside the `send` patch, call `patchV3MiddlewareStack` on
`this.middlewareStack` directly — since `constructStack` is a
closed-over local in the bundle, wrapping the export is ineffective.
Added `isWrapped` guards on `clone` and `concat` in
`patchV3MiddlewareStack` to make repeated calls safe, and threaded
`moduleVersion` through `patchV3SmithyClient` and
`_getV3SmithyClientSendPatch`.

## Testing

Existing SQS, S3, and other v3 tests in `.tav.yml` cover this — the
`max-7` version matrix will exercise versions of `@aws-sdk/client-*`
that pull in `@smithy/core>=3.24.0` transitively.