### PR TITLE
docs(instrumentation-router): document Router 2 support

### DIFF
--- a/packages/instrumentation-router/README.md
+++ b/packages/instrumentation-router/README.md
@@ -17,7 +17,7 @@ npm install --save @opentelemetry/instrumentation-router
 
 ### Supported Versions
 
-- [`router`](https://www.npmjs.com/package/router) versions `>=1.0.0 <2`
+- [`router`](https://www.npmjs.com/package/router) versions `>=1.0.0 <3`
 
 ## Usage
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Router 2.x support was added in #3442, but the instrumentation README still documents the supported range as `>=1.0.0 <2`.

## Short description of the changes

- Update the documented supported range to `>=1.0.0 <3`, matching the implementation and test matrix.