### PR TITLE
fix(scripts): build glob patterns with forward slashes for Windows

### DIFF
--- a/scripts/bitrot.mjs
+++ b/scripts/bitrot.mjs
@@ -27,6 +27,15 @@ const TOP = path.resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
 const USE_COLOR = process.stdout.isTTY && !process.env.NO_COLOR?.length > 0;
 const BUILD_DIR = path.join(TOP, 'build', 'bitrot');
 
+// `glob` always wants forward slashes in its patterns, even on Windows,
+// where `path.join` produces backslashes.
+function toGlobPattern(...parts) {
+  return path
+    .join(...parts)
+    .split(path.sep)
+    .join('/');
+}
+
 let numProbs = 0;
 function problem(...args) {
   numProbs += 1;
@@ -93,7 +102,7 @@ function bitrotRenovateCoreExperimental() {
   }
 
   const pkgNames = globSync(
-    path.join(ojDir, 'experimental/packages/*/package.json')
+    toGlobPattern(ojDir, 'experimental/packages/*/package.json')
   )
     .map(packageJson => JSON.parse(fs.readFileSync(packageJson)))
     .filter(pj => isPublicPackage(pj))
@@ -168,7 +177,7 @@ function getNpmInfo(name) {
  */
 function bitrotInstrumentations() {
   const instrReadmes = globSync(
-    path.join(TOP, 'packages/instrumentation-*/README.md')
+    toGlobPattern(TOP, 'packages/instrumentation-*/README.md')
   );
 
   // Match examples:

--- a/scripts/check-release-please.mjs
+++ b/scripts/check-release-please.mjs
@@ -31,12 +31,17 @@ const getPackages = () => {
   const TOP = process.cwd();
   const pj = readJson(path.join(TOP, 'package.json'));
   return pj.workspaces
-    .map(wsGlob => globSync(path.join(wsGlob, 'package.json')))
+    .map(wsGlob => globSync(`${wsGlob}/package.json`))
     .flat()
     .map(p => {
       const pkgInfo = readJson(p);
       pkgInfo.location = path.dirname(p);
-      pkgInfo.relativeLocation = path.relative(PROJECT_ROOT, pkgInfo.location);
+      // release-please's manifest/config files always use forward slashes
+      // for their package location keys, regardless of platform.
+      pkgInfo.relativeLocation = path
+        .relative(PROJECT_ROOT, pkgInfo.location)
+        .split(path.sep)
+        .join('/');
       return pkgInfo;
     });
 };

--- a/scripts/codecov-upload-flags.mjs
+++ b/scripts/codecov-upload-flags.mjs
@@ -18,7 +18,7 @@ const readPkg = dir =>
   JSON.parse(readFileSync(path.join(dir, 'package.json'), 'utf8'));
 const pkgInfo = readPkg('.');
 const pkgFiles = pkgInfo.workspaces.map(exp =>
-  globSync(path.join(exp, 'package.json'))
+  globSync(`${exp}/package.json`, { posix: true })
 );
 const pkgsWithFlag = pkgFiles.flat().map(f => {
   const path = f.replace('package.json', '');

--- a/scripts/gen-component-label-map.mjs
+++ b/scripts/gen-component-label-map.mjs
@@ -41,7 +41,7 @@ function warn(...args) {
 function getAllWorkspaceDirs() {
   const pj = JSON.parse(fs.readFileSync(join(TOP, 'package.json'), 'utf8'));
   return pj.workspaces
-    .map(wsGlob => globSync(join(wsGlob, 'package.json')))
+    .map(wsGlob => globSync(`${wsGlob}/package.json`, { posix: true }))
     .flat()
     .map(dirname);
 }

--- a/scripts/gen-semconv-ts.js
+++ b/scripts/gen-semconv-ts.js
@@ -51,9 +51,18 @@ function getAllWorkspaceDirs() {
     fs.readFileSync(path.join(TOP, 'package.json'), 'utf8')
   );
   return pj.workspaces
-    .map(wsGlob => globSync(path.join(wsGlob, 'package.json')))
+    .map(wsGlob => globSync(`${wsGlob}/package.json`, { posix: true }))
     .flat()
     .map(path.dirname);
+}
+
+// `glob` always wants forward slashes in its patterns, even on Windows,
+// where `path.join`/`path.resolve` produce backslashes.
+function toGlobPattern(...parts) {
+  return path
+    .join(...parts)
+    .split(path.sep)
+    .join('/');
 }
 
 function genSemconvTs(wsDir) {
@@ -68,7 +77,9 @@ function genSemconvTs(wsDir) {
   // Gather unstable semconv imports. Consider any imports from
   // '@opentelemetry/semantic-conventions/incubating' or from an existing local
   // '.../semconv'.
-  const srcFiles = globSync(path.join(wsDir, '{src,test}', '**', '*.ts'));
+  const srcFiles = globSync(toGlobPattern(wsDir, '{src,test}', '**', '*.ts'), {
+    posix: true,
+  });
   const importRes = [
     /import\s+{([^}]*)}\s+from\s+'@opentelemetry\/semantic-conventions\/incubating'/s,
     /import\s+{([^}]*)}\s+from\s+'\.[^']*\/semconv'/s,
@@ -150,7 +161,7 @@ function genSemconvTs(wsDir) {
     console.log(`Using sources at "${semconvSrcDir}"`);
   }
   const srcPaths = globSync(
-    path.join(semconvSrcDir, 'src', 'experimental_*.ts')
+    toGlobPattern(semconvSrcDir, 'src', 'experimental_*.ts')
   );
   const src = srcPaths.map(f => fs.readFileSync(f)).join('\n\n');
 

--- a/scripts/lint-semconv-deps.mjs
+++ b/scripts/lint-semconv-deps.mjs
@@ -41,9 +41,18 @@ function getAllWorkspaceDirs() {
     fs.readFileSync(path.join(TOP, 'package.json'), 'utf8')
   );
   return pj.workspaces
-    .map(wsGlob => globSync(path.join(wsGlob, 'package.json')))
+    .map(wsGlob => globSync(`${wsGlob}/package.json`, { posix: true }))
     .flat()
     .map(path.dirname);
+}
+
+// `glob` always wants forward slashes in its patterns, even on Windows,
+// where `path.join` produces backslashes.
+function toGlobPattern(...parts) {
+  return path
+    .join(...parts)
+    .split(path.sep)
+    .join('/');
 }
 
 function lintSemconvDeps(excludePaths) {
@@ -72,7 +81,9 @@ function lintSemconvDeps(excludePaths) {
     }
 
     // Rule: The incubating entry-point should not be used.
-    const srcFiles = globSync(path.join(wsDir, 'src', '**', '*.ts'));
+    const srcFiles = globSync(toGlobPattern(wsDir, 'src', '**', '*.ts'), {
+      posix: true,
+    });
     const usesIncubatingRe =
       /import\s+\{?[^{;]*\s+from\s+'@opentelemetry\/semantic-conventions\/incubating'/s;
     for (let srcFile of srcFiles) {

--- a/scripts/peer-api-check.js
+++ b/scripts/peer-api-check.js
@@ -15,7 +15,7 @@ function getAllWorkspaceDirs() {
     fs.readFileSync(path.join(TOP, 'package.json'), 'utf8')
   );
   return pj.workspaces
-    .map(wsGlob => globSync(path.join(wsGlob, 'package.json')))
+    .map(wsGlob => globSync(`${wsGlob}/package.json`, { posix: true }))
     .flat()
     .map(path.dirname);
 }

--- a/scripts/update-otel-deps.js
+++ b/scripts/update-otel-deps.js
@@ -36,7 +36,7 @@ function getAllWorkspaceDirs() {
     fs.readFileSync(path.join(TOP, 'package.json'), 'utf8')
   );
   return pj.workspaces
-    .map(wsGlob => globSync(path.join(wsGlob, 'package.json')))
+    .map(wsGlob => globSync(`${wsGlob}/package.json`, { posix: true }))
     .flat()
     .map(path.dirname);
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #3625

Several repo tooling scripts enumerate workspace packages (and source files) with `glob`, but build the glob pattern using `path.join(...)`. On Windows, `path.join` uses `\` as the separator, and `glob` treats `\` as an escape character rather than a path separator, so the pattern silently matches nothing.

The clearest case is `scripts/gen-semconv-ts.js`, the documented way to regenerate a package's local `src/semconv.ts`:

```
node scripts/gen-semconv-ts.js packages/resource-detector-github
```

On Windows this printed `Did not find any usage of unstable semconv exports...` and no-op'd, even though the package imports unstable semconv definitions. Every affected script has the same failure mode: it finds zero matches and silently behaves as if the monorepo were empty, with no error.

Because `lint-semconv-deps` is part of `npm run lint`, its checks were effectively skipped for Windows contributors - it passed by matching nothing rather than by finding no problems.

## Short description of the changes

- `scripts/gen-semconv-ts.js`, `scripts/lint-semconv-deps.mjs`, `scripts/peer-api-check.js`, `scripts/update-otel-deps.js`, `scripts/codecov-upload-flags.mjs`, `scripts/gen-component-label-map.mjs`: build glob patterns with forward slashes instead of `path.join(...)`, and pass `posix: true` to `globSync` so the returned paths are also forward-slash (needed since some of these scripts compare returned paths against forward-slash strings from `package.json`/YAML files, e.g. the `lint-semconv-deps` exclude list and `component_owners.yml` lookups).
- `scripts/check-release-please.mjs` uses `node:fs`'s `globSync`, which already handles `path.join`-built patterns fine on Windows. However, it builds its manifest/config lookup keys with `path.relative(...)`, which returns platform-native separators - producing backslash keys that never matched the forward-slash keys already in `.release-please-manifest.json` and `release-please-config.json`. Normalized those to forward slashes too, since this failed outright on Windows before this fix (every package was reported as a missing manifest/config entry).

No dependency changes; the change is isolated to `scripts/` and has no runtime/package impact.

## Test plan

Verified interactively on a Windows checkout (all previously reported zero matches, now find the expected workspaces/files):

- `node scripts/gen-semconv-ts.js packages/contrib-test-utils` finds the package's unstable semconv imports and regenerates `src/semconv.ts` (previously reported "Did not find any usage...").
- `node scripts/lint-semconv-deps.mjs -x packages/contrib-test-utils/src/resource-assertions.ts` (the exact `npm run lint:semconv-deps` invocation) now runs its checks across all workspaces and exits 0 (previously silently checked nothing).
- `node scripts/peer-api-check.js` now checks all workspace packages instead of none.
- `node scripts/check-release-please.mjs` now exits `OK` instead of reporting every package as missing from the manifest/config.
- `node scripts/gen-component-label-map.mjs` now correctly enumerates workspace dirs.

Ran `eslint` and `prettier --check` on all changed files.