### PR TITLE
fix(deps): Add missing dev dependency breaking the build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22364,9 +22364,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -22381,9 +22378,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -22398,9 +22392,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -22415,9 +22406,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -37219,6 +37207,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.65.0",
+        "@opentelemetry/instrumentation-http": "^0.218.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0"
       },
       "engines": {

--- a/packages/resource-detector-alibaba-cloud/package.json
+++ b/packages/resource-detector-alibaba-cloud/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/contrib-test-utils": "^0.65.0",
+    "@opentelemetry/instrumentation-http": "^0.218.0",
     "@opentelemetry/sdk-trace-base": "^2.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
❌ > nx run @opentelemetry/resource-detector-alibaba-cloud:compile
  
  
  > @opentelemetry/resource-detector-alibaba-cloud@0.33.8 compile
  > tsc --build tsconfig.json tsconfig.esm.json
  
  Error: test/detectors/AlibabaCloudEcsDetectorIntegration.test.ts(8,37): error TS2307: Cannot find module '@opentelemetry/instrumentation-http' or its corresponding type declarations.
  npm error Lifecycle script `compile` failed with error:
  npm error code 2
  npm error path /home/runner/work/opentelemetry-js-contrib/opentelemetry-js-contrib/packages/resource-detector-alibaba-cloud
  npm error workspace @opentelemetry/resource-detector-alibaba-cloud@0.33.8
  npm error location /home/runner/work/opentelemetry-js-contrib/opentelemetry-js-contrib/packages/resource-detector-alibaba-cloud
  npm error command failed
  npm error command sh -c tsc --build tsconfig.json tsconfig.esm.json