### PR TITLE
ci: zizmor updates for 'github-app' audit and 'ref-version-mismatch'

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write # required for closing stale PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           days-before-stale: 60
           days-before-close: 14
@@ -26,7 +26,7 @@ jobs:
           exempt-issue-labels: never-stale
           exempt-pr-labels: never-stale
           any-of-labels: information-requested
-      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           days-before-issue-stale: 0
           days-before-issue-close: 14
@@ -38,7 +38,7 @@ jobs:
           only-labels: pkg-status:unmaintained,feature-request
           exempt-issue-labels: bug,has:sponsor,type:semconv-update
           remove-stale-when-updated: false
-      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           days-before-pr-stale: 0
           days-before-pr-close: 14

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,11 +35,16 @@ jobs:
         run: |
           npm ci --ignore-scripts
 
-      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
           app-id: ${{ vars.OTELBOT_JS_CONTRIB_APP_ID }}
           private-key: ${{ secrets.OTELBOT_JS_CONTRIB_PRIVATE_KEY }}
+          repositories: ${{ github.repository }}
+          # Scope to just the permissions required by googleapis/release-please-action.
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
 
       - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
         id: release

--- a/.github/workflows/survey-on-merged-pr.yml
+++ b/.github/workflows/survey-on-merged-pr.yml
@@ -21,11 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
     steps:
-      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
           app-id: ${{ vars.OTELBOT_APP_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          repositories: ${{ github.repository }}
+          permission-issues: write
 
       - name: Add survey comment if author is not a member or bot
         run: |

--- a/.github/workflows/update-otel-deps.yaml
+++ b/.github/workflows/update-otel-deps.yaml
@@ -1,4 +1,4 @@
-name: Create or Update OpenTelemetry Update PR
+name: Create OTel deps update PR
 
 on:
   workflow_dispatch:
@@ -10,11 +10,15 @@ jobs:
   create-or-update-deps-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
           app-id: ${{ vars.OTELBOT_JS_CONTRIB_APP_ID }}
           private-key: ${{ secrets.OTELBOT_JS_CONTRIB_PRIVATE_KEY }}
+          repositories: ${{ github.repository }}
+          # Scope to just the permissions required by "Create PR" step below.
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -32,7 +36,7 @@ jobs:
 
       - run: npm ci --ignore-scripts
 
-      - name: Create/Update Release PR
+      - name: Create PR
         run: |
           git config user.name otelbot
           git config user.email 197425009+otelbot@users.noreply.github.com

--- a/.github/workflows/zizmor-checks.yml
+++ b/.github/workflows/zizmor-checks.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          filter: 'tree:0'
           persist-credentials: false
 
       - name: Run zizmor

--- a/.github/workflows/zizmor-checks.yml
+++ b/.github/workflows/zizmor-checks.yml
@@ -1,3 +1,7 @@
+# Zizmor can be run locally:
+#   zizmor --gh-token $(gh auth token) .github/workflows
+# Sometimes there are automatic fixes to findings:
+#   zizmor --gh-token $(gh auth token) --fix=all .github/workflows
 name: Zizmor GitHub Actions Security Analysis
 
 on:


### PR DESCRIPTION
Use the exact tag name in the comment for hash-pinned 'uses:' deps.
This ensures that the zizmor ref-version-mismatch rule does not
complain when there is a new minor or patch release of the action
dependency. The hope is that *renovate* will handle updating the hash and
tag comment -- which allows using cooldowns, etc.
https://docs.zizmor.sh/audits/#ref-version-mismatch

https://docs.zizmor.sh/audits/#github-app is new in zizmor v1.25.
Scope the actions/create-github-app-token to the current repo
and to the minimum set of permissions required.
