### PR TITLE
chore(deps): add @opentelemetry/context-async-hooks dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9110,9 +9110,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9130,9 +9127,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9150,9 +9144,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9170,9 +9161,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9190,9 +9178,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9210,9 +9195,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9230,9 +9212,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9250,9 +9229,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9495,9 +9471,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9512,9 +9485,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9529,9 +9499,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9546,9 +9513,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9563,9 +9527,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9580,9 +9541,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9597,9 +9555,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9614,9 +9569,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -36909,6 +36861,7 @@
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/context-async-hooks": "^2.9.0",
         "@opentelemetry/sdk-logs": "^0.220.0",
         "@opentelemetry/sdk-trace": "^2.9.0"
       },
@@ -36931,6 +36884,7 @@
         "@cucumber/cucumber": "^12.0.0",
         "@cucumber/messages": "^32.0.0",
         "@opentelemetry/api": "^1.0.0",
+        "@opentelemetry/context-async-hooks": "^2.9.0",
         "@opentelemetry/core": "^2.9.0",
         "@opentelemetry/sdk-trace": "^2.9.0"
       },

--- a/packages/instrumentation-console/package.json
+++ b/packages/instrumentation-console/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/context-async-hooks": "^2.9.0",
     "@opentelemetry/sdk-logs": "^0.220.0",
     "@opentelemetry/sdk-trace": "^2.9.0"
   },

--- a/packages/instrumentation-cucumber/package.json
+++ b/packages/instrumentation-cucumber/package.json
@@ -48,6 +48,7 @@
     "@cucumber/cucumber": "^12.0.0",
     "@cucumber/messages": "^32.0.0",
     "@opentelemetry/api": "^1.0.0",
+    "@opentelemetry/context-async-hooks": "^2.9.0",
     "@opentelemetry/core": "^2.9.0",
     "@opentelemetry/sdk-trace": "^2.9.0"
   },


### PR DESCRIPTION
## Which problem is this PR solving?

- The `instrumentation-console` and `instrumentation-cucumber` packages use `@opentelemetry/context-async-hooks` in their tests without declaring it as a dev dependency, relying on it being hoisted from elsewhere in the workspace.

## Short description of the changes

- Add `@opentelemetry/context-async-hooks` as a devDependency to `packages/instrumentation-console/package.json` and `packages/instrumentation-cucumber/package.json`.
- Update `package-lock.json` accordingly.