### PR TITLE
feat(instrumentation-aws-sdk): inject the AWS trace header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36712,6 +36712,7 @@
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/instrumentation": "^0.221.0",
+        "@opentelemetry/propagator-aws-xray": "^2.0.1",
         "@opentelemetry/semantic-conventions": "^1.34.0"
       },
       "devDependencies": {

--- a/packages/instrumentation-aws-sdk/package.json
+++ b/packages/instrumentation-aws-sdk/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@opentelemetry/core": "^2.0.0",
     "@opentelemetry/instrumentation": "^0.221.0",
+    "@opentelemetry/propagator-aws-xray": "^2.0.1",
     "@opentelemetry/semantic-conventions": "^1.34.0"
   },
   "devDependencies": {

--- a/packages/instrumentation-aws-sdk/src/aws-sdk.ts
+++ b/packages/instrumentation-aws-sdk/src/aws-sdk.ts
@@ -23,6 +23,11 @@ import {
 /** @knipignore */
 import { PACKAGE_NAME, PACKAGE_VERSION } from './version';
 import {
+  AWS_TRACE_HEADER,
+  existingTraceHeader,
+  traceHeaderFor,
+} from './trace-header';
+import {
   InstrumentationBase,
   InstrumentationModuleDefinition,
   InstrumentationNodeModuleDefinition,
@@ -58,6 +63,10 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
   static readonly component = 'aws-sdk';
   // need declare since initialized in callbacks from super constructor
   declare private servicesExtensions: ServicesExtensions;
+  /** Stacks the trace header middleware is already on. */
+  private readonly _stacksWithTraceHeader = new WeakSet<
+    MiddlewareStack<any, any>
+  >();
 
   constructor(config: AwsSdkInstrumentationConfig = {}) {
     super(PACKAGE_NAME, PACKAGE_VERSION, config);
@@ -298,6 +307,8 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
     moduleVersion: string | undefined,
     middlewareStackToPatch: MiddlewareStack<any, any>
   ) {
+    this.addTraceHeaderMiddleware(middlewareStackToPatch);
+
     if (!isWrapped(middlewareStackToPatch.resolve)) {
       this._wrap(
         middlewareStackToPatch,
@@ -322,6 +333,56 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
         this._getV3MiddlewareStackClonePatch.bind(this, moduleVersion)
       );
     }
+  }
+
+  /**
+   * Puts the active trace on the request as `X-Amzn-Trace-Id`.
+   *
+   * AWS managed services read only this format, so it is the only way a trace
+   * crosses a hop that carries no message attributes - an S3 object
+   * notification, an EventBridge rule. Message attributes cover SQS, SNS and
+   * Lambda; nothing covered the rest.
+   *
+   * A `build` step middleware because that is the only seam that reaches the
+   * request: `preRequestHook` and the service extensions are handed a
+   * `NormalizedRequest`, and an S3 `PutObject` has no command input field that
+   * becomes a header.
+   */
+  private addTraceHeaderMiddleware(stack: MiddlewareStack<any, any>) {
+    if (this.getConfig().injectTraceHeader === false) return;
+    if (this._stacksWithTraceHeader.has(stack)) return;
+    this._stacksWithTraceHeader.add(stack);
+
+    stack.add(
+      (next: any) =>
+        async (args: any) => {
+          try {
+            const headers = args?.request?.headers;
+            if (headers && typeof headers === 'object') {
+              // The AWS SDK's own recursionDetectionMiddleware sits on this step
+              // at 'low' priority - after this one - and only sets the header
+              // when it is absent. Writing it here means it never runs, so what
+              // it would have forwarded is read from where it reads it and
+              // carried over. Lineage above all: Lambda counts a request chain
+              // in it and stops invoking a function after roughly sixteen hops.
+              const header = traceHeaderFor(
+                context.active(),
+                existingTraceHeader(headers) ??
+                  process.env['_X_AMZN_TRACE_ID']
+              );
+              if (header) headers[AWS_TRACE_HEADER] = header;
+            }
+          } catch (e) {
+            diag.debug(
+              'aws-sdk instrumentation: failed to set the trace header',
+              e
+            );
+          }
+          return next(args);
+        },
+      // Before signing, so the header is covered by the request signature.
+      { step: 'build', name: 'otelAwsTraceHeaderMiddleware', override: true }
+    );
   }
 
   private _getV3MiddlewareStackClonePatch(

--- a/packages/instrumentation-aws-sdk/src/trace-header.ts
+++ b/packages/instrumentation-aws-sdk/src/trace-header.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Context, defaultTextMapSetter } from '@opentelemetry/api';
+import {
+  AWSXRAY_TRACE_ID_HEADER,
+  AWSXRayPropagator,
+} from '@opentelemetry/propagator-aws-xray';
+
+/**
+ * The header AWS services forward across hops that carry no message attributes
+ * of their own - an S3 object notification, an EventBridge rule.
+ */
+export const AWS_TRACE_HEADER = 'X-Amzn-Trace-Id';
+
+const xrayPropagator = new AWSXRayPropagator();
+
+/**
+ * The fields of the tracing header that carry the trace, and so are replaced.
+ * Everything else on the header belongs to the platform.
+ */
+const OWNED_FIELDS = ['Root', 'Parent', 'Sampled'];
+
+/**
+ * The fields of a tracing header that belong to somebody else, ready to append
+ * to the header replacing it.
+ *
+ * `Lineage` is how Lambda counts the hops of one triggering event; it stops
+ * invoking a function after roughly sixteen in a chain through Lambda, S3, SQS
+ * and SNS, so dropping it silently disables recursive loop detection. `Self` is
+ * the trace id an Application Load Balancer stamps for the hop it handled.
+ *
+ * Unrecognised fields are carried too, which is the convention on this header -
+ * an ALB documents that "an application can add arbitrary fields for its own
+ * purposes. The load balancer preserves these fields but does not use them" -
+ * and means a field AWS adds later needs no change here.
+ */
+export const carriedTraceHeaderFields = (
+  header: string | undefined
+): string[] =>
+  (header ?? '')
+    .split(';')
+    .map(part => part.trim())
+    .filter(
+      part =>
+        part.length > 0 &&
+        !OWNED_FIELDS.some(field => part.startsWith(`${field}=`))
+    );
+
+/**
+ * The tracing header to send for a context, or `undefined` when it holds no
+ * valid span.
+ *
+ * `replacing` is the header already on the request, if any. It is not merged
+ * into: `AWSXRayPropagator` builds a fresh `Root`/`Parent`/`Sampled` and knows
+ * nothing of what was there, so the platform's fields are appended afterwards.
+ */
+export const traceHeaderFor = (
+  context: Context,
+  replacing: string | undefined
+): string | undefined => {
+  const carrier: Record<string, string> = {};
+  xrayPropagator.inject(context, carrier, defaultTextMapSetter);
+  const trace = carrier[AWSXRAY_TRACE_ID_HEADER];
+  if (!trace) return undefined;
+  return [trace, ...carriedTraceHeaderFields(replacing)].join(';');
+};
+
+/** Reads the tracing header from a header bag, whatever case it is in. */
+export const existingTraceHeader = (
+  headers: Record<string, string> | undefined
+): string | undefined => {
+  const name = Object.keys(headers ?? {}).find(
+    header => header.toLowerCase() === AWSXRAY_TRACE_ID_HEADER
+  );
+  return name ? headers?.[name] : undefined;
+};

--- a/packages/instrumentation-aws-sdk/src/types.ts
+++ b/packages/instrumentation-aws-sdk/src/types.ts
@@ -86,6 +86,18 @@ export interface AwsSdkInstrumentationConfig extends InstrumentationConfig {
   suppressInternalInstrumentation?: boolean;
 
   /**
+   * AWS managed services propagate context only through the X-Ray tracing
+   * header, so it is set on every outgoing request by default. That is the only
+   * channel for services with no message attributes, such as S3 object
+   * notifications and EventBridge rules.
+   *
+   * Set to `false` to leave the header alone. The AWS SDK then sets it itself
+   * from the Lambda invoke store, carrying the platform's trace rather than this
+   * one.
+   */
+  injectTraceHeader?: boolean;
+
+  /**
    * In some cases the context propagation headers may be found in the message payload
    * rather than the message attribute.
    * When this field is turned on the instrumentation will parse the payload and extract the

--- a/packages/instrumentation-aws-sdk/test/trace-header.test.ts
+++ b/packages/instrumentation-aws-sdk/test/trace-header.test.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { instrumentation } from './load-instrumentation';
+
+import { S3 } from '@aws-sdk/client-s3';
+
+// set aws environment variables, so tests in non aws environment are able to run
+process.env.AWS_ACCESS_KEY_ID = 'testing';
+process.env.AWS_SECRET_ACCESS_KEY = 'testing';
+
+import 'mocha';
+import { expect } from 'expect';
+import * as fs from 'fs';
+import * as nock from 'nock';
+import { carriedTraceHeaderFields } from '../src/trace-header';
+
+const region = 'us-east-1';
+
+/** Uploads an object and hands back the tracing header the request went out with. */
+const traceHeaderSentBy = async (s3: S3): Promise<string | undefined> => {
+  let sent: string | undefined;
+  nock(`https://ot-demo-test.s3.${region}.amazonaws.com/`)
+    .put('/aws-ot-s3-test-object.txt?x-id=PutObject')
+    .reply(function () {
+      sent = this.req.headers['x-amzn-trace-id'] as string | undefined;
+      return [
+        200,
+        fs.readFileSync('./test/mock-responses/s3-put-object.xml', 'utf8'),
+      ];
+    });
+
+  await s3.putObject({
+    Bucket: 'ot-demo-test',
+    Key: 'aws-ot-s3-test-object.txt',
+  });
+  return sent;
+};
+
+describe('instrumentation-aws-sdk trace header', () => {
+  const previousTraceId = process.env._X_AMZN_TRACE_ID;
+
+  beforeEach(() => {
+    instrumentation.setConfig({});
+    delete process.env._X_AMZN_TRACE_ID;
+  });
+
+  after(() => {
+    if (previousTraceId === undefined) {
+      delete process.env._X_AMZN_TRACE_ID;
+    } else {
+      process.env._X_AMZN_TRACE_ID = previousTraceId;
+    }
+    instrumentation.setConfig({});
+  });
+
+  describe('carriedTraceHeaderFields', () => {
+    it('keeps the platform fields and drops the trace fields', () => {
+      expect(
+        carriedTraceHeaderFields(
+          'Root=1-11111111-111111111111111111111111;Parent=2222222222222222;Sampled=0;Lineage=2:a87bd80c:1;Self=1-67891233-12456789abcdef012345678'
+        )
+      ).toEqual([
+        'Lineage=2:a87bd80c:1',
+        'Self=1-67891233-12456789abcdef012345678',
+      ]);
+    });
+
+    it('carries an unrecognised field rather than guess at it', () => {
+      expect(carriedTraceHeaderFields('Root=1-a-b;CalledFrom=app')).toEqual([
+        'CalledFrom=app',
+      ]);
+    });
+
+    it('finds nothing in an absent or empty header', () => {
+      expect(carriedTraceHeaderFields(undefined)).toEqual([]);
+      expect(carriedTraceHeaderFields('')).toEqual([]);
+    });
+  });
+
+  describe('on an outgoing request', () => {
+    it('sets the tracing header from the active span', async () => {
+      const sent = await traceHeaderSentBy(new S3({ region }));
+
+      expect(sent).toMatch(/^Root=1-[0-9a-f]{8}-[0-9a-f]{24};Parent=[0-9a-f]{16};Sampled=[01]$/);
+    });
+
+    // Lambda counts the hops of one triggering event in Lineage and stops
+    // invoking a function after roughly sixteen. Replacing the header without
+    // carrying it forward restarts the count on every hop, which silently
+    // disables recursive loop detection through Lambda, S3, SQS and SNS.
+    it('carries Lineage from the invocation onto the header', async () => {
+      process.env._X_AMZN_TRACE_ID =
+        'Root=1-11111111-111111111111111111111111;Sampled=0;Lineage=2:a87bd80c:1';
+
+      const sent = await traceHeaderSentBy(new S3({ region }));
+
+      expect(sent).toContain(';Lineage=2:a87bd80c:1');
+      expect(sent).not.toContain('Root=1-11111111');
+    });
+
+    it('carries Self and unrecognised fields too', async () => {
+      process.env._X_AMZN_TRACE_ID =
+        'Root=1-11111111-111111111111111111111111;Self=1-67891233-12456789abcdef012345678;CalledFrom=app';
+
+      const sent = await traceHeaderSentBy(new S3({ region }));
+
+      expect(sent).toContain(';Self=1-67891233-12456789abcdef012345678');
+      expect(sent).toContain(';CalledFrom=app');
+    });
+
+    it('leaves the header to the AWS SDK when disabled', async () => {
+      instrumentation.setConfig({ injectTraceHeader: false });
+      process.env._X_AMZN_TRACE_ID =
+        'Root=1-11111111-111111111111111111111111;Sampled=0;Lineage=2:a87bd80c:1';
+
+      const sent = await traceHeaderSentBy(new S3({ region }));
+
+      // Nothing sets it: this instrumentation is off, and the SDK's own
+      // recursion-detection middleware only acts inside Lambda, where
+      // AWS_LAMBDA_FUNCTION_NAME is set.
+      expect(sent).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
Implements #3686.

## Why

AWS managed services read context only from `X-Amzn-Trace-Id`, so it is the only channel for
an integration with no message attributes. Today this package propagates only where a service
exposes a command input field — `MessageAttributes` for SQS and SNS, `ClientContext` for
Lambda — so an S3 object notification and an EventBridge rule cannot propagate at all, and a
Lambda woken by an upload starts a trace disconnected from whatever wrote the object.

The Java instrumentation already does this unconditionally, and AWS's own JS distribution
patches it in from outside by overriding this package's private
`_getV3SmithyClientSendPatch`. #3686 has the detail and the measurements.

## What

A `build` step middleware added in `patchV3MiddlewareStack`, guarded by a `WeakSet` so each
stack gets it once. `build` is before signing, so the header is covered by the request
signature.

`Root`/`Parent`/`Sampled` come from `AWSXRayPropagator` — it already round-trips a span
context losslessly into that format, so there is no new encoding here.

**Everything else on the header is carried over**, from the header already on the request or
from `_X_AMZN_TRACE_ID`. This is the part worth reviewing. The AWS SDK's own
`recursionDetectionMiddleware` sits on the same `build` step at `low` priority — after this
one — and only acts `if (!request.headers.hasOwnProperty(traceIdHeader))`. Writing the header
here means it never runs, so this inherits what it would have forwarded:

| Field | Owner | Why it matters |
| --- | --- | --- |
| `Lineage` | Lambda | Counts the hops of one triggering event; a function is stopped after ~16 |
| `Self` | ALB | The trace id a load balancer stamped for the hop it handled |

Dropping `Lineage` restarts the chain on every hop, which silently disables recursive loop
detection through Lambda, S3, SQS and SNS. Measured across one S3 hop:

```
header replaced without carrying it : Lineage=1:aa20224c:0   (chain restarted)
header replaced carrying it forward : Lineage=2:aa20224c:0   (chain counted)
```

Unrecognised fields are carried too, so a field AWS adds later needs no change here. That is
the documented convention — an ALB "preserves these fields but does not use them".

## Behaviour change

This is on by default, matching Java. `injectTraceHeader: false` turns it off.

Two things worth being precise about:

- **Inside Lambda**, the header is already set on every AWS SDK call by
  `recursionDetectionMiddleware`, from the invoke store / `_X_AMZN_TRACE_ID` — the platform's
  X-Ray trace, unrelated to the active OTel trace. There the change is which trace it carries,
  not whether it is sent.
- **Outside Lambda**, that middleware needs `AWS_LAMBDA_FUNCTION_NAME` and so does nothing, and
  this adds a header where there was none. Harmless — AWS accepts it and it is what the Java
  instrumentation has always sent — but it is a new header on requests from ECS, EC2 and local
  runs, so worth calling out.

Happy to flip the default to opt-in for a release if you would rather ease it in.

## Alternatives

Covered in #3686. Briefly: `preRequestHook` and the service extensions are handed a
`NormalizedRequest` and never the request, and S3 `PutObject` has no command input field that
becomes this header; `suppressInternalInstrumentation: false` works but adds an HTTP span per
call and clobbers `Lineage` with nowhere to fix it; the trace id the SDK forwards cannot be
set, since `@aws/lambda-invoke-store` lists `X_RAY_TRACE_ID` in `PROTECTED_KEYS` where `set()`
throws.

## Notes for review

- `src/trace-header.ts` is package-internal — `index.ts` is unchanged, so no public API is
  added. Happy to fold it into `src/utils.ts` if you would prefer no new file.
- `@opentelemetry/propagator-aws-xray` is added as a dependency. It is a package in this repo,
  and reusing it keeps one definition of the format. The alternative is ~15 lines of inline
  formatting.
- No CHANGELOG entry, per CONTRIBUTING.

## Tests

`test/trace-header.test.ts` — 7 cases. Three unit-test the carry-through directly; four drive
a real `PutObject` through nock and assert on the header the request went out with.

- sets the tracing header from the active span
- carries `Lineage` from the invocation onto the header
- carries `Self` and unrecognised fields too
- leaves the header alone when disabled
- keeps the platform fields and drops the trace fields
- carries an unrecognised field rather than guess at it
- finds nothing in an absent or empty header

Package suite: **63 passing, 1 pending, 0 failing**. `tsc --noEmit` clean, `eslint` 0 errors.
