### PR TITLE
feat(instr-tedious): support tedious@20

### DIFF
--- a/packages/instrumentation-tedious/.tav.yml
+++ b/packages/instrumentation-tedious/.tav.yml
@@ -38,3 +38,10 @@ tedious:
     commands: npm run test
     # See typescript@5 note above.
     peerDependencies: typescript@5
+  - versions:
+      include: ">=20 <21"
+      mode: latest-majors
+    node: '>=22'
+    commands: npm run test
+    # See typescript@5 note above.
+    peerDependencies: typescript@5

--- a/packages/instrumentation-tedious/README.md
+++ b/packages/instrumentation-tedious/README.md
@@ -17,7 +17,7 @@ npm install --save @opentelemetry/instrumentation-tedious
 
 ## Supported Versions
 
-- [tedious](https://www.npmjs.com/package/tedious) `>=1.11.0 <20`
+- [tedious](https://www.npmjs.com/package/tedious) `>=1.11.0 <21`
 
 ## Usage
 

--- a/packages/instrumentation-tedious/src/instrumentation.ts
+++ b/packages/instrumentation-tedious/src/instrumentation.ts
@@ -99,7 +99,7 @@ export class TediousInstrumentation extends InstrumentationBase<TediousInstrumen
     return [
       new InstrumentationNodeModuleDefinition(
         TediousInstrumentation.COMPONENT,
-        ['>=1.11.0 <20'],
+        ['>=1.11.0 <21'],
         (moduleExports: typeof tedious) => {
           const ConnectionPrototype: any = moduleExports.Connection.prototype;
           for (const method of PATCHED_METHODS) {

--- a/packages/instrumentation-tedious/test/instrumentation.test.ts
+++ b/packages/instrumentation-tedious/test/instrumentation.test.ts
@@ -90,7 +90,9 @@ const incompatVersions =
     semver.gte(tediousVersion, '17.0.0')) ||
   // tedious@19 removed support for node <18.17.0 https://github.com/tediousjs/tedious/releases/tag/v19.0.0
   (semver.lt(processVersion, '18.17.0') &&
-    semver.gte(tediousVersion, '19.0.0'));
+    semver.gte(tediousVersion, '19.0.0')) ||
+  // tedious@20 removed support for node <22 https://github.com/tediousjs/tedious/releases/tag/v20.0.0
+  (semver.lt(processVersion, '22.0.0') && semver.gte(tediousVersion, '20.0.0'));
 
 describe('tedious', () => {
   let tedious: any;


### PR DESCRIPTION
### Which problem is this PR solving?

Adds support for `tedious` v20.

### Short description of the changes

* Extend the supported `tedious` version range to `<21`.
* No instrumentation changes were required; `tedious` v20 only raises the minimum supported Node.js version to 22.
* Add TAV coverage for `tedious` v20 on Node.js 22+.

Reference: https://github.com/tediousjs/tedious/releases/tag/v20.0.0

closes #3595
