### PR TITLE
chore: expose release-please validation script

### DIFF
--- a/.github/workflows/release-please-validate.yaml
+++ b/.github/workflows/release-please-validate.yaml
@@ -21,4 +21,4 @@ jobs:
           persist-credentials: false
 
       - name: Ensure Release Please Config and Manifest are in sync with the repository
-        run: node scripts/check-release-please.mjs
+        run: npm run lint:release-please

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lint:prettier": "prettier --check .",
     "lint:prettier:fix": "prettier --write .",
     "lint:readme": "nx run-many -t lint:readme",
+    "lint:release-please": "node scripts/check-release-please.mjs",
     "lint:semconv-deps": "./scripts/lint-semconv-deps.mjs -x packages/contrib-test-utils/src/resource-assertions.ts"
   },
   "keywords": [

--- a/scripts/check-release-please.mjs
+++ b/scripts/check-release-please.mjs
@@ -100,7 +100,7 @@ configPackages.forEach(relativeLocation => {
 });
 
 if (errors.length) {
-  console.error('Errors occured:\n');
+  console.error('Errors occurred:\n');
   console.error(errors.join('\n\n'));
   process.exit(1);
 } else {


### PR DESCRIPTION
## Which problem is this PR solving?

Makes the release-please validation check easier to run locally by exposing the existing checker as a root npm script, and updates the CI workflow to use that script.

Related to #888.

## Short description of the changes

- Adds `npm run lint:release-please` for `scripts/check-release-please.mjs`
- Updates the release-please validation workflow to call the npm script
- Fixes a typo in the checker failure heading

## How was this change tested?

- `npm run lint:release-please`

## Notes

AI assistance was used to help prepare this change.