### PR TITLE
test(instrumentation-aws-sdk): fix assertions that can never fail

### DIFF
--- a/packages/instrumentation-aws-sdk/test/aws-sdk-v3-s3.test.ts
+++ b/packages/instrumentation-aws-sdk/test/aws-sdk-v3-s3.test.ts
@@ -136,31 +136,35 @@ describe('instrumentation-aws-sdk-v3 (client-s3)', () => {
         Key: 'aws-ot-s3-test-object.txt',
       };
 
+      let thrownError: any;
       try {
         await s3Client.putObject(params);
-      } catch {
-        expect(getTestSpans().length).toBe(1);
-        const [span] = getTestSpans();
-
-        // expect error attributes
-        expect(span.status.code).toEqual(SpanStatusCode.ERROR);
-        expect(span.status.message).toEqual('Access Denied');
-        expect(span.events.length).toBe(1);
-        expect(span.events[0].name).toEqual('exception');
-
-        expect(span.attributes[ATTR_RPC_SYSTEM]).toEqual('aws-api');
-        expect(span.attributes[ATTR_RPC_METHOD]).toEqual('PutObject');
-        expect(span.attributes[ATTR_RPC_SERVICE]).toEqual('S3');
-        expect(span.attributes[AttributeNames.AWS_S3_BUCKET]).toEqual(
-          'invalid-bucket-name'
-        );
-        expect(span.attributes[ATTR_HTTP_RESPONSE_STATUS_CODE]).toEqual(403);
-        expect(span.attributes[AttributeNames.CLOUD_REGION]).toEqual(region);
-        expect(span.attributes[AttributeNames.AWS_REQUEST_ID]).toEqual(
-          'MS95GTS7KXQ34X2S'
-        );
-        expect(span.name).toEqual('S3.PutObject');
+      } catch (err) {
+        thrownError = err;
       }
+      expect(thrownError).toBeDefined();
+
+      expect(getTestSpans().length).toBe(1);
+      const [span] = getTestSpans();
+
+      // expect error attributes
+      expect(span.status.code).toEqual(SpanStatusCode.ERROR);
+      expect(span.status.message).toEqual('Access Denied');
+      expect(span.events.length).toBe(1);
+      expect(span.events[0].name).toEqual('exception');
+
+      expect(span.attributes[ATTR_RPC_SYSTEM]).toEqual('aws-api');
+      expect(span.attributes[ATTR_RPC_METHOD]).toEqual('PutObject');
+      expect(span.attributes[ATTR_RPC_SERVICE]).toEqual('S3');
+      expect(span.attributes[AttributeNames.AWS_S3_BUCKET]).toEqual(
+        'invalid-bucket-name'
+      );
+      expect(span.attributes[ATTR_HTTP_RESPONSE_STATUS_CODE]).toEqual(403);
+      expect(span.attributes[AttributeNames.CLOUD_REGION]).toEqual(region);
+      expect(span.attributes[AttributeNames.AWS_REQUEST_ID]).toEqual(
+        'MS95GTS7KXQ34X2S'
+      );
+      expect(span.name).toEqual('S3.PutObject');
     });
   });
 
@@ -289,18 +293,20 @@ describe('instrumentation-aws-sdk-v3 (client-s3)', () => {
         Bucket: 'ot-demo-test',
         Key: 'aws-ot-s3-test-object.txt',
       };
+      let thrownError: any;
       try {
         await s3Client.putObject(params);
-      } catch {
-        expect(getTestSpans().length).toBe(1);
-        const [span] = getTestSpans();
-        expect(span.attributes['attribute.from.exception.hook']).toEqual(
-          params.Bucket
-        );
-        expect(span.attributes['error.from.exception.hook']).toEqual(
-          'NotFound'
-        );
+      } catch (err) {
+        thrownError = err;
       }
+      expect(thrownError).toBeDefined();
+
+      expect(getTestSpans().length).toBe(1);
+      const [span] = getTestSpans();
+      expect(span.attributes['attribute.from.exception.hook']).toEqual(
+        params.Bucket
+      );
+      expect(span.attributes['error.from.exception.hook']).toEqual('NotFound');
     });
   });
 });

--- a/packages/instrumentation-aws-sdk/test/bedrock-runtime.test.ts
+++ b/packages/instrumentation-aws-sdk/test/bedrock-runtime.test.ts
@@ -16,6 +16,7 @@
  * keeping existing recordings, set NOCK_BACK_MODE to 'record'.
  */
 
+import * as assert from 'assert';
 import { getTestSpans } from '@opentelemetry/contrib-test-utils';
 import { meterProvider, metricExporter } from './load-instrumentation';
 
@@ -658,7 +659,7 @@ describe('Bedrock', () => {
       const response = await client.send(command);
 
       let collectedText = '';
-      if (!response.body) return;
+      assert.ok(response.body);
       for await (const chunk of response.body) {
         if (chunk?.chunk?.bytes instanceof Uint8Array) {
           const parsed = JSON.parse(decodeChunk(chunk));
@@ -717,7 +718,7 @@ describe('Bedrock', () => {
       const response = await client.send(command);
 
       let collectedText = '';
-      if (!response.body) return;
+      assert.ok(response.body);
       for await (const chunk of response.body) {
         if (chunk?.chunk?.bytes instanceof Uint8Array) {
           const parsed = JSON.parse(decodeChunk(chunk));
@@ -770,7 +771,7 @@ describe('Bedrock', () => {
       const response = await client.send(command);
 
       let collectedText = '';
-      if (!response.body) return;
+      assert.ok(response.body);
       for await (const chunk of response.body) {
         if (chunk?.chunk?.bytes instanceof Uint8Array) {
           const parsed = JSON.parse(decodeChunk(chunk));
@@ -820,7 +821,7 @@ describe('Bedrock', () => {
       const response = await client.send(command);
 
       let collectedText = '';
-      if (!response.body) return;
+      assert.ok(response.body);
       for await (const chunk of response.body) {
         if (chunk?.chunk?.bytes instanceof Uint8Array) {
           const parsed = JSON.parse(decodeChunk(chunk));
@@ -870,7 +871,7 @@ describe('Bedrock', () => {
       const response = await client.send(command);
 
       let collectedText = '';
-      if (!response.body) return;
+      assert.ok(response.body);
       for await (const chunk of response.body) {
         if (chunk?.chunk?.bytes instanceof Uint8Array) {
           const parsed = JSON.parse(decodeChunk(chunk));
@@ -917,7 +918,7 @@ describe('Bedrock', () => {
       const response = await client.send(command);
 
       let collectedText = '';
-      if (!response.body) return;
+      assert.ok(response.body);
       for await (const chunk of response.body) {
         if (chunk?.chunk?.bytes instanceof Uint8Array) {
           const parsed = JSON.parse(decodeChunk(chunk));

--- a/packages/instrumentation-aws-sdk/test/stepfunctions.test.ts
+++ b/packages/instrumentation-aws-sdk/test/stepfunctions.test.ts
@@ -54,10 +54,6 @@ describe('SFN', () => {
 
       const stateMachineAttributeSpan = getStateMachineAttributeSpans[0];
       expect(
-        ATTR_AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN in
-          stateMachineAttributeSpan.attributes
-      );
-      expect(
         stateMachineAttributeSpan.attributes[
           ATTR_AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN
         ]
@@ -89,9 +85,6 @@ describe('SFN', () => {
       expect(getActivityAttributeSpans.length).toBe(1);
 
       const activityAttributeSpan = getActivityAttributeSpans[0];
-      expect(
-        ATTR_AWS_STEP_FUNCTIONS_ACTIVITY_ARN in activityAttributeSpan.attributes
-      );
       expect(
         activityAttributeSpan.attributes[ATTR_AWS_STEP_FUNCTIONS_ACTIVITY_ARN]
       ).toBe(activityArn);


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes #3529. Three test cases in `packages/instrumentation-aws-sdk/test/` are written so that the assertion they appear to make can never fail, so the test reports success even when the behavior under test is broken:
  - `stepfunctions.test.ts`: two `expect(...)` calls with no matcher chained (`expect(KEY in attributes);`), so nothing is actually asserted.
  - `aws-sdk-v3-s3.test.ts`: the `'aws error'` and `'handle aws sdk exception'` tests put all their error-path assertions inside a `catch { ... }` block with nothing verifying the call actually threw. If a regression makes the call resolve instead of reject, the `catch` is never entered and the test still passes.
  - `bedrock-runtime.test.ts`: six streaming tests use `if (!response.body) return;`, which Mocha treats as a successful early return instead of a failure.

## Short description of the changes

- `stepfunctions.test.ts`: removed the two no-op `expect(...)` calls, since the very next `expect(...).toBe(value)` in each test already covers both presence and value of the attribute.
- `aws-sdk-v3-s3.test.ts`: capture the thrown error in a variable and assert it's defined before checking the span attributes, so the test fails if the call unexpectedly succeeds.
- `bedrock-runtime.test.ts`: replaced the silent early return with `assert.ok(response.body)`, which both fails the test on a missing body and narrows the type for the `for await` loop that follows.