### PR TITLE
docs(instrumentation-socket.io): replace deprecated ignoreIncomingPaths with ignoreIncomingRequestHook

### DIFF
--- a/packages/instrumentation-socket.io/README.md
+++ b/packages/instrumentation-socket.io/README.md
@@ -50,7 +50,29 @@ registerInstrumentations({
 
 ## Filter Http Transport
 
-If you do not want to trace the socket.io http requests, add the default socket.io route (`/socket.io/`) to the `HttpInstrumentationConfig.ignoreIncomingPaths` array
+If you do not want to trace the socket.io HTTP polling requests, use the
+`ignoreIncomingRequestHook` option from `@opentelemetry/instrumentation-http`
+to filter out requests on the default socket.io route:
+
+```js
+const { HttpInstrumentation } = require("@opentelemetry/instrumentation-http");
+const {
+  SocketIoInstrumentation,
+} = require("@opentelemetry/instrumentation-socket.io");
+const { registerInstrumentations } = require("@opentelemetry/instrumentation");
+
+registerInstrumentations({
+  instrumentations: [
+    new HttpInstrumentation({
+      ignoreIncomingRequestHook(req) {
+        // Ignore socket.io HTTP polling transport requests
+        return !!req.url?.startsWith("/socket.io/");
+      },
+    }),
+    new SocketIoInstrumentation(),
+  ],
+});
+```
 
 ## Semantic Conventions
 


### PR DESCRIPTION
`ignoreIncomingPaths` was removed in open-telemetry/opentelemetry-js#5085.
Update the Filter Http Transport section to use `ignoreIncomingRequestHook`
instead, and add a working code example.

Fixes #3526