### PR TITLE
fix(instrumentation-winston): preserve log trace context

### DIFF
--- a/packages/instrumentation-winston/README.md
+++ b/packages/instrumentation-winston/README.md
@@ -66,6 +66,12 @@ logger.info('foobar');
 
 Winston Logger will automatically send log records to the OpenTelemetry Logs SDK if not explicitly disabled in config and @opentelemetry/winston-transport npm package is installed in the project. The OpenTelemetry SDK can be configured to handle those records, for example, sending them on to an OpenTelemetry collector for log archiving and processing. The example above shows a minimal configuration that emits OpenTelemetry log records to the console for debugging.
 
+When a Winston log call is made in an active span, the instrumentation preserves
+that context for log sending even if Winston processes the transport
+asynchronously. The OpenTelemetry LogRecord uses its native trace context fields;
+the `trace_id`, `span_id`, and `trace_flags` fields added for log correlation are
+not duplicated as LogRecord attributes.
+
 If the OpenTelemetry SDK is not configured with a Logger provider, then this will be a no-op.
 
 Log sending can be disabled with the `disableLogSending: true` option. Log sending is only available for Winston version 3 and later.

--- a/packages/instrumentation-winston/src/instrumentation.ts
+++ b/packages/instrumentation-winston/src/instrumentation.ts
@@ -25,6 +25,9 @@ import { PACKAGE_NAME, PACKAGE_VERSION } from './version';
 
 const winston3Versions = ['>=3 <4'];
 const winstonPre3Versions = ['>=1 <3'];
+const OTEL_CONTEXT_SYMBOL = Symbol.for(
+  'opentelemetry.js.contrib.winston.context'
+);
 
 export class WinstonInstrumentation extends InstrumentationBase<WinstonInstrumentationConfig> {
   constructor(config: WinstonInstrumentationConfig = {}) {
@@ -128,6 +131,7 @@ export class WinstonInstrumentation extends InstrumentationBase<WinstonInstrumen
         ...args: Parameters<typeof original>
       ) {
         const record = args[0];
+        record[OTEL_CONTEXT_SYMBOL] = context.active();
         instrumentation._handleLogCorrelation(record);
         return original.apply(this, args);
       };

--- a/packages/instrumentation-winston/test/winston.test.ts
+++ b/packages/instrumentation-winston/test/winston.test.ts
@@ -143,12 +143,12 @@ describe('WinstonInstrumentation', () => {
     const logRecords = memoryLogExporter.getFinishedLogRecords();
     assert.strictEqual(logRecords.length, 1);
     const { traceId, spanId, traceFlags } = span.spanContext();
-    assert.strictEqual(logRecords[0]['attributes']['trace_id'], traceId);
-    assert.strictEqual(logRecords[0]['attributes']['span_id'], spanId);
-    assert.strictEqual(
-      logRecords[0]['attributes']['trace_flags'],
-      `0${traceFlags.toString(16)}`
-    );
+    assert.strictEqual(logRecords[0].spanContext?.traceId, traceId);
+    assert.strictEqual(logRecords[0].spanContext?.spanId, spanId);
+    assert.strictEqual(logRecords[0].spanContext?.traceFlags, traceFlags);
+    assert.strictEqual(logRecords[0].attributes['trace_id'], undefined);
+    assert.strictEqual(logRecords[0].attributes['span_id'], undefined);
+    assert.strictEqual(logRecords[0].attributes['trace_flags'], undefined);
     assert.strictEqual(kMessage, logRecords[0].body, kMessage);
     return logRecords;
   }
@@ -222,6 +222,54 @@ describe('WinstonInstrumentation', () => {
         context.with(trace.setSpan(context.active(), span), () => {
           testEmitLogRecord(span);
         });
+      }
+    });
+
+    it('preserves span context across queued log records', async () => {
+      if (!isWinston2) {
+        const winston = require('winston');
+        class BlockingTransport extends Writable {
+          constructor() {
+            super({ objectMode: true, highWaterMark: 1 });
+          }
+
+          override _write(
+            _chunk: unknown,
+            _encoding: BufferEncoding,
+            callback: (error?: Error | null) => void
+          ) {
+            setImmediate(callback);
+          }
+
+          log(_info: unknown, callback: () => void) {
+            callback();
+          }
+        }
+
+        instrumentation.setConfig({
+          disableLogSending: false,
+        });
+        logger = winston.createLogger({
+          transports: [new BlockingTransport()],
+        });
+
+        logger.info('outside span');
+
+        const span = tracer.startSpan('abc');
+        context.with(trace.setSpan(context.active(), span), () => {
+          logger.info(kMessage);
+        });
+        span.end();
+
+        await new Promise<void>(resolve => setImmediate(resolve));
+
+        const logRecords = memoryLogExporter.getFinishedLogRecords();
+        assert.strictEqual(logRecords.length, 2);
+        assert.strictEqual(logRecords[0].spanContext, undefined);
+        const { traceId, spanId, traceFlags } = span.spanContext();
+        assert.strictEqual(logRecords[1].spanContext?.traceId, traceId);
+        assert.strictEqual(logRecords[1].spanContext?.spanId, spanId);
+        assert.strictEqual(logRecords[1].spanContext?.traceFlags, traceFlags);
       }
     });
 

--- a/packages/winston-transport/src/utils.ts
+++ b/packages/winston-transport/src/utils.ts
@@ -47,6 +47,15 @@ const cliLevels: Record<string, number> = {
   silly: SeverityNumber.TRACE,
 };
 
+const OTEL_CONTEXT_SYMBOL = Symbol.for(
+  'opentelemetry.js.contrib.winston.context'
+);
+const LOG_CORRELATION_FIELDS = new Set([
+  'trace_id',
+  'span_id',
+  'trace_flags',
+]);
+
 function getSeverityNumber(level: string): SeverityNumber | undefined {
   return npmLevels[level] ?? sysLoglevels[level] ?? cliLevels[level];
 }
@@ -317,7 +326,8 @@ export function emitLogRecord(
   for (const key in rest) {
     if (
       Object.prototype.hasOwnProperty.call(rest, key) &&
-      !excludedAttributes.has(key)
+      !excludedAttributes.has(key) &&
+      !LOG_CORRELATION_FIELDS.has(key)
     ) {
       attributes[key] = normalizeAttributeValue(rest[key]);
     }
@@ -336,12 +346,14 @@ export function emitLogRecord(
   }
   const normalizedEventName =
     typeof eventName === 'string' ? eventName : undefined;
+  const context = record[OTEL_CONTEXT_SYMBOL];
 
   const logRecord: LogRecord = {
     severityNumber: getSeverityNumber(levelSym),
     severityText: levelSym,
     body: message,
     attributes: attributes,
+    ...(context ? { context } : {}),
     ...(exceptionPayload ? { exception: exceptionPayload.exception } : {}),
     ...(normalizedEventName !== undefined
       ? { eventName: normalizedEventName }

--- a/packages/winston-transport/src/utils.ts
+++ b/packages/winston-transport/src/utils.ts
@@ -50,11 +50,7 @@ const cliLevels: Record<string, number> = {
 const OTEL_CONTEXT_SYMBOL = Symbol.for(
   'opentelemetry.js.contrib.winston.context'
 );
-const LOG_CORRELATION_FIELDS = new Set([
-  'trace_id',
-  'span_id',
-  'trace_flags',
-]);
+const LOG_CORRELATION_FIELDS = new Set(['trace_id', 'span_id', 'trace_flags']);
 
 function getSeverityNumber(level: string): SeverityNumber | undefined {
   return npmLevels[level] ?? sysLoglevels[level] ?? cliLevels[level];

--- a/packages/winston-transport/test/openTelemetryTransport.test.ts
+++ b/packages/winston-transport/test/openTelemetryTransport.test.ts
@@ -120,6 +120,24 @@ describe('OpenTelemetryTransportV3', () => {
     assert.strictEqual(metadata.error, error);
   });
 
+  it('does not emit log-correlation fields as attributes', () => {
+    const transport = new OpenTelemetryTransportV3();
+    transport.log(
+      {
+        message: kMessage,
+        trace_id: 'trace-id',
+        span_id: 'span-id',
+        trace_flags: '01',
+      },
+      () => {}
+    );
+    const logRecords = memoryLogExporter.getFinishedLogRecords();
+    assert.strictEqual(logRecords.length, 1);
+    assert.strictEqual(logRecords[0].attributes['trace_id'], undefined);
+    assert.strictEqual(logRecords[0].attributes['span_id'], undefined);
+    assert.strictEqual(logRecords[0].attributes['trace_flags'], undefined);
+  });
+
   it('emit LogRecord with exception from err field', () => {
     const transport = new OpenTelemetryTransportV3();
     transport.log({ message: kMessage, err: new Error('boom') }, () => {});


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes #2010.
- Winston can queue a record until after its active OpenTelemetry context has ended or changed, leaving emitted LogRecords without their native trace and span IDs.

## Short description of the changes

- Capture the active context when Winston receives the record and carry it privately to `@opentelemetry/winston-transport`.
- Pass the captured context explicitly to the Logs SDK so asynchronous transport processing preserves the original span relationship.
- Keep `trace_id`, `span_id`, and `trace_flags` on Winston correlation output while excluding them from OpenTelemetry LogRecord attributes.
- Add regression coverage for queued records and correlation-attribute filtering.

## Validation

- Winston instrumentation and transport test suites pass.
- Both packages compile and lint without errors.
- A disposable Application Insights stress test ingested 13 logs and 12 spans with 12 exact trace/span matches, no duplicates, and no leaked correlation attributes.