### PR TITLE
fix(instrumentation-user-interaction): compute the XPath inside the span creation try/catch

### DIFF
--- a/packages/instrumentation-user-interaction/src/instrumentation.ts
+++ b/packages/instrumentation-user-interaction/src/instrumentation.ts
@@ -128,8 +128,8 @@ export class UserInteractionInstrumentation extends InstrumentationBase<UserInte
     if (!this._allowEventName(eventName)) {
       return undefined;
     }
-    const xpath = getElementXPath(element, true);
     try {
+      const xpath = getElementXPath(element, true);
       const span = this.tracer.startSpan(
         eventName,
         {

--- a/packages/instrumentation-user-interaction/test/userInteraction.nozone.test.ts
+++ b/packages/instrumentation-user-interaction/test/userInteraction.nozone.test.ts
@@ -303,6 +303,35 @@ describe('UserInteractionInstrumentation', () => {
       sandbox.clock.tick(10);
     });
 
+    it('should invoke the listener when the XPath cannot be computed', () => {
+      // getElementXPath reads `localName` on every sibling it walks, which
+      // throws for a node from a cross-origin frame, e.g., an iframe injected
+      // by a browser extension
+      const crossOriginNode = document.createElement('iframe');
+      Object.defineProperty(crossOriginNode, 'localName', {
+        get() {
+          throw new Error('Permission denied to access property "localName"');
+        },
+      });
+      const element = createButton();
+      const parent = document.createElement('div');
+      parent.appendChild(crossOriginNode);
+      parent.appendChild(element);
+      document.body.appendChild(parent);
+
+      let called = false;
+      try {
+        fakeClickInteraction(() => {
+          called = true;
+        }, element);
+      } finally {
+        document.body.removeChild(parent);
+      }
+
+      assert.strictEqual(called, true, 'should invoke the listener');
+      assert.equal(exportSpy.args.length, 0, 'should NOT export any span');
+    });
+
     it('should handle task with navigation change', done => {
       fakeClickInteraction(() => {
         history.pushState(


### PR DESCRIPTION
Hi! I ran into this in my own app.

1. I was getting a ton of `Permission denied to access property "localName"` errors.

2. I'm on Firefox (Zen browser) with Bitwarden. If I disable Bitwarden, the error
   doesn't happen.

3. In my case the console gets flooded while Bitwarden's save-password modal is
   showing on the page.

4. I took a look at the code that throws. The block right after it already handles
   errors: it logs through `_diag` and just skips creating the span instead of
   letting the error out. If that's the intent, it seemed to me the XPath
   computation itself should be inside the try too.

5. So I moved it. Please take a look. I also saw similar reports in other
   frontend projects, so it's not just me, though it does look like a rare
   combination.

It was mostly console noise for me, but as far as I can tell the patched
listener throws before it reaches `_invokeListener()`, so the app's own
listener can get skipped.
