### PR TITLE
docs: fix typos in contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,12 +132,12 @@ The `opentelemetry-js-contrib` project is written in TypeScript.
 As a general rule, installing from the root directory should always be done first before anything else.
 Packages within this repository might have dependencies between them. This means the dependencies should
 be built before if you want to `compile` or `test` the changes you've made in a package. Each package
-has a script to ensure these dependecies are ready.
+has a script to ensure these dependencies are ready.
 
-The required steps to start development on a pacakge are:
+The required steps to start development on a package are:
 
 - `npm ci` from root folder to install dependencies ([see npm-ci docs](https://docs.npmjs.com/cli/v10/commands/npm-ci))
-- `cd` into the pacakge you want to apply changes.
+- `cd` into the package you want to apply changes.
 - `npm run compile:with-dependencies` compiles the TypeScript files for this package and its dependencies within the repository.
 
 Then you can proceed to do apply the changes and use the scripts below for development workflow

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -83,7 +83,7 @@ When invoking `npm run compile` on the instrumentation package, typescript will 
 
 - Types that are `export`ed from the module, or types that are transitively used in other types that are `export`ed from the module.
 - Types in `public` functions of exported classes such as `class InstrumentationFoo`.
-- Types used as [`Generic Type Varibles`] on exported generic types/classes/functions.
+- Types used as [`Generic Type Variables`] on exported generic types/classes/functions.
 
 Note that types that are used in non-public files (like `internal-types.ts` or `utils.ts`), or that are not somehow `export`ed from a module (for example - used in private function implementations), can safely use types from a "devDependency" package.
 


### PR DESCRIPTION
## Description

Fixes small typos in top-level contributor documentation:

- `CONTRIBUTING.md`: `dependecies` → `dependencies`, `pacakge` → `package` (2×)
- `GUIDELINES.md`: `Varibles` → `Variables`

Documentation-only change; no code or behavior affected.

## Type of change

- [x] This change requires a documentation update