### PR TITLE
chore(eslint): re-enable commented-out eslint-plugin-n recommended ru…

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,7 +43,10 @@ const baseConfig = tseslint.config(
       'yet-another-license-header': yalhPlugin,
       n: nodePlugin,
     },
-    extends: [eslint.configs.recommended],
+    extends: [
+      eslint.configs.recommended,
+      nodePlugin.configs['flat/recommended'],
+    ],
     languageOptions: {
       ecmaVersion: 2022,
       globals: {
@@ -90,7 +93,9 @@ const baseConfig = tseslint.config(
       },
     },
     rules: {
-      // 'n/no-missing-import': 'off',
+      'n/no-missing-import': 'off',
+      'n/no-unsupported-features/es-syntax': 'off',
+      'n/no-unsupported-features/node-builtins': 'off',
 
       // things that should be repaired
       '@typescript-eslint/no-explicit-any': 'warn',
@@ -146,6 +151,17 @@ const baseConfig = tseslint.config(
 
   // Test files have relaxed rules
   {
+    files: ['**/test/**/*', '**/*.test.*'],
+    rules: {
+      'n/no-extraneous-import': 'off',
+      'n/no-extraneous-require': 'off',
+      'n/no-missing-import': 'off',
+      'n/no-missing-require': 'off',
+      'n/no-unpublished-import': 'off',
+      'n/no-unpublished-require': 'off',
+    },
+  },
+  {
     files: ['**/test/**/*.ts', '**/*.test.ts'],
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
@@ -174,6 +190,29 @@ const baseConfig = tseslint.config(
     },
   },
 
+  // Scripts, examples, and root config files
+  {
+    files: [
+      '*.{js,mjs,cjs}',
+      'scripts/**/*',
+      'examples/**/*',
+      '**/karma*.js',
+      '**/*.conf.js',
+    ],
+    rules: {
+      'n/no-extraneous-import': 'off',
+      'n/no-extraneous-require': 'off',
+      'n/no-missing-import': 'off',
+      'n/no-missing-require': 'off',
+      'n/no-unpublished-import': 'off',
+      'n/no-unpublished-require': 'off',
+      'n/no-process-exit': 'off',
+      'n/hashbang': 'off',
+      'n/no-unsupported-features/node-builtins': 'off',
+      'n/no-unsupported-features/es-syntax': 'off',
+    },
+  },
+
   // ESM files
   {
     files: ['**/*.mjs'],
@@ -186,6 +225,7 @@ const baseConfig = tseslint.config(
   {
     files: [
       '**/examples/web/**/*',
+      '**/examples/react-load/**/*',
       '**/packages/**/browser/**/*',
       '**/packages/auto-instrumentations-web/**/*',
       '**/packages/instrumentation-document-load/**/*',
@@ -202,11 +242,18 @@ const baseConfig = tseslint.config(
       }),
     ],
     languageOptions: {
+      sourceType: 'module',
       globals: {
         ...globals.browser,
         Zone: 'readonly',
         Task: 'readonly',
       },
+    },
+    rules: {
+      'n/no-unsupported-features/es-syntax': 'off',
+      'n/no-unsupported-features/es-builtins': 'off',
+      'n/no-unsupported-features/node-builtins': 'off',
+      'n/no-missing-import': 'off',
     },
   },
 


### PR DESCRIPTION
…les (#3588)

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Fixes #3588. Re-enables the `eslint-plugin-n` recommended rules (`nodePlugin.configs['flat/recommended']`) that were commented out during the flat ESLint config migration in #3581.

## Short description of the changes

- Added `nodePlugin.configs['flat/recommended']` to the `extends` block in `eslint.config.mjs`.
- Disabled `n/no-missing-import`, `n/no-unsupported-features/es-syntax`, and `n/no-unsupported-features/node-builtins` for TypeScript files (`**/*.ts`), as `tsc` natively handles missing imports and transpiles ES module syntax.
- Relaxed monorepo `devDependencies` import rules (`n/no-extraneous-import`, `n/no-unpublished-import`, etc.) for test files (`**/test/**/*`).
- Added rule overrides for scripts, example apps, and config files (`scripts/**/*`, `examples/**/*`, `**/karma*.js`, `**/*.conf.js`) to allow root `devDependencies`, process exits, and shebangs.
- Configured `sourceType: 'module'` and disabled Node engine version checks for browser-targeted packages and web examples.
