### PR TITLE
fix(auto-instrumentations-node): avoid duplicate diag logger warning in register.js

### DIFF
--- a/packages/auto-instrumentations-node/src/register.ts
+++ b/packages/auto-instrumentations-node/src/register.ts
@@ -3,20 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as opentelemetry from '@opentelemetry/sdk-node';
-import { diag, DiagConsoleLogger } from '@opentelemetry/api';
-import { getStringFromEnv, diagLogLevelFromString } from '@opentelemetry/core';
+import { diag } from '@opentelemetry/api';
 import {
   getNodeAutoInstrumentations,
   getResourceDetectorsFromEnv,
 } from './utils';
 
-const logLevel = getStringFromEnv('OTEL_LOG_LEVEL');
-if (logLevel != null) {
-  diag.setLogger(new DiagConsoleLogger(), {
-    logLevel: diagLogLevelFromString(logLevel),
-  });
-}
-
+// `NodeSDK` already registers a `DiagConsoleLogger` based on `OTEL_LOG_LEVEL`
+// internally, so doing it here as well only results in the "Current logger
+// will be overwritten" warning being logged on every start.
 const sdk = new opentelemetry.NodeSDK({
   instrumentations: getNodeAutoInstrumentations(),
   resourceDetectors: getResourceDetectorsFromEnv(),

--- a/packages/auto-instrumentations-node/src/register.ts
+++ b/packages/auto-instrumentations-node/src/register.ts
@@ -3,18 +3,33 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as opentelemetry from '@opentelemetry/sdk-node';
-import { diag } from '@opentelemetry/api';
+import { diag, DiagConsoleLogger } from '@opentelemetry/api';
+import { getStringFromEnv, diagLogLevelFromString } from '@opentelemetry/core';
 import {
   getNodeAutoInstrumentations,
   getResourceDetectorsFromEnv,
 } from './utils';
 
-// `NodeSDK` already registers a `DiagConsoleLogger` based on `OTEL_LOG_LEVEL`
-// internally, so doing it here as well only results in the "Current logger
-// will be overwritten" warning being logged on every start.
+const logLevel = getStringFromEnv('OTEL_LOG_LEVEL');
+if (logLevel != null) {
+  diag.setLogger(new DiagConsoleLogger(), {
+    logLevel: diagLogLevelFromString(logLevel),
+  });
+}
+
+const instrumentations = getNodeAutoInstrumentations();
+const resourceDetectors = getResourceDetectorsFromEnv();
+
+// `NodeSDK` registers its own `DiagConsoleLogger` based on `OTEL_LOG_LEVEL`
+// internally, so disable the logger set up above to avoid the "Current
+// logger will be overwritten" warning being logged on every start.
+if (logLevel != null) {
+  diag.disable();
+}
+
 const sdk = new opentelemetry.NodeSDK({
-  instrumentations: getNodeAutoInstrumentations(),
-  resourceDetectors: getResourceDetectorsFromEnv(),
+  instrumentations,
+  resourceDetectors,
 });
 
 try {

--- a/packages/auto-instrumentations-node/test/register.test.ts
+++ b/packages/auto-instrumentations-node/test/register.test.ts
@@ -58,7 +58,7 @@ describe('Register', function () {
   it('can load auto instrumentation from command line', async () => {
     const runPromise = runWithRegister('./test-app/app.js');
     const { child } = runPromise;
-    const { stdout } = await runPromise;
+    const { stdout, stderr } = await runPromise;
     assert.equal(child.exitCode, 0, `child.exitCode (${child.exitCode})`);
     assert.equal(
       child.signalCode,
@@ -79,6 +79,14 @@ describe('Register', function () {
 
     // Check a span has been generated for the GET request done in app.js
     assert.ok(stdout.includes("name: 'GET'"), 'console span output in stdout');
+
+    // register.js used to set up its own diag logger and then let NodeSDK
+    // set up an equivalent one again, causing this warning to be logged
+    // on every single start.
+    assert.ok(
+      !stderr.includes('Current logger will be overwritten'),
+      `Process should not log a diag logger override warning, got stderr:\n${stderr}`
+    );
   });
 
   it('shuts down the NodeSDK when SIGTERM is received', async () => {


### PR DESCRIPTION
## Which problem is this PR solving?

- When using `@opentelemetry/auto-instrumentations-node/register` together with a manually configured diag log level (`OTEL_LOG_LEVEL`), the process prints a `Current logger will be overwritten` warning (with a full stack trace) on every single start, as reported in #2742.

  This happens because `register.js` registers a `DiagConsoleLogger` based on `OTEL_LOG_LEVEL` and then constructs `NodeSDK`, which registers an equivalent `DiagConsoleLogger` again internally based on the same env var. The second registration doesn't pass `suppressOverrideMessage`, so `diag.setLogger()` logs the override warning even though nothing is actually going wrong.

## Short description of the changes

- Remove the redundant diag logger setup in `register.js`. `NodeSDK` already reads `OTEL_LOG_LEVEL` and registers a `DiagConsoleLogger` on its own, so `register.js` no longer needs to do it a second time.
- Add a regression test asserting that starting via `register.js` with `OTEL_LOG_LEVEL` set does not log the `Current logger will be overwritten` warning.

Fixes #2742