### PR TITLE
docs: fix AWS X-Ray propagator link

### DIFF
--- a/packages/propagator-aws-xray-lambda/README.md
+++ b/packages/propagator-aws-xray-lambda/README.md
@@ -16,7 +16,7 @@ see the [semantic conventions specification for AWS Lambda](https://github.com/o
 ## Propagator Details
 
 The propagator extracts context from the `_X_AMZN_TRACE_ID` environment variable, except when there is already another
-context active. It also automatically uses the [AWS X-Ray propagator](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/propagators/opentelemetry-propagator-aws-xray).
+context active. It also automatically uses the [AWS X-Ray propagator](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/propagator-aws-xray).
 
 ## Useful links
 


### PR DESCRIPTION
## Summary
- update the AWS X-Ray Lambda propagator README link to the current AWS X-Ray propagator package path

## Testing
- ran `git diff --check`
- verified `packages/propagator-aws-xray` exists locally