### PR TITLE
ci: zizmor: pin one uses-dep, ignore current pull_request_target usages

### DIFF
--- a/.github/workflows/component-owners.yml
+++ b/.github/workflows/component-owners.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Auto Assign Owners
     steps:
-      - uses: dyladan/component-owners@7ff2b343629407c4dbe1c28ae66f55f723543d2b # v0.2
+      - uses: dyladan/component-owners@7ff2b343629407c4dbe1c28ae66f55f723543d2b # v0.2.0
         with:
           config-file: .github/component_owners.yml
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/component-owners.yml
+++ b/.github/workflows/component-owners.yml
@@ -1,6 +1,10 @@
 name: 'Component Owners'
 on:
+  # Using 'pull_request_target' for permission to assign owners to the PR.
+  # https://docs.zizmor.sh/audits/#dangerous-triggers
+  # zizmor: ignore[dangerous-triggers]
   pull_request_target:
+    branches: [main]
 
 permissions:
   contents: read
@@ -12,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Auto Assign Owners
     steps:
-      - uses: dyladan/component-owners@main
+      - uses: dyladan/component-owners@7ff2b343629407c4dbe1c28ae66f55f723543d2b # v0.2
         with:
           config-file: .github/component_owners.yml
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -1,6 +1,10 @@
 name: "Label PR"
 on:
-  - pull_request_target
+  # Using 'pull_request_target' for permission to add labels to the PR.
+  # https://docs.zizmor.sh/audits/#dangerous-triggers
+  # zizmor: ignore[dangerous-triggers]
+  pull_request_target:
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,6 +1,9 @@
 name: Lint PR
 
 on:
+  # Using 'pull_request_target' to *not* run changes in the PR branch.
+  # https://docs.zizmor.sh/audits/#dangerous-triggers
+  # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,6 +28,8 @@ jobs:
         with:
           node-version: 18
           registry-url: 'https://registry.npmjs.org'
+          # Disable caching in release workflows (https://docs.zizmor.sh/audits/#cache-poisoning).
+          package-manager-cache: false
 
       - name: Install packages
         run: |
@@ -75,6 +77,8 @@ jobs:
           # Require npm 11.5.1 or later for https://docs.npmjs.com/trusted-publishers.
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
+          # Disable caching in release workflows (https://docs.zizmor.sh/audits/#cache-poisoning).
+          package-manager-cache: false
       - run: npm ci --ignore-scripts
       - run: npm run compile
       # Release Please has already incremented versions and published tags, so we just

--- a/.github/workflows/survey-on-merged-pr.yml
+++ b/.github/workflows/survey-on-merged-pr.yml
@@ -1,8 +1,12 @@
 name: Survey on Merged PR by Non-Member
 
 on:
+  # Using 'pull_request_target' for permission to `gh pr comment`.
+  # https://docs.zizmor.sh/audits/#dangerous-triggers
+  # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types: [closed]
+    branches: [main]
 
 permissions:
   contents: read
@@ -28,19 +32,19 @@ jobs:
           USERNAME="${GITHUB_EVENT_PULL_REQUEST_USER_LOGIN}"
           USER_TYPE="${GITHUB_EVENT_PULL_REQUEST_USER_TYPE}"
           ORG="${{ github.repository_owner }}"
-          
+
           # Skip if user is a bot
           if [[ "$USER_TYPE" == "Bot" ]]; then
             echo "Skipping survey for bot user: $USERNAME"
             exit 0
           fi
-          
+
           # Skip if user is an org member
           if gh api "orgs/$ORG/members/$USERNAME" --silent; then
             echo "Skipping survey for org member: $USERNAME"
             exit 0
           fi
-          
+
           # Add survey comment for external contributor
           echo "Adding survey comment for external contributor: $USERNAME"
           gh pr comment ${PR_NUM} --repo ${{ github.repository }} --body "Thank you for your contribution @${USERNAME}! 🎉 We would like to hear from you about your experience contributing to OpenTelemetry by taking a few minutes to fill out this [survey](${SURVEY_URL})."


### PR DESCRIPTION
See https://docs.zizmor.sh/audits/#dangerous-triggers

My best understanding of the workflows using `pull_request_target` is that they:
- need to use `pull_request_target` for the permissions to edit the PR (add labels, owners), or prefer `pull_request_target` to `pull_request` to *not* run with possible changes from the PR branch (for pr-title.yml)
- do not execute any code from the PR branch (i.e. none of them are using the PR branch git ref and checking it out)
- properly escape/quote any `github.event.*` or `github.context.*` data from the PR branch (e.g. using the shell for quoting in `survey-on-merged-pr.yml`)