### PR TITLE
chore(ci): tweak yaml indentation for zizmor's YAML parser

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -32,7 +32,7 @@ jobs:
           days-before-issue-close: 14
           stale-issue-message: 'This package does not have an assigned [component owner](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/CONTRIBUTING.md#component-ownership) and is considered [unmaintained](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/CONTRIBUTING.md#unmaintained). As such this package is in feature-freeze and this issue will be closed with 14 days unless a new owner or a sponsor (a member of @open-telemetry/javascript-approvers) for the feature is found. It is the responsibility of the author to find a sponsor for this feature.
 
-          Are you familiar with this package? Consider [becoming a component owner](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/CONTRIBUTING.md#becoming-a-component-owner).'
+            Are you familiar with this package? Consider [becoming a component owner](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/CONTRIBUTING.md#becoming-a-component-owner).'
           close-issue-message: 'This issue was closed because no owner or sponsor has been found after 14 days'
           stale-issue-label: pkg-status:unmaintained:autoclose-scheduled
           only-labels: pkg-status:unmaintained,feature-request
@@ -44,7 +44,7 @@ jobs:
           days-before-pr-close: 14
           stale-pr-message: 'This package does not have an assigned [component owner](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/CONTRIBUTING.md#component-ownership) and is considered [unmaintained](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/CONTRIBUTING.md#unmaintained). As such this package is in feature-freeze and this PR will be closed with 14 days unless a new owner or a sponsor (a member of @open-telemetry/javascript-approvers) for the feature is found. It is the responsibility of the author to find a sponsor for this feature.
 
-          Are you familiar with this package? Consider [becoming a component owner](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/CONTRIBUTING.md#becoming-a-component-owner).'
+            Are you familiar with this package? Consider [becoming a component owner](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/CONTRIBUTING.md#becoming-a-component-owner).'
           close-pr-message: 'This issue was closed because no owner or sponsor has been found after 14 days'
           stale-pr-label: pkg-status:unmaintained:autoclose-scheduled
           only-labels: pkg-status:unmaintained


### PR DESCRIPTION
This change in indentation of multiline strings in YAML avoids this
limitation error with zizmor (e.g. https://github.com/open-telemetry/opentelemetry-js-contrib/actions/runs/26177574936/job/77011612744?pr=3531):

     INFO zizmor: 🌈 zizmor v1.25.2
    fatal: no audit was performed
    error: failed to load file://./.github/workflows/close-stale.yml as workflow
      |
      = help: this typically indicates a bug in zizmor; please report it
      = help: https://github.com/zizmorcore/zizmor/issues/new?template=bug-report.yml

    Caused by:
        0: failed to load file://./.github/workflows/close-stale.yml as workflow
        1: failed to load internal pathing document
        2: input is not valid YAML

Refs: https://github.com/zizmorcore/zizmor/issues/1116
