### PR TITLE
fix(instrumentation-user-interaction): preserve bare event listener calls

### DIFF
--- a/packages/instrumentation-user-interaction/src/instrumentation.ts
+++ b/packages/instrumentation-user-interaction/src/instrumentation.ts
@@ -29,6 +29,25 @@ import { PACKAGE_NAME, PACKAGE_VERSION } from './version';
 const ZONE_CONTEXT_KEY = 'OT_ZONE_CONTEXT';
 const EVENT_NAVIGATION_NAME = 'Navigation:';
 const DEFAULT_EVENT_NAMES: EventName[] = ['click'];
+const SUPPORTS_UNREGISTERED_SYMBOL_WEAK_MAP_KEYS = (() => {
+  try {
+    const key = Symbol();
+    new WeakMap().set(key as unknown as object, true);
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+function isWeakMapKey(value: unknown): boolean {
+  return (
+    (typeof value === 'object' && value !== null) ||
+    typeof value === 'function' ||
+    (typeof value === 'symbol' &&
+      Symbol.keyFor(value) === undefined &&
+      SUPPORTS_UNREGISTERED_SYMBOL_WEAK_MAP_KEYS)
+  );
+}
 
 function defaultShouldPreventSpanCreation() {
   return false;
@@ -277,7 +296,7 @@ export class UserInteractionInstrumentation extends InstrumentationBase<UserInte
         useCapture?: boolean | AddEventListenerOptions
       ) {
         // Forward calls with listener = null
-        if (!listener) {
+        if (!listener || !isWeakMapKey(this)) {
           return original.call(this, type, listener, useCapture);
         }
 

--- a/packages/instrumentation-user-interaction/test/userInteraction.nozone.test.ts
+++ b/packages/instrumentation-user-interaction/test/userInteraction.nozone.test.ts
@@ -716,6 +716,52 @@ describe('UserInteractionInstrumentation', () => {
       document.removeEventListener('click', listener, null);
     });
 
+    it('should preserve bare global addEventListener calls', () => {
+      // web-vitals calls the global event-listener function without a receiver.
+      // The native browser implementation accepts that form, so instrumentation
+      // must not use the undefined receiver as a WeakMap key first.
+      const { addEventListener, removeEventListener } = window;
+      let calls = 0;
+      const listener = () => {
+        calls++;
+      };
+
+      addEventListener('open-telemetry-bare-listener', listener);
+      window.dispatchEvent(new Event('open-telemetry-bare-listener'));
+      removeEventListener('open-telemetry-bare-listener', listener);
+
+      assert.strictEqual(calls, 1);
+    });
+
+    it('should preserve valid weak-map symbols and delegate invalid receivers', () => {
+      // Symbols cannot be EventTarget receivers in a browser, so use the real
+      // wrapper with a narrow original-function double to assert its boundary.
+      type OriginalAddEventListener = (
+        type: string,
+        listener: EventListenerOrEventListenerObject | null,
+        useCapture?: boolean | AddEventListenerOptions
+      ) => void;
+      const original = sandbox.stub();
+      const patched = (
+        userInteractionInstrumentation as unknown as {
+          _patchAddEventListener: () => (
+            original: OriginalAddEventListener
+          ) => unknown;
+        }
+      )._patchAddEventListener()(original) as {
+        call(thisArg: unknown, type: string, listener: () => void): unknown;
+      };
+      const listener = () => {};
+
+      assert.doesNotThrow(() => {
+        patched.call(Symbol('unregistered'), 'click', listener);
+      });
+      assert.doesNotThrow(() => {
+        patched.call(Symbol.for('registered'), 'click', listener);
+      });
+      assert.strictEqual(original.callCount, 2);
+    });
+
     it('should handle disable', () => {
       const element = createButton();
       element.addEventListener('click', () => {});


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #3639.

`@opentelemetry/instrumentation-user-interaction` patches `EventTarget.prototype.addEventListener` in the no-Zone path. A bare global call such as the one used by `web-vitals` has an `undefined` receiver in the strict-mode wrapper. The wrapper then tried to use that receiver as a `WeakMap` key before delegating to the native method, producing `TypeError: Invalid value used as weak map key` and preventing the application from loading.

## Short description of the changes

- Delegate immediately to the original listener method when the receiver cannot be a `WeakMap` key, preserving native behavior for bare calls and other invalid receivers.
- Keep support for non-registered `Symbol` keys on runtimes that implement them; feature-detect that capability so engines that do not yet accept Symbol keys also fall back safely.
- Add browser regressions for the real bare-global `addEventListener` path and for the receiver boundary.

## Validation

- Reproduced red in Chrome Headless 150: the new bare-global regression failed with `Invalid value used as weak map key` at `WeakMap.set`.
- Green after the change: `npm run test:browser -w @opentelemetry/instrumentation-user-interaction` — **45/45** in Chrome Headless 150.
- `npm run compile -w @opentelemetry/instrumentation-user-interaction`
- `npx prettier --check` on both touched TypeScript files
- `npx eslint` on both touched files (no new errors; existing package warnings remain)
- `git diff --check`

The issue maintainer also independently reproduced the original error in a browser and requested the Symbol detail handled here.

## AI disclosure

Added after the fact, for consistency with the OpenTelemetry Generative AI policy and with my other PR in this repository (#3661), which carries the same note. It was an omission, not a claim that no assistance was used.

I used an AI coding assistant (Claude) while working on this change: to trace how the patched `addEventListener` reaches the bare-global path, to draft the implementation and the browser regressions, and to help draft this description. I ran every command listed under Validation myself, reviewed every line, and the reasoning about the receiver boundary is my own. This text is written in my own words.
