### PR TITLE
feat(instrumentation-typeorm): add support for typeorm@1.x

### DIFF
--- a/packages/instrumentation-typeorm/.tav.yml
+++ b/packages/instrumentation-typeorm/.tav.yml
@@ -1,5 +1,12 @@
 typeorm:
-  versions:
-    include: ">=0.3.0 <1"
-    mode: max-7
-  commands: npm run test
+  jobs:
+    - versions:
+        include: ">=0.3.0 <1"
+        mode: max-7
+      commands: npm run test
+    - versions:
+        include: ">=1.0.0 <2"
+        mode: max-7
+      node: '>=20'
+      peerDependencies: "better-sqlite3@^11.0.0"
+      commands: npm run test

--- a/packages/instrumentation-typeorm/src/typeorm.ts
+++ b/packages/instrumentation-typeorm/src/typeorm.ts
@@ -70,14 +70,16 @@ const functionsUsingQueryBuilder: EntityManagerMethods[] = [
   'count',
   'find',
   'findAndCount',
-  'findByIds',
   'findOne',
   'increment',
   'decrement',
 ];
-const entityManagerMethods: EntityManagerMethods[] = [
+// 'findByIds' was removed in typeorm 1.x. Keep it in the runtime list so it is
+// still instrumented on 0.3.x; the patch loop skips it when absent.
+const entityManagerMethods: string[] = [
   ...functionsUsingEntityPersistExecutor,
   ...functionsUsingQueryBuilder,
+  'findByIds',
 ];
 
 export class TypeormInstrumentation extends InstrumentationBase<TypeormInstrumentationConfig> {
@@ -88,7 +90,7 @@ export class TypeormInstrumentation extends InstrumentationBase<TypeormInstrumen
   protected init() {
     const selectQueryBuilder = new InstrumentationNodeModuleFile(
       'typeorm/query-builder/SelectQueryBuilder.js',
-      ['>=0.3.0 <1'],
+      ['>=0.3.0 <2'],
       moduleExports => {
         selectQueryBuilderExecuteMethods.map(method => {
           if (isWrapped(moduleExports.SelectQueryBuilder.prototype?.[method])) {
@@ -115,7 +117,7 @@ export class TypeormInstrumentation extends InstrumentationBase<TypeormInstrumen
 
     const dataSource = new InstrumentationNodeModuleFile(
       'typeorm/data-source/DataSource.js',
-      ['>=0.3.0 <1'],
+      ['>=0.3.0 <2'],
       moduleExports => {
         if (isWrapped(moduleExports.DataSource.prototype?.[rawQueryFuncName])) {
           this._unwrap(moduleExports.DataSource.prototype, rawQueryFuncName);
@@ -138,9 +140,10 @@ export class TypeormInstrumentation extends InstrumentationBase<TypeormInstrumen
 
     const entityManager = new InstrumentationNodeModuleFile(
       'typeorm/entity-manager/EntityManager.js',
-      ['>=0.3.0 <1'],
+      ['>=0.3.0 <2'],
       moduleExports => {
         entityManagerMethods.map(method => {
+          if (!moduleExports.EntityManager.prototype?.[method]) return;
           if (isWrapped(moduleExports.EntityManager.prototype?.[method])) {
             this._unwrap(moduleExports.EntityManager.prototype, method);
           }
@@ -165,7 +168,7 @@ export class TypeormInstrumentation extends InstrumentationBase<TypeormInstrumen
 
     const module = new InstrumentationNodeModuleDefinition(
       'typeorm',
-      ['>=0.3.0 <1'],
+      ['>=0.3.0 <2'],
       undefined,
       undefined,
       [selectQueryBuilder, entityManager, dataSource]

--- a/packages/instrumentation-typeorm/test/EntityManager.test.ts
+++ b/packages/instrumentation-typeorm/test/EntityManager.test.ts
@@ -21,7 +21,7 @@ const instrumentation = registerInstrumentationTesting(
   new TypeormInstrumentation()
 );
 import * as typeorm from 'typeorm';
-import { defaultOptions, User } from './utils';
+import { defaultOptions, secondaryOptions, User } from './utils';
 
 describe('EntityManager', () => {
   after(() => {
@@ -162,18 +162,10 @@ describe('EntityManager', () => {
   });
 
   describe('multiple connections', () => {
-    const options2: any = {
-      name: 'connection2',
-      type: 'sqlite',
-      database: 'connection2.db',
-      entities: [User],
-      synchronize: true,
-    };
-
     it('appends matching connection details to span', async () => {
       const ds1 = new typeorm.DataSource(defaultOptions);
       await ds1.initialize();
-      const ds2 = new typeorm.DataSource(options2);
+      const ds2 = new typeorm.DataSource(secondaryOptions);
       await ds2.initialize();
 
       const manager1 = ds1.manager;
@@ -209,11 +201,11 @@ describe('EntityManager', () => {
       assert.strictEqual(sqlite2Span.name, 'remove user');
       assert.strictEqual(
         sqlite2Span.attributes[ATTR_DB_SYSTEM_NAME],
-        options2.type
+        secondaryOptions.type
       );
       assert.strictEqual(
         sqlite2Span.attributes[ATTR_DB_NAMESPACE],
-        options2.database
+        secondaryOptions.database
       );
       assert.strictEqual(
         sqlite2Span.attributes[ATTR_DB_OPERATION_NAME],

--- a/packages/instrumentation-typeorm/test/utils.ts
+++ b/packages/instrumentation-typeorm/test/utils.ts
@@ -22,10 +22,45 @@ export class User {
   }
 }
 
-export const defaultOptions: any = {
-  type: 'sqlite',
-  database: ':memory:',
-  dropSchema: true,
-  synchronize: true,
-  entities: [User],
-};
+// typeorm 1.x removed the 'sqlite' driver in favour of 'better-sqlite3'.
+// Detect which driver is available at runtime so tests run with either version.
+function detectDriver(): 'sqlite' | 'better-sqlite3' {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('typeorm/driver/sqlite/SqliteDriver');
+    return 'sqlite';
+  } catch {
+    return 'better-sqlite3';
+  }
+}
+
+const driver = detectDriver();
+
+function buildOptions(extra: Record<string, unknown> = {}): any {
+  if (driver === 'better-sqlite3') {
+    return {
+      type: 'better-sqlite3',
+      database: ':memory:',
+      dropSchema: true,
+      synchronize: true,
+      entities: [User],
+      ...extra,
+    };
+  }
+  return {
+    type: 'sqlite',
+    database: ':memory:',
+    dropSchema: true,
+    synchronize: true,
+    entities: [User],
+    ...extra,
+  };
+}
+
+export const defaultOptions: any = buildOptions();
+
+// Options for a second connection used in multi-connection tests.
+export const secondaryOptions: any =
+  driver === 'sqlite'
+    ? buildOptions({ name: 'connection2', database: 'connection2.db' })
+    : buildOptions();


### PR DESCRIPTION
## Summary

- Extend `supportedVersions` from `<1` to `<2` in all `InstrumentationNodeModuleFile` / `InstrumentationNodeModuleDefinition` definitions so the instrumentation activates for typeorm 1.x
- Guard EntityManager method wrapping with an existence check to handle methods removed in typeorm 1.x (`findByIds` was deleted in 1.0); other methods and the `connection` getter (now a deprecated alias for `dataSource`) remain compatible
- Update `.tav.yml` to split into two jobs: 0.3.x range unchanged, 1.x range with `node: '>=20'` constraint (typeorm 1.0 requires Node 20+) and `better-sqlite3` as a peer dependency (typeorm 1.x removed the `sqlite` driver)
- Update test helpers to auto-detect the available SQLite driver (`sqlite` for 0.3.x, `better-sqlite3` for 1.x) so the same test suite runs against both supported version ranges without changes to individual test files

## Root cause of the TAV failure (Refs #3545)

typeorm 1.0 removed `EntityManager.prototype.findByIds`. When the instrumentation attempted to wrap it via `shimmer.wrap`, it threw `"Attempt to wrap undefined property findByIds as function"`, crashing the patch phase entirely. The fix is a one-line existence guard before the wrap call.

The `connection` property (also listed as a breaking change) was kept as a deprecated getter returning `this.dataSource` in typeorm 1.x, so no changes to attribute collection code were necessary.

## Test plan

- [x] `npm test` passes (13/13) with typeorm@0.3.x locally
- [ ] TAV CI (`test-all-versions` job in `test.yml`) passes for both the `>=0.3.0 <1` and `>=1.0.0 <2` ranges on Ubuntu — verifying typeorm@1.x with `better-sqlite3`

## Compatibility

- typeorm 0.3.x: no behaviour change; all existing tests pass
- typeorm 1.x: `findByIds` is silently skipped (method no longer exists); all other EntityManager, SelectQueryBuilder, and DataSource patches apply normally

Refs #3545

🤖 Generated with [Claude Code](https://claude.com/claude-code)