### PR TITLE
feat(instrumentation-oracledb): add support for oracledb v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11984,9 +11984,9 @@
       "license": "MIT"
     },
     "node_modules/@types/oracledb": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/@types/oracledb/-/oracledb-6.5.2.tgz",
-      "integrity": "sha512-kK1eBS/Adeyis+3OlBDMeQQuasIDLUYXsi2T15ccNJ0iyUpQ4xDF7svFu3+bGVrI0CMBUclPciz+lsQR3JX3TQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@types/oracledb/-/oracledb-7.0.1.tgz",
+      "integrity": "sha512-0A6m9YE4yu73KXehr5D6cbyALUzZoANGY4bG5cAPQIpJoJG4eMVPbR1Vau8ycnC25V/+F4Au1pdFSy8ODOAD0w==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -37293,7 +37293,7 @@
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.220.0",
         "@opentelemetry/semantic-conventions": "^1.34.0",
-        "@types/oracledb": "6.5.2"
+        "@types/oracledb": "7.0.1"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",

--- a/packages/instrumentation-oracledb/package.json
+++ b/packages/instrumentation-oracledb/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.220.0",
     "@opentelemetry/semantic-conventions": "^1.34.0",
-    "@types/oracledb": "6.5.2"
+    "@types/oracledb": "7.0.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-oracledb#readme"
 }


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- This PR adds support for oracledb v7 and resolves https://github.com/open-telemetry/opentelemetry-js-contrib/issues/3572

## Short description of the changes

- Extended the support for oracledb v7 by bumping the supported versions
- Also bumped `@types/oracledb` to latest
- Not bumped development version; it will still point to the prev 6.7
