### PR TITLE
fix(instrumentation-undici): derive error.type from error code/name instead of message

### DIFF
--- a/packages/instrumentation-undici/src/undici.ts
+++ b/packages/instrumentation-undici/src/undici.ts
@@ -492,7 +492,11 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
       });
       span.end();
 
-      attributes[ATTR_ERROR_TYPE] = error.message;
+      // error.type must be a low-cardinality class of error per semconv, and an
+      // empty value collapses into a duplicate series on Prometheus-based
+      // exporters — use the error code/name, never the free-form (possibly
+      // empty) message.
+      attributes[ATTR_ERROR_TYPE] = error.code || error.name || 'Error';
     }
 
     this._recordFromReq.delete(request);

--- a/packages/instrumentation-undici/test/metrics.test.ts
+++ b/packages/instrumentation-undici/test/metrics.test.ts
@@ -161,9 +161,10 @@ describe('UndiciInstrumentation metrics tests', function () {
       assert.strictEqual(metricAttributes[ATTR_HTTP_REQUEST_METHOD], 'GET');
       assert.strictEqual(metricAttributes[ATTR_SERVER_ADDRESS], hostname);
       assert.strictEqual(metricAttributes[ATTR_SERVER_PORT], mockServer.port);
+      const errorType = metricAttributes[ATTR_ERROR_TYPE];
       assert.ok(
-        metricAttributes[ATTR_ERROR_TYPE],
-        `the metric contains "${ATTR_ERROR_TYPE}" attribute if request failed`
+        typeof errorType === 'string' && errorType.length > 0,
+        `the metric contains a non-empty "${ATTR_ERROR_TYPE}" attribute if request failed`
       );
     });
   });


### PR DESCRIPTION
## Which problem is this PR solving?

The `onError` handler sets the `error.type` metric attribute to `error.message`:

https://github.com/open-telemetry/opentelemetry-js-contrib/blob/b77dcadf974d1c6c741cd33e4ccbe2960e4f0511/packages/instrumentation-undici/src/undici.ts#L495

This is problematic in two ways:

1. **Semconv violation**: per the [`error.type` semantic convention](https://opentelemetry.io/docs/specs/semconv/attributes-registry/error/), the value "SHOULD have low cardinality" and describe a *class* of error (`ECONNRESET`, `timeout`, an exception class name, …). `error.message` is free-form, high-cardinality text.
2. **Empty attribute values break Prometheus export**: `error.message` can legitimately be an empty string. When a request receives response headers (e.g. `200`, merged into the record's attributes by `onResponseHeaders`) and then fails while the body is being consumed, `http.client.request.duration` is recorded with `{..., error.type: ""}`. In OTLP this is a stream distinct from the `{...}` stream recorded by `onDone`, each keeping its own cumulative sum — but the Prometheus data model treats an empty label value as an absent label, so on Prometheus remote write both streams collapse into the **same series**, producing two samples with identical timestamps and different values.

Observed in production (Node 22 app, operator auto-instrumentation, captured via a collector debug exporter):

```
http.client.request.duration
  {200, GET, news.google.com, 443, https}                  count=2449
  {200, GET, news.google.com, 443, https, error.type:""}   count=108
  → identical export timestamps
```

Cortex / Amazon Managed Prometheus rejects such writes with `400 duplicate sample for timestamp` and drops the entire remote-write batch — in our case ~2,100 unrelated datapoints dropped every minute.

## Short description of the changes

- `onError` now derives `error.type` from `error.code || error.name || 'Error'` instead of `error.message`. This matches undici (`UND_ERR_*`) and Node socket (`ECONNRESET`) error classes, and can never be empty since `Error#name` defaults to `'Error'`. The span *status description* (which may use free-form text) is unchanged.
- Strengthened the existing metrics test to assert `error.type` is a **non-empty** string, guarding against regressions of the empty-value case.

Note: this changes the observable values of `error.type` for existing users (error message → error class), which is the intended semconv-compliant behavior.
