### PR TITLE
fix(knex): use resolved connection settings

### DIFF
--- a/packages/instrumentation-knex/src/instrumentation.ts
+++ b/packages/instrumentation-knex/src/instrumentation.ts
@@ -133,6 +133,7 @@ export class KnexInstrumentation extends InstrumentationBase<KnexInstrumentation
     return function wrapQuery(original: (...args: any[]) => any) {
       return function wrapped_logging_method(this: any, query: any) {
         const config = this.client.config;
+        const connection = this.client.connectionSettings ?? config?.connection;
 
         const table = utils.extractTableName(this.builder);
         // `method` actually refers to the knex API method - Not exactly "operation"
@@ -140,10 +141,10 @@ export class KnexInstrumentation extends InstrumentationBase<KnexInstrumentation
         const operation = query?.method;
         // Knex can be configured with a connectionString instead of explicit fields.
         // Fall back to parsing the connectionString if filename and database are not set.
-        const connectionString = config?.connection?.connectionString;
+        const connectionString = connection?.connectionString;
         const name =
-          config?.connection?.filename ||
-          config?.connection?.database ||
+          connection?.filename ||
+          connection?.database ||
           utils.extractDatabaseFromConnectionString(connectionString);
         const { maxQueryLength } = instrumentation.getConfig();
 
@@ -151,21 +152,21 @@ export class KnexInstrumentation extends InstrumentationBase<KnexInstrumentation
           'knex.version': moduleVersion,
         };
         const transport =
-          config?.connection?.filename === ':memory:' ? 'inproc' : undefined;
+          connection?.filename === ':memory:' ? 'inproc' : undefined;
 
         if (instrumentation._semconvStability & SemconvStability.OLD) {
           Object.assign(attributes, {
             [ATTR_DB_SYSTEM]: utils.mapSystem(this.client.driverName),
             [ATTR_DB_SQL_TABLE]: table,
             [ATTR_DB_OPERATION]: operation,
-            [ATTR_DB_USER]: config?.connection?.user,
+            [ATTR_DB_USER]: connection?.user,
             [ATTR_DB_NAME]: name,
             // Fall back to parsing host and port from connectionString if not explicitly set.
             [ATTR_NET_PEER_NAME]:
-              config?.connection?.host ??
+              connection?.host ??
               utils.extractHostFromConnectionString(connectionString),
             [ATTR_NET_PEER_PORT]:
-              config?.connection?.port ??
+              connection?.port ??
               utils.extractPortFromConnectionString(connectionString),
             [ATTR_NET_TRANSPORT]: transport,
           });
@@ -178,10 +179,10 @@ export class KnexInstrumentation extends InstrumentationBase<KnexInstrumentation
             [ATTR_DB_NAMESPACE]: name,
             // Fall back to parsing host and port from connectionString if not explicitly set.
             [ATTR_SERVER_ADDRESS]:
-              config?.connection?.host ??
+              connection?.host ??
               utils.extractHostFromConnectionString(connectionString),
             [ATTR_SERVER_PORT]:
-              config?.connection?.port ??
+              connection?.port ??
               utils.extractPortFromConnectionString(connectionString),
           });
         }

--- a/packages/instrumentation-knex/test/index.test.ts
+++ b/packages/instrumentation-knex/test/index.test.ts
@@ -135,6 +135,33 @@ describe('Knex instrumentation', () => {
       );
     });
 
+    it('should collect connection attributes from dynamic connection settings', async () => {
+      await client.destroy();
+      client = knex({
+        client: 'sqlite3',
+        connection: () => ({
+          filename: ':memory:',
+        }),
+        useNullAsDefault: true,
+      });
+
+      const parentSpan = tracer.startSpan('parentSpan');
+      const statement = "select date('now')";
+
+      await context.with(
+        trace.setSpan(context.active(), parentSpan),
+        async () => {
+          await client.raw(statement);
+          parentSpan.end();
+
+          assertSpans(memoryExporter.getFinishedSpans(), [
+            { statement, op: 'raw', parentSpan },
+            null,
+          ]);
+        }
+      );
+    });
+
     it('should truncate the query', async () => {
       const statement = `select date('now'), "${'long-'.repeat(15)}"`;
       await client.raw(statement);

--- a/packages/instrumentation-knex/test/index.test.ts
+++ b/packages/instrumentation-knex/test/index.test.ts
@@ -15,6 +15,7 @@ import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
+import { SemconvStability } from '@opentelemetry/instrumentation';
 import * as assert from 'assert';
 
 import { KnexInstrumentation } from '../src';
@@ -160,6 +161,33 @@ describe('Knex instrumentation', () => {
           ]);
         }
       );
+    });
+
+    it('should collect stable connection attributes from dynamic connection settings', async () => {
+      const originalSemconvStability = (plugin as any)._semconvStability;
+      (plugin as any)._semconvStability = SemconvStability.STABLE;
+      await client.destroy();
+      client = knex({
+        client: 'sqlite3',
+        connection: () => ({
+          filename: ':memory:',
+        }),
+        useNullAsDefault: true,
+      });
+
+      const statement = "select date('now')";
+
+      try {
+        await client.raw(statement);
+
+        const [span] = memoryExporter.getFinishedSpans();
+        assert.strictEqual(span.attributes['db.system.name'], 'sqlite');
+        assert.strictEqual(span.attributes['db.namespace'], ':memory:');
+        assert.strictEqual(span.attributes['db.operation.name'], 'raw');
+        assert.strictEqual(span.attributes['db.query.text'], statement);
+      } finally {
+        (plugin as any)._semconvStability = originalSemconvStability;
+      }
     });
 
     it('should truncate the query', async () => {


### PR DESCRIPTION
Fixes #3489.

Uses knex's resolved `client.connectionSettings` when collecting connection attributes, so function-based connection configs populate database metadata.

Checks:
- npm ci
- npm run version:update -w @opentelemetry/instrumentation-knex
- npm run compile -w @opentelemetry/instrumentation-knex
- nyc mocha "test/**/*.ts"
- npm exec -- prettier --check packages/instrumentation-knex/src/instrumentation.ts packages/instrumentation-knex/test/index.test.ts
- git diff --check
