### PR TITLE
fix(examples/mysql): initialize tracing before requiring instrumented modules

### DIFF
--- a/examples/mysql/src/client.ts
+++ b/examples/mysql/src/client.ts
@@ -3,11 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as api from '@opentelemetry/api';
-import * as http from 'http';
 import { setupTracing } from './tracer';
 
 const tracer = setupTracing('example-mysql-client');
+
+import * as api from '@opentelemetry/api';
+import * as http from 'http';
 
 /** A function which makes requests and handles response. */
 function makeRequest() {

--- a/examples/mysql/src/server.ts
+++ b/examples/mysql/src/server.ts
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { setupTracing } from './tracer';
+
+setupTracing('example-mysql-server');
+
 import * as api from '@opentelemetry/api';
 import * as mysql from 'mysql';
 import * as http from 'http';
 import { MysqlError, PoolConnection } from 'mysql';
-import { setupTracing } from './tracer';
-
-setupTracing('example-mysql-server');
 
 const pool = mysql.createPool({
   host: 'localhost',


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #1795.

The MySQL example initializes tracing after importing `mysql` and `http`. Because `ts-node` compiles the files to CommonJS, those modules are loaded before the instrumentation hooks are registered. By that point, the modules are already cached and cannot be patched.

As a result, the server prints `traceid: undefined`, and no traces are sent to Zipkin.

## Short description of the changes

Moved the `setupTracing` import and call above the `mysql` and `http` imports in:

- `src/server.ts`
- `src/client.ts`

This makes sure tracing is initialized before the modules it needs to instrument are loaded.

## Testing

I tested the change locally using the Docker Compose stac with MySQL, Zipkin, and the OTel Collector. 

I then ran:

- `npm run zipkin:server`
- `npm run zipkin:client`

Before the change, the server printed `traceid: undefined`, and no trace was available in Zipkin. 

After the change, the server printed valid trace IDs. Zipkin showed the full trace across the client, server, and MySQL calls for all five example endpoints. 

## Screenshots

**Before:** No trace

<img width="728" alt="before: No trace found" src="https://github.com/user-attachments/assets/fa1fe66c-ac84-497f-b39f-00e9bd3fb1ad" />

**After:** full trace with client, server, and mysql spans

<img width="728" alt="after: full trace waterfall" src="https://github.com/user-attachments/assets/4a5b766f-6c5a-4252-b178-35e5f5b816a3" />
