### PR TITLE
docs: fix issue template contributing links

### DIFF
--- a/.github/ISSUE_TEMPLATE/instrumentation_request.md
+++ b/.github/ISSUE_TEMPLATE/instrumentation_request.md
@@ -5,7 +5,7 @@ labels: instrumentation-request
 ---
 
 <!--
-**NB:** Before opening an instrumentation request against this repo, please read [the contributing guidelines for new instrumentation](../blob/main/CONTRIBUTING.md#new-instrumentation).
+**NB:** Before opening an instrumentation request against this repo, please read [the contributing guidelines for new instrumentation](../../CONTRIBUTING.md#new-instrumentation).
 -->
 
 ### Which library do you want to instrument?
@@ -22,7 +22,7 @@ Any code-owners listed MUST fulfill all criteria laid out in the checklist below
 
 - Owner 1
   - [ ] I am a [member of the OpenTelemetry Organization](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#member)
-  - [ ] I have read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and understand the responsibilities of a component owner
+  - [ ] I have read [CONTRIBUTING.md](../../CONTRIBUTING.md) and understand the responsibilities of a component owner
   - [ ] I agree to follow and uphold the [mission, vision and values](https://github.com/open-telemetry/community/blob/main/mission-vision-values.md) of the OpenTelemetry project
   - [ ] I understand that the component may be subject to the [OpenTelemetry Semantic Conventions](https://github.com/open-telemetry/semantic-conventions) and agree to follow the rules set out therein
 - Owner 2

--- a/.github/ISSUE_TEMPLATE/instrumentation_request.md
+++ b/.github/ISSUE_TEMPLATE/instrumentation_request.md
@@ -5,7 +5,7 @@ labels: instrumentation-request
 ---
 
 <!--
-**NB:** Before opening an instrumentation request against this repo, please read [the contributing guidelines for new instrumentation](../../CONTRIBUTING.md#new-instrumentation).
+**NB:** Before opening an instrumentation request against this repo, please read [the contributing guidelines for new instrumentation](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/CONTRIBUTING.md#new-instrumentation).
 -->
 
 ### Which library do you want to instrument?
@@ -22,7 +22,7 @@ Any code-owners listed MUST fulfill all criteria laid out in the checklist below
 
 - Owner 1
   - [ ] I am a [member of the OpenTelemetry Organization](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#member)
-  - [ ] I have read [CONTRIBUTING.md](../../CONTRIBUTING.md) and understand the responsibilities of a component owner
+  - [ ] I have read [CONTRIBUTING.md](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/CONTRIBUTING.md) and understand the responsibilities of a component owner
   - [ ] I agree to follow and uphold the [mission, vision and values](https://github.com/open-telemetry/community/blob/main/mission-vision-values.md) of the OpenTelemetry project
   - [ ] I understand that the component may be subject to the [OpenTelemetry Semantic Conventions](https://github.com/open-telemetry/semantic-conventions) and agree to follow the rules set out therein
 - Owner 2

--- a/.github/ISSUE_TEMPLATE/ownership_request.md
+++ b/.github/ISSUE_TEMPLATE/ownership_request.md
@@ -5,7 +5,7 @@ labels: type:ownership-request
 ---
 
 <!--
-**NB:** Before opening a component ownership request against this repo, please read [CONTRIBUTING.md](../../CONTRIBUTING.md#component-ownership) and its subsections first.
+**NB:** Before opening a component ownership request against this repo, please read [CONTRIBUTING.md](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/CONTRIBUTING.md#component-ownership) and its subsections first.
 -->
 
 ### Which component are you requesting ownership of?
@@ -17,7 +17,7 @@ Put a link to the component here.
 ### Related Work and Qualifications
 
 <!--
-List here why you're qualified to take ownership of the component, see [CONTRIBUTING.md](../../CONTRIBUTING.md#becoming-a-component-owner) for details.
+List here why you're qualified to take ownership of the component, see [CONTRIBUTING.md](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/CONTRIBUTING.md#becoming-a-component-owner) for details.
 
 Examples:
 - I am working on <related open-source-project> and have deep knowledge of the instrumented package.
@@ -29,7 +29,7 @@ Examples:
 ### Checklist
 
 - [ ] I am a [member of the OpenTelemetry Organization](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#member)
-- [ ] I have read [CONTRIBUTING.md](../../CONTRIBUTING.md) and understand the responsibilities of a component owner.
+- [ ] I have read [CONTRIBUTING.md](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/CONTRIBUTING.md) and understand the responsibilities of a component owner.
 - [ ] I agree to follow and uphold the [mission, vision and values](https://github.com/open-telemetry/community/blob/main/mission-vision-values.md) of the OpenTelemetry project
 - [ ] I understand that the component I'm requesting ownership of may be subject to the [OpenTelemetry Semantic Conventions](https://github.com/open-telemetry/semantic-conventions) and agree to follow the rules set out therein.
 

--- a/.github/ISSUE_TEMPLATE/ownership_request.md
+++ b/.github/ISSUE_TEMPLATE/ownership_request.md
@@ -5,7 +5,7 @@ labels: type:ownership-request
 ---
 
 <!--
-**NB:** Before opening a component ownership request against this repo, please read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#component-ownership) and its subsections first.
+**NB:** Before opening a component ownership request against this repo, please read [CONTRIBUTING.md](../../CONTRIBUTING.md#component-ownership) and its subsections first.
 -->
 
 ### Which component are you requesting ownership of?
@@ -17,7 +17,7 @@ Put a link to the component here.
 ### Related Work and Qualifications
 
 <!--
-List here why you're qualified to take ownership of the component, see [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#becoming-a-component-owner) for details.
+List here why you're qualified to take ownership of the component, see [CONTRIBUTING.md](../../CONTRIBUTING.md#becoming-a-component-owner) for details.
 
 Examples:
 - I am working on <related open-source-project> and have deep knowledge of the instrumented package.
@@ -29,7 +29,7 @@ Examples:
 ### Checklist
 
 - [ ] I am a [member of the OpenTelemetry Organization](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#member)
-- [ ] I have read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) and understand the responsibilities of a component owner.
+- [ ] I have read [CONTRIBUTING.md](../../CONTRIBUTING.md) and understand the responsibilities of a component owner.
 - [ ] I agree to follow and uphold the [mission, vision and values](https://github.com/open-telemetry/community/blob/main/mission-vision-values.md) of the OpenTelemetry project
 - [ ] I understand that the component I'm requesting ownership of may be subject to the [OpenTelemetry Semantic Conventions](https://github.com/open-telemetry/semantic-conventions) and agree to follow the rules set out therein.
 


### PR DESCRIPTION
## Summary
- fix issue-template links that pointed to `.github/blob/main/CONTRIBUTING.md`
- use relative paths back to the repository root `CONTRIBUTING.md`

## Testing
- `git diff --check`