### PR TITLE
fix(instrumentation-express): filter Express v5 wildcard path fragmen…

### DIFF
--- a/packages/instrumentation-express/src/utils.ts
+++ b/packages/instrumentation-express/src/utils.ts
@@ -212,7 +212,13 @@ export function getConstructedRoute(req: {
     : [];
 
   const meaningfulPaths = layersStore.filter(
-    path => path !== '/' && path !== '/*'
+    path =>
+      path !== '/' &&
+      path !== '/*' &&
+      // Express v5 uses /{*param} wildcard syntax (path-to-regexp v8).
+      // These catch-all fragments are meaningless for route identification,
+      // the same as '/*' was in Express v4.
+      !/^\/\{\*[^}]*\}$/.test(path)
   );
 
   if (meaningfulPaths.length === 1 && meaningfulPaths[0] === '*') {

--- a/packages/instrumentation-express/test/express.test.ts
+++ b/packages/instrumentation-express/test/express.test.ts
@@ -499,6 +499,61 @@ describe('ExpressInstrumentation', () => {
       );
     });
 
+    it('should filter out Express v5 dynamic path fragments (/{*path})', async () => {
+      if (!isExpressV5) {
+        // /{*path} is an Express v5 wildcard syntax; skip on Express v4
+        return;
+      }
+      const rootSpan = tracer.startSpan('rootSpan');
+      let rpcMetadata: RPCMetadata | undefined;
+      const httpServer = await serverWithMiddleware(tracer, rootSpan, app => {
+        app.use(express.json());
+        app.use((req, res, next) => {
+          rpcMetadata = getRPCMetadata(context.active());
+          next();
+        });
+        // Express v5 wildcard middleware — /{*path} should not pollute http.route
+        const wildcardMiddleware: express.RequestHandler = (_req, _res, next) => {
+          next();
+        };
+        app.use('/{*path}', wildcardMiddleware);
+      });
+      server = httpServer.server;
+      port = httpServer.port;
+      assert.strictEqual(memoryExporter.getFinishedSpans().length, 0);
+      await context.with(
+        trace.setSpan(context.active(), rootSpan),
+        async () => {
+          const response = await httpRequest.get(
+            `http://localhost:${port}/toto/tata`
+          );
+          assert.strictEqual(response, 'tata');
+          rootSpan.end();
+
+          const requestHandlerSpan = memoryExporter
+            .getFinishedSpans()
+            .find(span => span.name.includes('request handler'));
+          assert.strictEqual(
+            requestHandlerSpan?.attributes[ATTR_HTTP_ROUTE],
+            '/toto/:id'
+          );
+          assert.strictEqual(rpcMetadata?.route, '/toto/:id');
+
+          // The wildcard fragment must not appear in any span's http.route
+          const spanWithWildcardFragment = memoryExporter
+            .getFinishedSpans()
+            .find(
+              span => span.attributes[ATTR_HTTP_ROUTE] === '/{*path}'
+            );
+          assert.strictEqual(
+            spanWithWildcardFragment,
+            undefined,
+            'Express v5 wildcard path fragment "/{*path}" must not appear in http.route'
+          );
+        }
+      );
+    });
+
     it('should ignore double slashes in routes', async () => {
       const rootSpan = tracer.startSpan('rootSpan');
       let rpcMetadata: RPCMetadata | undefined;

--- a/packages/instrumentation-express/test/utils.test.ts
+++ b/packages/instrumentation-express/test/utils.test.ts
@@ -450,6 +450,34 @@ describe('Utils', () => {
         assert.strictEqual(result, '/');
       });
 
+      it('should filter out Express v5 dynamic path fragment /{*path}', () => {
+        const req = createMockRequest('/api/users', [
+          '/',
+          '/{*path}',
+          '/api',
+          '/users',
+        ]);
+        const result = utils.getActualMatchedRoute(req);
+        assert.strictEqual(result, '/api/users');
+      });
+
+      it('should treat standalone /{*path} wildcard same as /* (returns /)', () => {
+        const req = createMockRequest('/test', ['/', '/{*path}']);
+        const result = utils.getActualMatchedRoute(req);
+        assert.strictEqual(result, '/');
+      });
+
+      it('should filter out /{*path} with any parameter name', () => {
+        const req = createMockRequest('/users/123', [
+          '/',
+          '/{*wildcard}',
+          '/users',
+          '/:id',
+        ]);
+        const result = utils.getActualMatchedRoute(req);
+        assert.strictEqual(result, '/users/:id');
+      });
+
       it('should handle complex nested routes', () => {
         const req = createMockRequest('/api/v2/users/123/posts/456/comments', [
           '/',


### PR DESCRIPTION
## Which problem is this PR solving?

- Express v5 (via path-to-regexp v8) introduced a new wildcard route syntax: /{*param} (for example, app.use('/{*path}', handler)).

- The existing route construction logic in getConstructedRoute() already filtered Express v4 wildcard fragments such as '/*', but did not filter the new Express v5 wildcard syntax. As a result, wildcard fragments could appear directly in the constructed route and http.route span attribute.

- This PR extends the existing filtering logic to treat Express v5 wildcard fragments the same way Express v4 wildcard fragments are treated.

- **Fixes #3551.**

## Short description of the changes

- Extended the `getConstructedRoute` filter in `src/utils.ts` to also strip
  Express v5 wildcard path segments matching `/^\/\{\*[^}]*\}$/`
- Added 3 unit tests in `utils.test.ts`
- Added 1 integration test in `express.test.ts` (v5-gated)

- Extend route filtering in getConstructedRoute() to exclude Express v5 wildcard fragments matching /{*param}.
- Added unit tests covering:
  - standalone wildcard fragments
  - wildcard fragments mixed with meaningful route segments
  - arbitrary wildcard parameter names
- Added an integration test verifying that Express v5 wildcard fragments do not appear in the generated http.route attribute.
- Preserve existing Express v4 wildcard behavior.



