### PR TITLE
test: add missing coverage for storeLayerPath

### DIFF
--- a/packages/instrumentation-express/test/utils.test.ts
+++ b/packages/instrumentation-express/test/utils.test.ts
@@ -90,6 +90,14 @@ describe('Utils', () => {
     });
   });
 
+  describe('storeLayerPath()', () => {
+    it('should return isLayerPathStored false when no value is provided', () => {
+      const req = {} as PatchedRequest;
+      const result = utils.storeLayerPath(req);
+      assert.deepEqual(result, { isLayerPathStored: false });
+    });
+  });
+
   describe('getLayerMetadata()', () => {
     it('should return router metadata', () => {
       assert.deepEqual(


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

`storeLayerPath` in `utils.ts` had an untested code path where calling the function without a `value` argument returns `{ isLayerPathStored: false }`. This branch had no test coverage.

## Short description of the changes

Adds a test case for `storeLayerPath()` when called without a value argument, covering the early return path that was previously missing from the test suite.
