### PR TITLE
feat: add opt-in attributes cluster_name, vhost

### DIFF
--- a/packages/instrumentation-amqplib/README.md
+++ b/packages/instrumentation-amqplib/README.md
@@ -40,6 +40,8 @@ const sdk = new NodeSDK({
       // consumeHook: (span: Span, consumeInfo: ConsumeInfo) => { },
       // consumeEndHook: (span: Span, consumeEndInfo: ConsumeEndInfo) => { },
       // useLinksForConsume: boolean,
+      // captureClusterName: boolean,
+      // captureVhostName: boolean,
     }),
   ],
 });
@@ -59,6 +61,8 @@ amqplib instrumentation has few options available to choose from. You can set th
 | `consumeEndHook`     | `AmqplibConsumeEndCustomAttributeFunction`     | hook for adding custom attributes after consumer message is acked to server.        |
 | `consumeTimeoutMs`   | `number`                                       | read [Consume Timeout](#consume-timeout) below                                      |
 | `useLinksForConsume` | `boolean`                                      | read [Links for Consume](#links-for-consume) below                                  |
+| `captureClusterName` | `boolean`                                      | capture `messaging.rabbitmq.cluster.name` span attribute. Default is `false`.       |
+| `captureVhostName`   | `boolean`                                      | capture `messaging.rabbitmq.vhost.name` span attribute. Default is `false`.         |
 
 ### Consume Timeout
 

--- a/packages/instrumentation-amqplib/src/amqplib.ts
+++ b/packages/instrumentation-amqplib/src/amqplib.ts
@@ -234,6 +234,7 @@ export class AmqplibInstrumentation extends InstrumentationBase<AmqplibInstrumen
       openCallback: (err: any, connection: Connection) => void
     ) => Connection
   ) {
+    const self = this;
     return function patchedConnect(
       this: unknown,
       url: string | Options.Connect,
@@ -246,8 +247,15 @@ export class AmqplibInstrumentation extends InstrumentationBase<AmqplibInstrumen
         socketOptions,
         function (this: unknown, err, conn: InstrumentationConnection) {
           if (err == null) {
-            const urlAttributes = getConnectionAttributesFromUrl(url);
-            const serverAttributes = getConnectionAttributesFromServer(conn);
+            const { captureClusterName, captureVhostName } = self.getConfig();
+            const urlAttributes = getConnectionAttributesFromUrl(
+              url,
+              !!captureVhostName
+            );
+            const serverAttributes = getConnectionAttributesFromServer(
+              conn,
+              !!captureClusterName
+            );
             conn[CONNECTION_ATTRIBUTES] = {
               ...urlAttributes,
               ...serverAttributes,

--- a/packages/instrumentation-amqplib/src/semconv.ts
+++ b/packages/instrumentation-amqplib/src/semconv.ts
@@ -30,3 +30,28 @@ export const ATTR_MESSAGING_OPERATION = 'messaging.operation' as const;
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_SYSTEM = 'messaging.system' as const;
+
+/**
+ * The RabbitMQ cluster name, obtained from the broker metadata exposed
+ * through the RabbitMQ client API.
+ *
+ * @note Not yet part of `@opentelemetry/semantic-conventions` — tracked in
+ * https://github.com/open-telemetry/semantic-conventions/issues/3997. Mirrors
+ * `messaging.kafka.cluster.id` in shape.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_MESSAGING_RABBITMQ_CLUSTER_NAME =
+  'messaging.rabbitmq.cluster.name' as const;
+
+/**
+ * The name of the RabbitMQ virtual host that the messaging operation is
+ * scoped to.
+ *
+ * @note Not yet part of `@opentelemetry/semantic-conventions` — tracked in
+ * https://github.com/open-telemetry/semantic-conventions/issues/3997.
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_MESSAGING_RABBITMQ_VHOST_NAME =
+  'messaging.rabbitmq.vhost.name' as const;

--- a/packages/instrumentation-amqplib/src/types.ts
+++ b/packages/instrumentation-amqplib/src/types.ts
@@ -88,11 +88,32 @@ export interface AmqplibInstrumentationConfig extends InstrumentationConfig {
 
   /** option to use a span link for the consume message instead of continuing a trace */
   useLinksForConsume?: boolean;
+
+  /**
+   * Capture the `messaging.rabbitmq.cluster.name` span attribute, populated from the
+   * broker's reported `cluster_name` server property. Not yet part of
+   * `@opentelemetry/semantic-conventions` (see `ATTR_MESSAGING_RABBITMQ_CLUSTER_NAME`'s
+   * doc comment in `./semconv`), and not every broker reports one, so this is opt-in.
+   *
+   * Default is false
+   */
+  captureClusterName?: boolean;
+
+  /**
+   * Capture the `messaging.rabbitmq.vhost.name` span attribute, populated from the
+   * connection's virtual host. Not yet part of `@opentelemetry/semantic-conventions`
+   * (see `ATTR_MESSAGING_RABBITMQ_VHOST_NAME`'s doc comment in `./semconv`).
+   *
+   * Default is false
+   */
+  captureVhostName?: boolean;
 }
 
 export const DEFAULT_CONFIG: AmqplibInstrumentationConfig = {
   consumeTimeoutMs: 1000 * 60, // 1 minute
   useLinksForConsume: false,
+  captureClusterName: false,
+  captureVhostName: false,
 };
 
 // The following types are vendored from `@types/amqplib@0.10.1` - commit SHA: 4205e03127692a40b4871709a7134fe4e2ed5510

--- a/packages/instrumentation-amqplib/src/utils.ts
+++ b/packages/instrumentation-amqplib/src/utils.ts
@@ -15,7 +15,11 @@ import {
   ATTR_SERVER_ADDRESS,
   ATTR_SERVER_PORT,
 } from '@opentelemetry/semantic-conventions';
-import { ATTR_MESSAGING_SYSTEM } from './semconv';
+import {
+  ATTR_MESSAGING_SYSTEM,
+  ATTR_MESSAGING_RABBITMQ_CLUSTER_NAME,
+  ATTR_MESSAGING_RABBITMQ_VHOST_NAME,
+} from './semconv';
 import {
   ATTR_MESSAGING_PROTOCOL,
   ATTR_MESSAGING_PROTOCOL_VERSION,
@@ -94,6 +98,12 @@ const getHostname = (hostnameFromUrl: string | undefined): string => {
   return hostnameFromUrl || 'localhost';
 };
 
+const getVhost = (vhostFromUrl: string | undefined | null): string => {
+  // Mirrors amqplib's own defaulting in lib/connect.js's openFrames:
+  // empty/missing vhost defaults to '/', otherwise it's percent-decoded.
+  return vhostFromUrl ? decodeURIComponent(vhostFromUrl) : '/';
+};
+
 const extractConnectionAttributeOrLog = (
   url: string | amqp.Options.Connect,
   attributeKey: string,
@@ -114,20 +124,28 @@ const extractConnectionAttributeOrLog = (
 };
 
 export const getConnectionAttributesFromServer = (
-  conn: amqp.Connection
+  conn: amqp.Connection,
+  captureClusterName: boolean
 ): Attributes => {
+  const attributes: Attributes = {};
   const product = conn.serverProperties.product?.toLowerCase?.();
   if (product) {
-    return {
-      [ATTR_MESSAGING_SYSTEM]: product,
-    };
-  } else {
-    return {};
+    attributes[ATTR_MESSAGING_SYSTEM] = product;
   }
+  if (captureClusterName) {
+    // Experimental — not yet in @opentelemetry/semantic-conventions, see
+    // ATTR_MESSAGING_RABBITMQ_CLUSTER_NAME's doc comment in ./semconv.
+    const clusterName = conn.serverProperties['cluster_name'];
+    if (clusterName) {
+      attributes[ATTR_MESSAGING_RABBITMQ_CLUSTER_NAME] = clusterName;
+    }
+  }
+  return attributes;
 };
 
 export const getConnectionAttributesFromUrl = (
-  url: string | amqp.Options.Connect
+  url: string | amqp.Options.Connect,
+  captureVhostName: boolean
 ): Attributes => {
   const attributes: Attributes = {
     [ATTR_MESSAGING_PROTOCOL_VERSION]: '0.9.1', // this is the only protocol supported by the instrumented library
@@ -162,6 +180,21 @@ export const getConnectionAttributesFromUrl = (
       attributes,
       extractConnectionAttributeOrLog(url, ATTR_SERVER_PORT, port, 'port')
     );
+
+    if (captureVhostName) {
+      // Experimental — not yet in @opentelemetry/semantic-conventions, see
+      // ATTR_MESSAGING_RABBITMQ_VHOST_NAME's doc comment in ./semconv.
+      const vhost = getVhost(connectOptions?.vhost);
+      Object.assign(
+        attributes,
+        extractConnectionAttributeOrLog(
+          url,
+          ATTR_MESSAGING_RABBITMQ_VHOST_NAME,
+          vhost,
+          'vhost'
+        )
+      );
+    }
   } else {
     const censoredUrl = censorPassword(url);
     attributes[ATTR_MESSAGING_URL] = censoredUrl;
@@ -201,6 +234,24 @@ export const getConnectionAttributesFromUrl = (
           'port'
         )
       );
+
+      if (captureVhostName) {
+        // Experimental — not yet in @opentelemetry/semantic-conventions, see
+        // ATTR_MESSAGING_RABBITMQ_VHOST_NAME's doc comment in ./semconv.
+        // Mirrors amqplib's own lib/connect.js: parts.pathname.substr(1).
+        const vhost = getVhost(
+          urlParts.pathname ? urlParts.pathname.substring(1) : null
+        );
+        Object.assign(
+          attributes,
+          extractConnectionAttributeOrLog(
+            censoredUrl,
+            ATTR_MESSAGING_RABBITMQ_VHOST_NAME,
+            vhost,
+            'vhost'
+          )
+        );
+      }
     } catch (err) {
       diag.error(
         'amqplib instrumentation: error while extracting connection details from connection url',

--- a/packages/instrumentation-amqplib/test/utils.test.ts
+++ b/packages/instrumentation-amqplib/test/utils.test.ts
@@ -12,7 +12,11 @@ import {
   ATTR_SERVER_ADDRESS,
   ATTR_SERVER_PORT,
 } from '@opentelemetry/semantic-conventions';
-import { ATTR_MESSAGING_SYSTEM } from '../src/semconv';
+import {
+  ATTR_MESSAGING_SYSTEM,
+  ATTR_MESSAGING_RABBITMQ_CLUSTER_NAME,
+  ATTR_MESSAGING_RABBITMQ_VHOST_NAME,
+} from '../src/semconv';
 import {
   ATTR_MESSAGING_PROTOCOL,
   ATTR_MESSAGING_PROTOCOL_VERSION,
@@ -39,17 +43,58 @@ describe('utils', () => {
     });
 
     it('messaging system attribute', () => {
-      const attributes = getConnectionAttributesFromServer(conn.connection);
-      expect(attributes).toStrictEqual({
-        [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
-      });
+      const attributes = getConnectionAttributesFromServer(
+        conn.connection,
+        false
+      );
+      // cluster_name is broker-reported (real RabbitMQ servers include it in
+      // server_properties, but this isn't guaranteed for every AMQP 0.9.1
+      // broker), so only messaging.system is asserted strictly here.
+      expect(attributes[ATTR_MESSAGING_SYSTEM]).toEqual('rabbitmq');
+    });
+  });
+
+  // Deliberately a sibling of getConnectionAttributesFromServer, not nested inside it -
+  // that describe block's `before` hook calls `this.skip()` (skipping the whole block,
+  // nested describes included) when no live broker is configured. These tests use a fake
+  // connection object and don't need one.
+  describe('getConnectionAttributesFromServer - captureClusterName', () => {
+    const fakeConn = {
+      serverProperties: {
+        product: 'RabbitMQ',
+        cluster_name: 'rabbit@localhost',
+      },
+    } as unknown as amqp.Connection;
+
+    it('is omitted by default (captureClusterName: false)', () => {
+      const attributes = getConnectionAttributesFromServer(fakeConn, false);
+      expect(attributes[ATTR_MESSAGING_RABBITMQ_CLUSTER_NAME]).toBeUndefined();
+    });
+
+    it('is included when captureClusterName: true', () => {
+      const attributes = getConnectionAttributesFromServer(fakeConn, true);
+      expect(attributes[ATTR_MESSAGING_RABBITMQ_CLUSTER_NAME]).toEqual(
+        'rabbit@localhost'
+      );
+    });
+
+    it('is omitted when captureClusterName: true but broker did not report one', () => {
+      const noClusterNameConn = {
+        serverProperties: { product: 'RabbitMQ' },
+      } as unknown as amqp.Connection;
+      const attributes = getConnectionAttributesFromServer(
+        noClusterNameConn,
+        true
+      );
+      expect(attributes[ATTR_MESSAGING_RABBITMQ_CLUSTER_NAME]).toBeUndefined();
     });
   });
 
   describe('getConnectionAttributesFromUrl', () => {
     it('all features', () => {
       const attributes = getConnectionAttributesFromUrl(
-        'amqp://user:pass@host:10000/vhost'
+        'amqp://user:pass@host:10000/vhost',
+        true
       );
       expect(attributes).toStrictEqual({
         [ATTR_MESSAGING_PROTOCOL]: 'AMQP',
@@ -57,12 +102,14 @@ describe('utils', () => {
         [ATTR_SERVER_ADDRESS]: 'host',
         [ATTR_SERVER_PORT]: 10000,
         [ATTR_MESSAGING_URL]: 'amqp://user:***@host:10000/vhost',
+        [ATTR_MESSAGING_RABBITMQ_VHOST_NAME]: 'vhost',
       });
     });
 
     it('all features encoded', () => {
       const attributes = getConnectionAttributesFromUrl(
-        'amqp://user%61:%61pass@ho%61st:10000/v%2fhost'
+        'amqp://user%61:%61pass@ho%61st:10000/v%2fhost',
+        true
       );
       expect(attributes).toStrictEqual({
         [ATTR_MESSAGING_PROTOCOL]: 'AMQP',
@@ -70,22 +117,24 @@ describe('utils', () => {
         [ATTR_SERVER_ADDRESS]: 'ho%61st',
         [ATTR_SERVER_PORT]: 10000,
         [ATTR_MESSAGING_URL]: 'amqp://user%61:***@ho%61st:10000/v%2fhost',
+        [ATTR_MESSAGING_RABBITMQ_VHOST_NAME]: 'v/host',
       });
     });
 
     it('only protocol', () => {
-      const attributes = getConnectionAttributesFromUrl('amqp://');
+      const attributes = getConnectionAttributesFromUrl('amqp://', true);
       expect(attributes).toStrictEqual({
         [ATTR_MESSAGING_PROTOCOL]: 'AMQP',
         [ATTR_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
         [ATTR_SERVER_ADDRESS]: 'localhost',
         [ATTR_SERVER_PORT]: 5672,
         [ATTR_MESSAGING_URL]: 'amqp://',
+        [ATTR_MESSAGING_RABBITMQ_VHOST_NAME]: '/',
       });
     });
 
     it('empty username and password', () => {
-      const attributes = getConnectionAttributesFromUrl('amqp://:@/');
+      const attributes = getConnectionAttributesFromUrl('amqp://:@/', true);
       expect(attributes).toStrictEqual({
         [ATTR_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
         [ATTR_MESSAGING_URL]: 'amqp://:***@/',
@@ -93,7 +142,10 @@ describe('utils', () => {
     });
 
     it('username and no password', () => {
-      const attributes = getConnectionAttributesFromUrl('amqp://user@');
+      const attributes = getConnectionAttributesFromUrl(
+        'amqp://user@',
+        true
+      );
       expect(attributes).toStrictEqual({
         [ATTR_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
         [ATTR_MESSAGING_URL]: 'amqp://user@',
@@ -101,7 +153,10 @@ describe('utils', () => {
     });
 
     it('username and password, no host', () => {
-      const attributes = getConnectionAttributesFromUrl('amqp://user:pass@');
+      const attributes = getConnectionAttributesFromUrl(
+        'amqp://user:pass@',
+        true
+      );
       expect(attributes).toStrictEqual({
         [ATTR_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
         [ATTR_MESSAGING_URL]: 'amqp://user:***@',
@@ -109,77 +164,153 @@ describe('utils', () => {
     });
 
     it('host only', () => {
-      const attributes = getConnectionAttributesFromUrl('amqp://host');
+      const attributes = getConnectionAttributesFromUrl('amqp://host', true);
       expect(attributes).toStrictEqual({
         [ATTR_MESSAGING_PROTOCOL]: 'AMQP',
         [ATTR_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
         [ATTR_SERVER_ADDRESS]: 'host',
         [ATTR_SERVER_PORT]: 5672,
         [ATTR_MESSAGING_URL]: 'amqp://host',
+        [ATTR_MESSAGING_RABBITMQ_VHOST_NAME]: '/',
       });
     });
 
     it('vhost only', () => {
-      const attributes = getConnectionAttributesFromUrl('amqp:///vhost');
+      const attributes = getConnectionAttributesFromUrl(
+        'amqp:///vhost',
+        true
+      );
       expect(attributes).toStrictEqual({
         [ATTR_MESSAGING_PROTOCOL]: 'AMQP',
         [ATTR_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
         [ATTR_SERVER_ADDRESS]: 'localhost',
         [ATTR_SERVER_PORT]: 5672,
         [ATTR_MESSAGING_URL]: 'amqp:///vhost',
+        [ATTR_MESSAGING_RABBITMQ_VHOST_NAME]: 'vhost',
       });
     });
 
     it('host only, trailing slash', () => {
-      const attributes = getConnectionAttributesFromUrl('amqp://host/');
+      const attributes = getConnectionAttributesFromUrl('amqp://host/', true);
       expect(attributes).toStrictEqual({
         [ATTR_MESSAGING_PROTOCOL]: 'AMQP',
         [ATTR_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
         [ATTR_SERVER_ADDRESS]: 'host',
         [ATTR_SERVER_PORT]: 5672,
         [ATTR_MESSAGING_URL]: 'amqp://host/',
+        [ATTR_MESSAGING_RABBITMQ_VHOST_NAME]: '/',
       });
     });
 
     it('vhost encoded', () => {
-      const attributes = getConnectionAttributesFromUrl('amqp://host/%2f');
+      const attributes = getConnectionAttributesFromUrl(
+        'amqp://host/%2f',
+        true
+      );
       expect(attributes).toStrictEqual({
         [ATTR_MESSAGING_PROTOCOL]: 'AMQP',
         [ATTR_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
         [ATTR_SERVER_ADDRESS]: 'host',
         [ATTR_SERVER_PORT]: 5672,
         [ATTR_MESSAGING_URL]: 'amqp://host/%2f',
+        [ATTR_MESSAGING_RABBITMQ_VHOST_NAME]: '/',
       });
     });
 
     it('IPv6 host', () => {
-      const attributes = getConnectionAttributesFromUrl('amqp://[::1]');
+      const attributes = getConnectionAttributesFromUrl('amqp://[::1]', true);
       expect(attributes).toStrictEqual({
         [ATTR_MESSAGING_PROTOCOL]: 'AMQP',
         [ATTR_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
         [ATTR_SERVER_ADDRESS]: '[::1]',
         [ATTR_SERVER_PORT]: 5672,
         [ATTR_MESSAGING_URL]: 'amqp://[::1]',
+        [ATTR_MESSAGING_RABBITMQ_VHOST_NAME]: '/',
       });
     });
 
     describe('semconv stability', () => {
       it('emits server.* attributes', () => {
         const attributes = getConnectionAttributesFromUrl(
-          'amqp://user:pass@host:10000/vhost'
+          'amqp://user:pass@host:10000/vhost',
+          true
         );
         expect(attributes[ATTR_SERVER_ADDRESS]).toEqual('host');
         expect(attributes[ATTR_SERVER_PORT]).toEqual(10000);
       });
 
       it('emits server.* attributes with url object', () => {
-        const attributes = getConnectionAttributesFromUrl({
-          protocol: 'amqp',
-          hostname: 'testhost',
-          port: 5673,
-        });
+        const attributes = getConnectionAttributesFromUrl(
+          {
+            protocol: 'amqp',
+            hostname: 'testhost',
+            port: 5673,
+          },
+          true
+        );
         expect(attributes[ATTR_SERVER_ADDRESS]).toEqual('testhost');
         expect(attributes[ATTR_SERVER_PORT]).toEqual(5673);
+      });
+    });
+
+    describe('vhost', () => {
+      it('defaults to / when not specified on a url object', () => {
+        const attributes = getConnectionAttributesFromUrl(
+          {
+            hostname: 'testhost',
+          },
+          true
+        );
+        expect(attributes[ATTR_MESSAGING_RABBITMQ_VHOST_NAME]).toEqual('/');
+      });
+
+      it('reads vhost from a url object', () => {
+        const attributes = getConnectionAttributesFromUrl(
+          {
+            hostname: 'testhost',
+            vhost: 'my-vhost',
+          },
+          true
+        );
+        expect(attributes[ATTR_MESSAGING_RABBITMQ_VHOST_NAME]).toEqual(
+          'my-vhost'
+        );
+      });
+
+      it('percent-decodes vhost from a url object', () => {
+        const attributes = getConnectionAttributesFromUrl(
+          {
+            hostname: 'testhost',
+            vhost: '%2f',
+          },
+          true
+        );
+        expect(attributes[ATTR_MESSAGING_RABBITMQ_VHOST_NAME]).toEqual('/');
+      });
+    });
+
+    describe('captureVhostName', () => {
+      it('is omitted by default (captureVhostName: false) - string url', () => {
+        const attributes = getConnectionAttributesFromUrl(
+          'amqp://host/vhost',
+          false
+        );
+        expect(
+          attributes[ATTR_MESSAGING_RABBITMQ_VHOST_NAME]
+        ).toBeUndefined();
+        // unrelated attributes are unaffected
+        expect(attributes[ATTR_SERVER_ADDRESS]).toEqual('host');
+      });
+
+      it('is omitted by default (captureVhostName: false) - url object', () => {
+        const attributes = getConnectionAttributesFromUrl(
+          { hostname: 'host', vhost: 'vhost' },
+          false
+        );
+        expect(
+          attributes[ATTR_MESSAGING_RABBITMQ_VHOST_NAME]
+        ).toBeUndefined();
+        expect(attributes[ATTR_SERVER_ADDRESS]).toEqual('host');
       });
     });
   });


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->
Fixed #3678 
## Which problem is this PR solving?
Without messaging.rabbitmq.cluster.name/messaging.rabbitmq.vhost.name, there's no way to
tell which RabbitMQ vhost or cluster a message was published to/consumed from. This matters for
anyone running multiple vhosts on a shared broker (multi-tenant) or multiple clusters


## Short description of the changes

- Added two boolean constructor config options, both `false` by default:
  `captureVhostName` (gates `messaging.rabbitmq.vhost.name`) and `captureClusterName` (gates
  `messaging.rabbitmq.cluster.name`) — matching this repo's existing convention for optional
  attributes (e.g. `instrumentation-graphql`'s `allowValues`),
