### PR TITLE
fix(sql-common): look for the block comment terminator after the opener

### DIFF
--- a/packages/sql-common/src/index.ts
+++ b/packages/sql-common/src/index.ts
@@ -45,8 +45,11 @@ function hasValidSqlComment(query: string): boolean {
     return false;
   }
 
-  const indexClosingSlashComment = query.indexOf('*/');
-  return indexOpeningDashDashComment < indexClosingSlashComment;
+  // The closing delimiter has to come after the opening one. Searching from
+  // the start would also match a `*/` that appears before the `/*`.
+  return (
+    query.indexOf('*/', indexOpeningSlashComment) > indexOpeningSlashComment
+  );
 }
 
 // sqlcommenter specification (https://google.github.io/sqlcommenter/spec/#value-serialization)

--- a/packages/sql-common/test/sql-common.test.ts
+++ b/packages/sql-common/test/sql-common.test.ts
@@ -48,6 +48,38 @@ describe('addSqlCommenterComment', () => {
     );
   });
 
+  it('does not add a comment when a stray closing delimiter precedes a block comment', () => {
+    const span = trace.wrapSpanContext({
+      traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+      spanId: '6e0c63257de34c92',
+      traceFlags: TraceFlags.SAMPLED,
+    });
+
+    // The `*/` inside the string literal comes before the real comment, so
+    // searching for it from the start of the query finds the wrong one.
+    const query = "SELECT '*/' as a /* Test comment */";
+    assert.strictEqual(addSqlCommenterComment(span, query), query);
+  });
+
+  it('adds a comment when a block comment is never closed', () => {
+    const span = trace.wrapSpanContext({
+      traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+      spanId: '6e0c63257de34c92',
+      traceFlags: TraceFlags.SAMPLED,
+    });
+
+    // An unterminated `/*` is not a complete comment, and that holds whether or
+    // not a stray `*/` appears earlier in the query.
+    assert.strictEqual(
+      addSqlCommenterComment(span, "SELECT '*/' as a /* unterminated"),
+      "SELECT '*/' as a /* unterminated /*traceparent='00-d4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-01'*/"
+    );
+    assert.strictEqual(
+      addSqlCommenterComment(span, 'SELECT 1 /* unterminated'),
+      "SELECT 1 /* unterminated /*traceparent='00-d4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-01'*/"
+    );
+  });
+
   it('does not add a comment to an empty query', () => {
     const spanContext: SpanContext = {
       traceId: 'd4cda95b652f4a1592b449d5929fda1b',


### PR DESCRIPTION
## Which problem is this PR solving?

`hasValidSqlComment` in `packages/sql-common/src/index.ts` ends with:

```ts
const indexOpeningDashDashComment = query.indexOf('--');
if (indexOpeningDashDashComment >= 0) {
  return true;
}

const indexOpeningSlashComment = query.indexOf('/*');
if (indexOpeningSlashComment < 0) {
  return false;
}

const indexClosingSlashComment = query.indexOf('*/');
return indexOpeningDashDashComment < indexClosingSlashComment;
```

`indexOpeningDashDashComment` is **always `-1`** on that last line — the function returns early whenever it is `>= 0`. So the ordering check it was meant to perform is dead, and the expression collapses to "does `*/` appear anywhere in the query".

The visible effect is inconsistent handling of an unterminated `/*`:

| query | before | after |
| --- | --- | --- |
| `SELECT 1 /* unterminated` | no comment → sqlcommenter appended | same |
| `SELECT '*/' as a /* unterminated` | treated as an existing comment → **skipped** | sqlcommenter appended |
| `SELECT '*/' as a /* Test comment */` | existing comment → skipped | same |

So the same unterminated `/*` is handled differently depending on whether a stray `*/` happens to appear earlier, e.g. inside a string literal. In that case the traceparent comment is silently not added.

## Short description of the changes

Search for the terminator starting from the opener: `query.indexOf('*/', indexOpeningSlashComment) > indexOpeningSlashComment`.

Worth flagging for review: simply swapping the variable to `indexOpeningSlashComment < indexClosingSlashComment` looks like the obvious one-character fix, but it introduces a *different* bug — a stray `*/` before a genuine comment would then make a real, properly closed comment look unterminated:

```js
'SELECT 1 */ /* c */'   // naive swap: false (wrong), this PR: true
```

I added a test pinning that case so the naive form can't be reintroduced.

This does not change the pre-existing false positive that the comment above the function already documents (comment characters inside string literals), which is why `SELECT '*/' as a /* Test comment */` is still reported as having a comment.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Two tests added to `packages/sql-common/test/sql-common.test.ts`:

- `does not add a comment when a stray closing delimiter precedes a block comment` — guards against the naive fix; passes before and after.
- `adds a comment when a block comment is never closed` — the regression test; fails before the change.

```console
$ cd packages/sql-common
$ mocha "test/**/*.test.ts" --require ts-node/register/transpile-only
8 passing
```

Baseline on an unmodified checkout is `6 passing`. Reverting only `src/index.ts` while keeping the tests gives `7 passing, 1 failing`:

```
✖ adds a comment when a block comment is never closed
```

`prettier --check` (3.6.2, the pinned version) passes on both files. No CHANGELOG entry per CONTRIBUTING, which states it is updated during the release process.

## Checklist:

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated — not applicable, `hasValidSqlComment` is internal and no documented behaviour changes
