### PR TITLE
docs: fixed two small typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This project includes:
 **Instrumentations**: OpenTelemetry can collect tracing data automatically using instrumentations. Vendors/Users can also create and use their own.
 Please read the [contributing guidelines on adding new instrumentation](CONTRIBUTING.md#new-instrumentation) before opening any PRs.
 
-**Resource Detectors**: OpenTelemetry can collect resource attributes of the entity that producing telemetry. For example, a process producing telemetry that is running in a container on Kubernetes has a Pod name, it is in a namespace and possibly is part of a Deployment which also has a name. All three of these attributes can be included in the `Resource`.
+**Resource Detectors**: OpenTelemetry can collect resource attributes of the entity that is producing telemetry. For example, a process producing telemetry that is running in a container on Kubernetes has a Pod name, it is in a namespace and possibly is part of a Deployment which also has a name. All three of these attributes can be included in the `Resource`.
 
 ## Component Ownership
 
@@ -58,7 +58,7 @@ is [.github/component_owners.yml](https://github.com/open-telemetry/opentelemetr
 
 ## Stability levels
 
-Stability level for components in this repository follow the definitions in [CONTRIBUTING.md](./CONTRIBUTING.md).
+Stability levels for components in this repository follow the definitions in [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## Supported Runtimes
 


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Fixes two small typos I noticed while reading the README.

## Short description of the changes

- "resource attributes of the entity that producing telemetry" → "...that **is** producing telemetry"
- "Stability level for components in this repository follow the definitions" → "Stability level**s** for components in this repository follow the definitions"
