### PR TITLE
fix(instrumentation-openai): guard stream iterator against chunks missing a choices array

### DIFF
--- a/packages/instrumentation-openai/src/instrumentation.ts
+++ b/packages/instrumentation-openai/src/instrumentation.ts
@@ -470,7 +470,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<OpenAIInstrumenta
         'OpenAI.Chat.Completions.create stream chunk: %O',
         chunk
       );
-      const idx = chunk.choices[0]?.index ?? 0;
+      const idx = chunk.choices?.[0]?.index ?? 0;
       if (!choices[idx]) {
         choices[idx] = {} as {
           content: string;
@@ -478,7 +478,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<OpenAIInstrumenta
         };
       }
       if (config.captureMessageContent) {
-        const contentPart = chunk.choices[0]?.delta?.content;
+        const contentPart = chunk.choices?.[0]?.delta?.content;
         if (contentPart) {
           if (!choices[idx].content) {
             choices[idx].content = '';
@@ -487,7 +487,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<OpenAIInstrumenta
         }
       }
       // Assume delta.tool_calls, if exists, is an array of length 1.
-      const toolCallPart = chunk.choices[0]?.delta?.tool_calls?.[0];
+      const toolCallPart = chunk.choices?.[0]?.delta?.tool_calls?.[0];
       if (toolCallPart) {
         if (!choices[idx].toolCalls) {
           choices[idx].toolCalls = [];
@@ -524,7 +524,7 @@ export class OpenAIInstrumentation extends InstrumentationBase<OpenAIInstrumenta
         span.setAttribute(ATTR_GEN_AI_RESPONSE_MODEL, model);
       }
       if (!finishReasons[idx]) {
-        const finishReason = chunk.choices[0]?.finish_reason;
+        const finishReason = chunk.choices?.[0]?.finish_reason;
         if (finishReason) {
           finishReasons[idx] = finishReason;
         }

--- a/packages/instrumentation-openai/test/mock-responses/openai-streaming-chat-completions-copes-with-chunks-missing-a-choices-array.json
+++ b/packages/instrumentation-openai/test/mock-responses/openai-streaming-chat-completions-copes-with-chunks-missing-a-choices-array.json
@@ -1,0 +1,25 @@
+[
+  {
+    "scope": "https://api.openai.com:443",
+    "method": "POST",
+    "path": "/v1/chat/completions",
+    "body": {
+      "model": "gpt-4o-mini",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Answer in up to 3 words: Which ocean contains Bouvet Island?"
+        }
+      ],
+      "stream": true
+    },
+    "status": 200,
+    "response": "data: {\"id\":\"chatcmpl-empty-choices-regression\",\"object\":\"chat.completion.chunk\",\"created\":1752737269,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"Atlantic Ocean.\"},\"logprobs\":null,\"finish_reason\":null}]}\n\ndata: {\"id\":\"chatcmpl-empty-choices-regression\",\"object\":\"chat.completion.chunk\",\"created\":1752737269,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":null}\n\ndata: {\"id\":\"chatcmpl-empty-choices-regression\",\"object\":\"chat.completion.chunk\",\"created\":1752737269,\"model\":\"gpt-4o-mini-2024-07-18\",\"service_tier\":\"default\",\"system_fingerprint\":null,\"choices\":[{\"index\":0,\"delta\":{},\"logprobs\":null,\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n",
+    "rawHeaders": {
+      "content-type": "text/event-stream; charset=utf-8",
+      "openai-version": "2020-10-01",
+      "x-request-id": "req_emptychoicesregression0000000000"
+    },
+    "responseIsBinary": false
+  }
+]

--- a/packages/instrumentation-openai/test/openai.test.ts
+++ b/packages/instrumentation-openai/test/openai.test.ts
@@ -1773,6 +1773,43 @@ describe('OpenAI', function () {
       });
     });
 
+    it('copes with chunks missing a choices array', async () => {
+      // Regression test for #3554. Some OpenAI-compatible backends (e.g.
+      // Gemini 2.5 via a gateway) stream a chunk that omits the `choices`
+      // array entirely. The stream iterator must not throw on such a chunk;
+      // previously `chunk.choices[0]` threw "Cannot read properties of
+      // undefined (reading '0')", which propagated into the caller's
+      // `for await` loop and failed the request.
+      const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [
+        {
+          role: 'user',
+          content: input,
+        },
+      ];
+      const stream = await client.chat.completions.create({
+        model,
+        messages,
+        stream: true,
+      });
+      let content = '';
+      for await (const part of stream) {
+        content += part.choices?.[0]?.delta?.content || '';
+      }
+      expect(content).toEqual('Atlantic Ocean.');
+
+      // The span is still produced and finished cleanly despite the
+      // choices-less chunk.
+      const spans = getTestSpans();
+      expect(spans.length).toBe(1);
+      expect(spans[0].attributes).toMatchObject({
+        [ATTR_GEN_AI_OPERATION_NAME]: 'chat',
+        [ATTR_GEN_AI_REQUEST_MODEL]: model,
+        [ATTR_GEN_AI_SYSTEM]: 'openai',
+        [ATTR_GEN_AI_RESPONSE_FINISH_REASONS]: ['stop'],
+        [ATTR_GEN_AI_RESPONSE_MODEL]: 'gpt-4o-mini-2024-07-18',
+      });
+    });
+
     it('copes with .withResponse() usage', async () => {
       const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [
         {


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #3554.

The streaming chat-completions instrumentation gathers telemetry from each
stream chunk with an unguarded `chunk.choices[0]`:

```ts
const idx = chunk.choices[0]?.index ?? 0;
```

The optional chaining is applied **after** the `[0]` index, so it guards
`choices[0]` being `undefined` but not `chunk.choices` itself being
`undefined`. Some OpenAI-compatible backends legitimately stream a chunk with
no `choices` array at all (e.g. **Gemini 2.5** behind an OpenAI-compatible
gateway, which emits metadata/usage-only chunks). On such a chunk,
`chunk.choices[0]` throws `TypeError: Cannot read properties of undefined
(reading '0')`.

Because the iterator `yield`s the chunk **before** gathering telemetry, the
throw surfaces inside the consumer's `for await` loop on the next iteration —
so an instrumentation-only defect breaks the application's stream consumption.
The OpenAI SDK itself tolerates these chunks; the instrumentation should too.

## Short description of the changes

- Guard all four `chunk.choices[0]` accesses in
  `_onChatCompletionsStreamIterator` with `chunk.choices?.[0]` so a chunk
  lacking a `choices` array is skipped for telemetry instead of throwing.
- Add a regression test (`copes with chunks missing a choices array`) plus its
  nock fixture. The fixture is hand-authored rather than recorded, because the
  triggering behavior comes from non-OpenAI backends and cannot be reproduced
  against `api.openai.com`; the stream contains a content chunk, a chunk with
  **no** `choices` key, and a terminating `finish_reason: "stop"` chunk. The
  test asserts the stream is consumed without throwing and the span is still
  produced.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `npm test` for `@opentelemetry/instrumentation-openai` (added regression test
  passes; existing tests unaffected).
- Verified the new test fails without the source change (throws
  `Cannot read properties of undefined (reading '0')`) and passes with it.

## Checklist:

- [x] Followed the [style guidelines](https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md) of this project
- [x] Unit tests have been added
- [ ] Documentation has been updated (n/a)
