### PR TITLE
test: do not test typeorm@1.x in TAV tests, it is not yet supported

### DIFF
--- a/packages/instrumentation-typeorm/.tav.yml
+++ b/packages/instrumentation-typeorm/.tav.yml
@@ -1,5 +1,5 @@
 typeorm:
   versions:
-    include: ">=0.3.0"
+    include: ">=0.3.0 <1"
     mode: max-7
   commands: npm run test


### PR DESCRIPTION
This should fix test-all-versions (TAV) tests for now.
Actual instrumentation and test support for typeorm 1.x should be
added in a separate PR.

Refs: https://github.com/open-telemetry/opentelemetry-js-contrib/issues/3545
