### PR TITLE
fix(instrumentation-long-task): deprecate package

### DIFF
--- a/packages/instrumentation-long-task/README.md
+++ b/packages/instrumentation-long-task/README.md
@@ -1,5 +1,7 @@
 # OpenTelemetry Long Task Instrumentation for web
 
+> **Deprecated:** This package is deprecated because the Long Tasks API is deprecated. Use instrumentation based on the [Long Animation Frames API][mdn-long-animation-frames] when available.
+
 [![NPM Published Version][npm-img]][npm-url]
 [![Apache License][license-image]][license-image]
 
@@ -81,3 +83,4 @@ Apache 2.0 - See [LICENSE][license-url] for more information.
 [npm-img]: https://badge.fury.io/js/%40opentelemetry%2Finstrumentation-long-task.svg
 [mdn-long-task]: https://developer.mozilla.org/en-US/docs/Web/API/Long_Tasks_API
 [mdn-performance-long-task-timing]: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceLongTaskTiming
+[mdn-long-animation-frames]: https://developer.mozilla.org/en-US/docs/Web/API/Performance_API/Long_animation_frame_timing

--- a/packages/instrumentation-long-task/src/instrumentation.ts
+++ b/packages/instrumentation-long-task/src/instrumentation.ts
@@ -26,6 +26,9 @@ export class LongTaskInstrumentation extends InstrumentationBase<LongtaskInstrum
 
   constructor(config: LongtaskInstrumentationConfig = {}) {
     super(PACKAGE_NAME, PACKAGE_VERSION, config);
+    diag.warn(
+      '@opentelemetry/instrumentation-long-task is deprecated. Use instrumentation based on the Long Animation Frames API when available.'
+    );
   }
 
   init() {}

--- a/packages/instrumentation-long-task/test/longTask.test.ts
+++ b/packages/instrumentation-long-task/test/longTask.test.ts
@@ -2,7 +2,7 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-import { trace } from '@opentelemetry/api';
+import { diag, DiagLogLevel, trace } from '@opentelemetry/api';
 import { hrTimeToMilliseconds, hrTimeToNanoseconds } from '@opentelemetry/core';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace';
@@ -71,7 +71,32 @@ describe('LongTaskInstrumentation', () => {
     deregister();
     sandbox.restore();
     exportSpy.restore();
+    diag.disable();
     trace.disable();
+  });
+
+  it('should warn that the instrumentation is deprecated', () => {
+    const warn = sandbox.spy();
+    diag.setLogger(
+      {
+        error() {},
+        warn,
+        info() {},
+        debug() {},
+        verbose() {},
+      },
+      DiagLogLevel.WARN
+    );
+
+    const instrumentation = new LongTaskInstrumentation({ enabled: false });
+
+    assert.ok(
+      warn.calledWithExactly(
+        '@opentelemetry/instrumentation-long-task is deprecated. Use instrumentation based on the Long Animation Frames API when available.'
+      )
+    );
+    assert.strictEqual(warn.callCount, 1);
+    instrumentation.disable();
   });
 
   it('should report long taking tasks', async () => {


### PR DESCRIPTION
## Which problem is this PR solving?

- Deprecates `@opentelemetry/instrumentation-long-task` because the Long Tasks API is deprecated.
- Relates to open-telemetry/opentelemetry-browser#395, which was created after the Browser SIG decided not to move this instrumentation to the Browser repository.

## Short description of the changes

- Adds a prominent README deprecation notice and points users toward instrumentation based on the Long Animation Frames API when available.
- Emits a diagnostic warning when `LongTaskInstrumentation` is instantiated.
- Adds a focused browser regression test that verifies the warning is emitted exactly once.
- Retains the implementation for a deprecation window rather than removing the package immediately.

## Validation

- `npm run compile --workspace @opentelemetry/instrumentation-long-task`
- `npm run test:browser --workspace @opentelemetry/instrumentation-long-task` (7 passing)
- `npm run lint`
- `npm run compile`
- `npm pack --workspace @opentelemetry/instrumentation-long-task --dry-run --json`
- `git diff --check`

The full repository test command also ran. Its only failure was the unrelated, unchanged `@opentelemetry/resource-detector-aws` integration test `AwsSuppressTracing.test.ts` timing out after 10 seconds; the focused long-task suite remained green.

## Maintainer follow-up

Per the component lifecycle policy, this deprecation needs confirmation from the long-task component owners (`@mhennoch`, `@t2t2`). Once merged/released, a maintainer will also need to mark the published npm package as deprecated; npm registry deprecation is not represented by a source-controlled `package.json` field.


## AI assistance disclosure

I used Hermes Agent (GPT-5.6) to assist with repository research, code and test drafting, and validation. I reviewed the final change and take responsibility for it.
