### PR TITLE
fix(resource-detector-azure): read AKS cluster metadata from a mounted ConfigMap

### DIFF
--- a/packages/resource-detector-azure/README.md
+++ b/packages/resource-detector-azure/README.md
@@ -106,7 +106,27 @@ env:
         key: clusterResourceId
 ```
 
-Alternatively, you can mount the ConfigMap as a file at `/etc/kubernetes/aks-cluster-metadata`.
+Alternatively, you can mount the ConfigMap at `/etc/kubernetes/aks-cluster-metadata`. Kubernetes
+projects each key into its own file, so the detector reads the resource ID from
+`/etc/kubernetes/aks-cluster-metadata/clusterResourceId`:
+
+```yaml
+volumes:
+  - name: aks-cluster-metadata
+    configMap:
+      name: aks-cluster-metadata
+volumeMounts:
+  - name: aks-cluster-metadata
+    mountPath: /etc/kubernetes/aks-cluster-metadata
+```
+
+Mounting the single key with `subPath`, so that `/etc/kubernetes/aks-cluster-metadata` is itself a
+file holding the resource ID, is also supported.
+
+Note that the `aks-cluster-metadata` ConfigMap lives in the `kube-public` namespace, and Kubernetes
+resolves `configMapKeyRef` and ConfigMap volumes within the pod's own namespace. To consume it from
+another namespace, copy the ConfigMap into that namespace, or have tooling such as an init
+container read it and write the value to one of the supported locations above.
 
 ```typescript
 import { detectResources } from '@opentelemetry/resources';

--- a/packages/resource-detector-azure/src/detectors/AzureAksDetector.ts
+++ b/packages/resource-detector-azure/src/detectors/AzureAksDetector.ts
@@ -4,6 +4,7 @@
  */
 
 import * as fs from 'fs';
+import * as path from 'path';
 
 import { diag } from '@opentelemetry/api';
 import { ResourceDetector, DetectedResource } from '@opentelemetry/resources';
@@ -16,6 +17,7 @@ import {
 } from '../semconv';
 import {
   AKS_CLUSTER_RESOURCE_ID,
+  AKS_CLUSTER_RESOURCE_ID_KEY,
   AKS_METADATA_FILE_PATH,
   AksClusterMetadata,
   CLOUD_RESOURCE_ID_RESOURCE_ATTRIBUTE,
@@ -80,31 +82,12 @@ class AzureAksDetector implements ResourceDetector {
 
   private getAksMetadataFromFile(): AksClusterMetadata | undefined {
     try {
-      if (!fs.existsSync(AKS_METADATA_FILE_PATH)) {
+      const content = this.readAksMetadataContent();
+      if (content === undefined) {
         return undefined;
       }
 
-      const content = fs.readFileSync(AKS_METADATA_FILE_PATH, 'utf8');
-      const metadata: AksClusterMetadata = {};
-
-      // Parse the ConfigMap file content (key=value format)
-      // The native aks-cluster-metadata ConfigMap has a single key: clusterResourceId
-      const lines = content.split('\n');
-      for (const line of lines) {
-        const trimmedLine = line.trim();
-        if (!trimmedLine || trimmedLine.startsWith('#')) {
-          continue;
-        }
-
-        const [key, ...valueParts] = trimmedLine.split('=');
-        const value = valueParts.join('=').trim();
-
-        if (key === 'clusterResourceId' && value) {
-          metadata.resourceId = value;
-          metadata.name = extractClusterNameFromResourceId(value);
-        }
-      }
-
+      const metadata = this.parseAksMetadata(content);
       if (metadata.resourceId) {
         return metadata;
       }
@@ -116,6 +99,80 @@ class AzureAksDetector implements ResourceDetector {
     }
 
     return undefined;
+  }
+
+  /**
+   * Reads the raw AKS metadata content, supporting the layouts the
+   * aks-cluster-metadata ConfigMap can take inside a pod:
+   *
+   * - mounted as a volume, where Kubernetes creates a directory containing one
+   *   file per key, so the value lives in `<path>/clusterResourceId`
+   * - mounted with `subPath`, or written by tooling, where the path is a file
+   *   holding either the raw resource ID or `clusterResourceId=<resource ID>`
+   */
+  private readAksMetadataContent(): string | undefined {
+    const stats = fs.statSync(AKS_METADATA_FILE_PATH, {
+      throwIfNoEntry: false,
+    });
+
+    if (!stats) {
+      return undefined;
+    }
+
+    if (stats.isDirectory()) {
+      const keyPath = path.join(
+        AKS_METADATA_FILE_PATH,
+        AKS_CLUSTER_RESOURCE_ID_KEY
+      );
+      if (!fs.existsSync(keyPath)) {
+        return undefined;
+      }
+      return fs.readFileSync(keyPath, 'utf8');
+    }
+
+    return fs.readFileSync(AKS_METADATA_FILE_PATH, 'utf8');
+  }
+
+  private parseAksMetadata(content: string): AksClusterMetadata {
+    const metadata: AksClusterMetadata = {};
+    let keyedResourceId: string | undefined;
+    const bareValues: string[] = [];
+
+    // The native aks-cluster-metadata ConfigMap has a single key: clusterResourceId.
+    const lines = content.split('\n');
+    for (const line of lines) {
+      const trimmedLine = line.trim();
+      if (!trimmedLine || trimmedLine.startsWith('#')) {
+        continue;
+      }
+
+      const separatorIndex = trimmedLine.indexOf('=');
+      if (separatorIndex === -1) {
+        bareValues.push(trimmedLine);
+        continue;
+      }
+
+      const key = trimmedLine.slice(0, separatorIndex).trim();
+      const value = trimmedLine.slice(separatorIndex + 1).trim();
+
+      if (key === AKS_CLUSTER_RESOURCE_ID_KEY && value) {
+        keyedResourceId = value;
+      }
+    }
+
+    // An explicit `clusterResourceId=<value>` entry always wins. Otherwise fall back to a
+    // bare value, which is what Kubernetes writes when the key is projected into a file of
+    // its own. Only a single unambiguous line is accepted so that unrelated content in a
+    // multi line file is never mistaken for the resource ID.
+    const resourceId =
+      keyedResourceId ?? (bareValues.length === 1 ? bareValues[0] : undefined);
+
+    if (resourceId) {
+      metadata.resourceId = resourceId;
+      metadata.name = extractClusterNameFromResourceId(resourceId);
+    }
+
+    return metadata;
   }
 }
 

--- a/packages/resource-detector-azure/src/types.ts
+++ b/packages/resource-detector-azure/src/types.ts
@@ -43,6 +43,10 @@ export const AKS_CLUSTER_RESOURCE_ID = 'CLUSTER_RESOURCE_ID';
 // AKS ConfigMap file path (mounted from aks-cluster-metadata ConfigMap in kube-public)
 export const AKS_METADATA_FILE_PATH = '/etc/kubernetes/aks-cluster-metadata';
 
+// The single key of the aks-cluster-metadata ConfigMap. When the ConfigMap is
+// mounted as a volume, Kubernetes creates a file with this name holding the raw value.
+export const AKS_CLUSTER_RESOURCE_ID_KEY = 'clusterResourceId';
+
 export interface AksClusterMetadata {
   name?: string;
   resourceId?: string;

--- a/packages/resource-detector-azure/test/detectors/AzureAksDetector.test.ts
+++ b/packages/resource-detector-azure/test/detectors/AzureAksDetector.test.ts
@@ -4,14 +4,23 @@
  */
 
 import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { azureAksDetector } from '../../src/detectors/AzureAksDetector';
 import {
   ATTR_CLOUD_PLATFORM,
   ATTR_CLOUD_PROVIDER,
   ATTR_K8S_CLUSTER_NAME,
 } from '../../src/semconv';
-import { CLOUD_RESOURCE_ID_RESOURCE_ATTRIBUTE } from '../../src/types';
+import {
+  AKS_METADATA_FILE_PATH,
+  CLOUD_RESOURCE_ID_RESOURCE_ATTRIBUTE,
+} from '../../src/types';
 import { detectResources } from '@opentelemetry/resources';
+
+const TEST_RESOURCE_ID =
+  '/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/test-aks-cluster';
 
 describe('AzureAksDetector', () => {
   let originalEnv: NodeJS.ProcessEnv;
@@ -75,5 +84,185 @@ describe('AzureAksDetector', () => {
       attributes[CLOUD_RESOURCE_ID_RESOURCE_ATTRIBUTE],
       undefined
     );
+  });
+
+  describe('mounted ConfigMap', () => {
+    let fixtureRoot: string;
+    let metadataPath: string;
+    const originalFs = {
+      statSync: fs.statSync,
+      existsSync: fs.existsSync,
+      readFileSync: fs.readFileSync,
+    };
+
+    // The detector reads a hard coded path, so redirect just that path onto a
+    // real temporary fixture. Everything else keeps hitting the real filesystem.
+    // Paths are normalized first so this also works on Windows, where path.join
+    // rewrites the POSIX constant with backslashes.
+    const normalizedRoot = path.normalize(AKS_METADATA_FILE_PATH);
+
+    function redirect(candidate: fs.PathLike): fs.PathLike {
+      const asString = path.normalize(String(candidate));
+      if (!asString.startsWith(normalizedRoot)) {
+        return candidate;
+      }
+      return path.join(metadataPath, asString.slice(normalizedRoot.length));
+    }
+
+    beforeEach(() => {
+      delete process.env.CLUSTER_RESOURCE_ID;
+      fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'aks-metadata-'));
+      metadataPath = path.join(fixtureRoot, 'aks-cluster-metadata');
+
+      const patched = fs as any;
+      patched.statSync = (p: fs.PathLike, options?: any) =>
+        (originalFs.statSync as any)(redirect(p), options);
+      patched.existsSync = (p: fs.PathLike) =>
+        originalFs.existsSync(redirect(p));
+      patched.readFileSync = (p: any, options?: any) =>
+        (originalFs.readFileSync as any)(
+          typeof p === 'number' ? p : redirect(p),
+          options
+        );
+    });
+
+    afterEach(() => {
+      const patched = fs as any;
+      patched.statSync = originalFs.statSync;
+      patched.existsSync = originalFs.existsSync;
+      patched.readFileSync = originalFs.readFileSync;
+      fs.rmSync(fixtureRoot, { recursive: true, force: true });
+    });
+
+    it('should detect AKS when the ConfigMap is mounted as a volume', () => {
+      // Kubernetes projects each ConfigMap key into its own file.
+      fs.mkdirSync(metadataPath);
+      fs.writeFileSync(
+        path.join(metadataPath, 'clusterResourceId'),
+        `${TEST_RESOURCE_ID}\n`
+      );
+
+      const attributes = detectResources({
+        detectors: [azureAksDetector],
+      }).attributes;
+
+      assert.strictEqual(attributes[ATTR_CLOUD_PROVIDER], 'azure');
+      assert.strictEqual(attributes[ATTR_CLOUD_PLATFORM], 'azure.aks');
+      assert.strictEqual(attributes[ATTR_K8S_CLUSTER_NAME], 'test-aks-cluster');
+      assert.strictEqual(
+        attributes[CLOUD_RESOURCE_ID_RESOURCE_ATTRIBUTE],
+        TEST_RESOURCE_ID
+      );
+    });
+
+    it('should detect AKS when the ConfigMap key is mounted with subPath', () => {
+      // A subPath mount produces a file holding only the raw value.
+      fs.writeFileSync(metadataPath, `${TEST_RESOURCE_ID}\n`);
+
+      const attributes = detectResources({
+        detectors: [azureAksDetector],
+      }).attributes;
+
+      assert.strictEqual(attributes[ATTR_K8S_CLUSTER_NAME], 'test-aks-cluster');
+      assert.strictEqual(
+        attributes[CLOUD_RESOURCE_ID_RESOURCE_ATTRIBUTE],
+        TEST_RESOURCE_ID
+      );
+    });
+
+    it('should detect AKS from a key=value metadata file', () => {
+      fs.writeFileSync(
+        metadataPath,
+        `# aks metadata\nclusterResourceId=${TEST_RESOURCE_ID}\n`
+      );
+
+      const attributes = detectResources({
+        detectors: [azureAksDetector],
+      }).attributes;
+
+      assert.strictEqual(attributes[ATTR_K8S_CLUSTER_NAME], 'test-aks-cluster');
+      assert.strictEqual(
+        attributes[CLOUD_RESOURCE_ID_RESOURCE_ATTRIBUTE],
+        TEST_RESOURCE_ID
+      );
+    });
+
+    it('should return an empty resource when the mounted directory has no clusterResourceId key', () => {
+      fs.mkdirSync(metadataPath);
+      fs.writeFileSync(path.join(metadataPath, 'somethingElse'), 'value\n');
+
+      const attributes = detectResources({
+        detectors: [azureAksDetector],
+      }).attributes;
+
+      assert.strictEqual(attributes[ATTR_CLOUD_PROVIDER], undefined);
+      assert.strictEqual(
+        attributes[CLOUD_RESOURCE_ID_RESOURCE_ATTRIBUTE],
+        undefined
+      );
+    });
+
+    it('should prefer an explicit clusterResourceId entry over unrelated bare lines', () => {
+      fs.writeFileSync(
+        metadataPath,
+        `clusterResourceId=${TEST_RESOURCE_ID}\nstray-token\n// not a comment format we strip\n`
+      );
+
+      const attributes = detectResources({
+        detectors: [azureAksDetector],
+      }).attributes;
+
+      assert.strictEqual(
+        attributes[CLOUD_RESOURCE_ID_RESOURCE_ATTRIBUTE],
+        TEST_RESOURCE_ID
+      );
+      assert.strictEqual(attributes[ATTR_K8S_CLUSTER_NAME], 'test-aks-cluster');
+    });
+
+    it('should ignore an ambiguous file with multiple bare lines', () => {
+      fs.writeFileSync(metadataPath, `${TEST_RESOURCE_ID}\nstray-token\n`);
+
+      const attributes = detectResources({
+        detectors: [azureAksDetector],
+      }).attributes;
+
+      assert.strictEqual(attributes[ATTR_CLOUD_PROVIDER], undefined);
+      assert.strictEqual(
+        attributes[CLOUD_RESOURCE_ID_RESOURCE_ATTRIBUTE],
+        undefined
+      );
+    });
+
+    it('should tolerate CRLF line endings and a byte order mark', () => {
+      fs.writeFileSync(
+        metadataPath,
+        `\ufeffclusterResourceId=${TEST_RESOURCE_ID}\r\n`
+      );
+
+      const attributes = detectResources({
+        detectors: [azureAksDetector],
+      }).attributes;
+
+      assert.strictEqual(
+        attributes[CLOUD_RESOURCE_ID_RESOURCE_ATTRIBUTE],
+        TEST_RESOURCE_ID
+      );
+    });
+
+    it('should prefer the CLUSTER_RESOURCE_ID environment variable over the mounted file', () => {
+      process.env.CLUSTER_RESOURCE_ID =
+        '/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/from-env';
+      fs.mkdirSync(metadataPath);
+      fs.writeFileSync(
+        path.join(metadataPath, 'clusterResourceId'),
+        `${TEST_RESOURCE_ID}\n`
+      );
+
+      const attributes = detectResources({
+        detectors: [azureAksDetector],
+      }).attributes;
+
+      assert.strictEqual(attributes[ATTR_K8S_CLUSTER_NAME], 'from-env');
+    });
   });
 });


### PR DESCRIPTION
### Which problem is this PR solving?

The AKS detector's documented mounted-ConfigMap fallback does not work.

Kubernetes mounts a ConfigMap as a directory containing one file per key, but the detector reads `/etc/kubernetes/aks-cluster-metadata` as a single `key=value` file. A normal ConfigMap volume therefore fails with `EISDIR`, which is caught, and the detector returns an empty resource.

### Short description of the changes

- If the metadata path is a directory, read its `clusterResourceId` file.
- If it is a file, support both a raw resource ID (`subPath`) and the existing `clusterResourceId=<value>` format.
- Preserve `CLUSTER_RESOURCE_ID` environment-variable precedence.
- Ignore ambiguous files containing multiple bare values.
- Correct the README examples and clarify that ConfigMap references are namespace-local.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- 11 focused detector tests pass, including directory mounts, `subPath`, legacy files, missing keys, ambiguous input, CRLF/BOM input, and environment-variable precedence.
- Tested on AKS 1.35.6 with the native `kube-public/aks-cluster-metadata` ConfigMap.
- `configMapKeyRef`, normal volume, and `subPath` layouts all produced:

```text
cloud.provider = azure
cloud.platform = azure.aks
k8s.cluster.name = <cluster>
cloud.resource_id = <managed-cluster ARM ID>
```

The exact artifact was also tested with microsoft/opentelemetry-distro-javascript#207 and Azure/azure-sdk-for-js#39469; both reported feature mask `265` for all three valid layouts.

### Checklist

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added
- [x] Documentation has been updated
