### PR TITLE
feat(instrumentation-tedious): add missing stable SemConv attributes

### DIFF
--- a/packages/instrumentation-tedious/README.md
+++ b/packages/instrumentation-tedious/README.md
@@ -57,6 +57,7 @@ The `instrumentation-tedious` versions 0.39.0 and later emit the stable v1.33.0+
 | `error.type`               | Describes a class of error the operation ended with.                                          |
 | `server.address`           | Remote hostname or similar.                                                                   |
 | `server.port`              | Remote port number.                                                                           |
+
 ### Trace Context Propagation
 
 Database trace context propagation can be enabled by setting `enableTraceContextPropagation` to `true`.

--- a/packages/instrumentation-tedious/README.md
+++ b/packages/instrumentation-tedious/README.md
@@ -45,20 +45,23 @@ This instrumentation creates spans with attributes from the stable database and 
 
 The `instrumentation-tedious` versions 0.39.0 and later emit the stable v1.33.0+ semantic conventions.
 
-| Attribute             | Description                                                                           |
-| --------------------- | ------------------------------------------------------------------------------------- |
-| `db.system.name`      | Database system identifier: `'microsoft.sql_server'`                                  |
-| `db.query.text`       | The database query being executed.                                                    |
-| `db.namespace`        | The database associated with the connection.                                          |
-| `db.collection.name`  | The name of a collection (table, container) within the database.                      |
-| `server.address`      | Remote hostname or similar.                                                           |
-| `server.port`         | Remote port number.                                                                   |
-
+| Attribute                  | Description                                                                                   |
+| -------------------------- | --------------------------------------------------------------------------------------------- |
+| `db.system.name`           | Database system identifier: `'microsoft.sql_server'`                                          |
+| `db.query.text`            | The database query being executed.                                                            |
+| `db.namespace`             | The database associated with the connection.                                                  |
+| `db.collection.name`       | The name of a collection (table, container) within the database.                              |
+| `db.operation.name`        | The name of the operation or command being executed.                                          |
+| `db.stored_procedure.name` | The stored procedure name.                                                                    |
+| `db.response.status_code`  | The SQL Server error number as a string, set on error (e.g. `"208"` for invalid object name). |
+| `error.type`               | Describes a class of error the operation ended with.                                          |
+| `server.address`           | Remote hostname or similar.                                                                   |
+| `server.port`              | Remote port number.                                                                           |
 ### Trace Context Propagation
 
-Database trace context propagation can be enabled by setting `enableTraceContextPropagation`to `true`.
+Database trace context propagation can be enabled by setting `enableTraceContextPropagation` to `true`.
 This uses the [SET CONTEXT_INFO](https://learn.microsoft.com/en-us/sql/t-sql/statements/set-context-info-transact-sql?view=sql-server-ver16)
-command to set [traceparent](https://www.w3.org/TR/trace-context/#traceparent-header)information
+command to set [traceparent](https://www.w3.org/TR/trace-context/#traceparent-header) information
 for the current connection, which results in **an additional round-trip to the database**.
 
 ## Useful links

--- a/packages/instrumentation-tedious/src/instrumentation.ts
+++ b/packages/instrumentation-tedious/src/instrumentation.ts
@@ -13,15 +13,19 @@ import {
 import {
   ATTR_DB_COLLECTION_NAME,
   ATTR_DB_NAMESPACE,
+  ATTR_DB_OPERATION_NAME,
   ATTR_DB_QUERY_TEXT,
+  ATTR_DB_RESPONSE_STATUS_CODE,
+  ATTR_DB_STORED_PROCEDURE_NAME,
   ATTR_DB_SYSTEM_NAME,
+  ATTR_ERROR_TYPE,
   ATTR_SERVER_ADDRESS,
   ATTR_SERVER_PORT,
   DB_SYSTEM_NAME_VALUE_MICROSOFT_SQL_SERVER,
 } from '@opentelemetry/semantic-conventions';
 import type * as tedious from 'tedious';
 import { TediousInstrumentationConfig } from './types';
-import { getSpanName, once } from './utils';
+import { getOperationName, getSpanName, once } from './utils';
 /** @knipignore */
 import { PACKAGE_NAME, PACKAGE_VERSION } from './version';
 
@@ -199,24 +203,37 @@ export class TediousInstrumentation extends InstrumentationBase<TediousInstrumen
 
         const attributes: api.Attributes = {};
 
-        // The OTel spec for "db.namespace" discusses handling for connection
-        // to MSSQL "named instances". This isn't currently supported.
-        //    https://opentelemetry.io/docs/specs/semconv/database/sql-server/#:~:text=%5B1%5D%20db%2Enamespace
-        attributes[ATTR_DB_NAMESPACE] = databaseName;
+        // db.namespace: for named instances include the instance name as a
+        // prefix separated by "|" per the SQL Server semconv spec.
+        // https://opentelemetry.io/docs/specs/semconv/database/sql-server/#:~:text=%5B1%5D%20db%2Enamespace
+        const instanceName = this.config?.options?.instanceName;
+        const dbNamespace = instanceName
+          ? `${instanceName}|${databaseName}`
+          : databaseName;
+        attributes[ATTR_DB_NAMESPACE] = dbNamespace;
         attributes[ATTR_DB_SYSTEM_NAME] =
           DB_SYSTEM_NAME_VALUE_MICROSOFT_SQL_SERVER;
         attributes[ATTR_DB_QUERY_TEXT] = sql;
         attributes[ATTR_DB_COLLECTION_NAME] = request.table;
-        // See https://opentelemetry.io/docs/specs/semconv/database/sql-server/#spans
-        // TODO(3290): can `db.response.status_code` be added?
-        // TODO(3290): is `operation` correct for `db.operation.name`
-        // TODO(3290): can `db.query.summary` reliably be calculated?
-        // TODO(3290): `db.stored_procedure.name`
+
+        const operationName = getOperationName(operation, sql);
+        if (operationName !== undefined) {
+          attributes[ATTR_DB_OPERATION_NAME] = operationName;
+        }
+
+        // db.stored_procedure.name: available directly from sqlTextOrProcedure
+        // when callProcedure is used.
+        if (operation === 'callProcedure' && sql) {
+          attributes[ATTR_DB_STORED_PROCEDURE_NAME] = sql;
+        }
 
         attributes[ATTR_SERVER_ADDRESS] = this.config?.server;
         attributes[ATTR_SERVER_PORT] = this.config?.options?.port;
+
+        const spanCollection =
+          operation === 'callProcedure' ? sql : request.table;
         const span = thisPlugin.tracer.startSpan(
-          getSpanName(operation, databaseName, sql, request.table),
+          getSpanName(operationName, dbNamespace, spanCollection),
           {
             kind: api.SpanKind.CLIENT,
             attributes,
@@ -237,7 +254,20 @@ export class TediousInstrumentation extends InstrumentationBase<TediousInstrumen
               code: api.SpanStatusCode.ERROR,
               message: err.message,
             });
-            // TODO(3290): set `error.type` attribute?
+
+            // error.type must be an error class identifier (e.g. "EREQUEST",
+            // "ETIMEOUT"), not a numeric SQL Server error number.
+            // See: https://opentelemetry.io/docs/specs/semconv/attributes-registry/error/
+            const errorType = err.constructor.name;
+            span.setAttribute(ATTR_ERROR_TYPE, errorType);
+
+            // db.response.status_code carries the SQL Server error number when
+            // present, otherwise the Tedious error code string.
+            const statusCode =
+              err.number != null ? String(err.number) : err.code;
+            if (statusCode) {
+              span.setAttribute(ATTR_DB_RESPONSE_STATUS_CODE, statusCode);
+            }
           }
           span.end();
         });

--- a/packages/instrumentation-tedious/src/instrumentation.ts
+++ b/packages/instrumentation-tedious/src/instrumentation.ts
@@ -255,9 +255,6 @@ export class TediousInstrumentation extends InstrumentationBase<TediousInstrumen
               message: err.message,
             });
 
-            // error.type must be an error class identifier (e.g. "EREQUEST",
-            // "ETIMEOUT"), not a numeric SQL Server error number.
-            // See: https://opentelemetry.io/docs/specs/semconv/attributes-registry/error/
             const errorType = err.constructor.name;
             span.setAttribute(ATTR_ERROR_TYPE, errorType);
 

--- a/packages/instrumentation-tedious/src/instrumentation.ts
+++ b/packages/instrumentation-tedious/src/instrumentation.ts
@@ -207,16 +207,17 @@ export class TediousInstrumentation extends InstrumentationBase<TediousInstrumen
         // prefix separated by "|" per the SQL Server semconv spec.
         // https://opentelemetry.io/docs/specs/semconv/database/sql-server/#:~:text=%5B1%5D%20db%2Enamespace
         const instanceName = this.config?.options?.instanceName;
-        const dbNamespace = instanceName
-          ? `${instanceName}|${databaseName}`
-          : databaseName;
+        const dbNamespace =
+          instanceName && databaseName
+            ? `${instanceName}|${databaseName}`
+            : databaseName;
         attributes[ATTR_DB_NAMESPACE] = dbNamespace;
         attributes[ATTR_DB_SYSTEM_NAME] =
           DB_SYSTEM_NAME_VALUE_MICROSOFT_SQL_SERVER;
         attributes[ATTR_DB_QUERY_TEXT] = sql;
         attributes[ATTR_DB_COLLECTION_NAME] = request.table;
 
-        const operationName = getOperationName(operation, sql);
+        const operationName = getOperationName(operation);
         if (operationName !== undefined) {
           attributes[ATTR_DB_OPERATION_NAME] = operationName;
         }
@@ -233,7 +234,12 @@ export class TediousInstrumentation extends InstrumentationBase<TediousInstrumen
         const spanCollection =
           operation === 'callProcedure' ? sql : request.table;
         const span = thisPlugin.tracer.startSpan(
-          getSpanName(operationName, dbNamespace, spanCollection),
+          getSpanName(
+            operationName,
+            dbNamespace,
+            spanCollection,
+            DB_SYSTEM_NAME_VALUE_MICROSOFT_SQL_SERVER
+          ),
           {
             kind: api.SpanKind.CLIENT,
             attributes,

--- a/packages/instrumentation-tedious/src/instrumentation.ts
+++ b/packages/instrumentation-tedious/src/instrumentation.ts
@@ -255,7 +255,7 @@ export class TediousInstrumentation extends InstrumentationBase<TediousInstrumen
               message: err.message,
             });
 
-            const errorType = err.constructor.name;
+            const errorType = err?.constructor?.name ?? 'Error';
             span.setAttribute(ATTR_ERROR_TYPE, errorType);
 
             // db.response.status_code carries the SQL Server error number when

--- a/packages/instrumentation-tedious/src/utils.ts
+++ b/packages/instrumentation-tedious/src/utils.ts
@@ -4,32 +4,53 @@
  */
 
 /**
- * The span name SHOULD be set to a low cardinality value
- * representing the statement executed on the database.
+ * Returns the `db.operation.name` value for a given tedious method and SQL text.
  *
- * @returns Operation executed on Tedious Connection. Does not map to SQL statement in any way.
+ * - `callProcedure` → `"EXECUTE"`
+ * - `execBulkLoad`  → `"BULK INSERT"`
+ * - SQL text        → first whitespace-delimited token, uppercased (e.g. `"SELECT"`)
+ */
+export function getOperationName(
+  tediousMethod: string,
+  sql: string | undefined
+): string | undefined {
+  if (tediousMethod === 'callProcedure') return 'EXECUTE';
+  if (tediousMethod === 'execBulkLoad') return 'BULK INSERT';
+  if (!sql) return undefined;
+  const trimmed = sql.trimStart();
+  const idx = trimmed.search(/\s/);
+  const verb = idx === -1 ? trimmed : trimmed.slice(0, idx);
+  const normalized = verb.replace(/;$/, '').toUpperCase();
+  return normalized || undefined;
+}
+
+/**
+ * The span name SHOULD be set to a low cardinality value representing the
+ * statement executed on the database, following the OTel convention:
+ *   "{db.operation.name} {db.collection.name}"   (when both are known)
+ *   "{db.operation.name} {db.namespace}"          (when collection is absent)
+ *   "{db.operation.name}"                         (when namespace is absent)
+ *   "db"                                          (fallback)
  */
 export function getSpanName(
-  operation: string,
+  operationName: string | undefined,
   db: string | undefined,
-  sql: string | undefined,
-  bulkLoadTable: string | undefined
+  collection: string | undefined
 ): string {
-  if (operation === 'execBulkLoad' && bulkLoadTable && db) {
-    return `${operation} ${bulkLoadTable} ${db}`;
+  if (!operationName) return 'db';
+
+  // For stored-procedure calls and bulk loads the "collection" is the
+  // procedure / table name, which gives a useful low-cardinality name.
+  if (collection && db) {
+    return `${operationName} ${collection} ${db}`;
   }
-  if (operation === 'callProcedure') {
-    // `sql` refers to procedure name with `callProcedure`
-    if (db) {
-      return `${operation} ${sql} ${db}`;
-    }
-    return `${operation} ${sql}`;
+  if (collection) {
+    return `${operationName} ${collection}`;
   }
-  // do not use `sql` in general case because of high-cardinality
   if (db) {
-    return `${operation} ${db}`;
+    return `${operationName} ${db}`;
   }
-  return `${operation}`;
+  return operationName;
 }
 
 export const once = (fn: Function) => {

--- a/packages/instrumentation-tedious/src/utils.ts
+++ b/packages/instrumentation-tedious/src/utils.ts
@@ -8,11 +8,12 @@
  *
  * - `callProcedure` → `"EXECUTE"`
  * - `execBulkLoad`  → `"BULK INSERT"`
+ * - everything else → the method name as-is (e.g. `"execSql"`, `"prepare"`)
  */
-export function getOperationName(tediousMethod: string): string | undefined {
+export function getOperationName(tediousMethod: string): string {
   if (tediousMethod === 'callProcedure') return 'EXECUTE';
   if (tediousMethod === 'execBulkLoad') return 'BULK INSERT';
-  return undefined;
+  return tediousMethod;
 }
 
 /**

--- a/packages/instrumentation-tedious/src/utils.ts
+++ b/packages/instrumentation-tedious/src/utils.ts
@@ -4,53 +4,37 @@
  */
 
 /**
- * Returns the `db.operation.name` value for a given tedious method and SQL text.
+ * Returns the `db.operation.name` value for a given tedious method.
  *
  * - `callProcedure` → `"EXECUTE"`
  * - `execBulkLoad`  → `"BULK INSERT"`
- * - SQL text        → first whitespace-delimited token, uppercased (e.g. `"SELECT"`)
  */
-export function getOperationName(
-  tediousMethod: string,
-  sql: string | undefined
-): string | undefined {
+export function getOperationName(tediousMethod: string): string | undefined {
   if (tediousMethod === 'callProcedure') return 'EXECUTE';
   if (tediousMethod === 'execBulkLoad') return 'BULK INSERT';
-  if (!sql) return undefined;
-  const trimmed = sql.trimStart();
-  const idx = trimmed.search(/\s/);
-  const verb = idx === -1 ? trimmed : trimmed.slice(0, idx);
-  const normalized = verb.replace(/;$/, '').toUpperCase();
-  return normalized || undefined;
+  return undefined;
 }
 
 /**
- * The span name SHOULD be set to a low cardinality value representing the
- * statement executed on the database, following the OTel convention:
- *   "{db.operation.name} {db.collection.name}"   (when both are known)
- *   "{db.operation.name} {db.namespace}"          (when collection is absent)
- *   "{db.operation.name}"                         (when namespace is absent)
- *   "db"                                          (fallback)
+ *   {db.operation.name} {target}
+ *   {db.operation.name}
+ *   {target}
+ *   {db.system.name}
+ *
+ * where {target} resolves to db.collection.name first, then db.namespace.
  */
 export function getSpanName(
   operationName: string | undefined,
   db: string | undefined,
-  collection: string | undefined
+  collection: string | undefined,
+  dbSystemName: string
 ): string {
-  if (!operationName) return 'db';
-
-  // For stored-procedure calls and bulk loads the "collection" is the
-  // procedure / table name, which gives a useful low-cardinality name.
-  if (collection && db) {
-    return `${operationName} ${collection} ${db}`;
-  }
-  if (collection) {
-    return `${operationName} ${collection}`;
-  }
-  if (db) {
-    return `${operationName} ${db}`;
-  }
-  return operationName;
+  // {target} = db.collection.name preferred over db.namespace
+  const target = collection ?? db;
+  if (operationName && target) return `${operationName} ${target}`;
+  if (operationName) return operationName;
+  if (target) return target;
+  return dbSystemName;
 }
 
 export const once = (fn: Function) => {

--- a/packages/instrumentation-tedious/test/instrumentation.test.ts
+++ b/packages/instrumentation-tedious/test/instrumentation.test.ts
@@ -13,11 +13,11 @@ import {
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import * as testUtils from '@opentelemetry/contrib-test-utils';
 import {
-  BasicTracerProvider,
+  TracerProvider,
   InMemorySpanExporter,
   ReadableSpan,
   SimpleSpanProcessor,
-} from '@opentelemetry/sdk-trace-base';
+} from '@opentelemetry/sdk-trace';
 import * as assert from 'assert';
 import { TediousInstrumentation } from '../src';
 import makeApi from './api';
@@ -87,8 +87,8 @@ describe('tedious', () => {
   let contextManager: AsyncLocalStorageContextManager;
   let connection: Connection;
   const memoryExporter = new InMemorySpanExporter();
-  const provider = new BasicTracerProvider({
-    spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
+  const provider = new TracerProvider({
+    spanProcessors: [new SimpleSpanProcessor({ exporter: memoryExporter })],
   });
   const shouldTest = process.env.RUN_MSSQL_TESTS;
 
@@ -448,7 +448,7 @@ function assertSpan(span: ReadableSpan, expected: any) {
     assert.strictEqual(actualAttrs[ATTR_DB_QUERY_TEXT], undefined);
   }
   delete actualAttrs[ATTR_DB_QUERY_TEXT];
-  
+
   if (expected.errorType) {
     assert.match(
       span.attributes[ATTR_ERROR_TYPE] as string,

--- a/packages/instrumentation-tedious/test/instrumentation.test.ts
+++ b/packages/instrumentation-tedious/test/instrumentation.test.ts
@@ -13,11 +13,11 @@ import {
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import * as testUtils from '@opentelemetry/contrib-test-utils';
 import {
-  TracerProvider,
+  BasicTracerProvider,
   InMemorySpanExporter,
   ReadableSpan,
   SimpleSpanProcessor,
-} from '@opentelemetry/sdk-trace';
+} from '@opentelemetry/sdk-trace-base';
 import * as assert from 'assert';
 import { TediousInstrumentation } from '../src';
 import makeApi from './api';
@@ -26,8 +26,12 @@ import * as semver from 'semver';
 import {
   ATTR_DB_COLLECTION_NAME,
   ATTR_DB_NAMESPACE,
+  ATTR_DB_OPERATION_NAME,
   ATTR_DB_QUERY_TEXT,
+  ATTR_DB_RESPONSE_STATUS_CODE,
+  ATTR_DB_STORED_PROCEDURE_NAME,
   ATTR_DB_SYSTEM_NAME,
+  ATTR_ERROR_TYPE,
   ATTR_SERVER_ADDRESS,
   ATTR_SERVER_PORT,
   DB_SYSTEM_NAME_VALUE_MICROSOFT_SQL_SERVER,
@@ -83,8 +87,8 @@ describe('tedious', () => {
   let contextManager: AsyncLocalStorageContextManager;
   let connection: Connection;
   const memoryExporter = new InMemorySpanExporter();
-  const provider = new TracerProvider({
-    spanProcessors: [new SimpleSpanProcessor({ exporter: memoryExporter })],
+  const provider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(memoryExporter)],
   });
   const shouldTest = process.env.RUN_MSSQL_TESTS;
 
@@ -140,7 +144,8 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 2, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'execSql master',
+      name: 'SELECT master',
+      operationName: 'SELECT',
       sql: queryString,
       parentSpan,
     });
@@ -159,9 +164,11 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 1, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'execSql master',
+      name: 'SELECT master',
+      operationName: 'SELECT',
       sql: queryString,
       error: /incorrect syntax/i,
+      errorType: /^RequestError$/,
       statementCount: 0,
     });
   });
@@ -181,7 +188,8 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 1, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'execSql master',
+      name: 'SELECT master',
+      operationName: 'SELECT',
       sql: queryString,
       procCount: 1,
       statementCount: 3,
@@ -198,7 +206,8 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 1, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'execSqlBatch master',
+      name: 'SELECT master',
+      operationName: 'SELECT',
       sql: queryString,
       procCount: 0,
       statementCount: 3,
@@ -214,12 +223,15 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 2, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'execSql master',
+      name: 'CREATE master',
+      operationName: 'CREATE',
       sql: /create or alter procedure/i,
     });
     assertSpan(spans[1], {
-      name: `callProcedure ${tedious.storedProcedure.procedureName} master`,
+      name: `EXECUTE ${tedious.storedProcedure.procedureName} master`,
+      operationName: 'EXECUTE',
       sql: tedious.storedProcedure.procedureName,
+      storedProcedureName: tedious.storedProcedure.procedureName,
     });
   });
 
@@ -234,16 +246,19 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 3, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'execSql master',
+      name: 'IF master',
+      operationName: 'IF',
       sql: /create table/i,
       statementCount: 2,
     });
     assertSpan(spans[1], {
-      name: 'prepare master',
+      name: 'INSERT master',
+      operationName: 'INSERT',
       sql: /INSERT INTO/,
     });
     assertSpan(spans[2], {
-      name: 'execute master',
+      name: 'INSERT master',
+      operationName: 'INSERT',
       sql: /INSERT INTO/,
     });
   });
@@ -265,15 +280,18 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 3, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'execSql master',
+      name: 'CREATE master',
+      operationName: 'CREATE',
       sql: sql.create,
     });
     assertSpan(spans[1], {
-      name: 'execSql master',
+      name: 'USE master',
+      operationName: 'USE',
       sql: sql.use,
     });
     assertSpan(spans[2], {
-      name: 'execSql temp_otel_db',
+      name: 'SELECT temp_otel_db',
+      operationName: 'SELECT',
       sql: sql.select,
       database: 'temp_otel_db',
     });
@@ -286,17 +304,20 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 3, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'execSql master',
+      name: 'IF master',
+      operationName: 'IF',
       sql: /create table/i,
       statementCount: 2,
     });
     assertSpan(spans[1], {
-      name: 'execSqlBatch master',
+      name: 'INSERT master',
+      operationName: 'INSERT',
       sql: /insert bulk/,
       procCount: 0,
     });
     assertSpan(spans[2], {
-      name: 'execBulkLoad test_bulk master',
+      name: 'BULK INSERT test_bulk master',
+      operationName: 'BULK INSERT',
       procCount: 0,
       table: 'test_bulk',
     });
@@ -405,7 +426,14 @@ function assertSpan(span: ReadableSpan, expected: any) {
   if (expected.table) {
     expectedAttrs[ATTR_DB_COLLECTION_NAME] = expected.table;
   }
-  // "db.statement"
+  if (expected.operationName) {
+    expectedAttrs[ATTR_DB_OPERATION_NAME] = expected.operationName;
+  }
+  if (expected.storedProcedureName) {
+    expectedAttrs[ATTR_DB_STORED_PROCEDURE_NAME] = expected.storedProcedureName;
+  }
+
+  // db.query.text
   if (expected.sql) {
     if (expected.sql instanceof RegExp) {
       assert.match(span.attributes[ATTR_DB_QUERY_TEXT] as string, expected.sql);
@@ -420,6 +448,23 @@ function assertSpan(span: ReadableSpan, expected: any) {
     assert.strictEqual(actualAttrs[ATTR_DB_QUERY_TEXT], undefined);
   }
   delete actualAttrs[ATTR_DB_QUERY_TEXT];
+  
+  if (expected.errorType) {
+    assert.match(
+      span.attributes[ATTR_ERROR_TYPE] as string,
+      expected.errorType
+    );
+  }
+  delete actualAttrs[ATTR_ERROR_TYPE];
+
+  if (expected.statusCode) {
+    assert.match(
+      span.attributes[ATTR_DB_RESPONSE_STATUS_CODE] as string,
+      expected.statusCode
+    );
+  }
+  delete actualAttrs[ATTR_DB_RESPONSE_STATUS_CODE];
+
   assert.deepEqual(actualAttrs, expectedAttrs);
 
   if (expected.parentSpan) {

--- a/packages/instrumentation-tedious/test/instrumentation.test.ts
+++ b/packages/instrumentation-tedious/test/instrumentation.test.ts
@@ -144,7 +144,8 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 2, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'master',
+      name: 'execSql master',
+      operationName: 'execSql',
       sql: queryString,
       parentSpan,
     });
@@ -163,7 +164,8 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 1, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'master',
+      name: 'execSql master',
+      operationName: 'execSql',
       sql: queryString,
       error: /incorrect syntax/i,
       errorType: /^RequestError$/,
@@ -186,7 +188,8 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 1, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'master',
+      name: 'execSql master',
+      operationName: 'execSql',
       sql: queryString,
       procCount: 1,
       statementCount: 3,
@@ -203,7 +206,8 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 1, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'master',
+      name: 'execSqlBatch master',
+      operationName: 'execSqlBatch',
       sql: queryString,
       procCount: 0,
       statementCount: 3,
@@ -219,11 +223,12 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 2, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'master',
+      name: 'execSql master',
+      operationName: 'execSql',
       sql: /create or alter procedure/i,
     });
     assertSpan(spans[1], {
-      name: `EXECUTE ${tedious.storedProcedure.procedureName} master`,
+      name: `EXECUTE ${tedious.storedProcedure.procedureName}`,
       operationName: 'EXECUTE',
       sql: tedious.storedProcedure.procedureName,
       storedProcedureName: tedious.storedProcedure.procedureName,
@@ -241,16 +246,19 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 3, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'master',
+      name: 'execSql master',
+      operationName: 'execSql',
       sql: /create table/i,
       statementCount: 2,
     });
     assertSpan(spans[1], {
-      name: 'master',
+      name: 'prepare master',
+      operationName: 'prepare',
       sql: /INSERT INTO/,
     });
     assertSpan(spans[2], {
-      name: 'master',
+      name: 'execute master',
+      operationName: 'execute',
       sql: /INSERT INTO/,
     });
   });
@@ -272,15 +280,18 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 3, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'master',
+      name: 'execSql master',
+      operationName: 'execSql',
       sql: sql.create,
     });
     assertSpan(spans[1], {
-      name: 'master',
+      name: 'execSql master',
+      operationName: 'execSql',
       sql: sql.use,
     });
     assertSpan(spans[2], {
-      name: 'temp_otel_db',
+      name: 'execSql temp_otel_db',
+      operationName: 'execSql',
       sql: sql.select,
       database: 'temp_otel_db',
     });
@@ -293,17 +304,19 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 3, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'master',
+      name: 'execSql master',
+      operationName: 'execSql',
       sql: /create table/i,
       statementCount: 2,
     });
     assertSpan(spans[1], {
-      name: 'master',
+      name: 'execSqlBatch master',
+      operationName: 'execSqlBatch',
       sql: /insert bulk/,
       procCount: 0,
     });
     assertSpan(spans[2], {
-      name: 'BULK INSERT test_bulk master',
+      name: 'BULK INSERT test_bulk',
       operationName: 'BULK INSERT',
       procCount: 0,
       table: 'test_bulk',

--- a/packages/instrumentation-tedious/test/instrumentation.test.ts
+++ b/packages/instrumentation-tedious/test/instrumentation.test.ts
@@ -144,8 +144,7 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 2, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'SELECT master',
-      operationName: 'SELECT',
+      name: 'master',
       sql: queryString,
       parentSpan,
     });
@@ -164,8 +163,7 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 1, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'SELECT master',
-      operationName: 'SELECT',
+      name: 'master',
       sql: queryString,
       error: /incorrect syntax/i,
       errorType: /^RequestError$/,
@@ -188,8 +186,7 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 1, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'SELECT master',
-      operationName: 'SELECT',
+      name: 'master',
       sql: queryString,
       procCount: 1,
       statementCount: 3,
@@ -206,8 +203,7 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 1, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'SELECT master',
-      operationName: 'SELECT',
+      name: 'master',
       sql: queryString,
       procCount: 0,
       statementCount: 3,
@@ -223,8 +219,7 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 2, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'CREATE master',
-      operationName: 'CREATE',
+      name: 'master',
       sql: /create or alter procedure/i,
     });
     assertSpan(spans[1], {
@@ -246,19 +241,16 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 3, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'IF master',
-      operationName: 'IF',
+      name: 'master',
       sql: /create table/i,
       statementCount: 2,
     });
     assertSpan(spans[1], {
-      name: 'INSERT master',
-      operationName: 'INSERT',
+      name: 'master',
       sql: /INSERT INTO/,
     });
     assertSpan(spans[2], {
-      name: 'INSERT master',
-      operationName: 'INSERT',
+      name: 'master',
       sql: /INSERT INTO/,
     });
   });
@@ -280,18 +272,15 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 3, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'CREATE master',
-      operationName: 'CREATE',
+      name: 'master',
       sql: sql.create,
     });
     assertSpan(spans[1], {
-      name: 'USE master',
-      operationName: 'USE',
+      name: 'master',
       sql: sql.use,
     });
     assertSpan(spans[2], {
-      name: 'SELECT temp_otel_db',
-      operationName: 'SELECT',
+      name: 'temp_otel_db',
       sql: sql.select,
       database: 'temp_otel_db',
     });
@@ -304,14 +293,12 @@ describe('tedious', () => {
     assert.strictEqual(spans.length, 3, 'Received incorrect number of spans');
 
     assertSpan(spans[0], {
-      name: 'IF master',
-      operationName: 'IF',
+      name: 'master',
       sql: /create table/i,
       statementCount: 2,
     });
     assertSpan(spans[1], {
-      name: 'INSERT master',
-      operationName: 'INSERT',
+      name: 'master',
       sql: /insert bulk/,
       procCount: 0,
     });


### PR DESCRIPTION
## Which problem is this PR solving?

This PR completes the remaining stable semantic convention support for `instrumentation-tedious`. A few database attributes introduced as part of the stable semconv migration were still missing, and `db.namespace` did not handle SQL Server named instances correctly.

## Short description of the changes

* Added `db.operation.name`.
* Added `db.stored_procedure.name` for `callProcedure`.
* Added `db.response.status_code` and `error.type` on failed requests.
* Fixed `db.namespace` for SQL Server named instances (`{instanceName}|{databaseName}`).
* Updated span names to use the resolved operation name.
* Updated unit tests for the new attributes and span names.
* Updated the README with the new attributes and span naming.

closes #3290 