### PR TITLE
feat(instrumentation-ioredis): support ioredis @v6

### DIFF
--- a/packages/instrumentation-ioredis/.tav.yml
+++ b/packages/instrumentation-ioredis/.tav.yml
@@ -1,7 +1,14 @@
 ioredis:
-  # Ignoring v4.19.0. Tests never ends. Caused by https://github.com/luin/ioredis/pull/1219
-  versions:
-    include: '>=2.0.0 <6'
-    exclude: '4.19.0'
-    mode: max-7
-  commands: npm run test
+  - versions:
+      # Ignoring v4.19.0. Tests never ends. Caused by https://github.com/luin/ioredis/pull/1219
+      include: '>=2.0.0 <6'
+      exclude: '4.19.0'
+      mode: max-7
+    commands: npm run test
+  - versions:
+      include: '>=6.0.0 <7'
+      mode: max-7
+    # ioredis v6 requires Node.js v20 or later.
+    # https://github.com/redis/ioredis/releases/tag/v6.0.0
+    node: ">=20"
+    commands: npm run test

--- a/packages/instrumentation-ioredis/README.md
+++ b/packages/instrumentation-ioredis/README.md
@@ -17,7 +17,7 @@ npm install --save @opentelemetry/instrumentation-ioredis
 
 ### Supported Versions
 
-- [`ioredis`](https://www.npmjs.com/package/ioredis) versions `>=2.0.0 <6`
+- [`ioredis`](https://www.npmjs.com/package/ioredis) versions `>=2.0.0 <7`
 
 ## Usage
 

--- a/packages/instrumentation-ioredis/src/instrumentation.ts
+++ b/packages/instrumentation-ioredis/src/instrumentation.ts
@@ -48,7 +48,7 @@ export class IORedisInstrumentation extends InstrumentationBase<IORedisInstrumen
     return [
       new InstrumentationNodeModuleDefinition(
         'ioredis',
-        ['>=2.0.0 <6'],
+        ['>=2.0.0 <7'],
         (module, moduleVersion?: string) => {
           const moduleExports =
             module[Symbol.toStringTag] === 'Module'

--- a/packages/instrumentation-ioredis/test/ioredis.test.ts
+++ b/packages/instrumentation-ioredis/test/ioredis.test.ts
@@ -124,9 +124,18 @@ describe('ioredis', () => {
         const endedSpans = memoryExporter.getFinishedSpans();
         try {
           assert.strictEqual(trace.getSpan(context.active()), span);
-          assert.strictEqual(endedSpans.length, 2);
+          // ioredis v6 defaults to RESP3 and sends a HELLO command during the
+          // handshake, producing an extra span between 'connect' and 'info'.
+          // v5: [connect, info]  v6: [connect, hello, info]
+          assert.ok(
+            endedSpans.length === 2 || endedSpans.length === 3,
+            `expected 2 or 3 handshake spans, got ${endedSpans.length}`
+          );
           assert.strictEqual(endedSpans[0].name, 'connect');
-          assert.strictEqual(endedSpans[1].name, 'info');
+          assert.ok(
+            endedSpans.some(s => s.name === 'info'),
+            'expected an info span'
+          );
           testUtils.assertPropagation(endedSpans[0], span);
 
           testUtils.assertSpan(
@@ -137,12 +146,29 @@ describe('ioredis', () => {
             unsetStatus
           );
           span.end();
-          assert.strictEqual(endedSpans.length, 3);
-          assert.strictEqual(endedSpans[2].name, 'test span');
+          // ioredis v6 defaults to RESP3 and sends a HELLO command during the
+          // handshake, producing an extra span.
+          const endedSpansAfterEnd = memoryExporter.getFinishedSpans();
+          assert.ok(
+            endedSpans.length === 3 || endedSpansAfterEnd.length === 4,
+            `expected 3 or 4 handshake spans, got ${endedSpansAfterEnd.length}`
+          );
+
+          assert.strictEqual(
+            endedSpansAfterEnd[endedSpansAfterEnd.length - 1].name,
+            'test span'
+          );
         } finally {
           client.quit(() => {
-            assert.strictEqual(endedSpans.length, 4);
-            assert.strictEqual(endedSpans[3].name, 'quit');
+            assert.ok(
+            endedSpans.length === 4 || endedSpans.length === 5,
+            `expected 4 or 5 handshake spans, got ${endedSpans.length}`
+          );
+          
+          assert.strictEqual(
+            endedSpans[endedSpans.length - 1].name,
+            'quit'
+          );
             done();
           });
         }
@@ -157,9 +183,6 @@ describe('ioredis', () => {
           // client info introduced in ioredis@5.8.0 - by disabling it we can ensure that assertions can remain
           // consistent with ioredis@<5.8.0.
           disableClientInfo: true,
-          // ioredis v6 defaults to protocol 3 (RESP3), which sends a HELLO command
-          // during handshake. Force protocol 2 for a consistent span count across versions.
-          protocol: 2,
         });
         client.on('ready', readyHandler);
         client.on('error', errorHandler);

--- a/packages/instrumentation-ioredis/test/ioredis.test.ts
+++ b/packages/instrumentation-ioredis/test/ioredis.test.ts
@@ -161,14 +161,11 @@ describe('ioredis', () => {
         } finally {
           client.quit(() => {
             assert.ok(
-            endedSpans.length === 4 || endedSpans.length === 5,
-            `expected 4 or 5 handshake spans, got ${endedSpans.length}`
-          );
-          
-          assert.strictEqual(
-            endedSpans[endedSpans.length - 1].name,
-            'quit'
-          );
+              endedSpans.length === 4 || endedSpans.length === 5,
+              `expected 4 or 5 handshake spans, got ${endedSpans.length}`
+            );
+
+            assert.strictEqual(endedSpans[endedSpans.length - 1].name, 'quit');
             done();
           });
         }

--- a/packages/instrumentation-ioredis/test/ioredis.test.ts
+++ b/packages/instrumentation-ioredis/test/ioredis.test.ts
@@ -157,6 +157,9 @@ describe('ioredis', () => {
           // client info introduced in ioredis@5.8.0 - by disabling it we can ensure that assertions can remain
           // consistent with ioredis@<5.8.0.
           disableClientInfo: true,
+          // ioredis v6 defaults to protocol 3 (RESP3), which sends a HELLO command
+          // during handshake. Force protocol 2 for a consistent span count across versions.
+          protocol: 2,
         });
         client.on('ready', readyHandler);
         client.on('error', errorHandler);


### PR DESCRIPTION
## Which problem is this PR solving?

Adds support for **[ioredis v6.0.0](https://github.com/redis/ioredis/releases/tag/v6.0.0)**. ioredis v6 retains the `sendCommand` API and the `Command` properties used by our instrumentation, so no patching logic changes are required.

## Short description of the changes

* Update the supported ioredis range to v6.
* Restrict ioredis v6 testing to **Node.js ≥ 20**.

reference: https://github.com/redis/ioredis/releases/tag/v6.0.0