### PR TITLE
ci: Control major docker updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,8 +19,17 @@
       "schedule": ["before 3am on Monday"]
     },
     {
+      "matchUpdateTypes": ["major"],
       "matchCategories": ["ci"],
       "schedule": ["before 3am on Monday"]
+    },
+    {
+      "description": "Wait 3 years for automated major docker updates",
+      "dependencyDashboardCategory": "Testing Docker service",
+      "matchUpdateTypes": ["major"],
+      "matchCategories": ["docker"],
+      "separateMultipleMajor": true,
+      "minimumReleaseAge": "1095 days",
     },
     {
       "matchPackageNames": ["@opentelemetry/api"],


### PR DESCRIPTION
## Which problem is this PR solving?

- Reducing the volume of renovate pr’s awaiting schedule

## Short description of the changes

- This only performs an automated major docker update once it has been out for 3 years. Updates can be performed sooner by ticking the checkbox on the dashboard.
- Each major update is treated as it’s own update

See an example of this in https://github.com/open-telemetry/opentelemetry-ruby-contrib/issues/1803 and in this repo it could result in upto 8 pr’s coming out of the queue