### PR TITLE
ci: Reduce renovate pr qty

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     {
       "groupName": "all patch versions",
       "groupSlug": "all-patch",
-      "matchUpdateTypes": ["patch"],
+      "matchUpdateTypes": ["patch", "digest"],
       "schedule": ["before 3am on Monday"],
       "matchPackageNames": ["!prettier"]
     },
@@ -14,8 +14,9 @@
       "dependencyDashboardApproval": true
     },
     {
+      "groupName": "minor infra",
       "matchUpdateTypes": ["minor"],
-      "matchCategories": ["!js"],
+      "matchCategories": ["ci", "docker"],
       "schedule": ["before 3am on Monday"]
     },
     {


### PR DESCRIPTION
## Which problem is this PR solving?

- Reducing renovate pr qty while not blocking updates

## Short description of the changes

- Groups minor ci & docker updates into 1 group
- Adds digest updates to patch group

Both of which will reduce the number of pr’s and based on current dashboard it would eliminate 8 pr’s
