### PR TITLE
ci: update otelbot token workflows to use client IDs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          app-id: ${{ vars.OTELBOT_JS_CONTRIB_APP_ID }}
+          client-id: ${{ vars.OTELBOT_JS_CONTRIB_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_JS_CONTRIB_PRIVATE_KEY }}
           # Scope to just the permissions required by googleapis/release-please-action.
           permission-contents: write

--- a/.github/workflows/update-otel-deps.yaml
+++ b/.github/workflows/update-otel-deps.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
-          app-id: ${{ vars.OTELBOT_JS_CONTRIB_APP_ID }}
+          client-id: ${{ vars.OTELBOT_JS_CONTRIB_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_JS_CONTRIB_PRIVATE_KEY }}
           # Scope to just the permissions required by "Create PR" step below.
           permission-contents: write


### PR DESCRIPTION
Update otelbot token creation to use GitHub App client IDs.

The `app-id` input for `actions/create-github-app-token` is deprecated in favor of `client-id`. The matching `OTELBOT_*_CLIENT_ID` organization variables have been provisioned, so this updates direct token creation from `app-id` / `*_APP_ID` to `client-id` / `*_CLIENT_ID`.

Survey-on-merged-PR workflow changes are intentionally left out because those are being migrated separately to `open-telemetry/shared-workflows`.

Tracking issue: https://github.com/open-telemetry/admin/issues/744