### PR TITLE
feat(instrumentation-amqplib): add RabbitMQ vhost and cluster name span attributes

### DIFF
--- a/packages/instrumentation-amqplib/README.md
+++ b/packages/instrumentation-amqplib/README.md
@@ -94,20 +94,22 @@ This instrumentation uses Semantic Conventions for messaging spans. The `instrum
 
 Attributes collected:
 
-| Attribute                        | Short Description                                                      |
-| -------------------------------- | ---------------------------------------------------------------------- |
-| `messaging.destination`          | The message destination name.                                          |
-| `messaging.destination_kind`     | The kind of message destination.                                       |
-| `messaging.rabbitmq.routing_key` | RabbitMQ message routing key.                                          |
-| `messaging.operation`            | A string identifying the kind of message consumption.                  |
-| `messaging.message_id`           | A value used by the messaging system as an identifier for the message. |
-| `messaging.conversation_id`      | The ID identifying the conversation to which the message belongs.      |
-| `messaging.protocol`             | The name of the transport protocol.                                    |
-| `messaging.protocol_version`     | The version of the transport protocol.                                 |
-| `messaging.system`               | A string identifying the messaging system.                             |
-| `messaging.url`                  | The connection string.                                                 |
-| `server.address`                 | Remote hostname.                                                       |
-| `server.port`                    | Remote port number.                                                    |
+| Attribute                         | Short Description                                                      |
+| --------------------------------- | ---------------------------------------------------------------------- |
+| `messaging.destination`           | The message destination name.                                          |
+| `messaging.destination_kind`      | The kind of message destination.                                       |
+| `messaging.rabbitmq.routing_key`  | RabbitMQ message routing key.                                          |
+| `messaging.operation`             | A string identifying the kind of message consumption.                  |
+| `messaging.message_id`            | A value used by the messaging system as an identifier for the message. |
+| `messaging.conversation_id`       | The ID identifying the conversation to which the message belongs.      |
+| `messaging.protocol`              | The name of the transport protocol.                                    |
+| `messaging.protocol_version`      | The version of the transport protocol.                                 |
+| `messaging.system`                | A string identifying the messaging system.                             |
+| `messaging.rabbitmq.vhost.name`   | The name of the RabbitMQ virtual host the connection is bound to.      |
+| `messaging.rabbitmq.cluster.name` | The name of the RabbitMQ cluster, as reported by the broker.           |
+| `messaging.url`                   | The connection string.                                                 |
+| `server.address`                  | Remote hostname.                                                       |
+| `server.port`                     | Remote port number.                                                    |
 
 ## Useful links
 

--- a/packages/instrumentation-amqplib/src/semconv.ts
+++ b/packages/instrumentation-amqplib/src/semconv.ts
@@ -30,3 +30,25 @@ export const ATTR_MESSAGING_OPERATION = 'messaging.operation' as const;
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_MESSAGING_SYSTEM = 'messaging.system' as const;
+
+/**
+ * The name of the RabbitMQ virtual host the connection is bound to.
+ *
+ * @example /
+ * @example tenant-a
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_MESSAGING_RABBITMQ_VHOST_NAME =
+  'messaging.rabbitmq.vhost.name' as const;
+
+/**
+ * The name of the RabbitMQ cluster the connection is established with, as
+ * reported by the broker in the `cluster_name` server property.
+ *
+ * @example rabbit@my-broker
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_MESSAGING_RABBITMQ_CLUSTER_NAME =
+  'messaging.rabbitmq.cluster.name' as const;

--- a/packages/instrumentation-amqplib/src/utils.ts
+++ b/packages/instrumentation-amqplib/src/utils.ts
@@ -15,12 +15,17 @@ import {
   ATTR_SERVER_ADDRESS,
   ATTR_SERVER_PORT,
 } from '@opentelemetry/semantic-conventions';
-import { ATTR_MESSAGING_SYSTEM } from './semconv';
+import {
+  ATTR_MESSAGING_RABBITMQ_CLUSTER_NAME,
+  ATTR_MESSAGING_RABBITMQ_VHOST_NAME,
+  ATTR_MESSAGING_SYSTEM,
+} from './semconv';
 import {
   ATTR_MESSAGING_PROTOCOL,
   ATTR_MESSAGING_PROTOCOL_VERSION,
   ATTR_MESSAGING_URL,
 } from '../src/semconv-obsolete';
+import { unescape as unescapeUriComponent } from 'querystring';
 import type * as amqp from 'amqplib';
 
 export const MESSAGE_STORED_SPAN: unique symbol = Symbol(
@@ -88,6 +93,21 @@ const getProtocol = (protocolFromUrl: string | undefined): string => {
   return noEndingColon.toUpperCase();
 };
 
+// amqplib falls back to the '/' vhost when the user did not supply one
+const DEFAULT_VHOST = '/';
+
+const getVhostFromOptions = (vhostFromOptions: string | undefined): string => {
+  return vhostFromOptions || DEFAULT_VHOST;
+};
+
+const getVhostFromUrlPath = (pathFromUrl: string | undefined): string => {
+  // this code mimics the behavior of amqplib, which takes the url path
+  // without its leading '/' and unescapes it, so that a vhost named '/' can
+  // be expressed as the '%2f' path
+  const vhost = pathFromUrl ? pathFromUrl.substring(1) : '';
+  return vhost ? unescapeUriComponent(vhost) : DEFAULT_VHOST;
+};
+
 const getHostname = (hostnameFromUrl: string | undefined): string => {
   // if user supplies empty hostname, it gets forwarded to 'net' package which default it to localhost.
   // https://nodejs.org/docs/latest-v12.x/api/net.html#net_socket_connect_options_connectlistener
@@ -116,14 +136,20 @@ const extractConnectionAttributeOrLog = (
 export const getConnectionAttributesFromServer = (
   conn: amqp.Connection
 ): Attributes => {
+  const attributes: Attributes = {};
+
   const product = conn.serverProperties.product?.toLowerCase?.();
   if (product) {
-    return {
-      [ATTR_MESSAGING_SYSTEM]: product,
-    };
-  } else {
-    return {};
+    attributes[ATTR_MESSAGING_SYSTEM] = product;
   }
+
+  // only RabbitMQ brokers report a cluster name in the connection handshake
+  const clusterName = conn.serverProperties['cluster_name'];
+  if (clusterName) {
+    attributes[ATTR_MESSAGING_RABBITMQ_CLUSTER_NAME] = clusterName;
+  }
+
+  return attributes;
 };
 
 export const getConnectionAttributesFromUrl = (
@@ -161,6 +187,10 @@ export const getConnectionAttributesFromUrl = (
     Object.assign(
       attributes,
       extractConnectionAttributeOrLog(url, ATTR_SERVER_PORT, port, 'port')
+    );
+
+    attributes[ATTR_MESSAGING_RABBITMQ_VHOST_NAME] = getVhostFromOptions(
+      connectOptions?.vhost
     );
   } else {
     const censoredUrl = censorPassword(url);
@@ -200,6 +230,10 @@ export const getConnectionAttributesFromUrl = (
           port,
           'port'
         )
+      );
+
+      attributes[ATTR_MESSAGING_RABBITMQ_VHOST_NAME] = getVhostFromUrlPath(
+        urlParts.pathname
       );
     } catch (err) {
       diag.error(

--- a/packages/instrumentation-amqplib/src/utils.ts
+++ b/packages/instrumentation-amqplib/src/utils.ts
@@ -96,14 +96,12 @@ const getProtocol = (protocolFromUrl: string | undefined): string => {
 // amqplib falls back to the '/' vhost when the user did not supply one
 const DEFAULT_VHOST = '/';
 
-const getVhostFromOptions = (vhostFromOptions: string | undefined): string => {
-  return vhostFromOptions || DEFAULT_VHOST;
-};
-
 const getVhostFromUrlPath = (pathFromUrl: string | undefined): string => {
   // this code mimics the behavior of amqplib, which takes the url path
   // without its leading '/' and unescapes it, so that a vhost named '/' can
-  // be expressed as the '%2f' path
+  // be expressed as the '%2f' path. amqplib uses querystring.unescape here,
+  // which returns malformed percent sequences as-is instead of throwing the
+  // way decodeURIComponent does
   const vhost = pathFromUrl ? pathFromUrl.substring(1) : '';
   return vhost ? unescapeUriComponent(vhost) : DEFAULT_VHOST;
 };
@@ -189,9 +187,8 @@ export const getConnectionAttributesFromUrl = (
       extractConnectionAttributeOrLog(url, ATTR_SERVER_PORT, port, 'port')
     );
 
-    attributes[ATTR_MESSAGING_RABBITMQ_VHOST_NAME] = getVhostFromOptions(
-      connectOptions?.vhost
-    );
+    attributes[ATTR_MESSAGING_RABBITMQ_VHOST_NAME] =
+      connectOptions?.vhost || DEFAULT_VHOST;
   } else {
     const censoredUrl = censorPassword(url);
     attributes[ATTR_MESSAGING_URL] = censoredUrl;

--- a/packages/instrumentation-amqplib/test/amqplib-connection.test.ts
+++ b/packages/instrumentation-amqplib/test/amqplib-connection.test.ts
@@ -21,7 +21,11 @@ import {
 
 registerInstrumentationTesting(new AmqplibInstrumentation());
 import * as amqp from 'amqplib';
-import { ATTR_MESSAGING_SYSTEM } from '../src/semconv';
+import {
+  ATTR_MESSAGING_RABBITMQ_CLUSTER_NAME,
+  ATTR_MESSAGING_RABBITMQ_VHOST_NAME,
+  ATTR_MESSAGING_SYSTEM,
+} from '../src/semconv';
 import {
   ATTR_SERVER_ADDRESS,
   ATTR_SERVER_PORT,
@@ -155,6 +159,57 @@ describe('amqplib instrumentation connection', () => {
         expect(publishSpan.attributes[ATTR_SERVER_PORT]).toEqual(
           TEST_RABBITMQ_PORT
         );
+      } finally {
+        await conn.close();
+      }
+    });
+  });
+
+  describe('rabbitmq vhost and cluster attributes', () => {
+    it('should set the vhost and cluster name on the span when connecting with a url object', async function () {
+      const testName = this.test!.title;
+      const conn = await amqp.connect({
+        protocol: 'amqp',
+        username: TEST_RABBITMQ_USER,
+        password: TEST_RABBITMQ_PASS,
+        hostname: TEST_RABBITMQ_HOST,
+        port: TEST_RABBITMQ_PORT,
+      });
+
+      try {
+        const channel = await conn.createChannel();
+        channel.sendToQueue(
+          testName,
+          Buffer.from('message created only to test connection attributes')
+        );
+        const [publishSpan] = getTestSpans();
+
+        expect(
+          publishSpan.attributes[ATTR_MESSAGING_RABBITMQ_VHOST_NAME]
+        ).toEqual('/');
+        expect(
+          publishSpan.attributes[ATTR_MESSAGING_RABBITMQ_CLUSTER_NAME]
+        ).toEqual(conn.connection.serverProperties.cluster_name);
+      } finally {
+        await conn.close();
+      }
+    });
+
+    it('should set the vhost on the span when connecting with a url string', async function () {
+      const testName = this.test!.title;
+      const conn = await amqp.connect(rabbitMqUrl);
+
+      try {
+        const channel = await conn.createChannel();
+        channel.sendToQueue(
+          testName,
+          Buffer.from('message created only to test connection attributes')
+        );
+        const [publishSpan] = getTestSpans();
+
+        expect(
+          publishSpan.attributes[ATTR_MESSAGING_RABBITMQ_VHOST_NAME]
+        ).toEqual('/');
       } finally {
         await conn.close();
       }

--- a/packages/instrumentation-amqplib/test/amqplib-connection.test.ts
+++ b/packages/instrumentation-amqplib/test/amqplib-connection.test.ts
@@ -187,9 +187,10 @@ describe('amqplib instrumentation connection', () => {
         expect(
           publishSpan.attributes[ATTR_MESSAGING_RABBITMQ_VHOST_NAME]
         ).toEqual('/');
-        expect(
-          publishSpan.attributes[ATTR_MESSAGING_RABBITMQ_CLUSTER_NAME]
-        ).toEqual(conn.connection.serverProperties.cluster_name);
+        const clusterName =
+          publishSpan.attributes[ATTR_MESSAGING_RABBITMQ_CLUSTER_NAME];
+        expect(typeof clusterName).toEqual('string');
+        expect(clusterName).not.toEqual('');
       } finally {
         await conn.close();
       }

--- a/packages/instrumentation-amqplib/test/utils.test.ts
+++ b/packages/instrumentation-amqplib/test/utils.test.ts
@@ -12,7 +12,11 @@ import {
   ATTR_SERVER_ADDRESS,
   ATTR_SERVER_PORT,
 } from '@opentelemetry/semantic-conventions';
-import { ATTR_MESSAGING_SYSTEM } from '../src/semconv';
+import {
+  ATTR_MESSAGING_RABBITMQ_CLUSTER_NAME,
+  ATTR_MESSAGING_RABBITMQ_VHOST_NAME,
+  ATTR_MESSAGING_SYSTEM,
+} from '../src/semconv';
 import {
   ATTR_MESSAGING_PROTOCOL,
   ATTR_MESSAGING_PROTOCOL_VERSION,
@@ -40,6 +44,20 @@ describe('utils', () => {
 
     it('messaging system attribute', () => {
       const attributes = getConnectionAttributesFromServer(conn.connection);
+      expect(attributes[ATTR_MESSAGING_SYSTEM]).toStrictEqual('rabbitmq');
+    });
+
+    it('cluster name attribute', () => {
+      const attributes = getConnectionAttributesFromServer(conn.connection);
+      expect(attributes[ATTR_MESSAGING_RABBITMQ_CLUSTER_NAME]).toStrictEqual(
+        conn.connection.serverProperties.cluster_name
+      );
+    });
+
+    it('cluster name attribute is omitted when the server does not report one', () => {
+      const attributes = getConnectionAttributesFromServer({
+        serverProperties: { product: 'RabbitMQ' },
+      } as unknown as amqp.Connection);
       expect(attributes).toStrictEqual({
         [ATTR_MESSAGING_SYSTEM]: 'rabbitmq',
       });
@@ -56,6 +74,7 @@ describe('utils', () => {
         [ATTR_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
         [ATTR_SERVER_ADDRESS]: 'host',
         [ATTR_SERVER_PORT]: 10000,
+        [ATTR_MESSAGING_RABBITMQ_VHOST_NAME]: 'vhost',
         [ATTR_MESSAGING_URL]: 'amqp://user:***@host:10000/vhost',
       });
     });
@@ -69,6 +88,7 @@ describe('utils', () => {
         [ATTR_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
         [ATTR_SERVER_ADDRESS]: 'ho%61st',
         [ATTR_SERVER_PORT]: 10000,
+        [ATTR_MESSAGING_RABBITMQ_VHOST_NAME]: 'v/host',
         [ATTR_MESSAGING_URL]: 'amqp://user%61:***@ho%61st:10000/v%2fhost',
       });
     });
@@ -80,6 +100,7 @@ describe('utils', () => {
         [ATTR_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
         [ATTR_SERVER_ADDRESS]: 'localhost',
         [ATTR_SERVER_PORT]: 5672,
+        [ATTR_MESSAGING_RABBITMQ_VHOST_NAME]: '/',
         [ATTR_MESSAGING_URL]: 'amqp://',
       });
     });
@@ -115,6 +136,7 @@ describe('utils', () => {
         [ATTR_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
         [ATTR_SERVER_ADDRESS]: 'host',
         [ATTR_SERVER_PORT]: 5672,
+        [ATTR_MESSAGING_RABBITMQ_VHOST_NAME]: '/',
         [ATTR_MESSAGING_URL]: 'amqp://host',
       });
     });
@@ -126,6 +148,7 @@ describe('utils', () => {
         [ATTR_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
         [ATTR_SERVER_ADDRESS]: 'localhost',
         [ATTR_SERVER_PORT]: 5672,
+        [ATTR_MESSAGING_RABBITMQ_VHOST_NAME]: 'vhost',
         [ATTR_MESSAGING_URL]: 'amqp:///vhost',
       });
     });
@@ -137,6 +160,7 @@ describe('utils', () => {
         [ATTR_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
         [ATTR_SERVER_ADDRESS]: 'host',
         [ATTR_SERVER_PORT]: 5672,
+        [ATTR_MESSAGING_RABBITMQ_VHOST_NAME]: '/',
         [ATTR_MESSAGING_URL]: 'amqp://host/',
       });
     });
@@ -148,6 +172,7 @@ describe('utils', () => {
         [ATTR_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
         [ATTR_SERVER_ADDRESS]: 'host',
         [ATTR_SERVER_PORT]: 5672,
+        [ATTR_MESSAGING_RABBITMQ_VHOST_NAME]: '/',
         [ATTR_MESSAGING_URL]: 'amqp://host/%2f',
       });
     });
@@ -159,7 +184,50 @@ describe('utils', () => {
         [ATTR_MESSAGING_PROTOCOL_VERSION]: '0.9.1',
         [ATTR_SERVER_ADDRESS]: '[::1]',
         [ATTR_SERVER_PORT]: 5672,
+        [ATTR_MESSAGING_RABBITMQ_VHOST_NAME]: '/',
         [ATTR_MESSAGING_URL]: 'amqp://[::1]',
+      });
+    });
+
+    describe('vhost', () => {
+      it('uses the vhost from the url options object', () => {
+        const attributes = getConnectionAttributesFromUrl({
+          protocol: 'amqp',
+          hostname: 'host',
+          port: 5672,
+          vhost: 'tenant-a',
+        });
+        expect(attributes[ATTR_MESSAGING_RABBITMQ_VHOST_NAME]).toEqual(
+          'tenant-a'
+        );
+      });
+
+      it('defaults to "/" when the url options object has no vhost', () => {
+        const attributes = getConnectionAttributesFromUrl({
+          protocol: 'amqp',
+          hostname: 'host',
+          port: 5672,
+        });
+        expect(attributes[ATTR_MESSAGING_RABBITMQ_VHOST_NAME]).toEqual('/');
+      });
+
+      it('defaults to "/" when the url options object has an empty vhost', () => {
+        const attributes = getConnectionAttributesFromUrl({
+          protocol: 'amqp',
+          hostname: 'host',
+          port: 5672,
+          vhost: '',
+        });
+        expect(attributes[ATTR_MESSAGING_RABBITMQ_VHOST_NAME]).toEqual('/');
+      });
+
+      it('reads the vhost from a url string with credentials', () => {
+        const attributes = getConnectionAttributesFromUrl(
+          'amqp://user:pass@host:5672/tenant-a'
+        );
+        expect(attributes[ATTR_MESSAGING_RABBITMQ_VHOST_NAME]).toEqual(
+          'tenant-a'
+        );
       });
     });
 

--- a/packages/instrumentation-amqplib/test/utils.test.ts
+++ b/packages/instrumentation-amqplib/test/utils.test.ts
@@ -49,9 +49,9 @@ describe('utils', () => {
 
     it('cluster name attribute', () => {
       const attributes = getConnectionAttributesFromServer(conn.connection);
-      expect(attributes[ATTR_MESSAGING_RABBITMQ_CLUSTER_NAME]).toStrictEqual(
-        conn.connection.serverProperties.cluster_name
-      );
+      const clusterName = attributes[ATTR_MESSAGING_RABBITMQ_CLUSTER_NAME];
+      expect(typeof clusterName).toStrictEqual('string');
+      expect(clusterName).not.toStrictEqual('');
     });
 
     it('cluster name attribute is omitted when the server does not report one', () => {


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #3678

and `server.port`. Two consequences:

- Messages published to different RabbitMQ virtual hosts on the same broker are
  indistinguishable — same address, same port, same destination name. Anyone running
  multiple vhosts on a shared broker (multi-tenant) can't separate them in traces.
- There is no way to tell one cluster from another, since `server.address` is
  whatever the client dialed (often a load balancer) rather than the broker's identity.

## Short description of the changes

Adds two connection attributes, both from data already present on the connection at
patch time:

- `messaging.rabbitmq.vhost.name` — from `connectOptions.vhost`, or the url path
  component. Resolved the way amqplib itself resolves it: unescaped (so `%2f` becomes
  `/`) and defaulting to `/` when absent.
- `messaging.rabbitmq.cluster.name` — from the `cluster_name` server property, omitted
  when the broker doesn't report one.