### PR TITLE
feat(resource-detector-github)!: use semconv cicd.* and vcs.* attributes

### DIFF
--- a/packages/resource-detector-github/README.md
+++ b/packages/resource-detector-github/README.md
@@ -36,16 +36,23 @@ run()
 
 ### GitHub Detector
 
-| Resource Attribute | Description                                               |
-| ------------------ | --------------------------------------------------------- |
-| github.actor       | Value of Process Environment Variable `GITHUB_ACTOR`      |
-| github.base_ref    | Value of Process Environment Variable `GITHUB_BASE_REF`   |
-| github.head_ref    | Value of Process Environment Variable `GITHUB_HEAD_REF`   |
-| github.ref         | Value of Process Environment Variable `GITHUB_REF`        |
-| github.run_id      | Value of Process Environment Variable `GITHUB_RUN_ID`     |
-| github.run_number  | Value of Process Environment Variable `GITHUB_RUN_NUMBER` |
-| github.sha         | Value of Process Environment Variable `GITHUB_SHA`        |
-| github.workflow    | Value of Process Environment Variable `GITHUB_WORKFLOW`   |
+| Resource Attribute    | Description                                                                           |
+| --------------------- | ------------------------------------------------------------------------------------- |
+| cicd.pipeline.name    | Value of Process Environment Variable `GITHUB_WORKFLOW`                               |
+| cicd.pipeline.run.id  | Value of Process Environment Variable `GITHUB_RUN_ID`                                 |
+| vcs.ref.base.name     | Value of Process Environment Variable `GITHUB_BASE_REF`                               |
+| vcs.ref.head.name     | Value of Process Environment Variable `GITHUB_HEAD_REF`, falling back to `GITHUB_REF` |
+| vcs.ref.head.revision | Value of Process Environment Variable `GITHUB_SHA`                                    |
+| github.actor          | Value of Process Environment Variable `GITHUB_ACTOR`                                  |
+| github.run_number     | Value of Process Environment Variable `GITHUB_RUN_NUMBER`                             |
+
+The `cicd.*` and `vcs.*` attributes follow the [CI/CD][semconv-cicd-url] and [VCS][semconv-vcs-url]
+semantic conventions. `github.actor` and `github.run_number` are kept as custom attributes because
+the semantic conventions do not currently define an equivalent for either.
+
+`GITHUB_HEAD_REF` is only set for pull request events; for those events `GITHUB_REF` holds the
+synthetic merge ref (for example `refs/pull/1/merge`) rather than the branch being merged, so
+`GITHUB_HEAD_REF` is preferred when present.
 
 ## Useful links
 
@@ -59,6 +66,8 @@ run()
 Apache 2.0 - See [LICENSE][license-url] for more information.
 
 [discussions-url]: https://github.com/open-telemetry/opentelemetry-js/discussions
+[semconv-cicd-url]: https://opentelemetry.io/docs/specs/semconv/registry/attributes/cicd/
+[semconv-vcs-url]: https://opentelemetry.io/docs/specs/semconv/registry/attributes/vcs/
 [license-url]: https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/LICENSE
 [license-image]: https://img.shields.io/badge/license-Apache_2.0-green.svg?style=flat
 [npm-url]: https://www.npmjs.com/package/@opentelemetry/resource-detector-github

--- a/packages/resource-detector-github/src/detectors/GitHubDetector.ts
+++ b/packages/resource-detector-github/src/detectors/GitHubDetector.ts
@@ -5,6 +5,14 @@
 
 import { ResourceDetector, DetectedResource } from '@opentelemetry/resources';
 
+import {
+  ATTR_CICD_PIPELINE_NAME,
+  ATTR_CICD_PIPELINE_RUN_ID,
+  ATTR_VCS_REF_BASE_NAME,
+  ATTR_VCS_REF_HEAD_NAME,
+  ATTR_VCS_REF_HEAD_REVISION,
+} from '../semconv';
+
 /**
  * The GitHubDetector can be used to detect GitHub Actions environment variables
  * and returns resource attributes with GitHub-specific metadata that exists
@@ -15,15 +23,19 @@ import { ResourceDetector, DetectedResource } from '@opentelemetry/resources';
  */
 class GitHubDetector implements ResourceDetector {
   public detect(): DetectedResource {
+    // GITHUB_HEAD_REF is only set for pull request events, where GITHUB_REF
+    // holds the synthetic merge ref instead of the branch being merged.
+    const headRef = process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF;
+
     const attributes = {
-      'github.workflow': process.env.GITHUB_WORKFLOW || undefined,
-      'github.run_id': process.env.GITHUB_RUN_ID || undefined,
+      [ATTR_CICD_PIPELINE_NAME]: process.env.GITHUB_WORKFLOW || undefined,
+      [ATTR_CICD_PIPELINE_RUN_ID]: process.env.GITHUB_RUN_ID || undefined,
+      [ATTR_VCS_REF_HEAD_NAME]: headRef || undefined,
+      [ATTR_VCS_REF_HEAD_REVISION]: process.env.GITHUB_SHA || undefined,
+      [ATTR_VCS_REF_BASE_NAME]: process.env.GITHUB_BASE_REF || undefined,
+      // Semconv has no equivalent for these two yet.
       'github.run_number': process.env.GITHUB_RUN_NUMBER || undefined,
       'github.actor': process.env.GITHUB_ACTOR || undefined,
-      'github.sha': process.env.GITHUB_SHA || undefined,
-      'github.ref': process.env.GITHUB_REF || undefined,
-      'github.head_ref': process.env.GITHUB_HEAD_REF || undefined,
-      'github.base_ref': process.env.GITHUB_BASE_REF || undefined,
     };
     return { attributes };
   }

--- a/packages/resource-detector-github/src/detectors/GitHubDetector.ts
+++ b/packages/resource-detector-github/src/detectors/GitHubDetector.ts
@@ -25,7 +25,10 @@ class GitHubDetector implements ResourceDetector {
   public detect(): DetectedResource {
     // GITHUB_HEAD_REF is only set for pull request events, where GITHUB_REF
     // holds the synthetic merge ref instead of the branch being merged.
-    const headRef = process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF;
+    const headRef =
+      process.env.GITHUB_HEAD_REF ||
+      process.env.GITHUB_REF_NAME ||
+      process.env.GITHUB_REF;
 
     const attributes = {
       [ATTR_CICD_PIPELINE_NAME]: process.env.GITHUB_WORKFLOW || undefined,

--- a/packages/resource-detector-github/src/semconv.ts
+++ b/packages/resource-detector-github/src/semconv.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * This file contains a copy of unstable semantic convention definitions
+ * used by this package.
+ * @see https://github.com/open-telemetry/opentelemetry-js/tree/main/semantic-conventions#unstable-semconv
+ */
+
+/**
+ * The human readable name of the pipeline within a CI/CD system.
+ *
+ * @example Build and Test
+ * @example Lint
+ * @example Deploy Go Project
+ * @example deploy_to_environment
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_CICD_PIPELINE_NAME = 'cicd.pipeline.name' as const;
+
+/**
+ * The unique identifier of a pipeline run within a CI/CD system.
+ *
+ * @example 120912
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_CICD_PIPELINE_RUN_ID = 'cicd.pipeline.run.id' as const;
+
+/**
+ * The name of the [reference](https://git-scm.com/docs/gitglossary#def_ref) such as **branch** or **tag** in the repository.
+ *
+ * @example my-feature-branch
+ * @example tag-1-test
+ *
+ * @note `base` refers to the starting point of a change. For example, `main`
+ * would be the base reference of type branch if you've created a new
+ * reference of type branch from it and created new commits.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_VCS_REF_BASE_NAME = 'vcs.ref.base.name' as const;
+
+/**
+ * The name of the [reference](https://git-scm.com/docs/gitglossary#def_ref) such as **branch** or **tag** in the repository.
+ *
+ * @example my-feature-branch
+ * @example tag-1-test
+ *
+ * @note `head` refers to where you are right now; the current reference at a
+ * given time.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_VCS_REF_HEAD_NAME = 'vcs.ref.head.name' as const;
+
+/**
+ * The revision, literally [revised version](https://www.merriam-webster.com/dictionary/revision), The revision most often refers to a commit object in Git, or a revision number in SVN.
+ *
+ * @example 9d59409acf479dfa0df1aa568182e43e43df8bbe28d60fcf2bc52e30068802cc
+ * @example main
+ * @example 123
+ * @example HEAD
+ *
+ * @note `head` refers to where you are right now; the current reference at a
+ * given time.The revision can be a full [hash value (see
+ * glossary)](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-5.pdf),
+ * of the recorded change to a ref within a repository pointing to a
+ * commit [commit](https://git-scm.com/docs/git-commit) object. It does
+ * not necessarily have to be a hash; it can simply define a [revision
+ * number](https://svnbook.red-bean.com/en/1.7/svn.tour.revs.specifiers.html)
+ * which is an integer that is monotonically increasing. In cases where
+ * it is identical to the `ref.head.name`, it **SHOULD** still be included.
+ * It is up to the implementer to decide which value to set as the
+ * revision based on the VCS system and situational context.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_VCS_REF_HEAD_REVISION = 'vcs.ref.head.revision' as const;

--- a/packages/resource-detector-github/test/detectors/GitHubDetector.test.ts
+++ b/packages/resource-detector-github/test/detectors/GitHubDetector.test.ts
@@ -9,6 +9,13 @@ import * as sinon from 'sinon';
 import { detectResources } from '@opentelemetry/resources';
 
 import { gitHubDetector } from '../../src/detectors';
+import {
+  ATTR_CICD_PIPELINE_NAME,
+  ATTR_CICD_PIPELINE_RUN_ID,
+  ATTR_VCS_REF_BASE_NAME,
+  ATTR_VCS_REF_HEAD_NAME,
+  ATTR_VCS_REF_HEAD_REVISION,
+} from '../../src/semconv';
 
 describe('GitHubResourceDetector', () => {
   let sandbox: sinon.SinonSandbox;
@@ -36,7 +43,7 @@ describe('GitHubResourceDetector', () => {
     process.env.GITHUB_RUN_NUMBER = '42';
     process.env.GITHUB_ACTOR = 'octocat';
     process.env.GITHUB_SHA = 'git-sha';
-    process.env.GITHUB_REF = 'git-ref';
+    process.env.GITHUB_REF = 'refs/pull/1/merge';
     process.env.GITHUB_HEAD_REF = 'ref/foo';
     process.env.GITHUB_BASE_REF = 'ref/bar';
 
@@ -44,14 +51,28 @@ describe('GitHubResourceDetector', () => {
 
     assert.ok(resource);
     assert.deepStrictEqual(resource.attributes, {
-      'github.workflow': 'workflow-foo',
-      'github.run_id': 'run-id-foo',
+      [ATTR_CICD_PIPELINE_NAME]: 'workflow-foo',
+      [ATTR_CICD_PIPELINE_RUN_ID]: 'run-id-foo',
+      [ATTR_VCS_REF_HEAD_NAME]: 'ref/foo',
+      [ATTR_VCS_REF_HEAD_REVISION]: 'git-sha',
+      [ATTR_VCS_REF_BASE_NAME]: 'ref/bar',
       'github.run_number': '42',
       'github.actor': 'octocat',
-      'github.sha': 'git-sha',
-      'github.ref': 'git-ref',
-      'github.head_ref': 'ref/foo',
-      'github.base_ref': 'ref/bar',
+    });
+  });
+
+  it('should fall back to GITHUB_REF for the head ref name outside of pull requests', async () => {
+    process.env.GITHUB_WORKFLOW = 'workflow-foo';
+    process.env.GITHUB_SHA = 'git-sha';
+    process.env.GITHUB_REF = 'refs/heads/main';
+
+    const resource = detectResources({ detectors: [gitHubDetector] });
+
+    assert.ok(resource);
+    assert.deepStrictEqual(resource.attributes, {
+      [ATTR_CICD_PIPELINE_NAME]: 'workflow-foo',
+      [ATTR_VCS_REF_HEAD_NAME]: 'refs/heads/main',
+      [ATTR_VCS_REF_HEAD_REVISION]: 'git-sha',
     });
   });
 

--- a/packages/resource-detector-github/test/detectors/GitHubDetector.test.ts
+++ b/packages/resource-detector-github/test/detectors/GitHubDetector.test.ts
@@ -29,6 +29,7 @@ describe('GitHubResourceDetector', () => {
     process.env.GITHUB_ACTOR = '';
     process.env.GITHUB_SHA = '';
     process.env.GITHUB_REF = '';
+    process.env.GITHUB_REF_NAME = '';
     process.env.GITHUB_HEAD_REF = '';
     process.env.GITHUB_BASE_REF = '';
   });
@@ -61,7 +62,22 @@ describe('GitHubResourceDetector', () => {
     });
   });
 
-  it('should fall back to GITHUB_REF for the head ref name outside of pull requests', async () => {
+  it('should fall back to GITHUB_REF_NAME then GITHUB_REF for the head ref name outside of pull requests', async () => {
+    process.env.GITHUB_WORKFLOW = 'workflow-foo';
+    process.env.GITHUB_SHA = 'git-sha';
+    process.env.GITHUB_REF_NAME = 'main';
+
+    const resource = detectResources({ detectors: [gitHubDetector] });
+
+    assert.ok(resource);
+    assert.deepStrictEqual(resource.attributes, {
+      [ATTR_CICD_PIPELINE_NAME]: 'workflow-foo',
+      [ATTR_VCS_REF_HEAD_NAME]: 'main',
+      [ATTR_VCS_REF_HEAD_REVISION]: 'git-sha',
+    });
+  });
+
+  it('should fall back to GITHUB_REF for the head ref name when GITHUB_REF_NAME is absent', async () => {
     process.env.GITHUB_WORKFLOW = 'workflow-foo';
     process.env.GITHUB_SHA = 'git-sha';
     process.env.GITHUB_REF = 'refs/heads/main';


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #2927

`gitHubDetector` emits custom `github.*` resource attributes for data that the
[CI/CD](https://opentelemetry.io/docs/specs/semconv/registry/attributes/cicd/) and
[VCS](https://opentelemetry.io/docs/specs/semconv/registry/attributes/vcs/) semantic
conventions already define, so the detector's output doesn't line up with what other
CI/CD and VCS instrumentation produces.

## Short description of the changes

Map the attributes that have a semconv equivalent onto it:

| Before | After |
| ------ | ----- |
| `github.workflow` | `cicd.pipeline.name` |
| `github.run_id` | `cicd.pipeline.run.id` |
| `github.sha` | `vcs.ref.head.revision` |
| `github.base_ref` | `vcs.ref.base.name` |
| `github.ref` / `github.head_ref` | `vcs.ref.head.name` |

`github.actor` and `github.run_number` are left as-is, since semconv doesn't currently
define an equivalent for either.

`GITHUB_REF` and `GITHUB_HEAD_REF` both map onto `vcs.ref.head.name`, so the detector
prefers `GITHUB_HEAD_REF` and falls back to `GITHUB_REF`. `GITHUB_HEAD_REF` is only set
for pull request events, and for those events `GITHUB_REF` holds the synthetic merge ref
(e.g. `refs/pull/1/merge`) rather than the branch being merged. There's a test covering
the non-PR fallback.

The unstable semconv definitions are copied into `src/semconv.ts` using
`scripts/gen-semconv-ts.js`, per the [unstable semconv guidance](https://github.com/open-telemetry/opentelemetry-js/tree/main/semantic-conventions#unstable-semconv).
No dependency on `@opentelemetry/semantic-conventions` is added, matching the other
detectors that only use copied definitions (gcp, alibaba-cloud, container, instana).

README updated; existing tests updated and one added.

## Note for reviewers

No rush on this — a couple of points worth your input whenever you get to it:

- This renames the emitted attributes outright, which is breaking for anyone matching on
  the old `github.*` names. I went with a straight rename since the package is pre-1.0 and
  that's what #2927 asks for, but I'm happy to emit both old and new for a transition period
  instead if that's preferred.
- Let me know if `github.actor` / `github.run_number` should be dropped rather than kept.
- I saw the bot's note that this package is in feature-freeze without a component owner. If
  the semconv alignment here is something a JS approver would be willing to sponsor, I'd
  appreciate it, but I completely understand if the package's status means that's not
  feasible. Either way I'm happy to keep contributing toward being able to help maintain
  this package longer term.
  
  
  
  
  
  
  
  
  
  
  
  @blumamir @jj22ee @trivikr @david-luna @pichlermarc @trentm
   it looks like it may be flagged for auto-close due to inactivity. Would appreciate a review whenever you get a chance. No         rush!

