### PR TITLE
fix(instrumentation-user-interaction): use WeakMap for per-element listener bookkeeping

### DIFF
--- a/packages/instrumentation-user-interaction/src/instrumentation.ts
+++ b/packages/instrumentation-user-interaction/src/instrumentation.ts
@@ -52,7 +52,7 @@ export class UserInteractionInstrumentation extends InstrumentationBase<UserInte
   // for addEventListener/removeEventListener state
   private _wrappedListeners = new WeakMap<
     Function | EventListenerObject,
-    Map<string, Map<HTMLElement, Function>>
+    Map<string, WeakMap<HTMLElement, Function>>
   >();
   // for event bubbling
   private _eventsSpanMap: WeakMap<Event, api.Span> = new WeakMap<
@@ -216,7 +216,7 @@ export class UserInteractionInstrumentation extends InstrumentationBase<UserInte
     }
     let element2patched = listener2Type.get(type);
     if (!element2patched) {
-      element2patched = new Map();
+      element2patched = new WeakMap();
       listener2Type.set(type, element2patched);
     }
     if (element2patched.has(on)) {
@@ -245,12 +245,6 @@ export class UserInteractionInstrumentation extends InstrumentationBase<UserInte
     const patched = element2patched.get(on);
     if (patched) {
       element2patched.delete(on);
-      if (element2patched.size === 0) {
-        listener2Type.delete(type);
-        if (listener2Type.size === 0) {
-          this._wrappedListeners.delete(listener);
-        }
-      }
     }
     return patched;
   }

--- a/packages/instrumentation-user-interaction/test/userInteraction.nozone.test.ts
+++ b/packages/instrumentation-user-interaction/test/userInteraction.nozone.test.ts
@@ -133,6 +133,42 @@ describe('UserInteractionInstrumentation', () => {
       assert.strictEqual(called, false);
     });
 
+    it('should not retain detached elements in listener bookkeeping when removeEventListener is never called', () => {
+      // Simulates the SPA framework pattern (Vue's createFnInvoker, React's
+      // bound handlers) where the same listener function is reused across
+      // many elements, and removeEventListener is never called on unmount -
+      // cleanup is expected to happen via garbage collection of the element
+      // instead. See open-telemetry/opentelemetry-js-contrib#3539.
+      const sharedListener = function () {};
+      const elements: HTMLElement[] = [];
+      for (let i = 0; i < 50; i++) {
+        const element = createButton();
+        elements.push(element);
+        element.addEventListener('click', sharedListener);
+      }
+
+      const instrumentationAny = userInteractionInstrumentation as any;
+      const wrappedListeners = instrumentationAny._wrappedListeners;
+
+      const listener2Type = wrappedListeners.get(sharedListener);
+      assert.ok(listener2Type, 'listener should be tracked');
+      const element2patched = listener2Type.get('click');
+      assert.ok(element2patched, 'click bookkeeping should exist');
+
+      // The bug: the per-element bookkeeping is a plain Map keyed by the
+      // HTMLElement itself, so every element added above is strongly
+      // retained here even though none of them were ever attached to the
+      // document and nothing else in the test references them anymore.
+      assert.ok(
+        element2patched instanceof WeakMap,
+        'per-element listener bookkeeping should be a WeakMap so detached ' +
+          'elements are not strongly retained (#3539)'
+      );
+
+      // Drop the only other reference we held.
+      elements.length = 0;
+    });
+
     it('should not double-register a listener', () => {
       let callCount = 0;
       const listener = function () {


### PR DESCRIPTION
## What

`_wrappedListeners` tracks patched event listeners via `WeakMap<listener, Map<type, Map<HTMLElement, Function>>>`. The innermost map was a plain `Map` keyed by the DOM element itself. That strongly retains every element a listener was ever attached to until the listener function itself becomes unreachable.

`removePatchedListener` only cleans up an entry when the consumer calls `removeEventListener` with the exact same listener reference. SPA frameworks often skip this on unmount. Vue's `createFnInvoker` and React's bound handlers generate fresh wrapper functions each render and rely on garbage collection of the element instead. Under that pattern every element a shared listener was attached to stays referenced for the life of the page, even after it's removed from the DOM.

In long-lived tabs with heavy DOM churn this leads to unbounded heap growth and eventual OOM crashes.

## Fix

Changes the innermost per-element map from `Map<HTMLElement, Function>` to `WeakMap<HTMLElement, Function>`. This is type-safe since the key is always an `HTMLElement`. The `type`-keyed `Map` above it stays a `Map`, since `string` keys aren't valid for `WeakMap`.

One side effect: `removePatchedListener` used to check `element2patched.size === 0` to prune the now-empty `type` entry from `listener2Type`. `WeakMap` has no `.size`, so that pruning is gone. A small empty `WeakMap` shell is left per `(listener, type)` pair after its last element is removed instead of being deleted outright. It doesn't grow with element count and clears once `listener` becomes unreachable, since the outer `_wrappedListeners` is already a `WeakMap`.

## Testing

Added a regression test in `userInteraction.nozone.test.ts` that attaches a shared listener to 50 elements with no `removeEventListener` call, simulating the SPA pattern above, and asserts the per-element bookkeeping is a `WeakMap`. Fails against the old `Map`-based code, passes with this fix. Full existing suite (42 tests) still passes.

Fixes #3539