### PR TITLE
feat(instrumentation-net): add requireParentSpan config option

### DIFF
--- a/packages/instrumentation-net/README.md
+++ b/packages/instrumentation-net/README.md
@@ -29,12 +29,22 @@ const { NetInstrumentation } = require('@opentelemetry/instrumentation-net');
 
 const sdk = new NodeSDK({
   instrumentations: [
-    new NetInstrumentation(),
+    new NetInstrumentation({
+      // see below for available configuration
+    }),
   ],
 });
 sdk.start();
 process.once('beforeExit', async () => { await sdk.shutdown(); });
 ```
+
+### Net Instrumentation Options
+
+You can set the following:
+
+| Options | Type | Description |
+| ------- | ---- | ----------- |
+| `requireParentSpan` | `boolean` | Require parent to create net span, default when unset is `false`. Connections opened outside of a request - a database driver's background heartbeat, for example - otherwise each become a standalone single-span trace. |
 
 ## Semantic Conventions
 

--- a/packages/instrumentation-net/src/index.ts
+++ b/packages/instrumentation-net/src/index.ts
@@ -5,3 +5,4 @@
 
 export { NetInstrumentation } from './instrumentation';
 export { TLSAttributes } from './types';
+export type { NetInstrumentationConfig } from './types';

--- a/packages/instrumentation-net/src/instrumentation.ts
+++ b/packages/instrumentation-net/src/instrumentation.ts
@@ -12,7 +12,6 @@ import {
 } from '@opentelemetry/api';
 import {
   InstrumentationBase,
-  InstrumentationConfig,
   InstrumentationNodeModuleDefinition,
   isWrapped,
   safeExecuteInTheMiddle,
@@ -26,7 +25,7 @@ import {
   ATTR_SERVER_PORT,
   NETWORK_TRANSPORT_VALUE_TCP,
 } from '@opentelemetry/semantic-conventions';
-import { TLSAttributes } from './types';
+import { NetInstrumentationConfig, TLSAttributes } from './types';
 import { NormalizedOptions, SocketEvent } from './internal-types';
 import { getNormalizedArgs, STABLE_IPC_TRANSPORT_VALUE } from './utils';
 /** @knipignore */
@@ -35,9 +34,17 @@ import { Socket } from 'net';
 import { TLSSocket } from 'tls';
 import type * as net from 'net';
 
-export class NetInstrumentation extends InstrumentationBase {
-  constructor(config: InstrumentationConfig = {}) {
-    super(PACKAGE_NAME, PACKAGE_VERSION, config);
+const DEFAULT_CONFIG: NetInstrumentationConfig = {
+  requireParentSpan: false,
+};
+
+export class NetInstrumentation extends InstrumentationBase<NetInstrumentationConfig> {
+  constructor(config: NetInstrumentationConfig = {}) {
+    super(PACKAGE_NAME, PACKAGE_VERSION, { ...DEFAULT_CONFIG, ...config });
+  }
+
+  override setConfig(config: NetInstrumentationConfig = {}) {
+    super.setConfig({ ...DEFAULT_CONFIG, ...config });
   }
 
   init(): InstrumentationNodeModuleDefinition[] {
@@ -69,6 +76,18 @@ export class NetInstrumentation extends InstrumentationBase {
     return (original: (...args: unknown[]) => void) => {
       const plugin = this;
       return function patchedConnect(this: Socket, ...args: unknown[]) {
+        // Checked once here rather than at each `startSpan` call site: every
+        // span this instrumentation creates (`connect`, `ipc.connect`,
+        // `tcp.connect` and `tls.connect`) originates from this function, and
+        // `tcp.connect` is parented to `tls.connect` on the TLS path, so a
+        // per-call-site check would still let the nested span through.
+        if (
+          plugin.getConfig().requireParentSpan &&
+          trace.getSpan(context.active()) === undefined
+        ) {
+          return original.apply(this, args);
+        }
+
         const options = getNormalizedArgs(args);
 
         const span =

--- a/packages/instrumentation-net/src/types.ts
+++ b/packages/instrumentation-net/src/types.ts
@@ -3,6 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+
+export interface NetInstrumentationConfig extends InstrumentationConfig {
+  /**
+   * Require a parent span in order to create net spans, default when unset is
+   * `false`.
+   *
+   * Connections opened outside of a request - a database driver's background
+   * heartbeat, for example - would otherwise each produce a standalone
+   * single-span trace.
+   */
+  requireParentSpan?: boolean;
+}
+
 /* The following attributes are not official, see open-telemetry/opentelemetry-specification#1652 */
 export enum TLSAttributes {
   PROTOCOL = 'tls.protocol',

--- a/packages/instrumentation-net/test/require-parent-span.test.ts
+++ b/packages/instrumentation-net/test/require-parent-span.test.ts
@@ -1,0 +1,226 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { context, trace } from '@opentelemetry/api';
+import {
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+  TracerProvider,
+} from '@opentelemetry/sdk-trace';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import * as assert from 'assert';
+import * as net from 'net';
+import * as os from 'os';
+import * as path from 'path';
+import * as tls from 'tls';
+import { NetInstrumentation } from '../src';
+import { SocketEvent } from '../src/internal-types';
+import { HOST, PORT, TLS_SERVER_CERT, TLS_SERVER_KEY } from './utils';
+
+// Dedicated endpoints so this suite never races with the servers started by
+// the other test files.
+const TLS_PORT = PORT + 1;
+const IPC_PATH =
+  os.platform() !== 'win32'
+    ? path.join(os.tmpdir(), 'otel-js-net-test-require-parent-span-ipc')
+    : '\\\\.\\pipe\\otel-js-net-test-require-parent-span-ipc';
+
+const memoryExporter = new InMemorySpanExporter();
+const provider = new TracerProvider({
+  spanProcessors: [new SimpleSpanProcessor({ exporter: memoryExporter })],
+});
+const tracer = provider.getTracer('test-require-parent-span');
+
+function assertNoSpans() {
+  assert.deepStrictEqual(
+    memoryExporter.getFinishedSpans().map(span => span.name),
+    []
+  );
+}
+
+describe('NetInstrumentation requireParentSpan', () => {
+  let instrumentation: NetInstrumentation;
+  let contextManager: AsyncLocalStorageContextManager;
+  let socket: net.Socket | undefined;
+  let tlsSocket: tls.TLSSocket | undefined;
+  let tcpServer: net.Server;
+  let ipcServer: net.Server;
+  let tlsServer: tls.Server;
+
+  before(() => {
+    instrumentation = new NetInstrumentation();
+    instrumentation.setTracerProvider(provider);
+    contextManager = new AsyncLocalStorageContextManager().enable();
+    context.setGlobalContextManager(contextManager);
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('net');
+  });
+
+  before(done => {
+    tcpServer = net.createServer();
+    tcpServer.listen(PORT, done);
+  });
+
+  before(done => {
+    ipcServer = net.createServer();
+    ipcServer.listen(IPC_PATH, done);
+  });
+
+  before(done => {
+    tlsServer = tls.createServer({
+      cert: TLS_SERVER_CERT,
+      key: TLS_SERVER_KEY,
+      maxVersion: 'TLSv1.2',
+    });
+    tlsServer.listen(TLS_PORT, done);
+  });
+
+  afterEach(() => {
+    socket?.destroy();
+    socket = undefined;
+    tlsSocket?.destroy();
+    tlsSocket = undefined;
+    memoryExporter.reset();
+  });
+
+  after(() => {
+    instrumentation.disable();
+    contextManager.disable();
+    context.disable();
+    tcpServer.close();
+    ipcServer.close();
+    tlsServer.close();
+  });
+
+  describe('when requireParentSpan is true', () => {
+    beforeEach(() => {
+      instrumentation.setConfig({ requireParentSpan: true });
+    });
+
+    it('should not create a tcp.connect span without a parent span', done => {
+      socket = net.connect(PORT, HOST, () => {
+        assertNoSpans();
+        done();
+      });
+    });
+
+    it('should not create an ipc.connect span without a parent span', done => {
+      socket = net.connect(IPC_PATH, () => {
+        assertNoSpans();
+        done();
+      });
+    });
+
+    it('should not create a generic connect span without a parent span', done => {
+      const assertSpans = () => {
+        try {
+          assertNoSpans();
+          done();
+        } catch (e) {
+          done(e);
+        }
+      };
+
+      socket = new net.Socket();
+      try {
+        // `socket.connect()` throws on newer runtimes and only emits 'close'
+        // on older ones. Either way no span must be created.
+        socket.once(SocketEvent.CLOSE, assertSpans);
+        socket.connect(undefined as unknown as string);
+      } catch {
+        socket.removeListener(SocketEvent.CLOSE, assertSpans);
+        assertSpans();
+      }
+    });
+
+    it('should not create tls.connect or tcp.connect spans without a parent span', done => {
+      tlsSocket = tls.connect(
+        TLS_PORT,
+        HOST,
+        {
+          ca: [TLS_SERVER_CERT],
+          checkServerIdentity: () => undefined,
+        },
+        () => {
+          assertNoSpans();
+          done();
+        }
+      );
+    });
+
+    it('should create a tcp.connect span when a parent span is active', done => {
+      const parent = tracer.startSpan('parent');
+      // Leave the parent context before handing control back to mocha, so the
+      // parent span does not leak into the next test through async storage.
+      const finish = context.bind(context.active(), done);
+
+      context.with(trace.setSpan(context.active(), parent), () => {
+        socket = net.connect(PORT, HOST, () => {
+          const spans = memoryExporter.getFinishedSpans();
+          assert.deepStrictEqual(
+            spans.map(span => span.name),
+            ['tcp.connect']
+          );
+          assert.strictEqual(
+            spans[0].parentSpanContext?.spanId,
+            parent.spanContext().spanId
+          );
+          finish();
+        });
+      });
+    });
+
+    it('should create tls.connect and tcp.connect spans when a parent span is active', done => {
+      const parent = tracer.startSpan('parent');
+      const finish = context.bind(context.active(), done);
+
+      context.with(trace.setSpan(context.active(), parent), () => {
+        tlsSocket = tls.connect(
+          TLS_PORT,
+          HOST,
+          {
+            ca: [TLS_SERVER_CERT],
+            checkServerIdentity: () => undefined,
+          },
+          () => {
+            const spans = memoryExporter.getFinishedSpans();
+            assert.deepStrictEqual(
+              spans.map(span => span.name),
+              ['tcp.connect', 'tls.connect']
+            );
+            const [tcpSpan, tlsSpan] = spans;
+            assert.strictEqual(
+              tlsSpan.parentSpanContext?.spanId,
+              parent.spanContext().spanId
+            );
+            assert.strictEqual(
+              tcpSpan.parentSpanContext?.spanId,
+              tlsSpan.spanContext().spanId
+            );
+            finish();
+          }
+        );
+      });
+    });
+  });
+
+  describe('when requireParentSpan is not set', () => {
+    beforeEach(() => {
+      instrumentation.setConfig({});
+    });
+
+    it('should create a tcp.connect span without a parent span', done => {
+      socket = net.connect(PORT, HOST, () => {
+        const spans = memoryExporter.getFinishedSpans();
+        assert.deepStrictEqual(
+          spans.map(span => span.name),
+          ['tcp.connect']
+        );
+        assert.strictEqual(spans[0].parentSpanContext, undefined);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
# feat(instrumentation-net): add requireParentSpan config option

Part of #3660.

**Rescoped to `instrumentation-net` only** (force-push, 2026-08-07). This PR originally also touched
`instrumentation-dns`, which has no component owner in `.github/component_owners.yml`. That is what
matched `pkg-status:unmaintained` in `component-label-map.yml`, which in turn started the 14-day
autoclose timer in `close-stale.yml`. The `-dns` half is held back and will go in its own PR.

Nothing was rewritten: the removed hunks are exactly the `instrumentation-dns` ones. I verified it
mechanically — applying both halves onto `main` reproduces the previous tree byte for byte, and the
line counts add up (276+160 = the previous 436, 6+3 = the previous 9).

@seemk you are already assigned here, and `instrumentation-net` is yours, so this should now be
reviewable on its own merits.

**One thing I cannot do myself:** the three labels are stale — `pkg:instrumentation-dns`,
`pkg-status:unmaintained` and `pkg-status:unmaintained:autoclose-scheduled` no longer match the
diff, but `actions/labeler` runs without `sync-labels`, so it only ever adds. Could a maintainer
remove them? Otherwise the timer keeps running against a PR that no longer touches an unmaintained
package. `remove-stale-when-updated: false` means neither this comment nor the push resets it.

## Summary

`instrumentation-net` records its spans unconditionally, including when no span is active. A
connection opened outside of a request therefore becomes its own single-span trace, forever, on
every interval. The most common source is a database driver's background monitoring: a MongoDB SDAM
heartbeat produces one `tcp.connect` trace per heartbeat.

Nested under an outbound call these spans are genuinely useful - TCP setup latency is exactly what
you want when a request is slow. Only the parentless case is noise.

This adds the `requireParentSpan` option. When enabled and no span is active, the original function
is called directly and no span is created.

## Mechanism

The option already exists in many instrumentations here, so this follows the established shape: a
`DEFAULT_CONFIG` merged in the constructor and in `setConfig`, and a
`trace.getSpan(context.active()) === undefined` check (`mongodb`, `pg`, `knex`, `ioredis`, `redis`,
`dataloader`, `fs`, `oracledb`).

`instrumentation-net` had no config interface at all - it took a bare `InstrumentationConfig` - so
this adds `NetInstrumentationConfig` and exports it as a type from `src/index.ts`.
`auto-instrumentations-node` infers config types from the constructor's first argument, so it picks
the new option up with no change there.

### Why the check lives in `patchedConnect`

`instrumentation-net` creates four spans: `connect`, `ipc.connect`, `tcp.connect` and `tls.connect`.
The check sits once at the top of `patchedConnect` rather than at each `startSpan` call site,
because all four originate from that function and, on the TLS path, `_startSpan` runs inside
`context.with(trace.setSpan(active, tlsSpan))`:

```ts
const tlsSpan = this.tracer.startSpan('tls.connect');
const netSpan = context.with(
  trace.setSpan(context.active(), tlsSpan),
  () => this._startSpan(options, socket)
);
```

Skipping only the `tls.connect` span would leave a non-recording span in context,
`trace.getSpan` would return it, and the nested `tcp.connect` span would still be created
parentless. There is a test covering exactly this case.

### Why the default is `false`

The default is `false`, so nothing changes for existing users and the new behaviour is opt-in.

`instrumentation-mongodb` defaults it to `true`, but the majority of instrumentations here default
to `false` (`knex`, `redis`, `pg`, `dataloader`, `fs`, `oracledb`), and `false` seems right for this
package specifically:

- Flipping the default would silently remove spans that people receive today. That is a behaviour
  change, and it would need to be a `feat!`.
- The package ships in `auto-instrumentations-node`, so a `true` default would reach a large number
  of users who never opted into it.
- #3660 notes that opt-in already solves the reported problem.

Happy to change it to `true` if maintainers prefer that trade-off - it is a one-line change.

## Tests

New file `packages/instrumentation-net/test/require-parent-span.test.ts`, 7 tests. It covers all
four span creation sites with the option enabled and no parent (`connect`, `ipc.connect`,
`tcp.connect`, `tls.connect`), the nested cases with a parent active (asserting `tcp.connect` is
still parented to `tls.connect`), and the default configuration still producing a parentless
`tcp.connect` span.

Environment for every run below: Ubuntu 24.04, **Node 18.20.8** (one of the versions in the CI
matrix), clean `npm ci` from the repository root.

### Red - the test file alone, applied on top of unmodified `main`

```
$ npm test -w @opentelemetry/instrumentation-net

  NetInstrumentation requireParentSpan
    when requireParentSpan is true
      1) should not create a tcp.connect span without a parent span
      2) should not create an ipc.connect span without a parent span
      3) should not create a generic connect span without a parent span
      4) should not create tls.connect or tcp.connect spans without a parent span
      ✔ should create a tcp.connect span when a parent span is active
      ✔ should create tls.connect and tcp.connect spans when a parent span is active
    when requireParentSpan is not set
      ✔ should create a tcp.connect span without a parent span

  23 passing (136ms)
  4 failing

  1) NetInstrumentation requireParentSpan
       when requireParentSpan is true
         should not create a tcp.connect span without a parent span:

      Uncaught AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
      + actual - expected

      + [
      +   'tcp.connect'
      + ]
      - []
```

The three tests that pass in the red run are the ones that assert existing behaviour - the two
parented cases and the default configuration - which is what you would expect from them.

### Green - this branch

```
$ npm test -w @opentelemetry/instrumentation-net

  NetInstrumentation requireParentSpan
    when requireParentSpan is true
      ✔ should not create a tcp.connect span without a parent span
      ✔ should not create an ipc.connect span without a parent span
      ✔ should not create a generic connect span without a parent span
      ✔ should not create tls.connect or tcp.connect spans without a parent span
      ✔ should create a tcp.connect span when a parent span is active
      ✔ should create tls.connect and tcp.connect spans when a parent span is active
    when requireParentSpan is not set
      ✔ should create a tcp.connect span without a parent span

  27 passing (102ms)
```

27 = 20 pre-existing + 7 new, 0 failing.

### Other CI gates, run locally on this branch

| Gate | Command | Result |
| --- | --- | --- |
| `test.yml` → compile | `npm run compile` | `NX Successfully ran target compile for 72 projects and 55 tasks they depend on` |
| `lint.yml` | `npm run lint` (Node 24) | exit 0 - `Successfully ran target lint for 84 projects`, `All matched files use Prettier code style!`, `lint:deps` (knip), `Successfully ran target lint:readme for 37 projects`, `lint:markdown`, `lint:semconv-deps` all clean |
| `peer-api.yaml` | `node ./scripts/peer-api-check.js` | exit 0, 70 packages `OK` |
| `test.yml` → unit-test, other affected project | `npm test -w @opentelemetry/auto-instrumentations-node` | `17 passing`, 0 failing |

`npm run compile` is `tsc -p .` per package and each package's `tsconfig.json` includes
`test/**/*.ts`, so the new test file is type-checked under `strict` by that gate too.

`nx affected -t test` for this branch resolves to `@opentelemetry/instrumentation-net` and
`@opentelemetry/auto-instrumentations-node`; both were run. Neither package has a `test:browser` or
a `test-all-versions` script, so those jobs have nothing to do here.

## What I did not verify

- I have not run the repository's full CI matrix. Tests were run on Node 18.20.8 only, not on
  20.6.0, 20, 22 or 24.
- I have no Docker on the machine I used, so I did not run anything that needs
  `test/docker-compose.yaml`. Neither of the two affected packages needs it.
- `zizmor-checks.yml` was not run - it needs an external binary and a GitHub token. This PR does not
  touch `.github/`.
- I did not reproduce the original MongoDB-heartbeat scenario end to end. The tests here are at the
  unit level.
- On **Node 24** the package test scripts fail before running anything, with
  `Directory import ... is not supported resolving ES modules`. That happens on unmodified `main`
  too, so it is unrelated to this change - Node 24's native type stripping loads the `.ts` files as
  ESM and the `ts-node` CJS hook never runs. `NODE_OPTIONS=--no-experimental-strip-types` works
  around it locally. I mention it only in case it is useful to others.

## AI disclosure

I used an AI coding assistant (Claude) while working on this change: to survey how
`requireParentSpan` is implemented across the other instrumentations in this repository, to draft
the implementation and the tests, and to help draft this description. I reviewed every line,
verified the behaviour myself with the runs described above, and the reasoning about the TLS nesting
and about the default value is my own. This text is written in my own words.
