### PR TITLE
fix(instrumentation-runtime-node): use finer GC duration buckets

### DIFF
--- a/packages/instrumentation-runtime-node/src/metrics/gcCollector.ts
+++ b/packages/instrumentation-runtime-node/src/metrics/gcCollector.ts
@@ -11,8 +11,6 @@ import { Histogram, ValueType } from '@opentelemetry/api';
 import { BaseCollector } from './baseCollector';
 import { ATTR_V8JS_GC_TYPE, METRIC_V8JS_GC_DURATION } from '../semconv';
 
-// Use latency-style second buckets so sub-second GC pauses do not all collapse
-// into the `<=1s` bucket in histogram-based backends.
 const DEFAULT_GC_DURATION_BUCKETS = [
   0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10,
 ];

--- a/packages/instrumentation-runtime-node/src/metrics/gcCollector.ts
+++ b/packages/instrumentation-runtime-node/src/metrics/gcCollector.ts
@@ -11,7 +11,11 @@ import { Histogram, ValueType } from '@opentelemetry/api';
 import { BaseCollector } from './baseCollector';
 import { ATTR_V8JS_GC_TYPE, METRIC_V8JS_GC_DURATION } from '../semconv';
 
-const DEFAULT_GC_DURATION_BUCKETS = [0.01, 0.1, 1, 10];
+// Use latency-style second buckets so sub-second GC pauses do not all collapse
+// into the `<=1s` bucket in histogram-based backends.
+const DEFAULT_GC_DURATION_BUCKETS = [
+  0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10,
+];
 
 const kinds: string[] = [];
 kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_MAJOR] = 'major';

--- a/packages/instrumentation-runtime-node/test/gc.test.ts
+++ b/packages/instrumentation-runtime-node/test/gc.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { Meter } from '@opentelemetry/api';
+
+import { GCCollector } from '../src/metrics/gcCollector';
+import { METRIC_V8JS_GC_DURATION } from '../src/semconv';
+
+describe('GCCollector', function () {
+  it('should configure GC duration histogram with sub-second buckets', function () {
+    const createHistogram = sinon.stub().returns({
+      record: sinon.stub(),
+    });
+    const meter = {
+      createHistogram,
+    } as unknown as Meter;
+
+    const collector = new GCCollector();
+    collector.updateMetricInstruments(meter);
+
+    sinon.assert.calledOnce(createHistogram);
+    const [name, options] = createHistogram.firstCall.args;
+
+    assert.strictEqual(name, METRIC_V8JS_GC_DURATION);
+    assert.deepStrictEqual(
+      options.advice?.explicitBucketBoundaries,
+      [
+        0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5,
+        10,
+      ]
+    );
+  });
+});


### PR DESCRIPTION
## Which problem is this PR solving?

- `v8js.gc.duration` used very coarse bucket boundaries (`[0.01, 0.1, 1, 10]`), which caused sub-second GC pauses like ~200ms to be reported in the `<=1s` bucket.

## Short description of the changes

- switch the GC duration histogram to latency-style second buckets
- add a unit test covering the configured bucket boundaries

## Validation

- `npm run version:update -w @opentelemetry/instrumentation-runtime-node`
- `npm run compile -w @opentelemetry/instrumentation-runtime-node`
- `npm test -w @opentelemetry/instrumentation-runtime-node`
