### PR TITLE
feat(instrumentation-redis): support redis@6

### DIFF
--- a/packages/instrumentation-redis/.tav.yml
+++ b/packages/instrumentation-redis/.tav.yml
@@ -9,3 +9,8 @@ redis:
       exclude: "4.6.9"
       mode: latest-minors
     commands: npm run test
+  - versions:
+      include: '>=6 <7'
+      mode: latest-minors
+    node: '>=20'
+    commands: npm run test

--- a/packages/instrumentation-redis/README.md
+++ b/packages/instrumentation-redis/README.md
@@ -17,7 +17,7 @@ npm install --save @opentelemetry/instrumentation-redis
 
 ### Supported Versions
 
-- [`redis`](https://www.npmjs.com/package/redis) versions `>=2.6.0 <6`
+- [`redis`](https://www.npmjs.com/package/redis) versions `>=2.6.0 <7`
 
 ## Usage
 

--- a/packages/instrumentation-redis/src/redis.ts
+++ b/packages/instrumentation-redis/src/redis.ts
@@ -11,6 +11,7 @@ import { RedisInstrumentationConfig } from './types';
 import { PACKAGE_NAME, PACKAGE_VERSION } from './version';
 import { RedisInstrumentationV2_V3 } from './v2-v3/instrumentation';
 import { TracerProvider } from '@opentelemetry/api';
+// "v4-v5" is a bit of a misnomer. It now supports redis@6 as well.
 import { RedisInstrumentationV4_V5 } from './v4-v5/instrumentation';
 
 const DEFAULT_CONFIG: RedisInstrumentationConfig = {

--- a/packages/instrumentation-redis/src/v4-v5/instrumentation.ts
+++ b/packages/instrumentation-redis/src/v4-v5/instrumentation.ts
@@ -107,7 +107,7 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
 
     const multiCommanderModule = new InstrumentationNodeModuleFile(
       `${basePackageName}/dist/lib/client/multi-command.js`,
-      ['^1.0.0', '^5.0.0'],
+      ['^1.0.0', '^5.0.0', '^6.0.0'],
       (moduleExports: any) => {
         const redisClientMultiCommandPrototype =
           moduleExports?.default?.prototype;
@@ -154,7 +154,7 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
 
     const clientIndexModule = new InstrumentationNodeModuleFile(
       `${basePackageName}/dist/lib/client/index.js`,
-      ['^1.0.0', '^5.0.0'],
+      ['^1.0.0', '^5.0.0', '^6.0.0'],
       (moduleExports: any) => {
         const redisClientPrototype = moduleExports?.default?.prototype;
 
@@ -217,7 +217,7 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
 
     const clusterIndexModule = new InstrumentationNodeModuleFile(
       `${basePackageName}/dist/lib/cluster/index.js`,
-      ['^1.0.0', '^5.0.0'],
+      ['^1.0.0', '^5.0.0', '^6.0.0'],
       (moduleExports: any) => {
         const redisClusterPrototype = moduleExports?.default?.prototype;
 
@@ -246,7 +246,7 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
 
     const clusterMultiCommanderModule = new InstrumentationNodeModuleFile(
       `${basePackageName}/dist/lib/cluster/multi-command.js`,
-      ['^1.0.0', '^5.0.0'],
+      ['^1.0.0', '^5.0.0', '^6.0.0'],
       (moduleExports: any) => {
         const redisClusterMultiCommandPrototype =
           moduleExports?.default?.prototype;
@@ -285,7 +285,7 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
 
     return new InstrumentationNodeModuleDefinition(
       basePackageName,
-      ['^1.0.0', '^5.0.0'],
+      ['^1.0.0', '^5.0.0', '^6.0.0'],
       (moduleExports: any) => {
         return moduleExports;
       },


### PR DESCRIPTION
This does the minimum: bump current monkey-patching to patch v6.
I haven't dug into whether there are architectural changes in v6
that could/should be adapted to.

For example, https://github.com/redis/node-redis/pull/3195 added
diagnostics channel support to redis, such that instrumentation
could be done without monkeypatching. This is worth considering.
