### PR TITLE
docs(instrumentation-runtime-node): fix README inaccuracies

### DIFF
--- a/packages/instrumentation-runtime-node/README.md
+++ b/packages/instrumentation-runtime-node/README.md
@@ -12,9 +12,7 @@ process termination.
 
 ## Supported Versions
 
-- Node.js `>=14.10`
-
-<!-- - 14.6.0 - this package uses _private properties_ -->
+- Node.js `^18.19.0 || >=20.6.0`
 
 ## Example
 
@@ -54,11 +52,7 @@ Go to [`localhost:9464/metrics`](http://localhost:9464/metrics), and you should 
 nodejs_performance_event_loop_utilization 0.010140079547955264
 ```
 
-> Metrics will only be exported after it has collected two ELU readings (at least approximately `RuntimeNodeInstrumentationConfig.monitoringPrecision` milliseconds after initialization). Otherwise, you may see:
->
-> ```txt
-> # no registered metrics
-> ```
+> On the very first metrics collection the event loop utilization and time metrics may report zero or near-zero values while the instrumentation establishes a baseline.
 
 ### Options
 
@@ -66,9 +60,9 @@ nodejs_performance_event_loop_utilization 0.010140079547955264
 
 | name                                        | type  | unit        | default | description                                                                                                                                                                                                                                                                                     |
 |---------------------------------------------|-------|-------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [`monitoringPrecision`](./src/types.ts#L25) | `int` | millisecond | `10`    | The approximate number of milliseconds for which to calculate event loop utilization averages. A larger value will result in more accurate averages at the expense of less granular data. Should be set to below the scrape interval of your metrics collector to avoid duplicated data points. |
-| [`captureUncaughtException`](./src/types.ts#L31) | `bool` | - | `false` | Whether to emit a `LogRecord` for uncaught exceptions (severity `FATAL`). Uses the `uncaughtExceptionMonitor` process event. |
-| [`applyCustomExceptionAttributes`](./src/types.ts#L43) | `function` | - | `undefined` | Optional callback to attach custom attributes to emitted exception log records. |
+| [`monitoringPrecision`](./src/types.ts#L10) | `int` | millisecond | `10`    | The resolution in milliseconds for the event loop delay histogram (`perf_hooks.monitorEventLoopDelay`). A smaller value gives finer-grained delay samples at the cost of more overhead. Has no effect on event loop utilization or time metrics. |
+| [`captureUncaughtException`](./src/types.ts#L16) | `bool` | - | `false` | Whether to emit a `LogRecord` for uncaught exceptions (severity `FATAL`). Uses the `uncaughtExceptionMonitor` process event. |
+| [`applyCustomExceptionAttributes`](./src/types.ts#L21) | `function` | - | `undefined` | Optional callback to attach custom attributes to emitted exception log records. |
 
 ## Semantic Conventions
 

--- a/packages/instrumentation-runtime-node/README.md
+++ b/packages/instrumentation-runtime-node/README.md
@@ -60,9 +60,9 @@ nodejs_performance_event_loop_utilization 0.010140079547955264
 
 | name                                        | type  | unit        | default | description                                                                                                                                                                                                                                                                                     |
 |---------------------------------------------|-------|-------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [`monitoringPrecision`](./src/types.ts#L10) | `int` | millisecond | `10`    | The resolution in milliseconds for the event loop delay histogram (`perf_hooks.monitorEventLoopDelay`). A smaller value gives finer-grained delay samples at the cost of more overhead. Has no effect on event loop utilization or time metrics. |
-| [`captureUncaughtException`](./src/types.ts#L16) | `bool` | - | `false` | Whether to emit a `LogRecord` for uncaught exceptions (severity `FATAL`). Uses the `uncaughtExceptionMonitor` process event. |
-| [`applyCustomExceptionAttributes`](./src/types.ts#L21) | `function` | - | `undefined` | Optional callback to attach custom attributes to emitted exception log records. |
+| [`monitoringPrecision`](./src/types.ts) | `int` | millisecond | `10`    | The resolution in milliseconds for the event loop delay histogram (`perf_hooks.monitorEventLoopDelay`). A smaller value gives finer-grained delay samples at the cost of more overhead. Has no effect on event loop utilization or time metrics. |
+| [`captureUncaughtException`](./src/types.ts) | `bool` | - | `false` | Whether to emit a `LogRecord` for uncaught exceptions (severity `FATAL`). Uses the `uncaughtExceptionMonitor` process event. |
+| [`applyCustomExceptionAttributes`](./src/types.ts) | `function` | - | `undefined` | Optional callback to attach custom attributes to emitted exception log records. |
 
 ## Semantic Conventions
 


### PR DESCRIPTION

## Which problem is this PR solving?

- Update supported Node.js version from >=14.10 to ^18.19.0 || >=20.6.0
  to match the engines field in package.json
- Remove stale "two ELU readings" note, outdated since the _lastValue
  initialization fix in PR #3118
- Fix wrong line number links in the options table 

