### PR TITLE
chore(resource-detector-alibaba): add http instrumentation as devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37219,6 +37219,7 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.0.0",
         "@opentelemetry/contrib-test-utils": "^0.65.0",
+        "@opentelemetry/instrumentation-http": "^0.218.0",
         "@opentelemetry/sdk-trace-base": "^2.0.0"
       },
       "engines": {

--- a/packages/resource-detector-alibaba-cloud/package.json
+++ b/packages/resource-detector-alibaba-cloud/package.json
@@ -46,7 +46,8 @@
   "devDependencies": {
     "@opentelemetry/api": "^1.0.0",
     "@opentelemetry/contrib-test-utils": "^0.65.0",
-    "@opentelemetry/sdk-trace-base": "^2.0.0"
+    "@opentelemetry/sdk-trace-base": "^2.0.0",
+    "@opentelemetry/instrumentation-http": "^0.218.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.0.0"


### PR DESCRIPTION
## Which problem is this PR solving?

In #3194, the build is failing due to a missing `devDependency` - `@opentelemetry/instrumentation-http` is used in tests but was not specified. This PR fixes that by adding it.