### PR TITLE
fix(ci): restore persisting git creds for update-otel-deps workflow, because they are needed in subsequent steps

### DIFF
--- a/.github/workflows/update-otel-deps.yaml
+++ b/.github/workflows/update-otel-deps.yaml
@@ -23,7 +23,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ steps.otelbot-token.outputs.token }}
-          persist-credentials: false
+          # Credentials are used in 'Create/Update Release PR' git commands below.
+          persist-credentials: true
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:


### PR DESCRIPTION
## Which problem is this PR solving?

This is essentially the same as https://github.com/open-telemetry/opentelemetry-js/pull/6755 in the core repo.
We need to keep the credentials so we can use them to create the PR later.