### PR TITLE
fix(instrumentation-console): restore console methods on disable when constructed with { enabled: true }

### DIFF
--- a/packages/instrumentation-console/src/instrumentation.ts
+++ b/packages/instrumentation-console/src/instrumentation.ts
@@ -36,7 +36,9 @@ const CONSOLE_SEVERITY_TEXT: Record<string, string> = {
 export class ConsoleInstrumentation extends InstrumentationBase<ConsoleInstrumentationConfig> {
   private _otelLogger: Logger | undefined;
   private _isEmitting = false;
-  private _originals: Map<string, (...args: unknown[]) => void> = new Map();
+  // Lazily created in _patchConsole(); `declare` avoids an inline initializer
+  // that would run after super()'s constructor-time enable() and wipe it.
+  private declare _originals: Map<string, (...args: unknown[]) => void>;
 
   constructor(config: ConsoleInstrumentationConfig = {}) {
     super(PACKAGE_NAME, PACKAGE_VERSION, config);
@@ -88,6 +90,7 @@ export class ConsoleInstrumentation extends InstrumentationBase<ConsoleInstrumen
   }
 
   private _unpatchConsole(): void {
+    if (!this._originals) return;
     for (const [method, original] of this._originals) {
       (console as any)[method] = original;
     }

--- a/packages/instrumentation-console/src/instrumentation.ts
+++ b/packages/instrumentation-console/src/instrumentation.ts
@@ -38,7 +38,7 @@ export class ConsoleInstrumentation extends InstrumentationBase<ConsoleInstrumen
   private _isEmitting = false;
   // Lazily created in _patchConsole(); `declare` avoids an inline initializer
   // that would run after super()'s constructor-time enable() and wipe it.
-  private declare _originals: Map<string, (...args: unknown[]) => void>;
+  declare private _originals: Map<string, (...args: unknown[]) => void>;
 
   constructor(config: ConsoleInstrumentationConfig = {}) {
     super(PACKAGE_NAME, PACKAGE_VERSION, config);

--- a/packages/instrumentation-console/test/console.test.ts
+++ b/packages/instrumentation-console/test/console.test.ts
@@ -171,13 +171,17 @@ describe('ConsoleInstrumentation', () => {
       // { enabled: true } triggers enable() from InstrumentationBase's
       // constructor, patching console and saving originals.
       const inst = new ConsoleInstrumentation({ enabled: true });
-      assert.notStrictEqual(
-        console.log,
-        beforeLog,
-        'expected console.log to be patched after construction'
-      );
-
-      inst.disable();
+      try {
+        assert.notStrictEqual(
+          console.log,
+          beforeLog,
+          'expected console.log to be patched after construction'
+        );
+      } finally {
+        // Ensure console is unpatched even if the assertion above fails so we
+        // don't leave console.log double-patched for subsequent tests.
+        inst.disable();
+      }
       assert.strictEqual(
         console.log,
         beforeLog,

--- a/packages/instrumentation-console/test/console.test.ts
+++ b/packages/instrumentation-console/test/console.test.ts
@@ -161,4 +161,28 @@ describe('ConsoleInstrumentation', () => {
       instrumentation.enable();
     });
   });
+
+  describe('construction-time enable', () => {
+    it('restores original console methods on disable() when constructed with { enabled: true }', () => {
+      // Capture the shared instrumentation's patched console.log so we can
+      // assert disable() restores it exactly.
+      const beforeLog = console.log;
+
+      // { enabled: true } triggers enable() from InstrumentationBase's
+      // constructor, patching console and saving originals.
+      const inst = new ConsoleInstrumentation({ enabled: true });
+      assert.notStrictEqual(
+        console.log,
+        beforeLog,
+        'expected console.log to be patched after construction'
+      );
+
+      inst.disable();
+      assert.strictEqual(
+        console.log,
+        beforeLog,
+        'expected console.log to be restored after disable()'
+      );
+    });
+  });
 });


### PR DESCRIPTION
Fixes a bug where the console instrumentation permanently hijacks the global `console` when constructed with `{ enabled: true }`.

## Problem

`new ConsoleInstrumentation({ enabled: true })` triggers `enable()` from `InstrumentationBase`'s constructor, which patches `console` and saves the originals into `this._originals`. Because the package targets `es2022`, `useDefineForClassFields` defaults to `true`, so the subclass field initializer `private _originals = new Map()` runs (via `defineProperty`) **after** `super()` returns — wiping the just-saved originals.

As a result, a later `disable()` iterates an empty map and restores nothing, leaving `console.log`/`warn`/`error` patched for the life of the process. (Constructing disabled and calling `enable()` afterwards was unaffected, since the wipe happened before the save.)

## Fix

- Declare `_originals` with `declare` so no inline initializer runs; it is created lazily in `_patchConsole()` (existing guard).
- Guard `_unpatchConsole()` against an unset map.

## Testing

- Added a regression test covering the construction-time `{ enabled: true }` path that asserts `disable()` restores the original `console.log`.
- `npm run compile` clean; all 14 tests pass; eslint reports no new errors.
