### PR TITLE
chore(eslint): use canonical n/ prefix for eslint-plugin-n in flat config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,9 +43,7 @@ const baseConfig = tseslint.config(
       'yet-another-license-header': yalhPlugin,
       n: nodePlugin,
     },
-    extends: [
-      eslint.configs.recommended,
-    ],
+    extends: [eslint.configs.recommended],
     languageOptions: {
       ecmaVersion: 2022,
       globals: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -41,11 +41,10 @@ const baseConfig = tseslint.config(
     files: ['**/*.{js,ts,mjs}'],
     plugins: {
       'yet-another-license-header': yalhPlugin,
-      node: nodePlugin,
+      n: nodePlugin,
     },
     extends: [
       eslint.configs.recommended,
-      // nodePlugin.configs['flat/recommended'],
     ],
     languageOptions: {
       ecmaVersion: 2022,
@@ -54,7 +53,7 @@ const baseConfig = tseslint.config(
       },
     },
     settings: {
-      node: {
+      n: {
         tryExtensions: ['.js', '.json', '.node', '.ts', '.tsx'],
       },
     },
@@ -73,7 +72,7 @@ const baseConfig = tseslint.config(
 
       // new rules
       'no-unused-vars': 'warn',
-      'node/no-deprecated-api': 'warn',
+      'n/no-deprecated-api': 'warn',
     },
   },
 
@@ -93,7 +92,7 @@ const baseConfig = tseslint.config(
       },
     },
     rules: {
-      // 'node/no-missing-import': 'off',
+      // 'n/no-missing-import': 'off',
 
       // things that should be repaired
       '@typescript-eslint/no-explicit-any': 'warn',


### PR DESCRIPTION
## Which problem is this PR solving?

The `eslint-plugin-n` package (the successor to the now-deprecated `eslint-plugin-node`) uses `n` as its canonical rule namespace in flat config. The current `eslint.config.mjs` still registers the plugin under the legacy `node:` key and references rules with the `node/` prefix, which is inconsistent with the package's actual name and its flat-config conventions.

## Short description of the changes

- Rename the plugin registration from `node: nodePlugin` to `n: nodePlugin` so the namespace matches the package name
- Update `settings.node` to `settings.n` to align with the plugin's settings key
- Rename the `node/no-deprecated-api` rule reference to `n/no-deprecated-api`
- Update the commented-out `node/no-missing-import` placeholder to `n/no-missing-import` for consistency
- Remove the stale `// nodePlugin.configs['flat/recommended']` comment (the individual rule overrides in the `rules` block already express the intended configuration explicitly)