### PR TITLE
fix(instrumentation-runtime-node): prevent unbounded PerformanceObserver buffer in GCCollector

### DIFF
--- a/packages/instrumentation-runtime-node/src/metrics/gcCollector.ts
+++ b/packages/instrumentation-runtime-node/src/metrics/gcCollector.ts
@@ -59,7 +59,7 @@ export class GCCollector extends BaseCollector {
   }
 
   internalEnable(): void {
-    this._observer.observe({ entryTypes: ['gc'] });
+    this._observer.observe({ entryTypes: ['gc'], buffered: false });
   }
 
   internalDisable(): void {

--- a/packages/instrumentation-runtime-node/test/gc.test.ts
+++ b/packages/instrumentation-runtime-node/test/gc.test.ts
@@ -4,12 +4,39 @@
  */
 import * as assert from 'assert';
 import * as sinon from 'sinon';
+import * as perf_hooks from 'node:perf_hooks';
 import { Meter } from '@opentelemetry/api';
 
 import { GCCollector } from '../src/metrics/gcCollector';
 import { METRIC_V8JS_GC_DURATION } from '../src/semconv';
 
 describe('GCCollector', function () {
+  it('should observe with buffered: false to prevent unbounded buffer growth', function () {
+    const observeStub = sinon.stub();
+    const disconnectStub = sinon.stub();
+    const PerformanceObserverStub = sinon
+      .stub(perf_hooks, 'PerformanceObserver')
+      .callsFake(
+        () => ({ observe: observeStub, disconnect: disconnectStub }) as any
+      );
+
+    try {
+      const collector = new GCCollector();
+      collector.internalEnable();
+
+      sinon.assert.calledOnce(observeStub);
+      const [options] = observeStub.firstCall.args;
+      assert.deepStrictEqual(options.entryTypes, ['gc']);
+      assert.strictEqual(
+        options.buffered,
+        false,
+        'buffered must be false to prevent unbounded heap growth'
+      );
+    } finally {
+      PerformanceObserverStub.restore();
+    }
+  });
+
   it('should configure GC duration histogram with sub-second buckets', function () {
     const createHistogram = sinon.stub().returns({
       record: sinon.stub(),


### PR DESCRIPTION
## Which problem is this PR solving?

`GCCollector` calls `this._observer.observe({ entryTypes: ['gc'] })` without `buffered: false`. When `buffered` is omitted it defaults to `true`, so Node.js replays all GC entries accumulated since the last observation start into the observer's internal `#buffer`. This buffer is never drained, causing unbounded heap growth proportional to the number of GC cycles — a positive feedback loop under load (more heap pressure → more GC → more buffer entries → more heap pressure).

## Short description of the changes

- Pass `{ entryTypes: ['gc'], buffered: false }` to `PerformanceObserver.observe()` in `GCCollector.internalEnable()` so that historical entries are not buffered; the observer callback processes each entry immediately as it arrives.
- Add a unit test that stubs `PerformanceObserver` and asserts the `observe` call includes `buffered: false`.

## Notes

- The observer callback already processes only `list.getEntries()[0]` per invocation, so there is no dependency on historical replay.
- Setting `buffered: false` on `'gc'` entry types is safe: GC events are fire-and-forget metrics and do not require backfill on observation start.
