### PR TITLE
fix(instrumentation-router): prevent MaxListenersExceededWarning on response stream

### DIFF
--- a/packages/instrumentation-express/src/instrumentation.ts
+++ b/packages/instrumentation-express/src/instrumentation.ts
@@ -256,6 +256,10 @@ export class ExpressInstrumentation extends InstrumentationBase<ExpressInstrumen
         const onResponseEnded = () => {
           if (spanHasEnded === false) {
             spanHasEnded = true;
+            const currentMax = res.getMaxListeners();
+            if (currentMax !== 0) {
+              res.setMaxListeners(Math.max(currentMax - 1, 1));
+            }
             span.end();
           }
         };
@@ -282,7 +286,13 @@ export class ExpressInstrumentation extends InstrumentationBase<ExpressInstrumen
 
             if (spanHasEnded === false) {
               spanHasEnded = true;
-              req.res?.removeListener('close', onResponseEnded);
+              if (req.res) {
+                req.res.removeListener('close', onResponseEnded);
+                const currentMax = req.res.getMaxListeners();
+                if (currentMax !== 0) {
+                  req.res.setMaxListeners(Math.max(currentMax - 1, 1));
+                }
+              }
               span.end();
             }
             if (!(req.route && isError) && isLayerPathStored) {
@@ -319,6 +329,10 @@ export class ExpressInstrumentation extends InstrumentationBase<ExpressInstrumen
            * event to handle the later case.
            */
           if (!spanHasEnded) {
+            const currentMax = res.getMaxListeners();
+            if (currentMax !== 0) {
+              res.setMaxListeners(currentMax + 1);
+            }
             res.once('close', onResponseEnded);
           }
         }

--- a/packages/instrumentation-router/src/instrumentation.ts
+++ b/packages/instrumentation-router/src/instrumentation.ts
@@ -207,6 +207,10 @@ export class RouterInstrumentation extends InstrumentationBase {
     const onClose = () => {
       if (!spanEnded) {
         spanEnded = true;
+        const currentMax = res.getMaxListeners();
+        if (currentMax !== 0) {
+          res.setMaxListeners(Math.max(currentMax - 1, 1));
+        }
         span.end();
       }
     };
@@ -219,6 +223,10 @@ export class RouterInstrumentation extends InstrumentationBase {
         spanEnded = true;
         if (listenerAttached) {
           res.removeListener('close', onClose);
+          const currentMax = res.getMaxListeners();
+          if (currentMax !== 0) {
+            res.setMaxListeners(Math.max(currentMax - 1, 1));
+          }
         }
         span.end();
       }
@@ -234,6 +242,10 @@ export class RouterInstrumentation extends InstrumentationBase {
     const ensureFallbackListener = () => {
       if (!spanEnded && !listenerAttached) {
         listenerAttached = true;
+        const currentMax = res.getMaxListeners();
+        if (currentMax !== 0) {
+          res.setMaxListeners(currentMax + 1);
+        }
         res.once('close', onClose);
       }
     };

--- a/packages/instrumentation-router/test/index.test.ts
+++ b/packages/instrumentation-router/test/index.test.ts
@@ -362,4 +362,115 @@ describe('Router instrumentation', () => {
       }
     });
   });
+
+  describe('Response listener management (issue #3547)', () => {
+    it('does not emit MaxListenersExceededWarning with async middleware and streaming response', async () => {
+      const router = new Router();
+
+      // Async middleware: each defers calling next to the next event-loop
+      // iteration so that ensureFallbackListener runs before next() is called.
+      // This exercises the code path that attaches a 'close' listener and
+      // must not accumulate beyond Node's default threshold.
+      for (let i = 0; i < 20; i++) {
+        router.use((_req, _res, next) => setImmediate(next));
+      }
+
+      router.get('/stream', (_req, res) => {
+        // Stream the response without calling next to trigger the fallback
+        // close listener in the route handler layer as well.
+        const { Readable } = require('stream');
+        const readable = new Readable({
+          read() {
+            this.push('streamed');
+            this.push(null);
+          },
+        });
+        readable.pipe(res);
+      });
+
+      const server = http.createServer((req, res) => {
+        router(req, res, () => {
+          if (!res.headersSent) {
+            res.statusCode = 404;
+            res.end('not found');
+          }
+        });
+      });
+      await new Promise<void>(resolve => server.listen(0, resolve));
+
+      const warnings: Error[] = [];
+      const onWarning = (w: Error) => warnings.push(w);
+      process.on('warning', onWarning);
+
+      try {
+        assert.strictEqual(await request('/stream', server), 'streamed');
+        const maxListenersWarn = warnings.find(
+          w => w.name === 'MaxListenersExceededWarning'
+        );
+        assert.strictEqual(
+          maxListenersWarn,
+          undefined,
+          `unexpected warning: ${maxListenersWarn?.message}`
+        );
+      } finally {
+        process.removeListener('warning', onWarning);
+        server.close();
+      }
+    });
+
+    it('does not emit MaxListenersExceededWarning when response already has many close listeners', async () => {
+      const router = new Router();
+
+      // Pre-populate res with listeners to simulate third-party middleware
+      // (e.g. compression, logging) that also attach to 'close'.
+      router.use((_req, res, next) => {
+        // Add 9 external 'close' listeners to sit just below Node's default
+        // limit of 10 before the instrumentation adds its own.
+        for (let i = 0; i < 9; i++) {
+          res.on('close', () => {});
+        }
+        setImmediate(next);
+      });
+
+      router.get('/stream', (_req, res) => {
+        const { Readable } = require('stream');
+        const readable = new Readable({
+          read() {
+            this.push('ok');
+            this.push(null);
+          },
+        });
+        readable.pipe(res);
+      });
+
+      const server = http.createServer((req, res) => {
+        router(req, res, () => {
+          if (!res.headersSent) {
+            res.statusCode = 404;
+            res.end('not found');
+          }
+        });
+      });
+      await new Promise<void>(resolve => server.listen(0, resolve));
+
+      const warnings: Error[] = [];
+      const onWarning = (w: Error) => warnings.push(w);
+      process.on('warning', onWarning);
+
+      try {
+        assert.strictEqual(await request('/stream', server), 'ok');
+        const maxListenersWarn = warnings.find(
+          w => w.name === 'MaxListenersExceededWarning'
+        );
+        assert.strictEqual(
+          maxListenersWarn,
+          undefined,
+          `unexpected warning: ${maxListenersWarn?.message}`
+        );
+      } finally {
+        process.removeListener('warning', onWarning);
+        server.close();
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #3547

When using streams or async handlers with `@opentelemetry/instrumentation-router` and `@opentelemetry/instrumentation-express`, each pending layer registers a `close` listener on the response object via `ensureFallbackListener()`. When multiple async handlers or stream events stack up, Node emits a `MaxListenersExceededWarning: Possible EventEmitter memory leak detected` because `res.getMaxListeners()` is exceeded.

## Short description of the changes

- Increment `res.getMaxListeners()` by 1 whenever attaching a fallback `close` listener in both `@opentelemetry/instrumentation-router` and `@opentelemetry/instrumentation-express`.
- Decrement `res.getMaxListeners()` back down when the `close` event fires or when `removeListener('close', ...)` is called via `wrappedNext` / callback completion.
- Added unit tests in `instrumentation-router` verifying that async middleware with streaming responses and pre-populated listeners do not trigger `MaxListenersExceededWarning`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Added unit tests in `packages/instrumentation-router/test/index.test.ts` covering async middleware and response streaming scenarios to assert no `MaxListenersExceededWarning` is emitted.

## Checklist

- [x] Followed the style guidelines of this project
- [x] Unit tests added/updated for the change
- [x] No new warnings introduced
