### PR TITLE
fix(instrumentation-knex): use connectionSettings to support function-based connection configs

### DIFF
--- a/packages/instrumentation-knex/src/instrumentation.ts
+++ b/packages/instrumentation-knex/src/instrumentation.ts
@@ -132,18 +132,20 @@ export class KnexInstrumentation extends InstrumentationBase<KnexInstrumentation
 
     return function wrapQuery(original: (...args: any[]) => any) {
       return function wrapped_logging_method(this: any, query: any) {
-        const config = this.client.config;
-
         const table = utils.extractTableName(this.builder);
         // `method` actually refers to the knex API method - Not exactly "operation"
         // in the spec sense, but matches most of the time.
         const operation = query?.method;
+        // Use connectionSettings rather than config.connection so that function-based
+        // connection configs (e.g. `connection: async () => ({ host, user, ... })`) are
+        // resolved to their actual values before we read them.
+        const connectionSettings = this.client.connectionSettings;
         // Knex can be configured with a connectionString instead of explicit fields.
         // Fall back to parsing the connectionString if filename and database are not set.
-        const connectionString = config?.connection?.connectionString;
+        const connectionString = connectionSettings?.connectionString;
         const name =
-          config?.connection?.filename ||
-          config?.connection?.database ||
+          connectionSettings?.filename ||
+          connectionSettings?.database ||
           utils.extractDatabaseFromConnectionString(connectionString);
         const { maxQueryLength } = instrumentation.getConfig();
 
@@ -151,21 +153,21 @@ export class KnexInstrumentation extends InstrumentationBase<KnexInstrumentation
           'knex.version': moduleVersion,
         };
         const transport =
-          config?.connection?.filename === ':memory:' ? 'inproc' : undefined;
+          connectionSettings?.filename === ':memory:' ? 'inproc' : undefined;
 
         if (instrumentation._semconvStability & SemconvStability.OLD) {
           Object.assign(attributes, {
             [ATTR_DB_SYSTEM]: utils.mapSystem(this.client.driverName),
             [ATTR_DB_SQL_TABLE]: table,
             [ATTR_DB_OPERATION]: operation,
-            [ATTR_DB_USER]: config?.connection?.user,
+            [ATTR_DB_USER]: connectionSettings?.user,
             [ATTR_DB_NAME]: name,
             // Fall back to parsing host and port from connectionString if not explicitly set.
             [ATTR_NET_PEER_NAME]:
-              config?.connection?.host ??
+              connectionSettings?.host ??
               utils.extractHostFromConnectionString(connectionString),
             [ATTR_NET_PEER_PORT]:
-              config?.connection?.port ??
+              connectionSettings?.port ??
               utils.extractPortFromConnectionString(connectionString),
             [ATTR_NET_TRANSPORT]: transport,
           });
@@ -178,10 +180,10 @@ export class KnexInstrumentation extends InstrumentationBase<KnexInstrumentation
             [ATTR_DB_NAMESPACE]: name,
             // Fall back to parsing host and port from connectionString if not explicitly set.
             [ATTR_SERVER_ADDRESS]:
-              config?.connection?.host ??
+              connectionSettings?.host ??
               utils.extractHostFromConnectionString(connectionString),
             [ATTR_SERVER_PORT]:
-              config?.connection?.port ??
+              connectionSettings?.port ??
               utils.extractPortFromConnectionString(connectionString),
           });
         }

--- a/packages/instrumentation-knex/test/index.test.ts
+++ b/packages/instrumentation-knex/test/index.test.ts
@@ -145,6 +145,35 @@ describe('Knex instrumentation', () => {
       assert.ok(statement.startsWith(limitedStatement.substring(0, 50)));
     });
 
+    it('should read connection attributes when connection is configured as a function', async () => {
+      const functionClient = knex({
+        client: 'sqlite3',
+        connection: () => ({ filename: ':memory:' }),
+        useNullAsDefault: true,
+      });
+
+      try {
+        const parentSpan = tracer.startSpan('parentSpan');
+        await context.with(
+          trace.setSpan(context.active(), parentSpan),
+          async () => {
+            await functionClient.raw("select date('now')");
+            parentSpan.end();
+
+            const [span] = memoryExporter.getFinishedSpans();
+            assert.ok(span, 'expected a span');
+            assert.strictEqual(
+              span.attributes['db.name'],
+              ':memory:',
+              'db.name should be populated from function-based connection'
+            );
+          }
+        );
+      } finally {
+        await functionClient.destroy();
+      }
+    });
+
     it("should correctly capture the DB's system name even with custom client implementations", async () => {
       client = knex({
         client: BetterSqlite3Dialect,


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #3489

When knex is initialised with a function as the `connection` option — a common pattern for dynamic credential rotation — the instrumentation reads `this.client.config.connection`, which at query time is still the original function, not the resolved settings object. As a result, all connection-derived span attributes (`db.user`, `db.name`, `net.peer.name`, `net.peer.port`) are `undefined`, and the span name becomes `'select undefined.table'`.

## Short description of the changes

In `createQueryWrapper`, switch from reading `this.client.config.connection` to `this.client.connectionSettings`. Knex always resolves this property to the actual settings object (a plain `{host, user, database, ...}` dict) regardless of whether `connection` was configured as a static object or an async function. The fix is a minimal one-field rename across all attribute assignments in that method.

A new test case exercises the code path with `connection: () => ({ filename: ':memory:' })` and asserts that `db.name` is still populated correctly.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Added a unit test in `packages/instrumentation-knex/test/index.test.ts` that configures a knex client with a function-based `connection` option and asserts the resulting span carries the correct `db.name` attribute.

## Checklist

- [x] Followed the style guidelines of this project
- [x] Unit tests added/updated for the change
- [x] No new warnings introduced