### PR TITLE
fix(instrumentation-express): filter Express v5 wildcard paths in get…

### DIFF
--- a/packages/instrumentation-express/src/utils.ts
+++ b/packages/instrumentation-express/src/utils.ts
@@ -212,10 +212,7 @@ export function getConstructedRoute(req: {
     : [];
 
   const meaningfulPaths = layersStore.filter(
-    path =>
-      path !== '/' &&
-      path !== '/*' &&
-      !/^\/\{[*][^}]*\}$/.test(path)
+    path => path !== '/' && path !== '/*' && !/^\/\{[*][^}]*\}$/.test(path)
   );
 
   if (meaningfulPaths.length === 1 && meaningfulPaths[0] === '*') {

--- a/packages/instrumentation-express/src/utils.ts
+++ b/packages/instrumentation-express/src/utils.ts
@@ -212,6 +212,7 @@ export function getConstructedRoute(req: {
     : [];
 
   const meaningfulPaths = layersStore.filter(
+    // Exclude root path, wildcard '/*', and Express v5 wildcard segments like /{*param} or /{**param}
     path => path !== '/' && path !== '/*' && !/^\/\{[*][^}]*\}$/.test(path)
   );
 

--- a/packages/instrumentation-express/src/utils.ts
+++ b/packages/instrumentation-express/src/utils.ts
@@ -212,7 +212,10 @@ export function getConstructedRoute(req: {
     : [];
 
   const meaningfulPaths = layersStore.filter(
-    path => path !== '/' && path !== '/*'
+    path =>
+      path !== '/' &&
+      path !== '/*' &&
+      !/^\/\{[*][^}]*\}$/.test(path)
   );
 
   if (meaningfulPaths.length === 1 && meaningfulPaths[0] === '*') {

--- a/packages/instrumentation-express/test/express.test.ts
+++ b/packages/instrumentation-express/test/express.test.ts
@@ -680,6 +680,68 @@ describe('ExpressInstrumentation', () => {
         }
       );
     });
+    it('should not include Express v5 wildcard fragments in http.route', async () => {
+      // /{*path} syntax is Express v5 only, no point running this on v4
+      if (!isExpressV5) {
+        return;
+      }
+
+      const rootSpan = tracer.startSpan('rootSpan');
+      let rpcMetadata: RPCMetadata | undefined;
+
+      const httpServer = await serverWithMiddleware(tracer, rootSpan, app => {
+        app.use(express.json());
+        app.use((req, res, next) => {
+          rpcMetadata = getRPCMetadata(context.active());
+          next();
+        });
+
+        // mount a couple of catch-all wildcard middlewares using the new v5 syntax
+        // these should be stripped out when building the http.route, same as /* was in v4
+        const passthroughMiddleware: express.RequestHandler = (
+          _req,
+          _res,
+          next
+        ) => next();
+        app.use('/{*path}', passthroughMiddleware);
+        app.use('/{*wildcard}', passthroughMiddleware);
+      });
+
+      server = httpServer.server;
+      port = httpServer.port;
+
+      await context.with(
+        trace.setSpan(context.active(), rootSpan),
+        async () => {
+          const response = await httpRequest.get(
+            `http://localhost:${port}/toto/tata`
+          );
+          assert.strictEqual(response, 'tata');
+          rootSpan.end();
+
+          // route should still resolve correctly despite the wildcard middlewares
+          const requestHandlerSpan = memoryExporter
+            .getFinishedSpans()
+            .find(span => span.name.includes('request handler'));
+          assert.strictEqual(
+            requestHandlerSpan?.attributes[ATTR_HTTP_ROUTE],
+            '/toto/:id'
+          );
+          assert.strictEqual(rpcMetadata?.route, '/toto/:id');
+
+          // double-check that no span ended up with a raw wildcard fragment as its route
+          for (const span of memoryExporter.getFinishedSpans()) {
+            const route = span.attributes[ATTR_HTTP_ROUTE] as
+              | string
+              | undefined;
+            assert.ok(
+              !route || !/\/\{[*][^}]*\}/.test(route),
+              `span "${span.name}" still has a wildcard fragment in http.route: ${route}`
+            );
+          }
+        }
+      );
+    });
   });
 
   describe('Baggage propagation through middleware', () => {

--- a/packages/instrumentation-express/test/utils.test.ts
+++ b/packages/instrumentation-express/test/utils.test.ts
@@ -467,6 +467,27 @@ describe('Utils', () => {
           '/api/v2/users/:userId/posts/:postId/comments'
         );
       });
+      it('should filter out Express v5 wildcard paths like /{*path}', () => {
+        const req = createMockRequest('/api/users', [
+          '/',
+          '/{*path}',
+          '/api',
+          '/users',
+        ]);
+        const result = utils.getActualMatchedRoute(req);
+        assert.strictEqual(result, '/api/users');
+      });
+
+      it('should filter out Express v5 wildcard paths like /{*}', () => {
+        const req = createMockRequest('/api/users', [
+          '/',
+          '/{*}',
+          '/api',
+          '/users',
+        ]);
+        const result = utils.getActualMatchedRoute(req);
+        assert.strictEqual(result, '/api/users');
+      });
     });
 
     describe('Query parameters and fragments', () => {


### PR DESCRIPTION


## Which problem is this PR solving?

Express v5 changed how wildcard paths work, instead of `/*` it now uses syntax like `/{*path}` or `/{*}`. The existing filter in getConstructedRoute only knew about the old Express v4 style, so these new wildcards were leaking into span names and making http.route messy

Fixes #3551 

## Short description of the changes

Express v5 uses a new wildcard syntax like `/{*path}` for catch-all routes. These fragments were leaking into http.route span attributes because the filter in getConstructedRoute only stripped out `/` and `/*` from v4. This PR extends the filter with a regex to catch the v5 style too. Added unit tests in utils.test.ts for a few different patterns and an integration test in express.test.ts that actually spins up an Express v5 server with wildcard middlewares and checks that none of the spans end up with a wildcard fragment as their route, not just the request handler span.