### PR TITLE
feat(instrumentation-amqplib): support amqplib@2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12989,14 +12989,11 @@
       }
     },
     "node_modules/amqplib": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-1.0.3.tgz",
-      "integrity": "sha512-nsrXa59tvX4HPjPPW8JJGuBb/Db0MOq3DOhGdSbIY7bTsQDMV2fmF9c3i74g/8Gt9+QWyrxfEPppOOoV9lK1uQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-2.0.1.tgz",
+      "integrity": "sha512-a3P2MgfCf9nzVis12VxWEn0dS6hcqve7dlEAhXDtIWR27BlhtMkILOc+H9aeHjDi6i6r94dYKc2Kx2OFe3avvg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "buffer-more-ints": "~1.0.0"
-      },
       "engines": {
         "node": ">=18"
       }
@@ -14152,13 +14149,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/buffer-more-ints": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
-      "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==",
       "dev": true,
       "license": "MIT"
     },
@@ -35713,7 +35703,7 @@
         "@opentelemetry/contrib-test-utils": "^0.66.0",
         "@types/amqplib": "^0.10.7",
         "@types/lodash": "4.17.24",
-        "amqplib": "^1.0.3",
+        "amqplib": "^2.0.1",
         "lodash": "4.18.1"
       },
       "engines": {

--- a/packages/instrumentation-amqplib/.tav.yml
+++ b/packages/instrumentation-amqplib/.tav.yml
@@ -1,6 +1,6 @@
 amqplib:
   versions:
-    include: ">=0.5.5 <2"
+    include: ">=0.5.5 <3"
     mode: latest-minors
   commands:
     - npm test

--- a/packages/instrumentation-amqplib/README.md
+++ b/packages/instrumentation-amqplib/README.md
@@ -17,7 +17,7 @@ npm install --save @opentelemetry/instrumentation-amqplib
 
 ## Supported Versions
 
-- [`amqplib`](https://www.npmjs.com/package/amqplib) versions `>=0.5.5 <2`
+- [`amqplib`](https://www.npmjs.com/package/amqplib) versions `>=0.5.5 <3`
 
 ## Usage
 

--- a/packages/instrumentation-amqplib/package.json
+++ b/packages/instrumentation-amqplib/package.json
@@ -59,7 +59,7 @@
     "@opentelemetry/contrib-test-utils": "^0.66.0",
     "@types/amqplib": "^0.10.7",
     "@types/lodash": "4.17.24",
-    "amqplib": "^1.0.3",
+    "amqplib": "^2.0.1",
     "lodash": "4.18.1"
   },
   "engines": {

--- a/packages/instrumentation-amqplib/src/amqplib.ts
+++ b/packages/instrumentation-amqplib/src/amqplib.ts
@@ -70,7 +70,7 @@ import {
 /** @knipignore */
 import { PACKAGE_NAME, PACKAGE_VERSION } from './version';
 
-const supportedVersions = ['>=0.5.5 <2'];
+const supportedVersions = ['>=0.5.5 <3'];
 
 export class AmqplibInstrumentation extends InstrumentationBase<AmqplibInstrumentationConfig> {
   private _netSemconvStability!: SemconvStability;


### PR DESCRIPTION
New v2 releases of amqplib last month:

```
  '2.0.0': '2026-05-10T15:23:38.567Z',
  '2.0.1': '2026-05-10T15:40:48.816Z'
```

There are no substantive changes in amqplib@2 that impacts the instrumentation that I see, so adding support only involved bumping versions.