### PR TITLE
fix(winston-transport): serialize Error attributes

### DIFF
--- a/packages/instrumentation-winston/test/winston.test.ts
+++ b/packages/instrumentation-winston/test/winston.test.ts
@@ -250,6 +250,26 @@ describe('WinstonInstrumentation', () => {
       }
     });
 
+    it('serializes Error metadata attributes', () => {
+      if (!isWinston2) {
+        instrumentation.setConfig({
+          disableLogSending: false,
+        });
+        initLogger();
+        const failure = new TypeError('boom');
+
+        logger.log('info', kMessage, { failure });
+
+        const logRecords = memoryLogExporter.getFinishedLogRecords();
+        assert.strictEqual(logRecords.length, 1);
+        assert.deepStrictEqual(logRecords[0].attributes['failure'], {
+          name: 'TypeError',
+          message: 'boom',
+          stack: failure.stack,
+        });
+      }
+    });
+
     it('emit LogRecord with exception attributes', () => {
       if (!isWinston2) {
         instrumentation.setConfig({

--- a/packages/winston-transport/README.md
+++ b/packages/winston-transport/README.md
@@ -53,6 +53,15 @@ const logger = winston.createLogger({
 > [!IMPORTANT]
 > Logs will be duplicated if `@opentelemetry/winston-transport` is added as a transport in `winston` and `@opentelemetry/instrumentation-winston` is configured with `disableLogSending: false`.
 
+### Error handling
+
+`Error` instances assigned to the conventional `error` or `err` fields are
+emitted through the OpenTelemetry Logs API exception field. Instances assigned
+to other metadata fields, including errors nested in arrays or objects, are
+converted to structured attributes containing their `name`, `message`, `stack`,
+and other own properties. Circular references in serialized error metadata are
+represented as `[Circular]`.
+
 ### Supported versions
 
 - [`winston`](https://www.npmjs.com/package/winston) versions `>=3.0.0 <4`

--- a/packages/winston-transport/src/utils.ts
+++ b/packages/winston-transport/src/utils.ts
@@ -5,6 +5,7 @@
 
 import {
   AnyValue,
+  AnyValueMap,
   LogAttributes,
   LogRecord,
   Logger,
@@ -48,6 +49,101 @@ const cliLevels: Record<string, number> = {
 
 function getSeverityNumber(level: string): SeverityNumber | undefined {
   return npmLevels[level] ?? sysLoglevels[level] ?? cliLevels[level];
+}
+
+const CIRCULAR_REFERENCE_VALUE = '[Circular]';
+const ERROR_PROPERTY_NAMES = [
+  'name',
+  'message',
+  'stack',
+  'code',
+  'cause',
+  'errors',
+];
+
+function isPlainObject(value: object): value is Record<string, unknown> {
+  const constructor = (value as { constructor?: unknown }).constructor;
+  return constructor === Object || constructor === undefined;
+}
+
+function serializeError(error: Error, ancestors: Set<object>): AnyValueMap {
+  const serialized: AnyValueMap = {};
+  const propertyNames = new Set([
+    ...ERROR_PROPERTY_NAMES,
+    ...Object.getOwnPropertyNames(error),
+  ]);
+
+  ancestors.add(error);
+  for (const propertyName of propertyNames) {
+    const propertyValue = (error as unknown as Record<string, unknown>)[
+      propertyName
+    ];
+    if (propertyValue !== undefined) {
+      serialized[propertyName] = normalizeAttributeValue(
+        propertyValue,
+        ancestors,
+        true
+      );
+    }
+  }
+  ancestors.delete(error);
+
+  return serialized;
+}
+
+function normalizeAttributeValue(
+  value: unknown,
+  ancestors = new Set<object>(),
+  stringifyUnsupported = false
+): AnyValue {
+  if (
+    value == null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    value instanceof Uint8Array
+  ) {
+    return value;
+  }
+
+  if (typeof value !== 'object') {
+    return stringifyUnsupported ? String(value) : (value as AnyValue);
+  }
+
+  if (ancestors.has(value)) {
+    return CIRCULAR_REFERENCE_VALUE;
+  }
+
+  if (value instanceof Error) {
+    return serializeError(value, ancestors);
+  }
+
+  if (Array.isArray(value)) {
+    ancestors.add(value);
+    const normalized = value.map(item =>
+      normalizeAttributeValue(item, ancestors, stringifyUnsupported)
+    );
+    ancestors.delete(value);
+    return normalized;
+  }
+
+  if (isPlainObject(value)) {
+    ancestors.add(value);
+    const normalized: AnyValueMap = {};
+    for (const key in value) {
+      if (Object.prototype.hasOwnProperty.call(value, key)) {
+        normalized[key] = normalizeAttributeValue(
+          value[key],
+          ancestors,
+          stringifyUnsupported
+        );
+      }
+    }
+    ancestors.delete(value);
+    return normalized;
+  }
+
+  return stringifyUnsupported ? String(value) : (value as AnyValue);
 }
 
 /**
@@ -223,7 +319,7 @@ export function emitLogRecord(
       Object.prototype.hasOwnProperty.call(rest, key) &&
       !excludedAttributes.has(key)
     ) {
-      attributes[key] = rest[key];
+      attributes[key] = normalizeAttributeValue(rest[key]);
     }
   }
   if (exceptionPayload?.additionalAttributes) {

--- a/packages/winston-transport/test/openTelemetryTransport.test.ts
+++ b/packages/winston-transport/test/openTelemetryTransport.test.ts
@@ -60,6 +60,66 @@ describe('OpenTelemetryTransportV3', () => {
     );
   });
 
+  it('serializes Error values in attributes', () => {
+    const transport = new OpenTelemetryTransportV3();
+    const error = new TypeError('boom') as TypeError & {
+      details?: { attempt: number };
+    };
+    error.details = { attempt: 2 };
+    Object.defineProperty(error, 'code', {
+      value: 'E_BROKEN',
+      enumerable: false,
+    });
+
+    transport.log({ message: kMessage, failure: error }, () => {});
+
+    const logRecords = memoryLogExporter.getFinishedLogRecords();
+    assert.strictEqual(logRecords.length, 1);
+    assert.deepStrictEqual(logRecords[0].attributes['failure'], {
+      name: 'TypeError',
+      stack: error.stack,
+      message: 'boom',
+      details: { attempt: 2 },
+      code: 'E_BROKEN',
+    });
+    assert.ok(error instanceof TypeError);
+  });
+
+  it('serializes nested and circular Error values in attributes', () => {
+    const transport = new OpenTelemetryTransportV3();
+    const rootCause = new Error('root cause');
+    const error = new AggregateError([rootCause], 'aggregate failure', {
+      cause: rootCause,
+    }) as AggregateError & { self?: Error };
+    error.self = error;
+    const metadata = { error };
+
+    transport.log({ message: kMessage, metadata }, () => {});
+
+    const logRecords = memoryLogExporter.getFinishedLogRecords();
+    assert.strictEqual(logRecords.length, 1);
+    const serializedMetadata = logRecords[0].attributes['metadata'] as {
+      error: {
+        name: string;
+        message: string;
+        stack: string;
+        cause: { message: string };
+        errors: Array<{ message: string }>;
+        self: string;
+      };
+    };
+    assert.strictEqual(serializedMetadata.error.name, 'AggregateError');
+    assert.strictEqual(serializedMetadata.error.message, 'aggregate failure');
+    assert.strictEqual(serializedMetadata.error.stack, error.stack);
+    assert.strictEqual(serializedMetadata.error.cause.message, 'root cause');
+    assert.strictEqual(
+      serializedMetadata.error.errors[0].message,
+      'root cause'
+    );
+    assert.strictEqual(serializedMetadata.error.self, '[Circular]');
+    assert.strictEqual(metadata.error, error);
+  });
+
   it('emit LogRecord with exception from err field', () => {
     const transport = new OpenTelemetryTransportV3();
     transport.log({ message: kMessage, err: new Error('boom') }, () => {});


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #2443.

Winston metadata can contain `Error` instances, but those are not valid OpenTelemetry log attribute values. Conventional `error` and `err` fields are already promoted to the Logs API exception field; errors in other or nested metadata fields were still rejected and dropped by the SDK.

## Short description of the changes

- Recursively convert remaining `Error` instances to structured AnyValue maps.
- Preserve `name`, `message`, `stack`, `code`, `cause`, aggregate `errors`, and custom own properties, including non-enumerable properties.
- Represent circular references in serialized error metadata as `[Circular]` without mutating the Winston record.
- Add transport-level edge-case coverage, a real Winston instrumentation integration test, and README documentation.

## Testing

- Compiled `@opentelemetry/winston-transport` and `@opentelemetry/instrumentation-winston`.
- Ran the full Winston transport suite: 26 passing.
- Ran the full Winston instrumentation suite: 24 passing.
- Packed the modified transport and exercised it with Winston 3.19.0 through an OTLP/HTTP pipeline backed by `otel/opentelemetry-collector-contrib:0.158.0` (`sha256:c5918f78992ee73b0d6f0e599423ac5ec52dd5d9726733114d6eca53d5a32ed5`). Confirmed primary exception fields, structured top-level and nested errors, aggregate causes, custom non-enumerable fields, circular markers, and no invalid-attribute diagnostic.