### PR TITLE
docs(instrumentation-pg): clarify db.collection.name is not collected (#3614)

### DIFF
--- a/packages/instrumentation-pg/README.md
+++ b/packages/instrumentation-pg/README.md
@@ -80,6 +80,10 @@ The `@opentelemetry/instrumentation-pg` versions 0.72.0 and later emit the stabl
 | `server.port`         | Remote port number.                                                                        |
 | `error.type`          | Describes a class of error the operation ended with.                                       |
 
+> [!NOTE]
+> `db.collection.name` is not collected by this instrumentation.
+> The database client does not make the table/collection name easily available, and parsing the SQL query text is not compliant with the OpenTelemetry specification.
+
 Metrics Exported:
 
 - [`db.client.operation.duration`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-metrics.md#metric-dbclientoperationduration)

--- a/packages/instrumentation-pg/README.md
+++ b/packages/instrumentation-pg/README.md
@@ -81,8 +81,10 @@ The `@opentelemetry/instrumentation-pg` versions 0.72.0 and later emit the stabl
 | `error.type`          | Describes a class of error the operation ended with.                                       |
 
 > [!NOTE]
-> `db.collection.name` is not collected by this instrumentation.
-> The database client does not make the table/collection name easily available, and parsing the SQL query text is not compliant with the OpenTelemetry specification.
+> `db.collection.name` is not collected. The `pg` driver does not expose the table
+> name separately, and the OpenTelemetry specification advises against parsing
+> `db.query.text` when the database supports queries touching multiple
+> collections in non-batch operations, which is the case for PostgreSQL.
 
 Metrics Exported:
 


### PR DESCRIPTION
### Which problem is this PR solving?

`@opentelemetry/instrumentation-pg` does not emit `db.collection.name`. This PR updates the README to explicitly clarify why `db.collection.name` is not collected by this instrumentation, in accordance with the OpenTelemetry specification.

Fixes #3614

### Short description of the changes

- Updated `packages/instrumentation-pg/README.md` to document that `db.collection.name` is not collected.
- Clarified that the `pg` driver does not expose table names separately, and the OpenTelemetry specification advises against parsing `db.query.text` when the database supports queries touching multiple collections in non-batch operations (which is the case for PostgreSQL).
