### PR TITLE
fix(instrumentation-pg): Only treat "name" as relevant if it actually is a value

### DIFF
--- a/packages/instrumentation-pg/src/instrumentation.ts
+++ b/packages/instrumentation-pg/src/instrumentation.ts
@@ -390,10 +390,13 @@ export class PgInstrumentation extends InstrumentationBase<PgInstrumentationConf
         if (instrumentationConfig.addSqlCommenterCommentToQueries) {
           if (firstArgIsString) {
             args[0] = addSqlCommenterComment(span, arg0);
-          } else if (firstArgIsQueryObjectWithText && !('name' in arg0)) {
-            // In the case of a query object, we need to ensure there's no name field
-            // as this indicates a prepared query, where the comment would remain the same
-            // for every invocation and contain an outdated trace context.
+          } else if (
+            firstArgIsQueryObjectWithText &&
+            (!('name' in arg0) || arg0.name === undefined)
+          ) {
+            // In the case of a query object, only skip when there is an actual
+            // prepared statement name. The comment would remain the same for
+            // every invocation and contain an outdated trace context.
             args[0] = {
               ...arg0,
               text: addSqlCommenterComment(span, arg0.text),

--- a/packages/instrumentation-pg/test/pg.test.ts
+++ b/packages/instrumentation-pg/test/pg.test.ts
@@ -988,6 +988,37 @@ describe('pg', () => {
       });
     });
 
+    it('should add sqlcommenter comment when addSqlCommenterCommentToQueries=true is specified with name undefined', async () => {
+      instrumentation.setConfig({
+        addSqlCommenterCommentToQueries: true,
+      });
+
+      const span = tracer.startSpan('test span');
+      await context.with(trace.setSpan(context.active(), span), async () => {
+        try {
+          const query = 'SELECT NOW()';
+          const resPromise = await client.query({
+            text: query,
+            name: undefined,
+          });
+          assert.ok(resPromise);
+
+          const [span] = memoryExporter.getFinishedSpans();
+          const commentedQuery = addSqlCommenterComment(
+            trace.wrapSpanContext(span.spanContext()),
+            query
+          );
+
+          const executedQueries = getExecutedQueries();
+          assert.equal(executedQueries.length, 1);
+          assert.equal(executedQueries[0].text, commentedQuery);
+          assert.notEqual(query, commentedQuery);
+        } catch (e: any) {
+          assert.ok(false, e.message);
+        }
+      });
+    });
+
     it('should not add sqlcommenter comment when addSqlCommenterCommentToQueries=true is specified with a prepared statement', async () => {
       instrumentation.setConfig({
         addSqlCommenterCommentToQueries: true,


### PR DESCRIPTION
Related: https://github.com/drizzle-team/drizzle-orm/pull/5974 and https://github.com/open-telemetry/opentelemetry-js-contrib/issues/1705

Thank you tremendously for your work curating and maintaining the OTEL ecosystem, it has been a joy to use!

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- `instrumentation-pg` gates adding sql tracing comments on the presence of the `name` field, not the `name` field actually being defined. This means tooling that mechanically and indiscriminately populate that field make automatic traceparent comment injection impossible.

## Short description of the changes

- Simply change `!('name' in arg0)` into `!('name' in arg0) || arg0.name === undefined`, thus permitting the semantic intent even if the implementation of some libraries is a little fast and loose.
