### PR TITLE
feat(instrumentation-typeorm): add support for typeorm@1.x

### DIFF
--- a/packages/instrumentation-typeorm/.tav.yml
+++ b/packages/instrumentation-typeorm/.tav.yml
@@ -1,5 +1,13 @@
 typeorm:
-  versions:
-    include: ">=0.3.0 <1"
-    mode: max-7
-  commands: npm run test
+  - versions:
+      include: ">=0.3.0 <1"
+      mode: max-7
+    commands: npm run test
+  # typeorm@1.0.0 requires Node.js ^20.19.0 || ^22.13.0 || >=24.11.0 and
+  # replaced the `sqlite` (sqlite3) driver with `better-sqlite3`.
+  - versions:
+      include: ">=1.0.0 <2"
+      mode: max-7
+    node: ">=20"
+    peerDependencies: better-sqlite3@^12.0.0
+    commands: npm run test

--- a/packages/instrumentation-typeorm/README.md
+++ b/packages/instrumentation-typeorm/README.md
@@ -17,7 +17,7 @@ npm install --save @opentelemetry/instrumentation-typeorm
 
 ## Supported versions
 
-- [`typeorm`](https://www.npmjs.com/package/typeorm) versions `>=0.3.0 <1`
+- [`typeorm`](https://www.npmjs.com/package/typeorm) versions `>=0.3.0 <2`
 
 ## Usage
 

--- a/packages/instrumentation-typeorm/src/typeorm.ts
+++ b/packages/instrumentation-typeorm/src/typeorm.ts
@@ -79,6 +79,7 @@ const entityManagerMethods: EntityManagerMethods[] = [
   ...functionsUsingEntityPersistExecutor,
   ...functionsUsingQueryBuilder,
 ];
+const supportedVersions = ['>=0.3.0 <2'];
 
 export class TypeormInstrumentation extends InstrumentationBase<TypeormInstrumentationConfig> {
   constructor(config: TypeormInstrumentationConfig = {}) {
@@ -88,7 +89,7 @@ export class TypeormInstrumentation extends InstrumentationBase<TypeormInstrumen
   protected init() {
     const selectQueryBuilder = new InstrumentationNodeModuleFile(
       'typeorm/query-builder/SelectQueryBuilder.js',
-      ['>=0.3.0 <1'],
+      supportedVersions,
       moduleExports => {
         selectQueryBuilderExecuteMethods.map(method => {
           if (isWrapped(moduleExports.SelectQueryBuilder.prototype?.[method])) {
@@ -115,7 +116,7 @@ export class TypeormInstrumentation extends InstrumentationBase<TypeormInstrumen
 
     const dataSource = new InstrumentationNodeModuleFile(
       'typeorm/data-source/DataSource.js',
-      ['>=0.3.0 <1'],
+      supportedVersions,
       moduleExports => {
         if (isWrapped(moduleExports.DataSource.prototype?.[rawQueryFuncName])) {
           this._unwrap(moduleExports.DataSource.prototype, rawQueryFuncName);
@@ -138,10 +139,18 @@ export class TypeormInstrumentation extends InstrumentationBase<TypeormInstrumen
 
     const entityManager = new InstrumentationNodeModuleFile(
       'typeorm/entity-manager/EntityManager.js',
-      ['>=0.3.0 <1'],
+      supportedVersions,
       moduleExports => {
         entityManagerMethods.map(method => {
-          if (isWrapped(moduleExports.EntityManager.prototype?.[method])) {
+          // some methods do not exist in all supported versions,
+          // e.g. `findByIds` was removed in typeorm@1.0.0
+          if (
+            typeof moduleExports.EntityManager.prototype?.[method] !==
+            'function'
+          ) {
+            return;
+          }
+          if (isWrapped(moduleExports.EntityManager.prototype[method])) {
             this._unwrap(moduleExports.EntityManager.prototype, method);
           }
           this._wrap(
@@ -165,7 +174,7 @@ export class TypeormInstrumentation extends InstrumentationBase<TypeormInstrumen
 
     const module = new InstrumentationNodeModuleDefinition(
       'typeorm',
-      ['>=0.3.0 <1'],
+      supportedVersions,
       undefined,
       undefined,
       [selectQueryBuilder, entityManager, dataSource]

--- a/packages/instrumentation-typeorm/test/EntityManager.test.ts
+++ b/packages/instrumentation-typeorm/test/EntityManager.test.ts
@@ -21,7 +21,7 @@ const instrumentation = registerInstrumentationTesting(
   new TypeormInstrumentation()
 );
 import * as typeorm from 'typeorm';
-import { defaultOptions, User } from './utils';
+import { defaultOptions, sqliteDriverType, User } from './utils';
 
 describe('EntityManager', () => {
   after(() => {
@@ -164,7 +164,7 @@ describe('EntityManager', () => {
   describe('multiple connections', () => {
     const options2: any = {
       name: 'connection2',
-      type: 'sqlite',
+      type: sqliteDriverType,
       database: 'connection2.db',
       entities: [User],
       synchronize: true,

--- a/packages/instrumentation-typeorm/test/utils.ts
+++ b/packages/instrumentation-typeorm/test/utils.ts
@@ -22,8 +22,19 @@ export class User {
   }
 }
 
+// typeorm@1.0.0 removed the `sqlite` (sqlite3) driver in favor of
+// `better-sqlite3`, so pick whichever driver the installed typeorm supports.
+export const sqliteDriverType: 'sqlite' | 'better-sqlite3' = (() => {
+  try {
+    require.resolve('typeorm/driver/sqlite/SqliteDriver');
+    return 'sqlite';
+  } catch {
+    return 'better-sqlite3';
+  }
+})();
+
 export const defaultOptions: any = {
-  type: 'sqlite',
+  type: sqliteDriverType,
   database: ':memory:',
   dropSchema: true,
   synchronize: true,


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #3545

typeorm@1.0.0 removed `EntityManager#findByIds`, and the instrumentation tries to wrap it unconditionally, so patching crashes with "Attempt to wrap undefined property findByIds as function". Also `supportedVersions` is `>=0.3.0 <1`, so 1.x is not instrumented at all.

## Short description of the changes

- Extended the version range to `>=0.3.0 <2`. I kept the upper bound to avoid claiming support for major versions that are not verified yet, which is also why the existing code was capped at `<1`.
- Skip wrapping EntityManager methods that don't exist in the loaded version. In 1.x only `findByIds` is affected.
- I kept the `connection` getter as-is. In 1.x it is deprecated but still works (it just returns `dataSource`), and 0.3.x doesn't have `dataSource` on EntityManager, so `connection` is the only property that works on both.
- typeorm 1.x dropped the `sqlite` driver in favor of `better-sqlite3`, so the test helper now picks whichever driver the installed typeorm supports. The tests themselves are unchanged.
- `.tav.yml` runs 1.x in a separate job with `node: ">=20"` (typeorm 1.0 requires Node 20.19+) and `better-sqlite3@^12.0.0`, same range as typeorm's own peer dependency.

Tested with typeorm 0.3.x and 1.0.0, 13/13 passing on both. TAV run on my fork: https://github.com/katoztmy/opentelemetry-js-contrib/actions/runs/29142553352

I used AI assistance (Claude) for this change. I reviewed and tested everything myself.

This is my first contribution to this repo, so please let me know if I missed anything in the process.
