### PR TITLE
fix(instrumentation-undici): use low-cardinality error.type

### DIFF
--- a/packages/instrumentation-undici/src/undici.ts
+++ b/packages/instrumentation-undici/src/undici.ts
@@ -492,7 +492,11 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
       });
       span.end();
 
-      attributes[ATTR_ERROR_TYPE] = error.message;
+      // error.type must be a low-cardinality class of error per semconv, and an
+      // empty value collapses into a duplicate series on Prometheus-based
+      // exporters. Use the error code/name, never the free-form, possibly empty
+      // message.
+      attributes[ATTR_ERROR_TYPE] = error.code || error.name || 'Error';
     }
 
     this._recordFromReq.delete(request);

--- a/packages/instrumentation-undici/test/metrics.test.ts
+++ b/packages/instrumentation-undici/test/metrics.test.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as assert from 'assert';
+import * as diagch from 'diagnostics_channel';
 
 import { context, propagation } from '@opentelemetry/api';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
@@ -128,14 +129,19 @@ describe('UndiciInstrumentation metrics tests', function () {
       assert.strictEqual(metricAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE], 200);
     });
 
-    it('should have error.type in "http.client.request.duration" metric', async () => {
-      const fetchUrl = `${protocol}://${hostname}:${mockServer.port}/error`;
+    it('should use error code as error.type in "http.client.request.duration" metric', async () => {
+      const request: any = {
+        method: 'GET',
+        origin: `${protocol}://${hostname}:${mockServer.port}`,
+        path: '/error',
+        headers: [],
+      };
+      const error = Object.assign(new Error(''), {
+        code: 'UND_ERR_SOCKET',
+      });
 
-      try {
-        await fetch(fetchUrl);
-      } catch (err) {
-        // Expected error, do nothing
-      }
+      diagch.channel('undici:request:create').publish({ request });
+      diagch.channel('undici:request:error').publish({ request, error });
 
       await metricReader.collectAndExport();
       const resourceMetrics = metricsMemoryExporter.getMetrics();
@@ -161,10 +167,7 @@ describe('UndiciInstrumentation metrics tests', function () {
       assert.strictEqual(metricAttributes[ATTR_HTTP_REQUEST_METHOD], 'GET');
       assert.strictEqual(metricAttributes[ATTR_SERVER_ADDRESS], hostname);
       assert.strictEqual(metricAttributes[ATTR_SERVER_PORT], mockServer.port);
-      assert.ok(
-        metricAttributes[ATTR_ERROR_TYPE],
-        `the metric contains "${ATTR_ERROR_TYPE}" attribute if request failed`
-      );
+      assert.strictEqual(metricAttributes[ATTR_ERROR_TYPE], 'UND_ERR_SOCKET');
     });
   });
 });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- Fixes #3655
- `instrumentation-undici` was setting the `error.type` metric attribute from `error.message`, which is free-form and can be empty. `error.type` should be a low-cardinality error class.

## Short description of the changes

- Derive `error.type` from `error.code || error.name || 'Error'` instead of `error.message`.
- Update the Undici metrics test to assert that failed request duration metrics include a non-empty `error.type`.
- Reimplements the focused fix from #3654, which was closed unmerged because of a CLA mismatch.