### PR TITLE
ci: drop 'repositories:' unnecessary usage with actions/create-github-app-token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,7 +40,6 @@ jobs:
         with:
           app-id: ${{ vars.OTELBOT_JS_CONTRIB_APP_ID }}
           private-key: ${{ secrets.OTELBOT_JS_CONTRIB_PRIVATE_KEY }}
-          repositories: ${{ github.repository }}
           # Scope to just the permissions required by googleapis/release-please-action.
           permission-contents: write
           permission-issues: write

--- a/.github/workflows/survey-on-merged-pr.yml
+++ b/.github/workflows/survey-on-merged-pr.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           app-id: ${{ vars.OTELBOT_APP_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
-          repositories: ${{ github.repository }}
           permission-issues: write
 
       - name: Add survey comment if author is not a member or bot

--- a/.github/workflows/update-otel-deps.yaml
+++ b/.github/workflows/update-otel-deps.yaml
@@ -15,7 +15,6 @@ jobs:
         with:
           app-id: ${{ vars.OTELBOT_JS_CONTRIB_APP_ID }}
           private-key: ${{ secrets.OTELBOT_JS_CONTRIB_PRIVATE_KEY }}
-          repositories: ${{ github.repository }}
           # Scope to just the permissions required by "Create PR" step below.
           permission-contents: write
           permission-pull-requests: write


### PR DESCRIPTION
Scoping to just the curr repo is the default as long as the
'owner:' field is empty. I misread the action config earlier.
