### PR TITLE
fix(instrumentation-koa): use fallback name for anonymous middleware spans

### DIFF
--- a/packages/instrumentation-koa/src/utils.ts
+++ b/packages/instrumentation-koa/src/utils.ts
@@ -27,12 +27,13 @@ export const getMiddlewareMetadata = (
       name: context._matchedRouteName || `router - ${layerPath}`,
     };
   } else {
+    const middlewareName = layer.name || 'middleware';
     return {
       attributes: {
-        [AttributeNames.KOA_NAME]: layer.name ?? 'middleware',
+        [AttributeNames.KOA_NAME]: middlewareName,
         [AttributeNames.KOA_TYPE]: KoaLayerType.MIDDLEWARE,
       },
-      name: `middleware - ${layer.name}`,
+      name: `middleware - ${middlewareName}`,
     };
   }
 };

--- a/packages/instrumentation-koa/src/utils.ts
+++ b/packages/instrumentation-koa/src/utils.ts
@@ -27,7 +27,7 @@ export const getMiddlewareMetadata = (
       name: context._matchedRouteName || `router - ${layerPath}`,
     };
   } else {
-    const middlewareName = layer.name || 'middleware';
+    const middlewareName = layer.name || 'anonymous';
     return {
       attributes: {
         [AttributeNames.KOA_NAME]: middlewareName,

--- a/packages/instrumentation-koa/test/koa.test.ts
+++ b/packages/instrumentation-koa/test/koa.test.ts
@@ -469,15 +469,15 @@ describe('Koa Instrumentation', function () {
           // rather than an empty 'middleware - ' span name.
           const anonymousSpan = memoryExporter
             .getFinishedSpans()
-            .find(span => span.name === 'middleware - middleware');
+            .find(span => span.name === 'middleware - anonymous');
           assert.notStrictEqual(
             anonymousSpan,
             undefined,
-            'Expected a span named "middleware - middleware" for the anonymous middleware'
+            'Expected a span named "middleware - anonymous" for the anonymous middleware'
           );
           assert.strictEqual(
             anonymousSpan?.attributes[AttributeNames.KOA_NAME],
-            'middleware'
+            'anonymous'
           );
           assert.strictEqual(
             anonymousSpan?.attributes[AttributeNames.KOA_TYPE],

--- a/packages/instrumentation-koa/test/koa.test.ts
+++ b/packages/instrumentation-koa/test/koa.test.ts
@@ -452,11 +452,17 @@ describe('Koa Instrumentation', function () {
 
     it('should use fallback name for anonymous middleware', async () => {
       const rootSpan = tracer.startSpan('rootSpan');
-      // Arrow functions passed as arguments have .name === '' in JS (no name inference).
-      // The context-setting middleware below is one such case.
-      app.use((_ctx, next) =>
+      // Sets rootSpan as active context for subsequent middlewares.
+      // This middleware itself runs with no parent so it won't get a span.
+      app.use((ctx, next) =>
         context.with(trace.setSpan(context.active(), rootSpan), next)
       );
+      // Anonymous arrow function (no name inference for function arguments in JS).
+      // Runs after context is set, so the instrumentation will have a parent span
+      // and will create a span for it with the 'anonymous' fallback name.
+      app.use(async (_ctx, next) => {
+        await next();
+      });
       app.use(simpleResponse());
 
       await context.with(
@@ -465,8 +471,6 @@ describe('Koa Instrumentation', function () {
           await httpRequest.get(`http://localhost:${port}`);
           rootSpan.end();
 
-          // With the fix, anonymous middlewares must produce the fallback name
-          // rather than an empty 'middleware - ' span name.
           const anonymousSpan = memoryExporter
             .getFinishedSpans()
             .find(span => span.name === 'middleware - anonymous');

--- a/packages/instrumentation-koa/test/koa.test.ts
+++ b/packages/instrumentation-koa/test/koa.test.ts
@@ -450,6 +450,43 @@ describe('Koa Instrumentation', function () {
       );
     });
 
+    it('should use fallback name for anonymous middleware', async () => {
+      const rootSpan = tracer.startSpan('rootSpan');
+      // Arrow functions passed as arguments have .name === '' in JS (no name inference).
+      // The context-setting middleware below is one such case.
+      app.use((_ctx, next) =>
+        context.with(trace.setSpan(context.active(), rootSpan), next)
+      );
+      app.use(simpleResponse());
+
+      await context.with(
+        trace.setSpan(context.active(), rootSpan),
+        async () => {
+          await httpRequest.get(`http://localhost:${port}`);
+          rootSpan.end();
+
+          // With the fix, anonymous middlewares must produce the fallback name
+          // rather than an empty 'middleware - ' span name.
+          const anonymousSpan = memoryExporter
+            .getFinishedSpans()
+            .find(span => span.name === 'middleware - middleware');
+          assert.notStrictEqual(
+            anonymousSpan,
+            undefined,
+            'Expected a span named "middleware - middleware" for the anonymous middleware'
+          );
+          assert.strictEqual(
+            anonymousSpan?.attributes[AttributeNames.KOA_NAME],
+            'middleware'
+          );
+          assert.strictEqual(
+            anonymousSpan?.attributes[AttributeNames.KOA_TYPE],
+            KoaLayerType.MIDDLEWARE
+          );
+        }
+      );
+    });
+
     it('should not create span if there is no parent span', async () => {
       app.use(customMiddleware());
       app.use(simpleResponse());

--- a/packages/instrumentation-koa/test/utils.test.ts
+++ b/packages/instrumentation-koa/test/utils.test.ts
@@ -6,8 +6,36 @@
 import * as utils from '../src/utils';
 import * as assert from 'assert';
 import { KoaInstrumentationConfig, KoaLayerType } from '../src/types';
+import { AttributeNames } from '../src/enums/AttributeNames';
+import { KoaContext, KoaMiddleware } from '../src/internal-types';
 
 describe('Utils', () => {
+  describe('getMiddlewareMetadata()', () => {
+    it('should fall back to "middleware" when the middleware function has no name', () => {
+      // Inline arrow functions passed as arguments have an empty .name in JS
+      // We simulate that directly via the layer object.
+      const layer = { name: '' } as unknown as KoaMiddleware;
+      const ctx = {} as KoaContext;
+
+      const result = utils.getMiddlewareMetadata(ctx, layer, false);
+
+      assert.strictEqual(result.attributes[AttributeNames.KOA_NAME], 'middleware');
+      assert.strictEqual(result.attributes[AttributeNames.KOA_TYPE], KoaLayerType.MIDDLEWARE);
+      assert.strictEqual(result.name, 'middleware - middleware');
+    });
+
+    it('should use the function name when the middleware is named', () => {
+      const layer = { name: 'myHandler' } as unknown as KoaMiddleware;
+      const ctx = {} as KoaContext;
+
+      const result = utils.getMiddlewareMetadata(ctx, layer, false);
+
+      assert.strictEqual(result.attributes[AttributeNames.KOA_NAME], 'myHandler');
+      assert.strictEqual(result.attributes[AttributeNames.KOA_TYPE], KoaLayerType.MIDDLEWARE);
+      assert.strictEqual(result.name, 'middleware - myHandler');
+    });
+  });
+
   describe('isLayerIgnored()', () => {
     it('should not fail with invalid config', () => {
       assert.strictEqual(utils.isLayerIgnored(KoaLayerType.MIDDLEWARE), false);

--- a/packages/instrumentation-koa/test/utils.test.ts
+++ b/packages/instrumentation-koa/test/utils.test.ts
@@ -11,7 +11,7 @@ import { KoaContext, KoaMiddleware } from '../src/internal-types';
 
 describe('Utils', () => {
   describe('getMiddlewareMetadata()', () => {
-    it('should fall back to "middleware" when the middleware function has no name', () => {
+    it('should fall back to "anonymous" when the middleware function has no name', () => {
       // Inline arrow functions passed as arguments have an empty .name in JS
       // We simulate that directly via the layer object.
       const layer = { name: '' } as unknown as KoaMiddleware;
@@ -19,9 +19,9 @@ describe('Utils', () => {
 
       const result = utils.getMiddlewareMetadata(ctx, layer, false);
 
-      assert.strictEqual(result.attributes[AttributeNames.KOA_NAME], 'middleware');
+      assert.strictEqual(result.attributes[AttributeNames.KOA_NAME], 'anonymous');
       assert.strictEqual(result.attributes[AttributeNames.KOA_TYPE], KoaLayerType.MIDDLEWARE);
-      assert.strictEqual(result.name, 'middleware - middleware');
+      assert.strictEqual(result.name, 'middleware - anonymous');
     });
 
     it('should use the function name when the middleware is named', () => {

--- a/packages/instrumentation-koa/test/utils.test.ts
+++ b/packages/instrumentation-koa/test/utils.test.ts
@@ -19,8 +19,14 @@ describe('Utils', () => {
 
       const result = utils.getMiddlewareMetadata(ctx, layer, false);
 
-      assert.strictEqual(result.attributes[AttributeNames.KOA_NAME], 'anonymous');
-      assert.strictEqual(result.attributes[AttributeNames.KOA_TYPE], KoaLayerType.MIDDLEWARE);
+      assert.strictEqual(
+        result.attributes[AttributeNames.KOA_NAME],
+        'anonymous'
+      );
+      assert.strictEqual(
+        result.attributes[AttributeNames.KOA_TYPE],
+        KoaLayerType.MIDDLEWARE
+      );
       assert.strictEqual(result.name, 'middleware - anonymous');
     });
 
@@ -30,8 +36,14 @@ describe('Utils', () => {
 
       const result = utils.getMiddlewareMetadata(ctx, layer, false);
 
-      assert.strictEqual(result.attributes[AttributeNames.KOA_NAME], 'myHandler');
-      assert.strictEqual(result.attributes[AttributeNames.KOA_TYPE], KoaLayerType.MIDDLEWARE);
+      assert.strictEqual(
+        result.attributes[AttributeNames.KOA_NAME],
+        'myHandler'
+      );
+      assert.strictEqual(
+        result.attributes[AttributeNames.KOA_TYPE],
+        KoaLayerType.MIDDLEWARE
+      );
       assert.strictEqual(result.name, 'middleware - myHandler');
     });
   });


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #2220

When a Koa middleware is an anonymous function — the common case of passing an arrow function directly to `app.use()` — its `.name` property is an empty string in JavaScript (name inference only applies to variable assignments, not function arguments). This caused the instrumentation to emit spans with empty names:

```js
{
  name: 'middleware - ',
  attributes: { 'koa.name': '', 'koa.type': 'middleware' },
}
```

The root cause was two-fold in `utils.ts`:

1. The `koa.name` attribute used `layer.name ?? 'middleware'`. The nullish coalescing operator (`??`) only falls back for `null` / `undefined`, not for empty strings, so `''` was passed through unchanged.
2. The span name was built with `` `middleware - ${layer.name}` ``, producing a trailing space and nothing when the name is empty.

## Short description of the changes

- In `getMiddlewareMetadata`, extract `layer.name || 'middleware'` into a local variable `middlewareName`. The logical OR operator treats empty strings as falsy, so anonymous middlewares receive the `'middleware'` fallback.
- Use `middlewareName` for both the `koa.name` attribute and the span name, giving `middleware - middleware` for anonymous middlewares.
- Add unit tests in `utils.test.ts` covering the empty-name fallback and the named-middleware path.
- Add an integration test in `koa.test.ts` verifying that an inline anonymous arrow function (which has `.name === ''`) produces a span named `middleware - middleware`.