### PR TITLE
feat(instrumentation-pg)!: sanitize `db.query.text` by default

### DIFF
--- a/packages/instrumentation-pg/README.md
+++ b/packages/instrumentation-pg/README.md
@@ -89,6 +89,14 @@ The `@opentelemetry/instrumentation-pg` versions 0.72.0 and later emit the stabl
 
 ### Sanitizing `db.query.text`
 
+> [!IMPORTANT]
+> Versions 0.74.0 and later sanitize `db.query.text` for non-parameterized
+> queries by default. Earlier versions recorded it verbatim. Queries built by
+> string concatenation therefore record `?` in place of their literals, which
+> changes the value of an attribute existing dashboards and saved queries may
+> match on. Set `skipQueryTextSanitization: true` to restore the previous
+> behaviour.
+
 The `pg` driver never interpolates parameter values into the query text, so a
 parameterized query records placeholders rather than values — which is why
 the specification advises against

--- a/packages/instrumentation-pg/README.md
+++ b/packages/instrumentation-pg/README.md
@@ -89,17 +89,18 @@ The `@opentelemetry/instrumentation-pg` versions 0.72.0 and later emit the stabl
 
 ### Masking `db.query.text`
 
-By default `db.query.text` records the query text exactly as it was passed to
-`client.query()`. The `pg` driver never interpolates parameter values into the
-query text, so a parameterized query records placeholders rather than values —
-which is why the specification advises against
+The `pg` driver never interpolates parameter values into the query text, so a
+parameterized query records placeholders rather than values — which is why
+the specification advises against
 [sanitizing](https://opentelemetry.io/docs/specs/semconv/database/database-spans/#sanitization-of-dbquerytext)
-parameterized query text.
+parameterized query text. A parameterized call (one made with a `values`
+array) always has its `db.query.text` recorded exactly as passed to
+`client.query()`, regardless of `skipQueryTextSanitization`.
 
 Applications that build SQL by string concatenation put literals into the query
-text, and therefore onto the span. `db.query.text` is masked by default to
-strip those out; set `skipQueryTextSanitization: true` to record it verbatim
-instead. By default:
+text, and therefore onto the span. For a non-parameterized query, `db.query.text`
+is masked by default to strip those out; set `skipQueryTextSanitization: true`
+to record it verbatim instead. By default:
 
 - string, numeric, bit-string and dollar-quoted literals become `?`
 - `--` and (nestable) `/* */` comments are removed

--- a/packages/instrumentation-pg/README.md
+++ b/packages/instrumentation-pg/README.md
@@ -55,12 +55,15 @@ PostgreSQL instrumentation has few options available to choose from. You can set
 
 | Options | Type | Description |
 | ------- | ---- | ----------- |
-| [`enhancedDatabaseReporting`](./src/types.ts#L30) | `boolean` | If true, additional information about query parameters and results will be attached (as `attributes`) to spans representing database operations |
+| `enhancedDatabaseReporting` | `boolean` | If true, additional information about query parameters and results will be attached (as `attributes`) to spans representing database operations |
 | `requestHook` | `PgInstrumentationExecutionRequestHook` (function) | Function for adding custom span attributes using information about the query being issued and the db to which it's directed |
 | `responseHook` | `PgInstrumentationExecutionResponseHook` (function) | Function for adding custom span attributes from db response |
 | `requireParentSpan` | `boolean` | If true, requires a parent span to create new spans (default false) |
 | `addSqlCommenterCommentToQueries` | `boolean` | If true, adds [sqlcommenter](https://github.com/open-telemetry/opentelemetry-sqlcommenter) specification compliant comment to queries with tracing context (default false). _NOTE: A comment will not be added to queries that already contain `--` or `/* ... */` in them, even if these are not actually part of comments_ |
 | `ignoreConnectSpans` | `boolean` | If true, `pg.connect` and `pg-pool.connect` spans will not be created. Query spans and pool metrics are still recorded (default false) |
+| `maskStatement` | `boolean` | If true, the `db.query.text` attribute is masked by `maskStatementHook` before being recorded (default false). The query sent to the server is never modified |
+| `maskStatementHook` | `PgInstrumentationQueryMaskingHook` (function) | Function used to mask `db.query.text` when `maskStatement` is true. Defaults to `sanitizeSql` from [`@opentelemetry/sql-common`](../sql-common). If it throws or returns a non-string, `db.query.text` is omitted |
+| `enableTraceContextPropagation` | `boolean` | If true, injects the current span's W3C traceparent into the PostgreSQL session via `SET application_name` before each query (default false). _NOTE: this adds a round-trip per query_ |
 
 ## Semantic Conventions
 
@@ -83,6 +86,54 @@ The `@opentelemetry/instrumentation-pg` versions 0.72.0 and later emit the stabl
 > name separately, and the OpenTelemetry specification advises against parsing
 > `db.query.text` when the database supports queries touching multiple
 > collections in non-batch operations, which is the case for PostgreSQL.
+
+### Masking `db.query.text`
+
+By default `db.query.text` records the query text exactly as it was passed to
+`client.query()`. The `pg` driver never interpolates parameter values into the
+query text, so a parameterized query records placeholders rather than values —
+which is why the specification advises against
+[sanitizing](https://opentelemetry.io/docs/specs/semconv/database/database-spans/#sanitization-of-dbquerytext)
+parameterized query text.
+
+Applications that build SQL by string concatenation put literals into the query
+text, and therefore onto the span. Set `maskStatement: true` for those. When
+enabled:
+
+- string, numeric, bit-string and dollar-quoted literals become `?`
+- `--` and (nestable) `/* */` comments are removed
+- runs of whitespace collapse to a single space
+- `$n` parameter placeholders and identifiers, including `"quoted"` ones, are preserved
+- the result is truncated at 32 KiB
+
+So `SELECT * FROM users WHERE email = 'a@b.c' -- lookup` is recorded as
+`SELECT * FROM users WHERE email = ?`, while
+`SELECT * FROM users WHERE id = $1` is recorded unchanged.
+
+Limits worth knowing:
+
+- Only `db.query.text` is masked. The query sent to PostgreSQL is untouched, and
+  `requestHook` still receives the original text.
+- `db.operation.name` and the span name are derived from the raw query text, not
+  the masked text. Both take everything up to the first space character, so a
+  statement separating its leading keyword with a tab or newline instead carries
+  more of the raw text than intended -- and because `db.operation.name` is also a
+  dimension of the `db.client.operation.duration` metric, that text reaches
+  metrics as well.
+- Double-quoted identifiers are preserved, because in PostgreSQL `"` delimits an
+  identifier rather than a string literal. An application that quotes _dynamic_
+  identifiers should supply its own `maskStatementHook`.
+- `db.postgresql.values` (see `enhancedDatabaseReporting`) and
+  `db.postgresql.plan` (the prepared-statement name) are not masked. Enabling
+  `enhancedDatabaseReporting` together with `maskStatement` records masked query
+  text alongside raw parameter values.
+- If `maskStatementHook` throws or returns a non-string, `db.query.text` is
+  omitted rather than falling back to the raw text, and a warning is logged
+  through the API diagnostic logger.
+- The default hook assumes `standard_conforming_strings` is on, which has been
+  PostgreSQL's default since version 9.1. A server with it explicitly turned
+  off can use a backslash to escape a quote inside an ordinary string, which
+  the default hook does not account for and can mask incorrectly.
 
 Metrics Exported:
 

--- a/packages/instrumentation-pg/README.md
+++ b/packages/instrumentation-pg/README.md
@@ -61,8 +61,8 @@ PostgreSQL instrumentation has few options available to choose from. You can set
 | `requireParentSpan` | `boolean` | If true, requires a parent span to create new spans (default false) |
 | `addSqlCommenterCommentToQueries` | `boolean` | If true, adds [sqlcommenter](https://github.com/open-telemetry/opentelemetry-sqlcommenter) specification compliant comment to queries with tracing context (default false). _NOTE: A comment will not be added to queries that already contain `--` or `/* ... */` in them, even if these are not actually part of comments_ |
 | `ignoreConnectSpans` | `boolean` | If true, `pg.connect` and `pg-pool.connect` spans will not be created. Query spans and pool metrics are still recorded (default false) |
-| `maskStatement` | `boolean` | If true, the `db.query.text` attribute is masked by `maskStatementHook` before being recorded (default false). The query sent to the server is never modified |
-| `maskStatementHook` | `PgInstrumentationQueryMaskingHook` (function) | Function used to mask `db.query.text` when `maskStatement` is true. Defaults to `sanitizeSql` from [`@opentelemetry/sql-common`](../sql-common). If it throws or returns a non-string, `db.query.text` is omitted |
+| `skipQueryTextSanitization` | `boolean` | If true, the `db.query.text` attribute is recorded as-is instead of being masked by `maskStatementHook` (default false, i.e. masked by default). The query sent to the server is never modified |
+| `maskStatementHook` | `PgInstrumentationQueryMaskingHook` (function) | Function used to mask `db.query.text` unless `skipQueryTextSanitization` is true. Defaults to `sanitizeSql` from [`@opentelemetry/sql-common`](../sql-common). If it throws or returns a non-string, `db.query.text` is omitted |
 | `enableTraceContextPropagation` | `boolean` | If true, injects the current span's W3C traceparent into the PostgreSQL session via `SET application_name` before each query (default false). _NOTE: this adds a round-trip per query_ |
 
 ## Semantic Conventions
@@ -97,8 +97,9 @@ which is why the specification advises against
 parameterized query text.
 
 Applications that build SQL by string concatenation put literals into the query
-text, and therefore onto the span. Set `maskStatement: true` for those. When
-enabled:
+text, and therefore onto the span. `db.query.text` is masked by default to
+strip those out; set `skipQueryTextSanitization: true` to record it verbatim
+instead. By default:
 
 - string, numeric, bit-string and dollar-quoted literals become `?`
 - `--` and (nestable) `/* */` comments are removed
@@ -125,8 +126,8 @@ Limits worth knowing:
   identifiers should supply its own `maskStatementHook`.
 - `db.postgresql.values` (see `enhancedDatabaseReporting`) and
   `db.postgresql.plan` (the prepared-statement name) are not masked. Enabling
-  `enhancedDatabaseReporting` together with `maskStatement` records masked query
-  text alongside raw parameter values.
+  `enhancedDatabaseReporting` records masked query text alongside raw parameter
+  values, unless `skipQueryTextSanitization` is also set.
 - If `maskStatementHook` throws or returns a non-string, `db.query.text` is
   omitted rather than falling back to the raw text, and a warning is logged
   through the API diagnostic logger.

--- a/packages/instrumentation-pg/README.md
+++ b/packages/instrumentation-pg/README.md
@@ -61,8 +61,8 @@ PostgreSQL instrumentation has few options available to choose from. You can set
 | `requireParentSpan` | `boolean` | If true, requires a parent span to create new spans (default false) |
 | `addSqlCommenterCommentToQueries` | `boolean` | If true, adds [sqlcommenter](https://github.com/open-telemetry/opentelemetry-sqlcommenter) specification compliant comment to queries with tracing context (default false). _NOTE: A comment will not be added to queries that already contain `--` or `/* ... */` in them, even if these are not actually part of comments_ |
 | `ignoreConnectSpans` | `boolean` | If true, `pg.connect` and `pg-pool.connect` spans will not be created. Query spans and pool metrics are still recorded (default false) |
-| `skipQueryTextSanitization` | `boolean` | If true, the `db.query.text` attribute is recorded as-is instead of being masked by `maskStatementHook` (default false, i.e. masked by default). The query sent to the server is never modified |
-| `maskStatementHook` | `PgInstrumentationQueryMaskingHook` (function) | Function used to mask `db.query.text` unless `skipQueryTextSanitization` is true. Defaults to `sanitizeSql` from [`@opentelemetry/sql-common`](../sql-common). If it throws or returns a non-string, `db.query.text` is omitted |
+| `skipQueryTextSanitization` | `boolean` | If true, the `db.query.text` attribute is recorded as-is instead of being sanitized by `queryTextSanitizationHook` (default false, i.e. sanitized by default). The query sent to the server is never modified |
+| `queryTextSanitizationHook` | `PgInstrumentationQueryTextSanitizationHook` (function) | Function used to sanitize `db.query.text` unless `skipQueryTextSanitization` is true. Defaults to `sanitizeSql` from [`@opentelemetry/sql-common`](../sql-common). If it throws or returns a non-string, `db.query.text` is omitted |
 | `enableTraceContextPropagation` | `boolean` | If true, injects the current span's W3C traceparent into the PostgreSQL session via `SET application_name` before each query (default false). _NOTE: this adds a round-trip per query_ |
 
 ## Semantic Conventions
@@ -87,7 +87,7 @@ The `@opentelemetry/instrumentation-pg` versions 0.72.0 and later emit the stabl
 > `db.query.text` when the database supports queries touching multiple
 > collections in non-batch operations, which is the case for PostgreSQL.
 
-### Masking `db.query.text`
+### Sanitizing `db.query.text`
 
 The `pg` driver never interpolates parameter values into the query text, so a
 parameterized query records placeholders rather than values — which is why
@@ -99,7 +99,7 @@ array) always has its `db.query.text` recorded exactly as passed to
 
 Applications that build SQL by string concatenation put literals into the query
 text, and therefore onto the span. For a non-parameterized query, `db.query.text`
-is masked by default to strip those out; set `skipQueryTextSanitization: true`
+is sanitized by default to strip those out; set `skipQueryTextSanitization: true`
 to record it verbatim instead. By default:
 
 - string, numeric, bit-string and dollar-quoted literals become `?`
@@ -114,28 +114,28 @@ So `SELECT * FROM users WHERE email = 'a@b.c' -- lookup` is recorded as
 
 Limits worth knowing:
 
-- Only `db.query.text` is masked. The query sent to PostgreSQL is untouched, and
-  `requestHook` still receives the original text.
+- Only `db.query.text` is sanitized. The query sent to PostgreSQL is untouched,
+  and `requestHook` still receives the original text.
 - `db.operation.name` and the span name are derived from the raw query text, not
-  the masked text -- and because `db.operation.name` is also a dimension of the
-  `db.client.operation.duration` metric, that text reaches metrics as well.
+  the sanitized text -- and because `db.operation.name` is also a dimension of
+  the `db.client.operation.duration` metric, that text reaches metrics as well.
   Only the leading keyword is used, though, so this is limited to the SQL
   command name (`SELECT`, `INSERT`, etc.), never a literal.
 - Double-quoted identifiers are preserved, because in PostgreSQL `"` delimits an
   identifier rather than a string literal. An application that quotes _dynamic_
-  identifiers should supply its own `maskStatementHook`.
+  identifiers should supply its own `queryTextSanitizationHook`.
 - `db.postgresql.values` (see `enhancedDatabaseReporting`) and
-  `db.postgresql.plan` (the prepared-statement name) are not masked.
+  `db.postgresql.plan` (the prepared-statement name) are not sanitized.
   `db.postgresql.values` is only ever populated for a parameterized query, and
   a parameterized query's `db.query.text` is always recorded as-is (see
-  above), so the two are never a mix of masked text and raw values.
-- If `maskStatementHook` throws or returns a non-string, `db.query.text` is
-  omitted rather than falling back to the raw text, and a warning is logged
+  above), so the two are never a mix of sanitized text and raw values.
+- If `queryTextSanitizationHook` throws or returns a non-string, `db.query.text`
+  is omitted rather than falling back to the raw text, and a warning is logged
   through the API diagnostic logger.
 - The default hook assumes `standard_conforming_strings` is on, which has been
   PostgreSQL's default since version 9.1. A server with it explicitly turned
   off can use a backslash to escape a quote inside an ordinary string, which
-  the default hook does not account for and can mask incorrectly.
+  the default hook does not account for and can sanitize incorrectly.
 
 Metrics Exported:
 

--- a/packages/instrumentation-pg/README.md
+++ b/packages/instrumentation-pg/README.md
@@ -117,11 +117,10 @@ Limits worth knowing:
 - Only `db.query.text` is masked. The query sent to PostgreSQL is untouched, and
   `requestHook` still receives the original text.
 - `db.operation.name` and the span name are derived from the raw query text, not
-  the masked text. Both take everything up to the first space character, so a
-  statement separating its leading keyword with a tab or newline instead carries
-  more of the raw text than intended -- and because `db.operation.name` is also a
-  dimension of the `db.client.operation.duration` metric, that text reaches
-  metrics as well.
+  the masked text -- and because `db.operation.name` is also a dimension of the
+  `db.client.operation.duration` metric, that text reaches metrics as well.
+  Only the leading keyword is used, though, so this is limited to the SQL
+  command name (`SELECT`, `INSERT`, etc.), never a literal.
 - Double-quoted identifiers are preserved, because in PostgreSQL `"` delimits an
   identifier rather than a string literal. An application that quotes _dynamic_
   identifiers should supply its own `maskStatementHook`.

--- a/packages/instrumentation-pg/README.md
+++ b/packages/instrumentation-pg/README.md
@@ -93,9 +93,13 @@ The `pg` driver never interpolates parameter values into the query text, so a
 parameterized query records placeholders rather than values — which is why
 the specification advises against
 [sanitizing](https://opentelemetry.io/docs/specs/semconv/database/database-spans/#sanitization-of-dbquerytext)
-parameterized query text. A parameterized call (one made with a `values`
-array) always has its `db.query.text` recorded exactly as passed to
-`client.query()`, regardless of `skipQueryTextSanitization`.
+parameterized query text. A parameterized call — one made with a non-empty
+`values` array — always has its `db.query.text` recorded exactly as passed to
+`client.query()`, regardless of `skipQueryTextSanitization`. An empty `values`
+array does not count: nothing is travelling beside the text, so the text is
+sanitized as it would be for any other non-parameterized query. This matters
+for the common wrapper `query(text, params = [])`, which would otherwise send
+every concatenated query down the unsanitized path.
 
 Applications that build SQL by string concatenation put literals into the query
 text, and therefore onto the span. For a non-parameterized query, `db.query.text`

--- a/packages/instrumentation-pg/README.md
+++ b/packages/instrumentation-pg/README.md
@@ -116,6 +116,19 @@ So `SELECT * FROM users WHERE email = 'a@b.c' -- lookup` is recorded as
 `SELECT * FROM users WHERE email = ?`, while
 `SELECT * FROM users WHERE id = $1` is recorded unchanged.
 
+The default is `sanitizeSql` from
+[`@opentelemetry/sql-common`](../sql-common) called with no options beyond the
+dialect, so a hook that wants a different truncation limit can call it directly:
+
+```js
+const { sanitizeSql } = require('@opentelemetry/sql-common');
+
+new PgInstrumentation({
+  queryTextSanitizationHook: query =>
+    sanitizeSql(query, { dialect: 'postgresql', maxLength: 4096 }),
+});
+```
+
 Limits worth knowing:
 
 - Only `db.query.text` is sanitized. The query sent to PostgreSQL is untouched,

--- a/packages/instrumentation-pg/README.md
+++ b/packages/instrumentation-pg/README.md
@@ -110,7 +110,7 @@ to record it verbatim instead. By default:
 - `--` and (nestable) `/* */` comments are removed
 - runs of whitespace collapse to a single space
 - `$n` parameter placeholders and identifiers, including `"quoted"` ones, are preserved
-- the result is truncated at 32 KiB
+- the result is truncated at 32768 characters
 
 So `SELECT * FROM users WHERE email = 'a@b.c' -- lookup` is recorded as
 `SELECT * FROM users WHERE email = ?`, while

--- a/packages/instrumentation-pg/README.md
+++ b/packages/instrumentation-pg/README.md
@@ -125,9 +125,10 @@ Limits worth knowing:
   identifier rather than a string literal. An application that quotes _dynamic_
   identifiers should supply its own `maskStatementHook`.
 - `db.postgresql.values` (see `enhancedDatabaseReporting`) and
-  `db.postgresql.plan` (the prepared-statement name) are not masked. Enabling
-  `enhancedDatabaseReporting` records masked query text alongside raw parameter
-  values, unless `skipQueryTextSanitization` is also set.
+  `db.postgresql.plan` (the prepared-statement name) are not masked.
+  `db.postgresql.values` is only ever populated for a parameterized query, and
+  a parameterized query's `db.query.text` is always recorded as-is (see
+  above), so the two are never a mix of masked text and raw values.
 - If `maskStatementHook` throws or returns a non-string, `db.query.text` is
   omitted rather than falling back to the raw text, and a warning is logged
   through the API diagnostic logger.

--- a/packages/instrumentation-pg/src/index.ts
+++ b/packages/instrumentation-pg/src/index.ts
@@ -9,7 +9,7 @@ export type {
   PgInstrumentationConfig,
   PgInstrumentationExecutionRequestHook,
   PgInstrumentationExecutionResponseHook,
-  PgInstrumentationQueryMaskingHook,
+  PgInstrumentationQueryTextSanitizationHook,
   PgRequestHookInformation,
   PgResponseHookInformation,
 } from './types';

--- a/packages/instrumentation-pg/src/index.ts
+++ b/packages/instrumentation-pg/src/index.ts
@@ -9,6 +9,7 @@ export type {
   PgInstrumentationConfig,
   PgInstrumentationExecutionRequestHook,
   PgInstrumentationExecutionResponseHook,
+  PgInstrumentationQueryMaskingHook,
   PgRequestHookInformation,
   PgResponseHookInformation,
 } from './types';

--- a/packages/instrumentation-pg/src/types.ts
+++ b/packages/instrumentation-pg/src/types.ts
@@ -49,8 +49,9 @@ export interface PgInstrumentationConfig extends InstrumentationConfig {
    * {@link queryTextSanitizationHook} before it is recorded as the
    * `db.query.text` attribute.
    *
-   * Only affects non-parameterized queries (a call with no `values`). A
-   * parameterized query's text is always recorded as-is: the specification
+   * Only affects non-parameterized queries -- a call with no `values`, or
+   * with an empty `values` array. A parameterized query's text is always
+   * recorded as-is: the specification
    * advises against sanitizing it, since parameter values -- where any
    * sensitive data would be -- are passed separately rather than
    * interpolated into the text.

--- a/packages/instrumentation-pg/src/types.ts
+++ b/packages/instrumentation-pg/src/types.ts
@@ -33,7 +33,7 @@ export interface PgInstrumentationExecutionRequestHook {
   (span: api.Span, queryInfo: PgRequestHookInformation): void;
 }
 
-export interface PgInstrumentationQueryMaskingHook {
+export interface PgInstrumentationQueryTextSanitizationHook {
   (query: string): string;
 }
 
@@ -45,9 +45,9 @@ export interface PgInstrumentationConfig extends InstrumentationConfig {
   enhancedDatabaseReporting?: boolean;
 
   /**
-   * If true, the query text is recorded as-is instead of being masked by
-   * {@link maskStatementHook} before it is recorded as the `db.query.text`
-   * attribute.
+   * If true, the query text is recorded as-is instead of being sanitized by
+   * {@link queryTextSanitizationHook} before it is recorded as the
+   * `db.query.text` attribute.
    *
    * Only affects non-parameterized queries (a call with no `values`). A
    * parameterized query's text is always recorded as-is: the specification
@@ -57,16 +57,16 @@ export interface PgInstrumentationConfig extends InstrumentationConfig {
    *
    * This is independent of {@link enhancedDatabaseReporting}, which controls a
    * separate attribute holding the raw parameter values. Leaving this false
-   * while enabling {@link enhancedDatabaseReporting} records masked query text
-   * alongside unmasked values.
+   * while enabling {@link enhancedDatabaseReporting} records sanitized query
+   * text alongside unsanitized values.
    *
    * @default false
-   * @see maskStatementHook
+   * @see queryTextSanitizationHook
    */
   skipQueryTextSanitization?: boolean;
 
   /**
-   * Hook that masks the query text before it is recorded as the
+   * Hook that sanitizes the query text before it is recorded as the
    * `db.query.text` attribute. Only consulted for a non-parameterized query
    * when {@link skipQueryTextSanitization} is false, and never applied to the
    * query sent to the server or to the text passed to {@link requestHook}.
@@ -80,7 +80,7 @@ export interface PgInstrumentationConfig extends InstrumentationConfig {
    *
    * @default (query) => sanitizeSql(query, { dialect: 'postgresql' })
    */
-  maskStatementHook?: PgInstrumentationQueryMaskingHook;
+  queryTextSanitizationHook?: PgInstrumentationQueryTextSanitizationHook;
 
   /**
    * Hook that allows adding custom span attributes or updating the

--- a/packages/instrumentation-pg/src/types.ts
+++ b/packages/instrumentation-pg/src/types.ts
@@ -33,12 +33,46 @@ export interface PgInstrumentationExecutionRequestHook {
   (span: api.Span, queryInfo: PgRequestHookInformation): void;
 }
 
+export interface PgInstrumentationQueryMaskingHook {
+  (query: string): string;
+}
+
 export interface PgInstrumentationConfig extends InstrumentationConfig {
   /**
    * If true, an attribute containing the query's parameters will be attached
    * the spans generated to represent the query.
    */
   enhancedDatabaseReporting?: boolean;
+
+  /**
+   * If true, the query text is masked by {@link maskStatementHook} before it is
+   * recorded as the `db.query.text` attribute.
+   *
+   * This is independent of {@link enhancedDatabaseReporting}, which controls a
+   * separate attribute holding the raw parameter values. Enabling both records
+   * masked query text alongside unmasked values.
+   *
+   * @default false
+   * @see maskStatementHook
+   */
+  maskStatement?: boolean;
+
+  /**
+   * Hook that masks the query text before it is recorded as the
+   * `db.query.text` attribute. Only consulted when {@link maskStatement} is
+   * true, and never applied to the query sent to the server or to the text
+   * passed to {@link requestHook}.
+   *
+   * The default replaces literals with `?` while preserving parameter
+   * placeholders and identifiers. It is `sanitizeSql` from
+   * `@opentelemetry/sql-common`, so a custom hook can build on it.
+   *
+   * If the hook throws or returns something other than a string,
+   * `db.query.text` is omitted rather than falling back to the raw text.
+   *
+   * @default (query) => sanitizeSql(query, { dialect: 'postgresql' })
+   */
+  maskStatementHook?: PgInstrumentationQueryMaskingHook;
 
   /**
    * Hook that allows adding custom span attributes or updating the

--- a/packages/instrumentation-pg/src/types.ts
+++ b/packages/instrumentation-pg/src/types.ts
@@ -49,17 +49,10 @@ export interface PgInstrumentationConfig extends InstrumentationConfig {
    * {@link queryTextSanitizationHook} before it is recorded as the
    * `db.query.text` attribute.
    *
-   * Only affects non-parameterized queries -- a call with no `values`, or
-   * with an empty `values` array. A parameterized query's text is always
-   * recorded as-is: the specification
-   * advises against sanitizing it, since parameter values -- where any
-   * sensitive data would be -- are passed separately rather than
-   * interpolated into the text.
-   *
-   * This is independent of {@link enhancedDatabaseReporting}, which controls a
-   * separate attribute holding the raw parameter values. Leaving this false
-   * while enabling {@link enhancedDatabaseReporting} records sanitized query
-   * text alongside unsanitized values.
+   * Only affects non-parameterized queries -- a call with no `values`, or with
+   * an empty `values` array. A parameterized query's text is always recorded
+   * as-is, whatever this is set to. See the package README for why, and for
+   * how this interacts with {@link enhancedDatabaseReporting}.
    *
    * @default false
    * @see queryTextSanitizationHook

--- a/packages/instrumentation-pg/src/types.ts
+++ b/packages/instrumentation-pg/src/types.ts
@@ -49,6 +49,12 @@ export interface PgInstrumentationConfig extends InstrumentationConfig {
    * {@link maskStatementHook} before it is recorded as the `db.query.text`
    * attribute.
    *
+   * Only affects non-parameterized queries (a call with no `values`). A
+   * parameterized query's text is always recorded as-is: the specification
+   * advises against sanitizing it, since parameter values -- where any
+   * sensitive data would be -- are passed separately rather than
+   * interpolated into the text.
+   *
    * This is independent of {@link enhancedDatabaseReporting}, which controls a
    * separate attribute holding the raw parameter values. Leaving this false
    * while enabling {@link enhancedDatabaseReporting} records masked query text
@@ -61,8 +67,8 @@ export interface PgInstrumentationConfig extends InstrumentationConfig {
 
   /**
    * Hook that masks the query text before it is recorded as the
-   * `db.query.text` attribute. Only consulted when
-   * {@link skipQueryTextSanitization} is false, and never applied to the
+   * `db.query.text` attribute. Only consulted for a non-parameterized query
+   * when {@link skipQueryTextSanitization} is false, and never applied to the
    * query sent to the server or to the text passed to {@link requestHook}.
    *
    * The default replaces literals with `?` while preserving parameter

--- a/packages/instrumentation-pg/src/types.ts
+++ b/packages/instrumentation-pg/src/types.ts
@@ -45,23 +45,25 @@ export interface PgInstrumentationConfig extends InstrumentationConfig {
   enhancedDatabaseReporting?: boolean;
 
   /**
-   * If true, the query text is masked by {@link maskStatementHook} before it is
-   * recorded as the `db.query.text` attribute.
+   * If true, the query text is recorded as-is instead of being masked by
+   * {@link maskStatementHook} before it is recorded as the `db.query.text`
+   * attribute.
    *
    * This is independent of {@link enhancedDatabaseReporting}, which controls a
-   * separate attribute holding the raw parameter values. Enabling both records
-   * masked query text alongside unmasked values.
+   * separate attribute holding the raw parameter values. Leaving this false
+   * while enabling {@link enhancedDatabaseReporting} records masked query text
+   * alongside unmasked values.
    *
    * @default false
    * @see maskStatementHook
    */
-  maskStatement?: boolean;
+  skipQueryTextSanitization?: boolean;
 
   /**
    * Hook that masks the query text before it is recorded as the
-   * `db.query.text` attribute. Only consulted when {@link maskStatement} is
-   * true, and never applied to the query sent to the server or to the text
-   * passed to {@link requestHook}.
+   * `db.query.text` attribute. Only consulted when
+   * {@link skipQueryTextSanitization} is false, and never applied to the
+   * query sent to the server or to the text passed to {@link requestHook}.
    *
    * The default replaces literals with `?` while preserving parameter
    * placeholders and identifiers. It is `sanitizeSql` from

--- a/packages/instrumentation-pg/src/utils.ts
+++ b/packages/instrumentation-pg/src/utils.ts
@@ -200,10 +200,6 @@ export function sanitizeQueryText(
     instrumentationConfig.queryTextSanitizationHook ??
     defaultQueryTextSanitizationHook;
 
-  // A plain try/catch rather than safeExecuteInTheMiddle: the hook returns a
-  // value, and that helper reports a throw as undefined -- indistinguishable
-  // from a hook missing a return statement, which is the likelier mistake and
-  // the one worth its own diagnostic.
   let sanitized: unknown;
   try {
     sanitized = hook(text);

--- a/packages/instrumentation-pg/src/utils.ts
+++ b/packages/instrumentation-pg/src/utils.ts
@@ -196,7 +196,7 @@ export function maskQueryText(
   text: string,
   instrumentationConfig: PgInstrumentationConfig
 ): string | undefined {
-  if (!instrumentationConfig.maskStatement) {
+  if (instrumentationConfig.skipQueryTextSanitization) {
     return text;
   }
 

--- a/packages/instrumentation-pg/src/utils.ts
+++ b/packages/instrumentation-pg/src/utils.ts
@@ -251,12 +251,8 @@ export function handleConfigQuery(
       ? queryConfig.values
       : undefined;
 
-    // A parameterized query's text is recorded as-is: the specification
-    // advises against sanitizing it, since any sensitive data is passed as
-    // parameter values rather than interpolated into the text. Supplying at
-    // least one value is what carries that assurance, so an empty array is
-    // not a parameterized call -- there is nothing travelling beside the
-    // text for the text to have been kept free of.
+    // An empty array is not a parameterized call: nothing travels beside the
+    // text, so the text has no assurance of having been kept free of values.
     const isParameterized = values !== undefined && values.length > 0;
 
     if (queryConfig.text) {

--- a/packages/instrumentation-pg/src/utils.ts
+++ b/packages/instrumentation-pg/src/utils.ts
@@ -253,10 +253,12 @@ export function handleConfigQuery(
     // A parameterized query's text is recorded as-is: the specification
     // advises against sanitizing it, since any sensitive data is passed as
     // parameter values rather than interpolated into the text.
-    const isParameterized = Array.isArray(queryConfig.values);
+    const values = Array.isArray(queryConfig.values)
+      ? queryConfig.values
+      : undefined;
 
     if (queryConfig.text) {
-      const queryText = isParameterized
+      const queryText = values
         ? queryConfig.text
         : maskQueryText(queryConfig.text, instrumentationConfig);
       if (queryText !== undefined) {
@@ -264,12 +266,9 @@ export function handleConfigQuery(
       }
     }
 
-    if (
-      instrumentationConfig.enhancedDatabaseReporting &&
-      Array.isArray(queryConfig.values)
-    ) {
+    if (instrumentationConfig.enhancedDatabaseReporting && values) {
       try {
-        const convertedValues = queryConfig.values.map(value => {
+        const convertedValues = values.map(value => {
           if (value == null) {
             return 'null';
           } else if (value instanceof Buffer) {
@@ -286,7 +285,7 @@ export function handleConfigQuery(
         });
         span.setAttribute(AttributeNames.PG_VALUES, convertedValues);
       } catch (e) {
-        diag.error('failed to stringify ', queryConfig.values, e);
+        diag.error('failed to stringify ', values, e);
       }
     }
 

--- a/packages/instrumentation-pg/src/utils.ts
+++ b/packages/instrumentation-pg/src/utils.ts
@@ -176,7 +176,7 @@ export function shouldSkipInstrumentation(
   );
 }
 
-function defaultMaskStatementHook(query: string): string {
+function defaultQueryTextSanitizationHook(query: string): string {
   return sanitizeSql(query, { dialect: 'postgresql' });
 }
 
@@ -184,11 +184,11 @@ function defaultMaskStatementHook(query: string): string {
  * Resolves the value for the `db.query.text` attribute, returning undefined
  * when the attribute should be left off the span.
  *
- * A masking hook that fails is treated as a refusal to record the text rather
- * than as a reason to fall back to it: falling back would turn a bug in the
- * hook into the data leak that masking was enabled to prevent.
+ * A sanitization hook that fails is treated as a refusal to record the text
+ * rather than as a reason to fall back to it: falling back would turn a bug in
+ * the hook into the data leak that sanitization was enabled to prevent.
  */
-export function maskQueryText(
+export function sanitizeQueryText(
   text: string,
   instrumentationConfig: PgInstrumentationConfig
 ): string | undefined {
@@ -197,33 +197,34 @@ export function maskQueryText(
   }
 
   const hook =
-    instrumentationConfig.maskStatementHook ?? defaultMaskStatementHook;
+    instrumentationConfig.queryTextSanitizationHook ??
+    defaultQueryTextSanitizationHook;
 
   // A plain try/catch rather than safeExecuteInTheMiddle: the hook returns a
   // value, and that helper reports a throw as undefined -- indistinguishable
   // from a hook missing a return statement, which is the likelier mistake and
   // the one worth its own diagnostic.
-  let masked: unknown;
+  let sanitized: unknown;
   try {
-    masked = hook(text);
+    sanitized = hook(text);
   } catch (err) {
     diag.warn(
-      'Error running maskStatementHook, omitting the db.query.text attribute',
+      'Error running queryTextSanitizationHook, omitting the db.query.text attribute',
       err
     );
     return undefined;
   }
 
-  if (typeof masked !== 'string') {
+  if (typeof sanitized !== 'string') {
     diag.warn(
-      'maskStatementHook returned a non-string value, omitting the db.query.text attribute'
+      'queryTextSanitizationHook returned a non-string value, omitting the db.query.text attribute'
     );
     return undefined;
   }
 
   // Empty text says less than no attribute does: a consumer cannot tell it
   // apart from a statement that carried no text to begin with.
-  return masked === '' ? undefined : masked;
+  return sanitized === '' ? undefined : sanitized;
 }
 
 // Create a span from our normalized queryConfig object,
@@ -260,7 +261,7 @@ export function handleConfigQuery(
     if (queryConfig.text) {
       const queryText = values
         ? queryConfig.text
-        : maskQueryText(queryConfig.text, instrumentationConfig);
+        : sanitizeQueryText(queryConfig.text, instrumentationConfig);
       if (queryText !== undefined) {
         span.setAttribute(ATTR_DB_QUERY_TEXT, queryText);
       }

--- a/packages/instrumentation-pg/src/utils.ts
+++ b/packages/instrumentation-pg/src/utils.ts
@@ -254,8 +254,15 @@ export function handleConfigQuery(
 
   // Set attributes
   if (span.isRecording()) {
+    // A parameterized query's text is recorded as-is: the specification
+    // advises against sanitizing it, since any sensitive data is passed as
+    // parameter values rather than interpolated into the text.
+    const isParameterized = Array.isArray(queryConfig.values);
+
     if (queryConfig.text) {
-      const queryText = maskQueryText(queryConfig.text, instrumentationConfig);
+      const queryText = isParameterized
+        ? queryConfig.text
+        : maskQueryText(queryConfig.text, instrumentationConfig);
       if (queryText !== undefined) {
         span.setAttribute(ATTR_DB_QUERY_TEXT, queryText);
       }

--- a/packages/instrumentation-pg/src/utils.ts
+++ b/packages/instrumentation-pg/src/utils.ts
@@ -245,7 +245,8 @@ export function handleConfigQuery(
     return span;
   }
 
-  // Set attributes
+  // Gated on isRecording so that an unsampled span does not pay for
+  // sanitizing the query text or stringifying the parameter values.
   if (span.isRecording()) {
     const values = Array.isArray(queryConfig.values)
       ? queryConfig.values

--- a/packages/instrumentation-pg/src/utils.ts
+++ b/packages/instrumentation-pg/src/utils.ts
@@ -41,6 +41,7 @@ import {
 import { PgInstrumentationConfig } from './types';
 import type * as pgTypes from 'pg';
 import { safeExecuteInTheMiddle } from '@opentelemetry/instrumentation';
+import { sanitizeSql } from '@opentelemetry/sql-common';
 import { SpanNames } from './enums/SpanNames';
 
 /**
@@ -179,6 +180,56 @@ export function shouldSkipInstrumentation(
   );
 }
 
+function defaultMaskStatementHook(query: string): string {
+  return sanitizeSql(query, { dialect: 'postgresql' });
+}
+
+/**
+ * Resolves the value for the `db.query.text` attribute, returning undefined
+ * when the attribute should be left off the span.
+ *
+ * A masking hook that fails is treated as a refusal to record the text rather
+ * than as a reason to fall back to it: falling back would turn a bug in the
+ * hook into the data leak that masking was enabled to prevent.
+ */
+export function maskQueryText(
+  text: string,
+  instrumentationConfig: PgInstrumentationConfig
+): string | undefined {
+  if (!instrumentationConfig.maskStatement) {
+    return text;
+  }
+
+  const hook =
+    instrumentationConfig.maskStatementHook ?? defaultMaskStatementHook;
+
+  // A plain try/catch rather than safeExecuteInTheMiddle: the hook returns a
+  // value, and that helper reports a throw as undefined -- indistinguishable
+  // from a hook missing a return statement, which is the likelier mistake and
+  // the one worth its own diagnostic.
+  let masked: unknown;
+  try {
+    masked = hook(text);
+  } catch (err) {
+    diag.warn(
+      'Error running maskStatementHook, omitting the db.query.text attribute',
+      err
+    );
+    return undefined;
+  }
+
+  if (typeof masked !== 'string') {
+    diag.warn(
+      'maskStatementHook returned a non-string value, omitting the db.query.text attribute'
+    );
+    return undefined;
+  }
+
+  // Empty text says less than no attribute does: a consumer cannot tell it
+  // apart from a statement that carried no text to begin with.
+  return masked === '' ? undefined : masked;
+}
+
 // Create a span from our normalized queryConfig object,
 // or return a basic span if no queryConfig was given/could be created.
 export function handleConfigQuery(
@@ -202,39 +253,44 @@ export function handleConfigQuery(
   }
 
   // Set attributes
-  if (queryConfig.text) {
-    span.setAttribute(ATTR_DB_QUERY_TEXT, queryConfig.text);
-  }
-
-  if (
-    instrumentationConfig.enhancedDatabaseReporting &&
-    Array.isArray(queryConfig.values)
-  ) {
-    try {
-      const convertedValues = queryConfig.values.map(value => {
-        if (value == null) {
-          return 'null';
-        } else if (value instanceof Buffer) {
-          return value.toString();
-        } else if (typeof value === 'object') {
-          if (typeof value.toPostgres === 'function') {
-            return value.toPostgres();
-          }
-          return JSON.stringify(value);
-        } else {
-          //string, number
-          return value.toString();
-        }
-      });
-      span.setAttribute(AttributeNames.PG_VALUES, convertedValues);
-    } catch (e) {
-      diag.error('failed to stringify ', queryConfig.values, e);
+  if (span.isRecording()) {
+    if (queryConfig.text) {
+      const queryText = maskQueryText(queryConfig.text, instrumentationConfig);
+      if (queryText !== undefined) {
+        span.setAttribute(ATTR_DB_QUERY_TEXT, queryText);
+      }
     }
-  }
 
-  // Set plan name attribute, if present
-  if (typeof queryConfig.name === 'string') {
-    span.setAttribute(AttributeNames.PG_PLAN, queryConfig.name);
+    if (
+      instrumentationConfig.enhancedDatabaseReporting &&
+      Array.isArray(queryConfig.values)
+    ) {
+      try {
+        const convertedValues = queryConfig.values.map(value => {
+          if (value == null) {
+            return 'null';
+          } else if (value instanceof Buffer) {
+            return value.toString();
+          } else if (typeof value === 'object') {
+            if (typeof value.toPostgres === 'function') {
+              return value.toPostgres();
+            }
+            return JSON.stringify(value);
+          } else {
+            //string, number
+            return value.toString();
+          }
+        });
+        span.setAttribute(AttributeNames.PG_VALUES, convertedValues);
+      } catch (e) {
+        diag.error('failed to stringify ', queryConfig.values, e);
+      }
+    }
+
+    // Set plan name attribute, if present
+    if (typeof queryConfig.name === 'string') {
+      span.setAttribute(AttributeNames.PG_PLAN, queryConfig.name);
+    }
   }
 
   return span;

--- a/packages/instrumentation-pg/src/utils.ts
+++ b/packages/instrumentation-pg/src/utils.ts
@@ -83,14 +83,10 @@ export function getQuerySpanName(
 }
 
 export function parseNormalizedOperationName(queryText: string) {
-  // Trim the query text to handle leading/trailing whitespace
-  const trimmedQuery = queryText.trim();
-  const indexOfFirstSpace = trimmedQuery.indexOf(' ');
-  let sqlCommand =
-    indexOfFirstSpace === -1
-      ? trimmedQuery
-      : trimmedQuery.slice(0, indexOfFirstSpace);
-  sqlCommand = sqlCommand.toUpperCase();
+  // The leading keyword, up to the first whitespace of any kind -- not just
+  // a space, since a statement may separate its keyword from the rest with
+  // a tab or newline instead.
+  const sqlCommand = (queryText.trim().match(/^\S+/)?.[0] ?? '').toUpperCase();
 
   // Handle query text being "COMMIT;", which has an extra semicolon before the space.
   return sqlCommand.endsWith(';') ? sqlCommand.slice(0, -1) : sqlCommand;

--- a/packages/instrumentation-pg/src/utils.ts
+++ b/packages/instrumentation-pg/src/utils.ts
@@ -251,15 +251,20 @@ export function handleConfigQuery(
 
   // Set attributes
   if (span.isRecording()) {
-    // A parameterized query's text is recorded as-is: the specification
-    // advises against sanitizing it, since any sensitive data is passed as
-    // parameter values rather than interpolated into the text.
     const values = Array.isArray(queryConfig.values)
       ? queryConfig.values
       : undefined;
 
+    // A parameterized query's text is recorded as-is: the specification
+    // advises against sanitizing it, since any sensitive data is passed as
+    // parameter values rather than interpolated into the text. Supplying at
+    // least one value is what carries that assurance, so an empty array is
+    // not a parameterized call -- there is nothing travelling beside the
+    // text for the text to have been kept free of.
+    const isParameterized = values !== undefined && values.length > 0;
+
     if (queryConfig.text) {
-      const queryText = values
+      const queryText = isParameterized
         ? queryConfig.text
         : sanitizeQueryText(queryConfig.text, instrumentationConfig);
       if (queryText !== undefined) {

--- a/packages/instrumentation-pg/test/pg-pool.test.ts
+++ b/packages/instrumentation-pg/test/pg-pool.test.ts
@@ -424,6 +424,9 @@ describe('pg-pool', () => {
     describe('when specifying a responseHook configuration', () => {
       const dataAttributeName = 'pg_data';
       const query = 'SELECT 0::text';
+      // db.query.text is sanitized by default, so the recorded attribute
+      // differs from the raw text the driver receives.
+      const sanitizedQuery = 'SELECT ?::text';
       const events: TimedEvent[] = [];
 
       describe('AND valid responseHook', () => {
@@ -432,7 +435,7 @@ describe('pg-pool', () => {
         };
         const pgAttributes = {
           ...DEFAULT_PG_ATTRIBUTES,
-          [ATTR_DB_QUERY_TEXT]: query,
+          [ATTR_DB_QUERY_TEXT]: sanitizedQuery,
           [dataAttributeName]: '{"rowCount":1}',
         };
 
@@ -514,7 +517,7 @@ describe('pg-pool', () => {
         };
         const pgAttributes = {
           ...DEFAULT_PG_ATTRIBUTES,
-          [ATTR_DB_QUERY_TEXT]: query,
+          [ATTR_DB_QUERY_TEXT]: sanitizedQuery,
         };
 
         beforeEach(async () => {

--- a/packages/instrumentation-pg/test/pg.test.ts
+++ b/packages/instrumentation-pg/test/pg.test.ts
@@ -621,11 +621,11 @@ describe('pg', () => {
       });
     });
 
-    describe('Check configuration maskStatement:true', () => {
+    describe('Check configuration skipQueryTextSanitization:false', () => {
       const events: TimedEvent[] = [];
 
       beforeEach(() => {
-        create({ maskStatement: true });
+        create({ skipQueryTextSanitization: false });
       });
 
       afterEach(() => {
@@ -712,7 +712,7 @@ describe('pg', () => {
 
       it('applies a custom hook without changing the query sent to the server', async () => {
         create({
-          maskStatement: true,
+          skipQueryTextSanitization: false,
           maskStatementHook: () => 'REDACTED',
         });
 
@@ -735,7 +735,7 @@ describe('pg', () => {
 
       it('omits the query text when the hook throws, without failing the query', async () => {
         create({
-          maskStatement: true,
+          skipQueryTextSanitization: false,
           maskStatementHook: () => {
             throw new Error('hook failure');
           },
@@ -758,7 +758,7 @@ describe('pg', () => {
 
       it('does not record the sqlcommenter comment it appends to the wire query', async () => {
         create({
-          maskStatement: true,
+          skipQueryTextSanitization: false,
           addSqlCommenterCommentToQueries: true,
         });
 
@@ -783,7 +783,7 @@ describe('pg', () => {
 
       it('still records raw values when enhancedDatabaseReporting is also enabled', done => {
         create({
-          maskStatement: true,
+          skipQueryTextSanitization: false,
           enhancedDatabaseReporting: true,
         });
 
@@ -805,8 +805,30 @@ describe('pg', () => {
       });
     });
 
-    describe('Check configuration maskStatement default', () => {
-      it('records a literal verbatim when masking is not enabled', done => {
+    describe('Check configuration skipQueryTextSanitization default', () => {
+      afterEach(() => {
+        create({});
+      });
+
+      it('masks a literal by default', done => {
+        const query = "SELECT 'hunter2' as msg";
+        const attributes = {
+          ...DEFAULT_ATTRIBUTES,
+          [ATTR_DB_QUERY_TEXT]: 'SELECT ? as msg',
+        };
+        const span = tracer.startSpan('test span');
+        context.with(trace.setSpan(context.active(), span), () => {
+          client.query(query, (err, res) => {
+            assert.strictEqual(err, null);
+            assert.ok(res);
+            runCallbackTest(span, attributes, []);
+            done();
+          });
+        });
+      });
+
+      it('records a literal verbatim when skipQueryTextSanitization is true', done => {
+        create({ skipQueryTextSanitization: true });
         const query = "SELECT 'hunter2' as msg";
         const attributes = {
           ...DEFAULT_ATTRIBUTES,

--- a/packages/instrumentation-pg/test/pg.test.ts
+++ b/packages/instrumentation-pg/test/pg.test.ts
@@ -649,6 +649,24 @@ describe('pg', () => {
         });
       });
 
+      it('does not mask a literal that accompanies parameter placeholders', done => {
+        const query = "SELECT $1::text as msg, 'literal' as note";
+        const attributes = {
+          ...DEFAULT_ATTRIBUTES,
+          [ATTR_DB_QUERY_TEXT]: query,
+        };
+        const span = tracer.startSpan('test span');
+        context.with(trace.setSpan(context.active(), span), () => {
+          client.query(query, ['hello'], (err, res) => {
+            assert.strictEqual(err, null);
+            assert.strictEqual(res.rows[0].msg, 'hello');
+            assert.strictEqual(res.rows[0].note, 'literal');
+            runCallbackTest(span, attributes, events);
+            done();
+          });
+        });
+      });
+
       it('masks a literal in a static query', done => {
         const attributes = {
           ...DEFAULT_ATTRIBUTES,

--- a/packages/instrumentation-pg/test/pg.test.ts
+++ b/packages/instrumentation-pg/test/pg.test.ts
@@ -621,6 +621,209 @@ describe('pg', () => {
       });
     });
 
+    describe('Check configuration maskStatement:true', () => {
+      const events: TimedEvent[] = [];
+
+      beforeEach(() => {
+        create({ maskStatement: true });
+      });
+
+      afterEach(() => {
+        create({});
+      });
+
+      it('leaves a fully parameterized query unchanged', done => {
+        const query = 'SELECT $1::text as msg';
+        const attributes = {
+          ...DEFAULT_ATTRIBUTES,
+          [ATTR_DB_QUERY_TEXT]: query,
+        };
+        const span = tracer.startSpan('test span');
+        context.with(trace.setSpan(context.active(), span), () => {
+          client.query(query, ['hello'], (err, res) => {
+            assert.strictEqual(err, null);
+            assert.strictEqual(res.rows[0].msg, 'hello');
+            runCallbackTest(span, attributes, events);
+            done();
+          });
+        });
+      });
+
+      it('masks a literal in a static query', done => {
+        const attributes = {
+          ...DEFAULT_ATTRIBUTES,
+          [ATTR_DB_QUERY_TEXT]: 'SELECT ? as msg',
+        };
+        const span = tracer.startSpan('test span');
+        context.with(trace.setSpan(context.active(), span), () => {
+          client.query("SELECT 'hunter2' as msg", (err, res) => {
+            assert.strictEqual(err, null);
+            assert.strictEqual(res.rows[0].msg, 'hunter2');
+
+            const [pgSpan] = memoryExporter.getFinishedSpans();
+            assert.ok(
+              !(pgSpan.attributes[ATTR_DB_QUERY_TEXT] as string).includes(
+                'hunter2'
+              ),
+              'query text should not contain the literal'
+            );
+            runCallbackTest(span, attributes, events);
+            done();
+          });
+        });
+      });
+
+      it('drops a comment from the query text', done => {
+        const attributes = {
+          ...DEFAULT_ATTRIBUTES,
+          [ATTR_DB_QUERY_TEXT]: 'SELECT ? as n',
+        };
+        const span = tracer.startSpan('test span');
+        context.with(trace.setSpan(context.active(), span), () => {
+          client.query('SELECT 42 as n -- secret', (err, res) => {
+            assert.strictEqual(err, null);
+            assert.ok(res);
+            runCallbackTest(span, attributes, events);
+            done();
+          });
+        });
+      });
+
+      it('masks the text of a prepared statement but keeps its name', done => {
+        const queryConfig = {
+          name: 'mask_test',
+          text: "SELECT * FROM pg_tables WHERE schemaname = 'public'",
+        };
+        const attributes = {
+          ...DEFAULT_ATTRIBUTES,
+          [ATTR_DB_QUERY_TEXT]: 'SELECT * FROM pg_tables WHERE schemaname = ?',
+          [AttributeNames.PG_PLAN]: queryConfig.name,
+        };
+        const span = tracer.startSpan('test span');
+        context.with(trace.setSpan(context.active(), span), () => {
+          client.query(queryConfig, (err, res) => {
+            assert.strictEqual(err, null);
+            assert.ok(Array.isArray(res.rows));
+            runCallbackTest(span, attributes, events);
+            done();
+          });
+        });
+      });
+
+      it('applies a custom hook without changing the query sent to the server', async () => {
+        create({
+          maskStatement: true,
+          maskStatementHook: () => 'REDACTED',
+        });
+
+        const query = "SELECT 'hunter2' as msg";
+        const span = tracer.startSpan('test span');
+        await context.with(trace.setSpan(context.active(), span), async () => {
+          const res = await client.query(query);
+          assert.strictEqual(res.rows[0].msg, 'hunter2');
+
+          const [pgSpan] = memoryExporter.getFinishedSpans();
+          assert.strictEqual(pgSpan.attributes[ATTR_DB_QUERY_TEXT], 'REDACTED');
+
+          // Masking is a telemetry concern only; the statement on the wire is
+          // whatever the application passed.
+          const executedQueries = getExecutedQueries();
+          assert.strictEqual(executedQueries.length, 1);
+          assert.strictEqual(executedQueries[0].text, query);
+        });
+      });
+
+      it('omits the query text when the hook throws, without failing the query', async () => {
+        create({
+          maskStatement: true,
+          maskStatementHook: () => {
+            throw new Error('hook failure');
+          },
+        });
+
+        const span = tracer.startSpan('test span');
+        await context.with(trace.setSpan(context.active(), span), async () => {
+          const res = await client.query("SELECT 'hunter2' as msg");
+          assert.strictEqual(res.rows[0].msg, 'hunter2');
+
+          const [pgSpan] = memoryExporter.getFinishedSpans();
+          assert.strictEqual(
+            pgSpan.attributes[ATTR_DB_QUERY_TEXT],
+            undefined,
+            'query text should be omitted rather than fall back to the raw text'
+          );
+          assert.deepStrictEqual(pgSpan.attributes, DEFAULT_ATTRIBUTES);
+        });
+      });
+
+      it('does not record the sqlcommenter comment it appends to the wire query', async () => {
+        create({
+          maskStatement: true,
+          addSqlCommenterCommentToQueries: true,
+        });
+
+        const span = tracer.startSpan('test span');
+        await context.with(trace.setSpan(context.active(), span), async () => {
+          await client.query("SELECT 'hunter2' as msg");
+
+          const [pgSpan] = memoryExporter.getFinishedSpans();
+          assert.strictEqual(
+            pgSpan.attributes[ATTR_DB_QUERY_TEXT],
+            'SELECT ? as msg'
+          );
+
+          const executedQueries = getExecutedQueries();
+          assert.strictEqual(executedQueries.length, 1);
+          assert.ok(
+            executedQueries[0].text?.includes('traceparent'),
+            'the query sent to the server should carry the comment'
+          );
+        });
+      });
+
+      it('still records raw values when enhancedDatabaseReporting is also enabled', done => {
+        create({
+          maskStatement: true,
+          enhancedDatabaseReporting: true,
+        });
+
+        const query = 'SELECT $1::text as msg';
+        const attributes = {
+          ...DEFAULT_ATTRIBUTES,
+          [ATTR_DB_QUERY_TEXT]: query,
+          [AttributeNames.PG_VALUES]: ['hello'],
+        };
+        const span = tracer.startSpan('test span');
+        context.with(trace.setSpan(context.active(), span), () => {
+          client.query(query, ['hello'], (err, res) => {
+            assert.strictEqual(err, null);
+            assert.ok(res);
+            runCallbackTest(span, attributes, events);
+            done();
+          });
+        });
+      });
+    });
+
+    describe('Check configuration maskStatement default', () => {
+      it('records a literal verbatim when masking is not enabled', done => {
+        const query = "SELECT 'hunter2' as msg";
+        const attributes = {
+          ...DEFAULT_ATTRIBUTES,
+          [ATTR_DB_QUERY_TEXT]: query,
+        };
+        const span = tracer.startSpan('test span');
+        context.with(trace.setSpan(context.active(), span), () => {
+          client.query(query, (err, res) => {
+            assert.strictEqual(err, null);
+            assert.ok(res);
+            runCallbackTest(span, attributes, []);
+            done();
+          });
+        });
+      });
+    });
+
     describe('when specifying a requestHook configuration', () => {
       const dataAttributeName = 'pg_data';
       const query = 'SELECT 0::text';

--- a/packages/instrumentation-pg/test/pg.test.ts
+++ b/packages/instrumentation-pg/test/pg.test.ts
@@ -649,7 +649,7 @@ describe('pg', () => {
         });
       });
 
-      it('does not mask a literal that accompanies parameter placeholders', done => {
+      it('does not sanitize a literal that accompanies parameter placeholders', done => {
         const query = "SELECT $1::text as msg, 'literal' as note";
         const attributes = {
           ...DEFAULT_ATTRIBUTES,
@@ -667,7 +667,7 @@ describe('pg', () => {
         });
       });
 
-      it('masks a literal in a static query', done => {
+      it('sanitizes a literal in a static query', done => {
         const attributes = {
           ...DEFAULT_ATTRIBUTES,
           [ATTR_DB_QUERY_TEXT]: 'SELECT ? as msg',
@@ -707,9 +707,9 @@ describe('pg', () => {
         });
       });
 
-      it('masks the text of a prepared statement but keeps its name', done => {
+      it('sanitizes the text of a prepared statement but keeps its name', done => {
         const queryConfig = {
-          name: 'mask_test',
+          name: 'sanitize_test',
           text: "SELECT * FROM pg_tables WHERE schemaname = 'public'",
         };
         const attributes = {
@@ -731,7 +731,7 @@ describe('pg', () => {
       it('applies a custom hook without changing the query sent to the server', async () => {
         create({
           skipQueryTextSanitization: false,
-          maskStatementHook: () => 'REDACTED',
+          queryTextSanitizationHook: () => 'REDACTED',
         });
 
         const query = "SELECT 'hunter2' as msg";
@@ -743,7 +743,7 @@ describe('pg', () => {
           const [pgSpan] = memoryExporter.getFinishedSpans();
           assert.strictEqual(pgSpan.attributes[ATTR_DB_QUERY_TEXT], 'REDACTED');
 
-          // Masking is a telemetry concern only; the statement on the wire is
+          // Sanitization is a telemetry concern only; the statement on the wire is
           // whatever the application passed.
           const executedQueries = getExecutedQueries();
           assert.strictEqual(executedQueries.length, 1);
@@ -754,7 +754,7 @@ describe('pg', () => {
       it('omits the query text when the hook throws, without failing the query', async () => {
         create({
           skipQueryTextSanitization: false,
-          maskStatementHook: () => {
+          queryTextSanitizationHook: () => {
             throw new Error('hook failure');
           },
         });
@@ -828,7 +828,7 @@ describe('pg', () => {
         create({});
       });
 
-      it('masks a literal by default', done => {
+      it('sanitizes a literal by default', done => {
         const query = "SELECT 'hunter2' as msg";
         const attributes = {
           ...DEFAULT_ATTRIBUTES,

--- a/packages/instrumentation-pg/test/pg.test.ts
+++ b/packages/instrumentation-pg/test/pg.test.ts
@@ -893,13 +893,16 @@ describe('pg', () => {
     describe('when specifying a requestHook configuration', () => {
       const dataAttributeName = 'pg_data';
       const query = 'SELECT 0::text';
+      // db.query.text is sanitized by default, so the recorded attribute
+      // differs from the raw text the driver and the hook receive.
+      const sanitizedQuery = 'SELECT ?::text';
       const events: TimedEvent[] = [];
 
       // these are the attributes that we'd expect would end up on the final
       // span if there is no requestHook.
       const attributes = {
         ...DEFAULT_ATTRIBUTES,
-        [ATTR_DB_QUERY_TEXT]: query,
+        [ATTR_DB_QUERY_TEXT]: sanitizedQuery,
       };
 
       // These are the attributes we expect on the span after the requestHook
@@ -987,12 +990,15 @@ describe('pg', () => {
     describe('when specifying a responseHook configuration', () => {
       const dataAttributeName = 'pg_data';
       const query = 'SELECT 0::text';
+      // db.query.text is sanitized by default, so the recorded attribute
+      // differs from the raw text the driver receives.
+      const sanitizedQuery = 'SELECT ?::text';
       const events: TimedEvent[] = [];
 
       describe('AND valid responseHook', () => {
         const attributes = {
           ...DEFAULT_ATTRIBUTES,
-          [ATTR_DB_QUERY_TEXT]: query,
+          [ATTR_DB_QUERY_TEXT]: sanitizedQuery,
           [dataAttributeName]: '{"rowCount":1}',
         };
         beforeEach(async () => {
@@ -1025,7 +1031,7 @@ describe('pg', () => {
         it('should attach response hook data to resulting spans for query returning a Promise', async () => {
           const attributes = {
             ...DEFAULT_ATTRIBUTES,
-            [ATTR_DB_QUERY_TEXT]: query,
+            [ATTR_DB_QUERY_TEXT]: sanitizedQuery,
             [dataAttributeName]: '{"rowCount":1}',
           };
 
@@ -1050,7 +1056,7 @@ describe('pg', () => {
       describe('AND invalid responseHook', () => {
         const attributes = {
           ...DEFAULT_ATTRIBUTES,
-          [ATTR_DB_QUERY_TEXT]: query,
+          [ATTR_DB_QUERY_TEXT]: sanitizedQuery,
         };
 
         beforeEach(async () => {

--- a/packages/instrumentation-pg/test/pg.test.ts
+++ b/packages/instrumentation-pg/test/pg.test.ts
@@ -667,6 +667,32 @@ describe('pg', () => {
         });
       });
 
+      it('sanitizes a query passed an empty values array', done => {
+        // The shape a wrapper such as `query(text, params = [])` produces for
+        // every call it forwards, including the concatenated ones.
+        const attributes = {
+          ...DEFAULT_ATTRIBUTES,
+          [ATTR_DB_QUERY_TEXT]: 'SELECT ? as msg',
+        };
+        const span = tracer.startSpan('test span');
+        context.with(trace.setSpan(context.active(), span), () => {
+          client.query("SELECT 'hunter2' as msg", [], (err, res) => {
+            assert.strictEqual(err, null);
+            assert.strictEqual(res.rows[0].msg, 'hunter2');
+
+            const [pgSpan] = memoryExporter.getFinishedSpans();
+            assert.ok(
+              !(pgSpan.attributes[ATTR_DB_QUERY_TEXT] as string).includes(
+                'hunter2'
+              ),
+              'query text should not contain the literal'
+            );
+            runCallbackTest(span, attributes, events);
+            done();
+          });
+        });
+      });
+
       it('sanitizes a literal in a static query', done => {
         const attributes = {
           ...DEFAULT_ATTRIBUTES,

--- a/packages/instrumentation-pg/test/utils.test.ts
+++ b/packages/instrumentation-pg/test/utils.test.ts
@@ -201,20 +201,23 @@ describe('utils.ts', () => {
       diag.disable();
     });
 
-    it('returns the query unchanged when masking is not configured', () => {
-      assert.strictEqual(utils.maskQueryText(query, {}), query);
+    it('applies the default hook when masking is not configured', () => {
+      assert.strictEqual(
+        utils.maskQueryText(query, {}),
+        'SELECT * FROM t WHERE a = ? AND b = ?'
+      );
     });
 
-    it('returns the query unchanged when masking is disabled', () => {
+    it('returns the query unchanged when skipQueryTextSanitization is true', () => {
       assert.strictEqual(
-        utils.maskQueryText(query, { maskStatement: false }),
+        utils.maskQueryText(query, { skipQueryTextSanitization: true }),
         query
       );
     });
 
-    it('applies the default hook when masking is enabled', () => {
+    it('applies the default hook when skipQueryTextSanitization is explicitly false', () => {
       assert.strictEqual(
-        utils.maskQueryText(query, { maskStatement: true }),
+        utils.maskQueryText(query, { skipQueryTextSanitization: false }),
         'SELECT * FROM t WHERE a = ? AND b = ?'
       );
     });
@@ -222,7 +225,7 @@ describe('utils.ts', () => {
     it('preserves parameter placeholders', () => {
       assert.strictEqual(
         utils.maskQueryText('SELECT * FROM t WHERE a = $1', {
-          maskStatement: true,
+          skipQueryTextSanitization: false,
         }),
         'SELECT * FROM t WHERE a = $1'
       );
@@ -231,7 +234,7 @@ describe('utils.ts', () => {
     it('applies a custom hook to the raw query text', () => {
       const seen: string[] = [];
       const masked = utils.maskQueryText(query, {
-        maskStatement: true,
+        skipQueryTextSanitization: false,
         maskStatementHook: text => {
           seen.push(text);
           return 'REDACTED';
@@ -245,7 +248,7 @@ describe('utils.ts', () => {
     it('does not call the hook when masking is disabled', () => {
       let called = false;
       utils.maskQueryText(query, {
-        maskStatement: false,
+        skipQueryTextSanitization: true,
         maskStatementHook: text => {
           called = true;
           return text;
@@ -258,7 +261,7 @@ describe('utils.ts', () => {
     it('omits the text and warns when the hook throws', () => {
       const warnings = captureDiagWarnings();
       const masked = utils.maskQueryText(query, {
-        maskStatement: true,
+        skipQueryTextSanitization: false,
         maskStatementHook: () => {
           throw new Error('hook failure');
         },
@@ -277,7 +280,7 @@ describe('utils.ts', () => {
       it(`omits the text and warns when the hook returns ${description}`, () => {
         const warnings = captureDiagWarnings();
         const masked = utils.maskQueryText(query, {
-          maskStatement: true,
+          skipQueryTextSanitization: false,
           maskStatementHook: (() => value) as unknown as (q: string) => string,
         });
 
@@ -290,7 +293,7 @@ describe('utils.ts', () => {
     it('omits the text when masking leaves it empty', () => {
       assert.strictEqual(
         utils.maskQueryText(query, {
-          maskStatement: true,
+          skipQueryTextSanitization: false,
           maskStatementHook: () => '',
         }),
         undefined
@@ -353,11 +356,11 @@ describe('utils.ts', () => {
       );
     });
 
-    it('records masked query text when maskStatement is enabled', () => {
+    it('records masked query text when sanitization is not skipped', () => {
       const querySpan = utils.handleConfigQuery.call(
         client,
         tracer,
-        { ...instrumentationConfig, maskStatement: true },
+        { ...instrumentationConfig, skipQueryTextSanitization: false },
         { text: "SELECT 'secret'::text" }
       );
       querySpan.end();
@@ -374,7 +377,7 @@ describe('utils.ts', () => {
         tracer,
         {
           ...instrumentationConfig,
-          maskStatement: true,
+          skipQueryTextSanitization: false,
           maskStatementHook: () => {
             throw new Error('hook failure');
           },
@@ -406,7 +409,7 @@ describe('utils.ts', () => {
         tracer,
         {
           ...instrumentationConfig,
-          maskStatement: true,
+          skipQueryTextSanitization: false,
           enhancedDatabaseReporting: true,
         },
         queryConfig
@@ -431,7 +434,7 @@ describe('utils.ts', () => {
         nonRecordingTracer,
         {
           ...instrumentationConfig,
-          maskStatement: true,
+          skipQueryTextSanitization: false,
           maskStatementHook: (text: string) => {
             called = true;
             return text;

--- a/packages/instrumentation-pg/test/utils.test.ts
+++ b/packages/instrumentation-pg/test/utils.test.ts
@@ -3,13 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { context, trace } from '@opentelemetry/api';
+import {
+  context,
+  diag,
+  DiagLogLevel,
+  trace,
+  DiagLogger,
+} from '@opentelemetry/api';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import {
   TracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
+  AlwaysOffSampler,
 } from '@opentelemetry/sdk-trace';
 import * as assert from 'assert';
 import * as pg from 'pg';
@@ -17,7 +24,27 @@ import { PgInstrumentationConfig } from '../src';
 import { AttributeNames } from '../src/enums/AttributeNames';
 import { PgClientExtended, PgPoolOptionsParams } from '../src/internal-types';
 import * as utils from '../src/utils';
-import { ATTR_SERVER_PORT } from '@opentelemetry/semantic-conventions';
+import {
+  ATTR_DB_QUERY_TEXT,
+  ATTR_SERVER_PORT,
+} from '@opentelemetry/semantic-conventions';
+
+/**
+ * Installs a diag logger that records warnings, so that tests can assert the
+ * instrumentation reported a failing hook rather than swallowing it.
+ */
+const captureDiagWarnings = () => {
+  const warnings: string[] = [];
+  const logger: DiagLogger = {
+    error: () => {},
+    warn: message => warnings.push(message),
+    info: () => {},
+    debug: () => {},
+    verbose: () => {},
+  };
+  diag.setLogger(logger, DiagLogLevel.WARN);
+  return warnings;
+};
 
 const memoryExporter = new InMemorySpanExporter();
 
@@ -42,6 +69,11 @@ describe('utils.ts', () => {
     spanProcessors: [new SimpleSpanProcessor({ exporter: memoryExporter })],
   });
   const tracer = provider.getTracer('external');
+  const nonRecordingProvider = new TracerProvider({
+    sampler: new AlwaysOffSampler(),
+    spanProcessors: [new SimpleSpanProcessor({ exporter: memoryExporter })],
+  });
+  const nonRecordingTracer = nonRecordingProvider.getTracer('external');
 
   const instrumentationConfig: PgInstrumentationConfig & InstrumentationConfig =
     {};
@@ -162,6 +194,110 @@ describe('utils.ts', () => {
     });
   });
 
+  describe('.maskQueryText()', () => {
+    const query = "SELECT * FROM t WHERE a = 'secret' AND b = 42";
+
+    afterEach(() => {
+      diag.disable();
+    });
+
+    it('returns the query unchanged when masking is not configured', () => {
+      assert.strictEqual(utils.maskQueryText(query, {}), query);
+    });
+
+    it('returns the query unchanged when masking is disabled', () => {
+      assert.strictEqual(
+        utils.maskQueryText(query, { maskStatement: false }),
+        query
+      );
+    });
+
+    it('applies the default hook when masking is enabled', () => {
+      assert.strictEqual(
+        utils.maskQueryText(query, { maskStatement: true }),
+        'SELECT * FROM t WHERE a = ? AND b = ?'
+      );
+    });
+
+    it('preserves parameter placeholders', () => {
+      assert.strictEqual(
+        utils.maskQueryText('SELECT * FROM t WHERE a = $1', {
+          maskStatement: true,
+        }),
+        'SELECT * FROM t WHERE a = $1'
+      );
+    });
+
+    it('applies a custom hook to the raw query text', () => {
+      const seen: string[] = [];
+      const masked = utils.maskQueryText(query, {
+        maskStatement: true,
+        maskStatementHook: text => {
+          seen.push(text);
+          return 'REDACTED';
+        },
+      });
+
+      assert.strictEqual(masked, 'REDACTED');
+      assert.deepStrictEqual(seen, [query]);
+    });
+
+    it('does not call the hook when masking is disabled', () => {
+      let called = false;
+      utils.maskQueryText(query, {
+        maskStatement: false,
+        maskStatementHook: text => {
+          called = true;
+          return text;
+        },
+      });
+
+      assert.strictEqual(called, false);
+    });
+
+    it('omits the text and warns when the hook throws', () => {
+      const warnings = captureDiagWarnings();
+      const masked = utils.maskQueryText(query, {
+        maskStatement: true,
+        maskStatementHook: () => {
+          throw new Error('hook failure');
+        },
+      });
+
+      assert.strictEqual(masked, undefined);
+      assert.strictEqual(warnings.length, 1);
+      assert.ok(warnings[0].includes('maskStatementHook'));
+    });
+
+    for (const [description, value] of [
+      ['a non-string', 42],
+      ['nothing', undefined],
+      ['null', null],
+    ] as const) {
+      it(`omits the text and warns when the hook returns ${description}`, () => {
+        const warnings = captureDiagWarnings();
+        const masked = utils.maskQueryText(query, {
+          maskStatement: true,
+          maskStatementHook: (() => value) as unknown as (q: string) => string,
+        });
+
+        assert.strictEqual(masked, undefined);
+        assert.strictEqual(warnings.length, 1);
+        assert.ok(warnings[0].includes('non-string'));
+      });
+    }
+
+    it('omits the text when masking leaves it empty', () => {
+      assert.strictEqual(
+        utils.maskQueryText(query, {
+          maskStatement: true,
+          maskStatementHook: () => '',
+        }),
+        undefined
+      );
+    });
+  });
+
   describe('.handleConfigQuery()', () => {
     const queryConfig = {
       text: 'SELECT $1::text',
@@ -200,6 +336,131 @@ describe('utils.ts', () => {
 
       const pgValues = readableSpan.attributes[AttributeNames.PG_VALUES];
       assert.deepStrictEqual(pgValues, ['0']);
+    });
+
+    it('records the query text verbatim by default', () => {
+      const querySpan = utils.handleConfigQuery.call(
+        client,
+        tracer,
+        instrumentationConfig,
+        queryConfig
+      );
+      querySpan.end();
+
+      assert.strictEqual(
+        getLatestSpan().attributes[ATTR_DB_QUERY_TEXT],
+        'SELECT $1::text'
+      );
+    });
+
+    it('records masked query text when maskStatement is enabled', () => {
+      const querySpan = utils.handleConfigQuery.call(
+        client,
+        tracer,
+        { ...instrumentationConfig, maskStatement: true },
+        { text: "SELECT 'secret'::text" }
+      );
+      querySpan.end();
+
+      assert.strictEqual(
+        getLatestSpan().attributes[ATTR_DB_QUERY_TEXT],
+        'SELECT ?::text'
+      );
+    });
+
+    it('omits only the query text when the masking hook fails', () => {
+      const querySpan = utils.handleConfigQuery.call(
+        client,
+        tracer,
+        {
+          ...instrumentationConfig,
+          maskStatement: true,
+          maskStatementHook: () => {
+            throw new Error('hook failure');
+          },
+        },
+        { ...queryConfig, name: 'a-plan' }
+      );
+      querySpan.end();
+
+      const readableSpan = getLatestSpan();
+      assert.strictEqual(
+        readableSpan.attributes[ATTR_DB_QUERY_TEXT],
+        undefined
+      );
+      // The rest of the span is unaffected: a failing hook withholds one
+      // attribute rather than degrading the span.
+      assert.strictEqual(
+        readableSpan.attributes[AttributeNames.PG_PLAN],
+        'a-plan'
+      );
+      assert.strictEqual(
+        readableSpan.attributes[ATTR_SERVER_PORT],
+        CONFIG.port
+      );
+    });
+
+    it('still records raw values when enhancedDatabaseReporting is combined with masking', () => {
+      const querySpan = utils.handleConfigQuery.call(
+        client,
+        tracer,
+        {
+          ...instrumentationConfig,
+          maskStatement: true,
+          enhancedDatabaseReporting: true,
+        },
+        queryConfig
+      );
+      querySpan.end();
+
+      const readableSpan = getLatestSpan();
+      assert.strictEqual(
+        readableSpan.attributes[ATTR_DB_QUERY_TEXT],
+        'SELECT $1::text'
+      );
+      assert.deepStrictEqual(
+        readableSpan.attributes[AttributeNames.PG_VALUES],
+        ['0']
+      );
+    });
+
+    it('does not run the masking hook for a non-recording span', () => {
+      let called = false;
+      const querySpan = utils.handleConfigQuery.call(
+        client,
+        nonRecordingTracer,
+        {
+          ...instrumentationConfig,
+          maskStatement: true,
+          maskStatementHook: (text: string) => {
+            called = true;
+            return text;
+          },
+        },
+        queryConfig
+      );
+      querySpan.end();
+
+      assert.strictEqual(called, false);
+    });
+
+    it('does not convert values for a non-recording span', () => {
+      const value = {
+        toPostgres: () => {
+          throw new Error('should not be called');
+        },
+      };
+      const querySpan = utils.handleConfigQuery.call(
+        client,
+        nonRecordingTracer,
+        {
+          ...instrumentationConfig,
+          enhancedDatabaseReporting: true,
+        },
+        { ...queryConfig, values: [value] }
+      );
+
+      assert.doesNotThrow(() => querySpan.end());
     });
   });
 

--- a/packages/instrumentation-pg/test/utils.test.ts
+++ b/packages/instrumentation-pg/test/utils.test.ts
@@ -356,6 +356,21 @@ describe('utils.ts', () => {
       );
     });
 
+    it('never sanitizes the text of a parameterized query, even when sanitization is not skipped', () => {
+      const querySpan = utils.handleConfigQuery.call(
+        client,
+        tracer,
+        { ...instrumentationConfig, skipQueryTextSanitization: false },
+        { text: "SELECT $1::text WHERE label = 'literal'", values: ['0'] }
+      );
+      querySpan.end();
+
+      assert.strictEqual(
+        getLatestSpan().attributes[ATTR_DB_QUERY_TEXT],
+        "SELECT $1::text WHERE label = 'literal'"
+      );
+    });
+
     it('records masked query text when sanitization is not skipped', () => {
       const querySpan = utils.handleConfigQuery.call(
         client,
@@ -382,7 +397,7 @@ describe('utils.ts', () => {
             throw new Error('hook failure');
           },
         },
-        { ...queryConfig, name: 'a-plan' }
+        { text: queryConfig.text, name: 'a-plan' }
       );
       querySpan.end();
 

--- a/packages/instrumentation-pg/test/utils.test.ts
+++ b/packages/instrumentation-pg/test/utils.test.ts
@@ -485,7 +485,9 @@ describe('utils.ts', () => {
             return text;
           },
         },
-        queryConfig
+        // Non-parameterized: a parameterized queryConfig would also skip the
+        // hook, which would leave this assertion true for the wrong reason.
+        { text: queryConfig.text }
       );
       querySpan.end();
 

--- a/packages/instrumentation-pg/test/utils.test.ts
+++ b/packages/instrumentation-pg/test/utils.test.ts
@@ -373,7 +373,7 @@ describe('utils.ts', () => {
       assert.deepStrictEqual(pgValues, ['0']);
     });
 
-    it('records the query text verbatim by default', () => {
+    it("records a parameterized query's text verbatim", () => {
       const querySpan = utils.handleConfigQuery.call(
         client,
         tracer,

--- a/packages/instrumentation-pg/test/utils.test.ts
+++ b/packages/instrumentation-pg/test/utils.test.ts
@@ -224,37 +224,37 @@ describe('utils.ts', () => {
     });
   });
 
-  describe('.maskQueryText()', () => {
+  describe('.sanitizeQueryText()', () => {
     const query = "SELECT * FROM t WHERE a = 'secret' AND b = 42";
 
     afterEach(() => {
       diag.disable();
     });
 
-    it('applies the default hook when masking is not configured', () => {
+    it('applies the default hook when sanitization is not configured', () => {
       assert.strictEqual(
-        utils.maskQueryText(query, {}),
+        utils.sanitizeQueryText(query, {}),
         'SELECT * FROM t WHERE a = ? AND b = ?'
       );
     });
 
     it('returns the query unchanged when skipQueryTextSanitization is true', () => {
       assert.strictEqual(
-        utils.maskQueryText(query, { skipQueryTextSanitization: true }),
+        utils.sanitizeQueryText(query, { skipQueryTextSanitization: true }),
         query
       );
     });
 
     it('applies the default hook when skipQueryTextSanitization is explicitly false', () => {
       assert.strictEqual(
-        utils.maskQueryText(query, { skipQueryTextSanitization: false }),
+        utils.sanitizeQueryText(query, { skipQueryTextSanitization: false }),
         'SELECT * FROM t WHERE a = ? AND b = ?'
       );
     });
 
     it('preserves parameter placeholders', () => {
       assert.strictEqual(
-        utils.maskQueryText('SELECT * FROM t WHERE a = $1', {
+        utils.sanitizeQueryText('SELECT * FROM t WHERE a = $1', {
           skipQueryTextSanitization: false,
         }),
         'SELECT * FROM t WHERE a = $1'
@@ -263,23 +263,23 @@ describe('utils.ts', () => {
 
     it('applies a custom hook to the raw query text', () => {
       const seen: string[] = [];
-      const masked = utils.maskQueryText(query, {
+      const sanitized = utils.sanitizeQueryText(query, {
         skipQueryTextSanitization: false,
-        maskStatementHook: text => {
+        queryTextSanitizationHook: text => {
           seen.push(text);
           return 'REDACTED';
         },
       });
 
-      assert.strictEqual(masked, 'REDACTED');
+      assert.strictEqual(sanitized, 'REDACTED');
       assert.deepStrictEqual(seen, [query]);
     });
 
-    it('does not call the hook when masking is disabled', () => {
+    it('does not call the hook when sanitization is skipped', () => {
       let called = false;
-      utils.maskQueryText(query, {
+      utils.sanitizeQueryText(query, {
         skipQueryTextSanitization: true,
-        maskStatementHook: text => {
+        queryTextSanitizationHook: text => {
           called = true;
           return text;
         },
@@ -290,16 +290,16 @@ describe('utils.ts', () => {
 
     it('omits the text and warns when the hook throws', () => {
       const warnings = captureDiagWarnings();
-      const masked = utils.maskQueryText(query, {
+      const sanitized = utils.sanitizeQueryText(query, {
         skipQueryTextSanitization: false,
-        maskStatementHook: () => {
+        queryTextSanitizationHook: () => {
           throw new Error('hook failure');
         },
       });
 
-      assert.strictEqual(masked, undefined);
+      assert.strictEqual(sanitized, undefined);
       assert.strictEqual(warnings.length, 1);
-      assert.ok(warnings[0].includes('maskStatementHook'));
+      assert.ok(warnings[0].includes('queryTextSanitizationHook'));
     });
 
     for (const [description, value] of [
@@ -309,22 +309,24 @@ describe('utils.ts', () => {
     ] as const) {
       it(`omits the text and warns when the hook returns ${description}`, () => {
         const warnings = captureDiagWarnings();
-        const masked = utils.maskQueryText(query, {
+        const sanitized = utils.sanitizeQueryText(query, {
           skipQueryTextSanitization: false,
-          maskStatementHook: (() => value) as unknown as (q: string) => string,
+          queryTextSanitizationHook: (() => value) as unknown as (
+            q: string
+          ) => string,
         });
 
-        assert.strictEqual(masked, undefined);
+        assert.strictEqual(sanitized, undefined);
         assert.strictEqual(warnings.length, 1);
         assert.ok(warnings[0].includes('non-string'));
       });
     }
 
-    it('omits the text when masking leaves it empty', () => {
+    it('omits the text when sanitization leaves it empty', () => {
       assert.strictEqual(
-        utils.maskQueryText(query, {
+        utils.sanitizeQueryText(query, {
           skipQueryTextSanitization: false,
-          maskStatementHook: () => '',
+          queryTextSanitizationHook: () => '',
         }),
         undefined
       );
@@ -401,7 +403,7 @@ describe('utils.ts', () => {
       );
     });
 
-    it('records masked query text when sanitization is not skipped', () => {
+    it('records sanitized query text when sanitization is not skipped', () => {
       const querySpan = utils.handleConfigQuery.call(
         client,
         tracer,
@@ -416,14 +418,14 @@ describe('utils.ts', () => {
       );
     });
 
-    it('omits only the query text when the masking hook fails', () => {
+    it('omits only the query text when the sanitization hook fails', () => {
       const querySpan = utils.handleConfigQuery.call(
         client,
         tracer,
         {
           ...instrumentationConfig,
           skipQueryTextSanitization: false,
-          maskStatementHook: () => {
+          queryTextSanitizationHook: () => {
             throw new Error('hook failure');
           },
         },
@@ -448,7 +450,7 @@ describe('utils.ts', () => {
       );
     });
 
-    it('still records raw values when enhancedDatabaseReporting is combined with masking', () => {
+    it('still records raw values when enhancedDatabaseReporting is combined with sanitization', () => {
       const querySpan = utils.handleConfigQuery.call(
         client,
         tracer,
@@ -472,7 +474,7 @@ describe('utils.ts', () => {
       );
     });
 
-    it('does not run the masking hook for a non-recording span', () => {
+    it('does not run the sanitization hook for a non-recording span', () => {
       let called = false;
       const querySpan = utils.handleConfigQuery.call(
         client,
@@ -480,7 +482,7 @@ describe('utils.ts', () => {
         {
           ...instrumentationConfig,
           skipQueryTextSanitization: false,
-          maskStatementHook: (text: string) => {
+          queryTextSanitizationHook: (text: string) => {
             called = true;
             return text;
           },

--- a/packages/instrumentation-pg/test/utils.test.ts
+++ b/packages/instrumentation-pg/test/utils.test.ts
@@ -162,6 +162,36 @@ describe('utils.ts', () => {
     });
   });
 
+  describe('.parseNormalizedOperationName()', () => {
+    it('splits on a tab as well as a space', () => {
+      assert.strictEqual(
+        utils.parseNormalizedOperationName("SELECT\t'x' FROM t"),
+        'SELECT'
+      );
+    });
+
+    it('splits on a newline', () => {
+      assert.strictEqual(
+        utils.parseNormalizedOperationName("SELECT\n'secret'"),
+        'SELECT'
+      );
+    });
+
+    it('splits on a carriage return', () => {
+      assert.strictEqual(
+        utils.parseNormalizedOperationName("UPDATE\r\nt SET c='x'"),
+        'UPDATE'
+      );
+    });
+
+    it('returns the whole trimmed input when it has no whitespace', () => {
+      assert.strictEqual(
+        utils.parseNormalizedOperationName('  SELECT  '),
+        'SELECT'
+      );
+    });
+  });
+
   describe('.shouldSkipInstrumentation()', () => {
     it('returns false when requireParentSpan=false', async () => {
       assert.strictEqual(

--- a/packages/instrumentation-pg/test/utils.test.ts
+++ b/packages/instrumentation-pg/test/utils.test.ts
@@ -403,6 +403,21 @@ describe('utils.ts', () => {
       );
     });
 
+    it('sanitizes the text of a query given an empty values array', () => {
+      const querySpan = utils.handleConfigQuery.call(
+        client,
+        tracer,
+        instrumentationConfig,
+        { text: "SELECT * FROM t WHERE label = 'literal'", values: [] }
+      );
+      querySpan.end();
+
+      assert.strictEqual(
+        getLatestSpan().attributes[ATTR_DB_QUERY_TEXT],
+        'SELECT * FROM t WHERE label = ?'
+      );
+    });
+
     it('records sanitized query text when sanitization is not skipped', () => {
       const querySpan = utils.handleConfigQuery.call(
         client,

--- a/packages/sql-common/README.md
+++ b/packages/sql-common/README.md
@@ -24,9 +24,9 @@ ones — and `$n` parameter placeholders. Output is truncated at `maxLength`
 
 PostgreSQL spells some operators with a question mark as well — `?`, `?|` and
 `?&` on jsonb among them — so a `?` in the output does not on its own mean a
-value was replaced there. The semantic conventions fix the placeholder character,
-and an operator is recoverable from the statement around it in a way a value is
-not.
+value was replaced there. `?` is the character the semantic conventions use
+throughout their sanitization examples, and an operator is recoverable from the
+statement around it in a way a value is not.
 
 `dialect` is required and only `'postgresql'` is implemented. There is no
 default because the rules differ in ways that decide whether characters are

--- a/packages/sql-common/README.md
+++ b/packages/sql-common/README.md
@@ -19,11 +19,11 @@ A single-pass, dependency-free lexer. It replaces string, numeric, bit-string
 and dollar-quoted literals with `?`, drops `--` and (nestable) `/* */` comments,
 collapses runs of whitespace, and preserves identifiers — including `"quoted"`
 ones — and `$n` parameter placeholders. Output is truncated at `maxLength`
-(default 32768) at a token boundary, so a masked value is never cut in half.
+(default 32768) at a token boundary, so a replaced value is never cut in half.
 
 PostgreSQL spells some operators with a question mark as well — `?`, `?|` and
 `?&` on jsonb among them — so a `?` in the output does not on its own mean a
-value was masked there. The semantic conventions fix the placeholder character,
+value was replaced there. The semantic conventions fix the placeholder character,
 and an operator is recoverable from the statement around it in a way a value is
 not.
 
@@ -33,6 +33,6 @@ data or structure: in PostgreSQL `"..."` is an identifier, while in MySQL's
 default `sql_mode` it is a string literal.
 
 `IN (...)` lists are deliberately not collapsed to `IN (?)`. Once the literals
-are masked the list carries no data, collapsing hides pathologically large
+are replaced the list carries no data, collapsing hides pathologically large
 lists, and the only consumers that would benefit are ones that do not exist
 yet.

--- a/packages/sql-common/README.md
+++ b/packages/sql-common/README.md
@@ -11,7 +11,8 @@ This is an internal utils package used for the different SQL instrumentations:
 - `addSqlCommenterComment(span, query)` — appends a
   [sqlcommenter](https://google.github.io/sqlcommenter/spec/) comment to a query.
 - `sanitizeSql(sql, { dialect, maxLength })` — replaces the literals in a SQL
-  statement with `?`, for use as `db.query.text`.
+  statement with `?`, for use as `db.query.text`. Its options are typed as
+  `SanitizeSqlOptions` and `SqlDialect`, both exported alongside it.
 
 ### `sanitizeSql`
 

--- a/packages/sql-common/README.md
+++ b/packages/sql-common/README.md
@@ -4,3 +4,35 @@ This is an internal utils package used for the different SQL instrumentations:
 
 1. mysql2
 2. pg
+
+## Exports
+
+- `buildTraceparent(span)` — the W3C `traceparent` string for a span.
+- `addSqlCommenterComment(span, query)` — appends a
+  [sqlcommenter](https://google.github.io/sqlcommenter/spec/) comment to a query.
+- `sanitizeSql(sql, { dialect, maxLength })` — replaces the literals in a SQL
+  statement with `?`, for use as `db.query.text`.
+
+### `sanitizeSql`
+
+A single-pass, dependency-free lexer. It replaces string, numeric, bit-string
+and dollar-quoted literals with `?`, drops `--` and (nestable) `/* */` comments,
+collapses runs of whitespace, and preserves identifiers — including `"quoted"`
+ones — and `$n` parameter placeholders. Output is truncated at `maxLength`
+(default 32768) at a token boundary, so a masked value is never cut in half.
+
+PostgreSQL spells some operators with a question mark as well — `?`, `?|` and
+`?&` on jsonb among them — so a `?` in the output does not on its own mean a
+value was masked there. The semantic conventions fix the placeholder character,
+and an operator is recoverable from the statement around it in a way a value is
+not.
+
+`dialect` is required and only `'postgresql'` is implemented. There is no
+default because the rules differ in ways that decide whether characters are
+data or structure: in PostgreSQL `"..."` is an identifier, while in MySQL's
+default `sql_mode` it is a string literal.
+
+`IN (...)` lists are deliberately not collapsed to `IN (?)`. Once the literals
+are masked the list carries no data, collapsing hides pathologically large
+lists, and the only consumers that would benefit are ones that do not exist
+yet.

--- a/packages/sql-common/src/index.ts
+++ b/packages/sql-common/src/index.ts
@@ -97,3 +97,4 @@ export function addSqlCommenterComment(span: Span, query: string): string {
 }
 
 export { sanitizeSql } from './sanitize';
+export type { SanitizeSqlOptions, SqlDialect } from './sanitize';

--- a/packages/sql-common/src/index.ts
+++ b/packages/sql-common/src/index.ts
@@ -95,3 +95,5 @@ export function addSqlCommenterComment(span: Span, query: string): string {
 
   return `${query} /*${commentString}*/`;
 }
+
+export { sanitizeSql } from './sanitize';

--- a/packages/sql-common/src/sanitize.ts
+++ b/packages/sql-common/src/sanitize.ts
@@ -206,6 +206,10 @@ function endOfDelimited(
  * prefix is only a prefix when the quote follows it immediately and nothing is
  * attached in front, so the `e` ending an identifier is never mistaken for an
  * escape-string marker.
+ *
+ * Only `E` gives a backslash meaning to the lexer. A `U&` string's Unicode
+ * escapes are decoded after it has been lexed, so its backslashes are ordinary
+ * characters when finding where it ends.
  */
 function endOfStringLiteral(
   sql: string,
@@ -228,7 +232,7 @@ function endOfStringLiteral(
     return undefined;
   }
   if (prefix === 'U' && sql[i + 2] === "'") {
-    return endOfDelimited(sql, i + 3, "'", true) ?? n;
+    return endOfDelimited(sql, i + 3, "'", false) ?? n;
   }
   return undefined;
 }

--- a/packages/sql-common/src/sanitize.ts
+++ b/packages/sql-common/src/sanitize.ts
@@ -6,7 +6,7 @@
 /**
  * A SQL dialect the sanitizer knows how to lex. Required, with no default:
  * dialects disagree about which characters are data and which are structure, so
- * guessing either masks structure or leaks data.
+ * guessing either hides structure or leaks data.
  */
 export type SqlDialect = 'postgresql';
 
@@ -173,7 +173,7 @@ function endOfNumber(
  * delimiter escapes it rather than ending the run, which is how PostgreSQL
  * spells a literal quote inside both strings and identifiers.
  *
- * Callers decide what an unterminated run means: string contents are masked
+ * Callers decide what an unterminated run means: string contents are replaced
  * either way, while text behind an unbalanced identifier quote is of unknown
  * provenance and so cannot be kept as a name.
  */
@@ -291,9 +291,9 @@ function sanitizePostgresql(sql: string, maxLength: number): string {
   };
 
   // Every token is emitted whole or not at all, which is what makes truncation
-  // safe: half a masked literal never reaches the output. `endsValue` records
+  // safe: half a replaced literal never reaches the output. `endsValue` records
   // whether a value could follow this token, since the emitted text no longer
-  // says -- a `?` may be either a masked literal or a jsonb operator.
+  // says -- a `?` may be either a replaced literal or a jsonb operator.
   const appendToken = (text: string, endsValue = true) => {
     append(text);
     valueEnded = endsValue;
@@ -372,7 +372,7 @@ function sanitizePostgresql(sql: string, maxLength: number): string {
 
     // Double quotes delimit an identifier in PostgreSQL, so what they hold is a
     // table or column name and is kept. An unbalanced quote is the exception:
-    // the remainder of the statement cannot be read as a name, so it is masked
+    // the remainder of the statement cannot be read as a name, so it is replaced
     // like any other construct that runs off the end of the input.
     if (ch === '"') {
       const end = endOfDelimited(sql, i + 1, '"', false);
@@ -400,7 +400,7 @@ function sanitizePostgresql(sql: string, maxLength: number): string {
  * statement can be recorded as `db.query.text` without carrying data with it.
  *
  * Parameter placeholders and identifiers -- including quoted ones -- are left
- * alone. Neither holds a value, and masking them would cost the statement the
+ * alone. Neither holds a value, and replacing them would cost the statement the
  * structure that makes it worth recording at all. Comments are removed, runs of
  * whitespace collapse to a single space, and the result is truncated at
  * `maxLength`.
@@ -416,7 +416,7 @@ function sanitizePostgresql(sql: string, maxLength: number): string {
 export function sanitizeSql(sql: string, options: SanitizeSqlOptions): string {
   // Compared directly rather than looked up in a table: a lookup on an object
   // would also reach inherited members, letting a name like `constructor`
-  // resolve to a function that returns the statement unmasked.
+  // resolve to a function that returns the statement unsanitized.
   if (options.dialect !== 'postgresql') {
     throw new TypeError(`unsupported SQL dialect: ${options.dialect}`);
   }

--- a/packages/sql-common/src/sanitize.ts
+++ b/packages/sql-common/src/sanitize.ts
@@ -11,7 +11,6 @@
 export type SqlDialect = 'postgresql';
 
 export interface SanitizeSqlOptions {
-  /** Lexical rules to apply to the statement. */
   dialect: SqlDialect;
   /**
    * Maximum length of the returned statement. Scanning stops at the last whole
@@ -25,13 +24,15 @@ export interface SanitizeSqlOptions {
   maxLength?: number;
 }
 
-/** The string that replaces a literal value, as the semantic conventions ask. */
+/**
+ * The string that replaces a literal value. `?` is the character the semantic
+ * conventions use throughout their sanitization examples.
+ */
 const PLACEHOLDER = '?';
 
 /**
- * A statement carrying thousands of inlined rows costs more to move through a
- * pipeline than it is worth as telemetry, so the result is cut off. The
- * semantic conventions allow truncating a sanitized value for this reason.
+ * A bound on the result, so that a statement with thousands of inlined rows
+ * cannot put an unbounded string on a span. Callers may override it.
  */
 const DEFAULT_MAX_LENGTH = 32 * 1024;
 
@@ -40,9 +41,9 @@ const DEFAULT_MAX_LENGTH = 32 * 1024;
  * shaped like an unquoted identifier without the dollar signs. The same
  * delimiter closes the string.
  *
- * Sticky rather than anchored so it can be matched at an offset without copying
- * the remainder of the statement, which would cost O(n^2). A tag may hold any
- * character PostgreSQL accepts in an identifier, including every non-ASCII one;
+ * Sticky so it can be matched at an offset without re-slicing the statement. A
+ * tag may hold any character PostgreSQL accepts in an identifier, including
+ * every non-ASCII one;
  * recognizing a narrower set would emit the body of a string tagged with
  * anything else as ordinary tokens.
  */
@@ -56,7 +57,7 @@ function isDigit(ch: string | undefined): boolean {
   return ch !== undefined && ch >= '0' && ch <= '9';
 }
 
-/** Underscores are permitted inside a numeral as group separators. */
+/** PostgreSQL 16 and later permit underscores between a numeral's digits. */
 function isDigitOrSeparator(ch: string | undefined): boolean {
   return isDigit(ch) || ch === '_';
 }
@@ -172,10 +173,6 @@ function endOfNumber(
  * at `contentsAt`, or undefined if the delimiter is never closed. Doubling the
  * delimiter escapes it rather than ending the run, which is how PostgreSQL
  * spells a literal quote inside both strings and identifiers.
- *
- * Callers decide what an unterminated run means: string contents are replaced
- * either way, while text behind an unbalanced identifier quote is of unknown
- * provenance and so cannot be kept as a name.
  */
 function endOfDelimited(
   sql: string,
@@ -218,8 +215,6 @@ function endOfStringLiteral(
   const n = sql.length;
   if (sql[i] === "'") return endOfDelimited(sql, i + 1, "'", false) ?? n;
 
-  // The character after the prefix discriminates before the prefix itself does,
-  // and it is the cheaper test of the two on a path every token start reaches.
   const next = sql[i + 1];
   if (next !== "'" && next !== '&') return undefined;
   if (prevIsIdentifierChar) return undefined;
@@ -277,8 +272,6 @@ function sanitizePostgresql(sql: string, maxLength: number): string {
     }
     out += text;
     prev = text.charAt(text.length - 1);
-    // Cached because two predicates in the loop below ask for it once per
-    // token, while it can only change where the output does.
     prevIsIdent = isIdentifierChar(prev);
   };
 
@@ -311,8 +304,7 @@ function sanitizePostgresql(sql: string, maxLength: number): string {
     // Comments are dropped rather than kept. A comment can hold a literal of
     // its own, and nothing distinguishes a benign one from a sensitive one.
     // A line comment ends at either newline character, as the server's lexer
-    // has it. Recognizing only one of the two would fold everything up to the
-    // next occurrence of that one into the comment and discard it.
+    // has it.
     if (ch === '-' && sql[i + 1] === '-') {
       let j = i + 2;
       while (j < n && sql[j] !== '\n' && sql[j] !== '\r') j++;
@@ -414,9 +406,6 @@ function sanitizePostgresql(sql: string, maxLength: number): string {
  * @throws TypeError if `options.dialect` is not a supported dialect
  */
 export function sanitizeSql(sql: string, options: SanitizeSqlOptions): string {
-  // Compared directly rather than looked up in a table: a lookup on an object
-  // would also reach inherited members, letting a name like `constructor`
-  // resolve to a function that returns the statement unsanitized.
   if (options.dialect !== 'postgresql') {
     throw new TypeError(`unsupported SQL dialect: ${options.dialect}`);
   }

--- a/packages/sql-common/src/sanitize.ts
+++ b/packages/sql-common/src/sanitize.ts
@@ -53,6 +53,97 @@ const DOLLAR_QUOTE_DELIMITER =
 const NON_DECIMAL_PREFIX = /[xXoObB]/;
 const NON_DECIMAL_DIGIT = /[0-9a-fA-F_]/;
 
+/**
+ * Keywords PostgreSQL's grammar never permits as a bare column or table
+ * reference, even unquoted -- the "reserved" and "reserved (can be function
+ * or type name)" categories of its keyword list. A value can never end on one
+ * of these, unlike an ordinary identifier, which is what tells `SELECT -5`
+ * (a sign) apart from `amount-5` (an operator on the column `amount`): both
+ * are an identifier immediately followed by `-`, and only the keyword lookup
+ * tells them apart.
+ *
+ * A non-reserved keyword (`LIMIT`, `OFFSET`, `RETURNING`, ...) is left out on
+ * purpose: PostgreSQL still permits those as an ordinary identifier, so
+ * treating one as never ending a value risks misreading an actual column of
+ * that name. A sign directly after one of them is a known gap this leaves
+ * unfixed.
+ *
+ * @see https://www.postgresql.org/docs/current/sql-keywords-appendix.html
+ */
+const RESERVED_KEYWORDS = new Set([
+  'ALL',
+  'AND',
+  'ANY',
+  'ARRAY',
+  'AS',
+  'ASYMMETRIC',
+  'AUTHORIZATION',
+  'BOTH',
+  'CASE',
+  'CAST',
+  'CHECK',
+  'COLLATE',
+  'COLUMN',
+  'CONCURRENTLY',
+  'CONSTRAINT',
+  'CROSS',
+  'DEFAULT',
+  'DISTINCT',
+  'ELSE',
+  'END',
+  'FALSE',
+  'FETCH',
+  'FOR',
+  'FOREIGN',
+  'FREEZE',
+  'FROM',
+  'FULL',
+  'GROUP',
+  'HAVING',
+  'ILIKE',
+  'IN',
+  'INITIALLY',
+  'INNER',
+  'INTERSECT',
+  'INTO',
+  'IS',
+  'JOIN',
+  'LATERAL',
+  'LEFT',
+  'LIKE',
+  'NATURAL',
+  'NOT',
+  'NULL',
+  'ONLY',
+  'OR',
+  'ORDER',
+  'OUTER',
+  'OVERLAPS',
+  'PRIMARY',
+  'REFERENCES',
+  'RIGHT',
+  'SELECT',
+  'SIMILAR',
+  'SOME',
+  'SYMMETRIC',
+  'TABLE',
+  'TABLESAMPLE',
+  'THEN',
+  'TO',
+  'TRAILING',
+  'TRUE',
+  'UNION',
+  'UNIQUE',
+  'USER',
+  'USING',
+  'VARIADIC',
+  'VERBOSE',
+  'WHEN',
+  'WHERE',
+  'WINDOW',
+  'WITH',
+]);
+
 function isDigit(ch: string | undefined): boolean {
   return ch !== undefined && ch >= '0' && ch <= '9';
 }
@@ -338,7 +429,8 @@ function sanitizePostgresql(sql: string, maxLength: number): string {
     if (isIdentifierStart(ch)) {
       let j = i + 1;
       while (j < n && isIdentifierChar(sql[j])) j++;
-      appendToken(sql.slice(i, j));
+      const text = sql.slice(i, j);
+      appendToken(text, !RESERVED_KEYWORDS.has(text.toUpperCase()));
       i = j;
       continue;
     }

--- a/packages/sql-common/src/sanitize.ts
+++ b/packages/sql-common/src/sanitize.ts
@@ -125,7 +125,7 @@ function endOfDigits(sql: string, start: number): number {
     if (sql[j] === '+' || sql[j] === '-') j++;
     if (isDigit(sql[j])) {
       i = j;
-      while (i < n && isDigit(sql[i])) i++;
+      while (i < n && isDigitOrSeparator(sql[i])) i++;
     }
   }
 

--- a/packages/sql-common/src/sanitize.ts
+++ b/packages/sql-common/src/sanitize.ts
@@ -1,0 +1,432 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * A SQL dialect the sanitizer knows how to lex. Required, with no default:
+ * dialects disagree about which characters are data and which are structure, so
+ * guessing either masks structure or leaks data.
+ */
+export type SqlDialect = 'postgresql';
+
+export interface SanitizeSqlOptions {
+  /** Lexical rules to apply to the statement. */
+  dialect: SqlDialect;
+  /**
+   * Maximum length of the returned statement. Scanning stops at the last whole
+   * token that fits, so truncation never splits a literal or an identifier. A
+   * limit small enough to exclude the first token yields an empty statement.
+   *
+   * Anything that is not a positive finite number falls back to the default.
+   *
+   * @default 32768
+   */
+  maxLength?: number;
+}
+
+/** The string that replaces a literal value, as the semantic conventions ask. */
+const PLACEHOLDER = '?';
+
+/**
+ * A statement carrying thousands of inlined rows costs more to move through a
+ * pipeline than it is worth as telemetry, so the result is cut off. The
+ * semantic conventions allow truncating a sanitized value for this reason.
+ */
+const DEFAULT_MAX_LENGTH = 32 * 1024;
+
+/**
+ * Opening delimiter of a dollar-quoted string: `$$`, or `$tag$` for a tag
+ * shaped like an unquoted identifier without the dollar signs. The same
+ * delimiter closes the string.
+ *
+ * Sticky rather than anchored so it can be matched at an offset without copying
+ * the remainder of the statement, which would cost O(n^2). A tag may hold any
+ * character PostgreSQL accepts in an identifier, including every non-ASCII one;
+ * recognizing a narrower set would emit the body of a string tagged with
+ * anything else as ordinary tokens.
+ */
+const DOLLAR_QUOTE_DELIMITER =
+  /\$([A-Za-z_\u0080-\uffff][A-Za-z0-9_\u0080-\uffff]*)?\$/y;
+
+const NON_DECIMAL_PREFIX = /[xXoObB]/;
+const NON_DECIMAL_DIGIT = /[0-9a-fA-F_]/;
+
+function isDigit(ch: string | undefined): boolean {
+  return ch !== undefined && ch >= '0' && ch <= '9';
+}
+
+/** Underscores are permitted inside a numeral as group separators. */
+function isDigitOrSeparator(ch: string | undefined): boolean {
+  return isDigit(ch) || ch === '_';
+}
+
+function isWhitespace(ch: string): boolean {
+  return (
+    ch === ' ' ||
+    ch === '\t' ||
+    ch === '\n' ||
+    ch === '\r' ||
+    ch === '\f' ||
+    ch === '\v'
+  );
+}
+
+/**
+ * Whether a character can begin an unquoted identifier. PostgreSQL admits every
+ * non-ASCII character here, so this is a range rather than a list of letters.
+ */
+function isIdentifierStart(ch: string | undefined): boolean {
+  return (
+    ch !== undefined &&
+    ((ch >= 'a' && ch <= 'z') ||
+      (ch >= 'A' && ch <= 'Z') ||
+      ch === '_' ||
+      ch >= '\u0080')
+  );
+}
+
+/**
+ * Whether a character can continue an unquoted identifier. `$` counts, which is
+ * what separates the identifier `a$1` from the placeholder `$1`.
+ */
+function isIdentifierChar(ch: string | undefined): boolean {
+  return (
+    ch !== undefined && (isIdentifierStart(ch) || isDigit(ch) || ch === '$')
+  );
+}
+
+/**
+ * Returns the index just past the digits of a numeric literal starting at
+ * `start`, which must be a digit.
+ */
+function endOfDigits(sql: string, start: number): number {
+  const n = sql.length;
+  let i = start;
+
+  // Hexadecimal, octal and binary integers.
+  if (sql[i] === '0' && NON_DECIMAL_PREFIX.test(sql[i + 1] ?? '')) {
+    i += 2;
+    while (i < n && NON_DECIMAL_DIGIT.test(sql[i])) i++;
+    return i;
+  }
+
+  while (i < n && isDigitOrSeparator(sql[i])) i++;
+
+  if (sql[i] === '.') {
+    i++;
+    while (i < n && isDigitOrSeparator(sql[i])) i++;
+  }
+
+  // An exponent marker belongs to the number only when digits follow it;
+  // otherwise it starts the next token.
+  if (sql[i] === 'e' || sql[i] === 'E') {
+    let j = i + 1;
+    if (sql[j] === '+' || sql[j] === '-') j++;
+    if (isDigit(sql[j])) {
+      i = j;
+      while (i < n && isDigit(sql[i])) i++;
+    }
+  }
+
+  return i;
+}
+
+/**
+ * Returns the index just past the numeric literal starting at `i`, or
+ * undefined if no literal starts there.
+ *
+ * `valueEnded` says whether the last token emitted was one a value cannot
+ * follow. That is what tells a sign apart from an operator: in `= -5` the minus
+ * belongs to the number, in `amount-5` it does not. A decimal point binds
+ * tightly instead, so `.5` is a number only when nothing at all is attached
+ * directly in front of it.
+ */
+function endOfNumber(
+  sql: string,
+  i: number,
+  prevIsIdentifierChar: boolean,
+  valueEnded: boolean
+): number | undefined {
+  const ch = sql[i];
+
+  if (ch === '-' || ch === '+') {
+    if (valueEnded) return undefined;
+    if (isDigit(sql[i + 1])) return endOfDigits(sql, i + 1);
+    if (sql[i + 1] === '.' && isDigit(sql[i + 2])) {
+      return endOfDigits(sql, i + 2);
+    }
+    return undefined;
+  }
+
+  if (prevIsIdentifierChar) return undefined;
+
+  if (isDigit(ch)) return endOfDigits(sql, i);
+  if (ch === '.' && isDigit(sql[i + 1])) return endOfDigits(sql, i + 1);
+
+  return undefined;
+}
+
+/**
+ * Returns the index just past a run delimited by `quote` whose contents begin
+ * at `contentsAt`, or undefined if the delimiter is never closed. Doubling the
+ * delimiter escapes it rather than ending the run, which is how PostgreSQL
+ * spells a literal quote inside both strings and identifiers.
+ *
+ * Callers decide what an unterminated run means: string contents are masked
+ * either way, while text behind an unbalanced identifier quote is of unknown
+ * provenance and so cannot be kept as a name.
+ */
+function endOfDelimited(
+  sql: string,
+  contentsAt: number,
+  quote: string,
+  backslashEscapes: boolean
+): number | undefined {
+  const n = sql.length;
+  let i = contentsAt;
+  while (i < n) {
+    if (backslashEscapes && sql[i] === '\\') {
+      i += 2;
+    } else if (sql[i] !== quote) {
+      i++;
+    } else if (sql[i + 1] === quote) {
+      i += 2;
+    } else {
+      return i + 1;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Returns the index just past a single-quoted string starting at `i`, or
+ * undefined if no string starts there. An unterminated string runs to the end
+ * of the input, which is what keeps its contents out of the result.
+ *
+ * PostgreSQL allows prefixes in front of a string: `E` for backslash escapes,
+ * `U&` for Unicode escapes, and `B`/`X` for bit and hexadecimal strings. A
+ * prefix is only a prefix when the quote follows it immediately and nothing is
+ * attached in front, so the `e` ending an identifier is never mistaken for an
+ * escape-string marker.
+ */
+function endOfStringLiteral(
+  sql: string,
+  i: number,
+  prevIsIdentifierChar: boolean
+): number | undefined {
+  const n = sql.length;
+  if (sql[i] === "'") return endOfDelimited(sql, i + 1, "'", false) ?? n;
+
+  // The character after the prefix discriminates before the prefix itself does,
+  // and it is the cheaper test of the two on a path every token start reaches.
+  const next = sql[i + 1];
+  if (next !== "'" && next !== '&') return undefined;
+  if (prevIsIdentifierChar) return undefined;
+
+  const prefix = sql[i].toUpperCase();
+  if (next === "'") {
+    if (prefix === 'E') return endOfDelimited(sql, i + 2, "'", true) ?? n;
+    if (prefix === 'B' || prefix === 'X') {
+      return endOfDelimited(sql, i + 2, "'", false) ?? n;
+    }
+    return undefined;
+  }
+  if (prefix === 'U' && sql[i + 2] === "'") {
+    return endOfDelimited(sql, i + 3, "'", true) ?? n;
+  }
+  return undefined;
+}
+
+/**
+ * Returns the index just past a block comment starting at `i`. Block comments
+ * nest in PostgreSQL, so this counts depth rather than stopping at the first
+ * closing delimiter.
+ */
+function endOfBlockComment(sql: string, i: number): number {
+  const n = sql.length;
+  let depth = 1;
+  let j = i + 2;
+  while (j < n && depth > 0) {
+    if (sql[j] === '/' && sql[j + 1] === '*') {
+      depth++;
+      j += 2;
+    } else if (sql[j] === '*' && sql[j + 1] === '/') {
+      depth--;
+      j += 2;
+    } else {
+      j++;
+    }
+  }
+  return j;
+}
+
+function sanitizePostgresql(sql: string, maxLength: number): string {
+  const n = sql.length;
+  let out = '';
+  let prev = '';
+  let prevIsIdent = false;
+  let valueEnded = false;
+  let full = false;
+  let i = 0;
+
+  const append = (text: string) => {
+    if (out.length + text.length > maxLength) {
+      full = true;
+      return;
+    }
+    out += text;
+    prev = text.charAt(text.length - 1);
+    // Cached because two predicates in the loop below ask for it once per
+    // token, while it can only change where the output does.
+    prevIsIdent = isIdentifierChar(prev);
+  };
+
+  // Collapsing runs of whitespace keeps statements that differ only in layout
+  // from looking like different statements. A dropped comment collapses the
+  // same way, which is why this looks at what was last emitted rather than at
+  // the input.
+  const appendSpace = () => {
+    if (out.length > 0 && prev !== ' ') append(' ');
+  };
+
+  // Every token is emitted whole or not at all, which is what makes truncation
+  // safe: half a masked literal never reaches the output. `endsValue` records
+  // whether a value could follow this token, since the emitted text no longer
+  // says -- a `?` may be either a masked literal or a jsonb operator.
+  const appendToken = (text: string, endsValue = true) => {
+    append(text);
+    valueEnded = endsValue;
+  };
+
+  while (i < n && !full) {
+    const ch = sql[i];
+
+    if (isWhitespace(ch)) {
+      i++;
+      appendSpace();
+      continue;
+    }
+
+    // Comments are dropped rather than kept. A comment can hold a literal of
+    // its own, and nothing distinguishes a benign one from a sensitive one.
+    // A line comment ends at either newline character, as the server's lexer
+    // has it. Recognizing only one of the two would fold everything up to the
+    // next occurrence of that one into the comment and discard it.
+    if (ch === '-' && sql[i + 1] === '-') {
+      let j = i + 2;
+      while (j < n && sql[j] !== '\n' && sql[j] !== '\r') j++;
+      i = j;
+      appendSpace();
+      continue;
+    }
+
+    if (ch === '/' && sql[i + 1] === '*') {
+      i = endOfBlockComment(sql, i);
+      appendSpace();
+      continue;
+    }
+
+    // Tried ahead of the identifier below, whose leading letter would otherwise
+    // swallow the prefix of a string such as `E'...'`.
+    const stringEnd = endOfStringLiteral(sql, i, prevIsIdent);
+    if (stringEnd !== undefined) {
+      i = stringEnd;
+      appendToken(PLACEHOLDER);
+      continue;
+    }
+
+    // An identifier is taken whole because `$` continues one, and PostgreSQL
+    // resolves that overlap in favour of the longer token: `a$$b` is a single
+    // identifier, not `a` followed by an empty dollar-quoted string.
+    if (isIdentifierStart(ch)) {
+      let j = i + 1;
+      while (j < n && isIdentifierChar(sql[j])) j++;
+      appendToken(sql.slice(i, j));
+      i = j;
+      continue;
+    }
+
+    if (ch === '$') {
+      DOLLAR_QUOTE_DELIMITER.lastIndex = i;
+      const delimiter = DOLLAR_QUOTE_DELIMITER.exec(sql)?.[0];
+      if (delimiter !== undefined) {
+        const end = sql.indexOf(delimiter, i + delimiter.length);
+        i = end === -1 ? n : end + delimiter.length;
+        appendToken(PLACEHOLDER);
+        continue;
+      }
+      // `$1`, `$2`, ... stand in for values that travel separately and never
+      // appear in the statement, so there is nothing here to replace.
+      if (isDigit(sql[i + 1])) {
+        let j = i + 1;
+        while (j < n && isDigit(sql[j])) j++;
+        appendToken(sql.slice(i, j));
+        i = j;
+        continue;
+      }
+      appendToken(ch);
+      i++;
+      continue;
+    }
+
+    // Double quotes delimit an identifier in PostgreSQL, so what they hold is a
+    // table or column name and is kept. An unbalanced quote is the exception:
+    // the remainder of the statement cannot be read as a name, so it is masked
+    // like any other construct that runs off the end of the input.
+    if (ch === '"') {
+      const end = endOfDelimited(sql, i + 1, '"', false);
+      appendToken(end === undefined ? PLACEHOLDER : sql.slice(i, end));
+      i = end ?? n;
+      continue;
+    }
+
+    const numberEnd = endOfNumber(sql, i, prevIsIdent, valueEnded);
+    if (numberEnd !== undefined) {
+      i = numberEnd;
+      appendToken(PLACEHOLDER);
+      continue;
+    }
+
+    appendToken(ch, ch === ')' || ch === ']');
+    i++;
+  }
+
+  return out.trim();
+}
+
+/**
+ * Replaces the literal values in a SQL statement with `?`, so that the
+ * statement can be recorded as `db.query.text` without carrying data with it.
+ *
+ * Parameter placeholders and identifiers -- including quoted ones -- are left
+ * alone. Neither holds a value, and masking them would cost the statement the
+ * structure that makes it worth recording at all. Comments are removed, runs of
+ * whitespace collapse to a single space, and the result is truncated at
+ * `maxLength`.
+ *
+ * This is a lexer, not a parser: it finds where literals begin and end, and it
+ * treats anything it cannot terminate as running to the end of the statement
+ * rather than guessing.
+ *
+ * @param sql the statement to sanitize
+ * @param options the dialect to lex as, and an optional length limit
+ * @throws TypeError if `options.dialect` is not a supported dialect
+ */
+export function sanitizeSql(sql: string, options: SanitizeSqlOptions): string {
+  // Compared directly rather than looked up in a table: a lookup on an object
+  // would also reach inherited members, letting a name like `constructor`
+  // resolve to a function that returns the statement unmasked.
+  if (options.dialect !== 'postgresql') {
+    throw new TypeError(`unsupported SQL dialect: ${options.dialect}`);
+  }
+  // A limit that is not a positive finite number cannot bound anything: every
+  // comparison against NaN is false, which would silently drop the limit
+  // altogether rather than fall back to the default.
+  const { maxLength } = options;
+  const limit =
+    typeof maxLength === 'number' && Number.isFinite(maxLength) && maxLength > 0
+      ? maxLength
+      : DEFAULT_MAX_LENGTH;
+  return sanitizePostgresql(sql, limit);
+}

--- a/packages/sql-common/test/sanitize.test.ts
+++ b/packages/sql-common/test/sanitize.test.ts
@@ -272,6 +272,11 @@ describe('sanitizeSql', () => {
           'SELECT * FROM t WHERE r = ?',
         ],
         ['masks an exponent', 'SELECT 1.5e-3, 1E10', 'SELECT ?, ?'],
+        [
+          'masks digit group separators in an exponent',
+          'SELECT 1e123_456',
+          'SELECT ?',
+        ],
         ['masks hexadecimal', 'SELECT 0x1F, 0XFF', 'SELECT ?, ?'],
         ['masks octal and binary', 'SELECT 0o17, 0b1010', 'SELECT ?, ?'],
         ['masks digit group separators', 'SELECT 1_000_000', 'SELECT ?'],

--- a/packages/sql-common/test/sanitize.test.ts
+++ b/packages/sql-common/test/sanitize.test.ts
@@ -9,6 +9,18 @@ import { sanitizeSql } from '../src/index';
 const sanitize = (sql: string, maxLength?: number) =>
   sanitizeSql(sql, { dialect: 'postgresql', maxLength });
 
+const SECRETS = ['a@b.c', 'hunter2', 's3cret', '19700101'];
+
+const assertNoSecrets = (sql: string, context = '') => {
+  const sanitized = sanitize(sql);
+  for (const secret of SECRETS) {
+    assert.ok(
+      !sanitized.includes(secret),
+      `expected ${secret} to be replaced${context}, got: ${sanitized}`
+    );
+  }
+};
+
 /** [description, input, expected] */
 type Case = [string, string, string];
 
@@ -26,22 +38,6 @@ describe('sanitizeSql', () => {
       () => sanitizeSql('SELECT 1', { dialect: 'oracle' as never }),
       TypeError
     );
-  });
-
-  it('rejects a dialect named after an inherited object property', () => {
-    for (const dialect of [
-      'constructor',
-      'toString',
-      'valueOf',
-      'hasOwnProperty',
-      '__proto__',
-    ]) {
-      assert.throws(
-        () => sanitizeSql("SELECT 'secret'", { dialect: dialect as never }),
-        TypeError,
-        `expected ${dialect} to be rejected`
-      );
-    }
   });
 
   describe('postgresql', () => {
@@ -384,10 +380,13 @@ describe('sanitizeSql', () => {
     describe('termination', () => {
       // A hand-written lexer's worst failure is a scan helper that returns -1
       // on end-of-input and sends the loop backwards, so every truncation of a
-      // statement that mixes the tricky forms is exercised.
-      it('terminates on every prefix of a statement mixing every construct', () => {
+      // statement that mixes the tricky forms is exercised. Each construct
+      // carries a literal, so a prefix that cuts one open has to keep that
+      // literal out of the result as well as terminate.
+      it('terminates and leaks nothing on every prefix of a statement mixing every construct', () => {
         const statement =
-          "SELECT $t$a$t$, E'\\'', /* /* */ */ \"q\"\"\", -1.5e-3, $1, U&'x' -- c";
+          "SELECT $t$hunter2$t$, E'a\\'b s3cret', /* /* a@b.c */ */ " +
+          '"q""", -19700101, $1, U&\'a@b.c\' -- s3cret';
         for (let i = 0; i <= statement.length; i++) {
           const prefix = statement.slice(0, i);
           assert.strictEqual(
@@ -395,23 +394,12 @@ describe('sanitizeSql', () => {
             'string',
             `did not return a string for prefix of length ${i}`
           );
+          assertNoSecrets(prefix, ` in prefix of length ${i}`);
         }
       });
     });
 
     describe('leakage', () => {
-      const secrets = ['a@b.c', 'hunter2', 's3cret', '19700101'];
-
-      const assertNoSecrets = (sql: string) => {
-        const sanitized = sanitize(sql);
-        for (const secret of secrets) {
-          assert.ok(
-            !sanitized.includes(secret),
-            `expected ${secret} to be masked, got: ${sanitized}`
-          );
-        }
-      };
-
       it('leaves no literal from any construct in the result', () => {
         assertNoSecrets(
           "SELECT * FROM u WHERE e='a@b.c' AND n=$$hunter2$$ " +

--- a/packages/sql-common/test/sanitize.test.ts
+++ b/packages/sql-common/test/sanitize.test.ts
@@ -103,6 +103,16 @@ describe('sanitizeSql', () => {
         ],
         ['replaces a unicode escape string', "SELECT U&'\\0441'", 'SELECT ?'],
         [
+          'ends a unicode escape string at a quote behind a backslash',
+          "SELECT U&'a\\', 'hunter2'",
+          'SELECT ?, ?',
+        ],
+        [
+          'honours a doubled quote inside a unicode escape string',
+          "SELECT U&'it''s', 'hunter2'",
+          'SELECT ?, ?',
+        ],
+        [
           'does not treat a word ending in a prefix letter as a prefix',
           'SELECT Encoding, Extract FROM t',
           'SELECT Encoding, Extract FROM t',

--- a/packages/sql-common/test/sanitize.test.ts
+++ b/packages/sql-common/test/sanitize.test.ts
@@ -44,7 +44,7 @@ describe('sanitizeSql', () => {
     describe('string literals', () => {
       run([
         [
-          'masks a quoted string',
+          'replaces a quoted string',
           "SELECT * FROM users WHERE name = 'John'",
           'SELECT * FROM users WHERE name = ?',
         ],
@@ -53,25 +53,29 @@ describe('sanitizeSql', () => {
           "SELECT * FROM t WHERE s = 'it''s'",
           'SELECT * FROM t WHERE s = ?',
         ],
-        ['masks an empty string', "SELECT ''", 'SELECT ?'],
+        ['replaces an empty string', "SELECT ''", 'SELECT ?'],
         [
-          'masks a string containing a comment marker',
+          'replaces a string containing a comment marker',
           "SELECT '-- not a comment'",
           'SELECT ?',
         ],
         [
-          'masks a string containing a statement separator',
+          'replaces a string containing a statement separator',
           "SELECT 'a; DROP TABLE t'",
           'SELECT ?',
         ],
         [
-          'masks a string containing a placeholder',
+          'replaces a string containing a placeholder',
           "SELECT 'literally $1'",
           'SELECT ?',
         ],
-        ['masks each of two adjacent strings', "SELECT 'a'\n'b'", 'SELECT ? ?'],
         [
-          'masks an unterminated string through end of input',
+          'replaces each of two adjacent strings',
+          "SELECT 'a'\n'b'",
+          'SELECT ? ?',
+        ],
+        [
+          'replaces an unterminated string through end of input',
           "SELECT 'unterminated",
           'SELECT ?',
         ],
@@ -85,19 +89,19 @@ describe('sanitizeSql', () => {
           "SELECT E'a\\'b', 'x'",
           'SELECT ?, ?',
         ],
-        ['masks a bit string', "SELECT B'10101'", 'SELECT ?'],
-        ['masks a hexadecimal string', "SELECT X'deadbeef'", 'SELECT ?'],
+        ['replaces a bit string', "SELECT B'10101'", 'SELECT ?'],
+        ['replaces a hexadecimal string', "SELECT X'deadbeef'", 'SELECT ?'],
         [
-          'masks an unterminated bit string through end of input',
+          'replaces an unterminated bit string through end of input',
           "SELECT B'10101",
           'SELECT ?',
         ],
         [
-          'masks an unterminated hexadecimal string through end of input',
+          'replaces an unterminated hexadecimal string through end of input',
           "SELECT X'deadbeef",
           'SELECT ?',
         ],
-        ['masks a unicode escape string', "SELECT U&'\\0441'", 'SELECT ?'],
+        ['replaces a unicode escape string', "SELECT U&'\\0441'", 'SELECT ?'],
         [
           'does not treat a word ending in a prefix letter as a prefix',
           'SELECT Encoding, Extract FROM t',
@@ -114,12 +118,12 @@ describe('sanitizeSql', () => {
     describe('dollar-quoted literals', () => {
       run([
         [
-          'masks an untagged dollar-quoted string',
+          'replaces an untagged dollar-quoted string',
           "SELECT $$body with 'quotes' and ; $$",
           'SELECT ?',
         ],
         [
-          'masks a tagged dollar-quoted string',
+          'replaces a tagged dollar-quoted string',
           'SELECT $tag$ x $tag$',
           'SELECT ?',
         ],
@@ -128,19 +132,19 @@ describe('sanitizeSql', () => {
           'SELECT $a$ $b$ $a$',
           'SELECT ?',
         ],
-        ['masks an empty dollar-quoted string', 'SELECT $$$$', 'SELECT ?'],
+        ['replaces an empty dollar-quoted string', 'SELECT $$$$', 'SELECT ?'],
         [
-          'masks an unterminated dollar-quoted string through end of input',
+          'replaces an unterminated dollar-quoted string through end of input',
           'SELECT $$never closed',
           'SELECT ?',
         ],
         [
-          'masks a dollar-quoted string with a non-ASCII tag',
+          'replaces a dollar-quoted string with a non-ASCII tag',
           'SELECT $caf\u00e9$my secret note$caf\u00e9$ FROM t',
           'SELECT ? FROM t',
         ],
         [
-          'masks a dollar-quoted string opening straight after a placeholder',
+          'replaces a dollar-quoted string opening straight after a placeholder',
           'SELECT * FROM t WHERE a = $1 AND b = $$secret$$',
           'SELECT * FROM t WHERE a = $1 AND b = ?',
         ],
@@ -166,7 +170,7 @@ describe('sanitizeSql', () => {
           'SELECT x::text FROM t WHERE y = $1::uuid',
         ],
         [
-          'masks literals alongside a placeholder',
+          'replaces literals alongside a placeholder',
           "SELECT * FROM t WHERE a = $1 AND b = 'secret'",
           'SELECT * FROM t WHERE a = $1 AND b = ?',
         ],
@@ -212,7 +216,7 @@ describe('sanitizeSql', () => {
           'SELECT caf\u00e9 FROM \u0442\u0430\u0431\u043b\u0438\u0446\u0430',
         ],
         [
-          'masks an unterminated identifier through end of input',
+          'replaces an unterminated identifier through end of input',
           'SELECT * FROM "never closed',
           'SELECT * FROM ?',
         ],
@@ -258,24 +262,24 @@ describe('sanitizeSql', () => {
 
     describe('numeric literals', () => {
       run([
-        ['masks an integer', 'SELECT 42', 'SELECT ?'],
-        ['masks a zero at end of input', 'SELECT 0', 'SELECT ?'],
-        ['masks a decimal', 'SELECT 3.14', 'SELECT ?'],
-        ['masks a leading-dot decimal', 'SELECT .5', 'SELECT ?'],
+        ['replaces an integer', 'SELECT 42', 'SELECT ?'],
+        ['replaces a zero at end of input', 'SELECT 0', 'SELECT ?'],
+        ['replaces a decimal', 'SELECT 3.14', 'SELECT ?'],
+        ['replaces a leading-dot decimal', 'SELECT .5', 'SELECT ?'],
         [
-          'masks a signed leading-dot decimal',
+          'replaces a signed leading-dot decimal',
           'SELECT * FROM t WHERE r = -.5',
           'SELECT * FROM t WHERE r = ?',
         ],
-        ['masks an exponent', 'SELECT 1.5e-3, 1E10', 'SELECT ?, ?'],
+        ['replaces an exponent', 'SELECT 1.5e-3, 1E10', 'SELECT ?, ?'],
         [
-          'masks digit group separators in an exponent',
+          'replaces digit group separators in an exponent',
           'SELECT 1e123_456',
           'SELECT ?',
         ],
-        ['masks hexadecimal', 'SELECT 0x1F, 0XFF', 'SELECT ?, ?'],
-        ['masks octal and binary', 'SELECT 0o17, 0b1010', 'SELECT ?, ?'],
-        ['masks digit group separators', 'SELECT 1_000_000', 'SELECT ?'],
+        ['replaces hexadecimal', 'SELECT 0x1F, 0XFF', 'SELECT ?, ?'],
+        ['replaces octal and binary', 'SELECT 0o17, 0b1010', 'SELECT ?, ?'],
+        ['replaces digit group separators', 'SELECT 1_000_000', 'SELECT ?'],
         [
           'absorbs a sign where a value is expected',
           'SELECT * FROM t WHERE id = -12 AND n = +7',

--- a/packages/sql-common/test/sanitize.test.ts
+++ b/packages/sql-common/test/sanitize.test.ts
@@ -1,0 +1,441 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert';
+import { sanitizeSql } from '../src/index';
+
+const sanitize = (sql: string, maxLength?: number) =>
+  sanitizeSql(sql, { dialect: 'postgresql', maxLength });
+
+/** [description, input, expected] */
+type Case = [string, string, string];
+
+const run = (cases: Case[]) => {
+  for (const [description, input, expected] of cases) {
+    it(description, () => {
+      assert.strictEqual(sanitize(input), expected);
+    });
+  }
+};
+
+describe('sanitizeSql', () => {
+  it('rejects an unknown dialect', () => {
+    assert.throws(
+      () => sanitizeSql('SELECT 1', { dialect: 'oracle' as never }),
+      TypeError
+    );
+  });
+
+  it('rejects a dialect named after an inherited object property', () => {
+    for (const dialect of [
+      'constructor',
+      'toString',
+      'valueOf',
+      'hasOwnProperty',
+      '__proto__',
+    ]) {
+      assert.throws(
+        () => sanitizeSql("SELECT 'secret'", { dialect: dialect as never }),
+        TypeError,
+        `expected ${dialect} to be rejected`
+      );
+    }
+  });
+
+  describe('postgresql', () => {
+    describe('string literals', () => {
+      run([
+        [
+          'masks a quoted string',
+          "SELECT * FROM users WHERE name = 'John'",
+          'SELECT * FROM users WHERE name = ?',
+        ],
+        [
+          'treats a doubled quote as an escaped quote',
+          "SELECT * FROM t WHERE s = 'it''s'",
+          'SELECT * FROM t WHERE s = ?',
+        ],
+        ['masks an empty string', "SELECT ''", 'SELECT ?'],
+        [
+          'masks a string containing a comment marker',
+          "SELECT '-- not a comment'",
+          'SELECT ?',
+        ],
+        [
+          'masks a string containing a statement separator',
+          "SELECT 'a; DROP TABLE t'",
+          'SELECT ?',
+        ],
+        [
+          'masks a string containing a placeholder',
+          "SELECT 'literally $1'",
+          'SELECT ?',
+        ],
+        ['masks each of two adjacent strings', "SELECT 'a'\n'b'", 'SELECT ? ?'],
+        [
+          'masks an unterminated string through end of input',
+          "SELECT 'unterminated",
+          'SELECT ?',
+        ],
+      ]);
+    });
+
+    describe('prefixed string literals', () => {
+      run([
+        [
+          'honours backslash escapes in an escape string',
+          "SELECT E'a\\'b', 'x'",
+          'SELECT ?, ?',
+        ],
+        ['masks a bit string', "SELECT B'10101'", 'SELECT ?'],
+        ['masks a hexadecimal string', "SELECT X'deadbeef'", 'SELECT ?'],
+        [
+          'masks an unterminated bit string through end of input',
+          "SELECT B'10101",
+          'SELECT ?',
+        ],
+        [
+          'masks an unterminated hexadecimal string through end of input',
+          "SELECT X'deadbeef",
+          'SELECT ?',
+        ],
+        ['masks a unicode escape string', "SELECT U&'\\0441'", 'SELECT ?'],
+        [
+          'does not treat a word ending in a prefix letter as a prefix',
+          'SELECT Encoding, Extract FROM t',
+          'SELECT Encoding, Extract FROM t',
+        ],
+        [
+          'leaves bare prefix letters used as column names alone',
+          'SELECT b, e, u, x FROM t',
+          'SELECT b, e, u, x FROM t',
+        ],
+      ]);
+    });
+
+    describe('dollar-quoted literals', () => {
+      run([
+        [
+          'masks an untagged dollar-quoted string',
+          "SELECT $$body with 'quotes' and ; $$",
+          'SELECT ?',
+        ],
+        [
+          'masks a tagged dollar-quoted string',
+          'SELECT $tag$ x $tag$',
+          'SELECT ?',
+        ],
+        [
+          'does not end a tagged string at a different tag',
+          'SELECT $a$ $b$ $a$',
+          'SELECT ?',
+        ],
+        ['masks an empty dollar-quoted string', 'SELECT $$$$', 'SELECT ?'],
+        [
+          'masks an unterminated dollar-quoted string through end of input',
+          'SELECT $$never closed',
+          'SELECT ?',
+        ],
+        [
+          'masks a dollar-quoted string with a non-ASCII tag',
+          'SELECT $caf\u00e9$my secret note$caf\u00e9$ FROM t',
+          'SELECT ? FROM t',
+        ],
+        [
+          'masks a dollar-quoted string opening straight after a placeholder',
+          'SELECT * FROM t WHERE a = $1 AND b = $$secret$$',
+          'SELECT * FROM t WHERE a = $1 AND b = ?',
+        ],
+      ]);
+    });
+
+    describe('parameter placeholders', () => {
+      run([
+        [
+          'preserves a placeholder',
+          'SELECT * FROM users WHERE name = $1',
+          'SELECT * FROM users WHERE name = $1',
+        ],
+        ['preserves a multi-digit placeholder', 'SELECT $42', 'SELECT $42'],
+        [
+          'preserves several placeholders',
+          'INSERT INTO t (a,b) VALUES ($1,$2) RETURNING id',
+          'INSERT INTO t (a,b) VALUES ($1,$2) RETURNING id',
+        ],
+        [
+          'preserves a cast placeholder',
+          'SELECT x::text FROM t WHERE y = $1::uuid',
+          'SELECT x::text FROM t WHERE y = $1::uuid',
+        ],
+        [
+          'masks literals alongside a placeholder',
+          "SELECT * FROM t WHERE a = $1 AND b = 'secret'",
+          'SELECT * FROM t WHERE a = $1 AND b = ?',
+        ],
+        [
+          'treats a dollar inside a word as part of the identifier',
+          'SELECT a$1 FROM t',
+          'SELECT a$1 FROM t',
+        ],
+        [
+          'treats doubled dollars inside a word as part of the identifier',
+          "SELECT a$$b FROM t WHERE email = 'a@b.c'",
+          'SELECT a$$b FROM t WHERE email = ?',
+        ],
+      ]);
+    });
+
+    describe('identifiers', () => {
+      run([
+        [
+          'preserves a quoted identifier',
+          'SELECT * FROM "MyTable" WHERE "colA" = $1',
+          'SELECT * FROM "MyTable" WHERE "colA" = $1',
+        ],
+        [
+          'preserves a doubled quote inside a quoted identifier',
+          'SELECT "weird""quoted" FROM t',
+          'SELECT "weird""quoted" FROM t',
+        ],
+        [
+          'preserves a quoted identifier containing a space',
+          'SELECT "has a space" FROM t',
+          'SELECT "has a space" FROM t',
+        ],
+        ['preserves case', 'SeLeCt A FROM T', 'SeLeCt A FROM T'],
+        [
+          'preserves digits that continue an identifier',
+          'SELECT t2.c3 FROM user2',
+          'SELECT t2.c3 FROM user2',
+        ],
+        [
+          'preserves a non-ASCII identifier',
+          'SELECT caf\u00e9 FROM \u0442\u0430\u0431\u043b\u0438\u0446\u0430',
+          'SELECT caf\u00e9 FROM \u0442\u0430\u0431\u043b\u0438\u0446\u0430',
+        ],
+        [
+          'masks an unterminated identifier through end of input',
+          'SELECT * FROM "never closed',
+          'SELECT * FROM ?',
+        ],
+        [
+          'does not keep literals trailing an unbalanced quote',
+          'SELECT * FROM "us"er" WHERE ssn = 123456789 AND pw = \'hunter2\'',
+          'SELECT * FROM "us"er?',
+        ],
+      ]);
+    });
+
+    describe('comments', () => {
+      run([
+        [
+          'drops a line comment at end of input',
+          "UPDATE t SET c='a' -- note 'x'",
+          'UPDATE t SET c=?',
+        ],
+        [
+          'drops a line comment in the middle of a statement',
+          'SELECT 1 -- secret\nFROM t',
+          'SELECT ? FROM t',
+        ],
+        ['drops a block comment', 'SELECT /* hi */ 1', 'SELECT ?'],
+        [
+          'tracks nested block comments',
+          '/* outer /* inner */ still */ SELECT 1',
+          'SELECT ?',
+        ],
+        [
+          'drops an unterminated block comment',
+          'SELECT /* never closed',
+          'SELECT',
+        ],
+        ['drops a comment-only statement', '/* only a comment */', ''],
+        [
+          'ends a line comment at a carriage return',
+          'SELECT 1 -- secret\rFROM t WHERE a = 2',
+          'SELECT ? FROM t WHERE a = ?',
+        ],
+      ]);
+    });
+
+    describe('numeric literals', () => {
+      run([
+        ['masks an integer', 'SELECT 42', 'SELECT ?'],
+        ['masks a zero at end of input', 'SELECT 0', 'SELECT ?'],
+        ['masks a decimal', 'SELECT 3.14', 'SELECT ?'],
+        ['masks a leading-dot decimal', 'SELECT .5', 'SELECT ?'],
+        [
+          'masks a signed leading-dot decimal',
+          'SELECT * FROM t WHERE r = -.5',
+          'SELECT * FROM t WHERE r = ?',
+        ],
+        ['masks an exponent', 'SELECT 1.5e-3, 1E10', 'SELECT ?, ?'],
+        ['masks hexadecimal', 'SELECT 0x1F, 0XFF', 'SELECT ?, ?'],
+        ['masks octal and binary', 'SELECT 0o17, 0b1010', 'SELECT ?, ?'],
+        ['masks digit group separators', 'SELECT 1_000_000', 'SELECT ?'],
+        [
+          'absorbs a sign where a value is expected',
+          'SELECT * FROM t WHERE id = -12 AND n = +7',
+          'SELECT * FROM t WHERE id = ? AND n = ?',
+        ],
+        [
+          'keeps a sign that is an operator',
+          'UPDATE t SET amount = amount-1',
+          'UPDATE t SET amount = amount-?',
+        ],
+        ['keeps an operator between two literals', 'SELECT 1-1', 'SELECT ?-?'],
+        [
+          'stops a number at the first non-digit',
+          'SELECT 1abc FROM t',
+          'SELECT ?abc FROM t',
+        ],
+        [
+          'absorbs a sign following an operator spelled with a question mark',
+          'SELECT * FROM t WHERE data ? -1',
+          'SELECT * FROM t WHERE data ? ?',
+        ],
+      ]);
+    });
+
+    describe('structure', () => {
+      run([
+        [
+          'does not collapse an IN list',
+          'SELECT * FROM t WHERE id IN (1,2,3,4)',
+          'SELECT * FROM t WHERE id IN (?,?,?,?)',
+        ],
+        [
+          'preserves array and cast syntax',
+          "SELECT ARRAY[1,2,3], '{a,b}'::text[]",
+          'SELECT ARRAY[?,?,?], ?::text[]',
+        ],
+        [
+          'preserves function calls',
+          "SELECT count(*) FROM t WHERE ts > now() - interval '1 day'",
+          'SELECT count(*) FROM t WHERE ts > now() - interval ?',
+        ],
+        [
+          'preserves a jsonb existence operator',
+          "SELECT * FROM t WHERE data ? 'k'",
+          'SELECT * FROM t WHERE data ? ?',
+        ],
+        ['preserves a trailing semicolon', 'SELECT 1;', 'SELECT ?;'],
+      ]);
+    });
+
+    describe('whitespace', () => {
+      run([
+        [
+          'collapses runs of whitespace',
+          'select\n  *\nfrom\n  t -- trailing\n',
+          'select * from t',
+        ],
+        [
+          'collapses tabs and carriage returns',
+          'SELECT\t1\r\nFROM t',
+          'SELECT ? FROM t',
+        ],
+        ['returns an empty string for empty input', '', ''],
+        ['returns an empty string for whitespace-only input', '   \n\t ', ''],
+      ]);
+    });
+
+    describe('truncation', () => {
+      it('caps output at the default length', () => {
+        const sanitized = sanitize('SELECT ' + "'x',".repeat(40000));
+        assert.ok(
+          sanitized.length <= 32 * 1024,
+          `expected <= 32768, got ${sanitized.length}`
+        );
+      });
+
+      it('caps output at an explicit length, at a token boundary', () => {
+        assert.strictEqual(
+          sanitize('SELECT a, b, c, d, e, f FROM t', 20),
+          'SELECT a, b, c, d, e'
+        );
+      });
+
+      it('drops a token that does not fit rather than splitting it', () => {
+        assert.strictEqual(
+          sanitize("SELECT * FROM verylongtable WHERE a = 'x'", 10),
+          'SELECT *'
+        );
+      });
+
+      it('falls back to the default for a limit that cannot bound anything', () => {
+        for (const maxLength of [NaN, 0, -5, Infinity]) {
+          assert.strictEqual(
+            sanitize("SELECT a, b FROM t WHERE c = 'x'", maxLength),
+            'SELECT a, b FROM t WHERE c = ?',
+            `expected maxLength ${maxLength} to fall back to the default`
+          );
+        }
+      });
+    });
+
+    describe('termination', () => {
+      // A hand-written lexer's worst failure is a scan helper that returns -1
+      // on end-of-input and sends the loop backwards, so every truncation of a
+      // statement that mixes the tricky forms is exercised.
+      it('terminates on every prefix of a statement mixing every construct', () => {
+        const statement =
+          "SELECT $t$a$t$, E'\\'', /* /* */ */ \"q\"\"\", -1.5e-3, $1, U&'x' -- c";
+        for (let i = 0; i <= statement.length; i++) {
+          const prefix = statement.slice(0, i);
+          assert.strictEqual(
+            typeof sanitize(prefix),
+            'string',
+            `did not return a string for prefix of length ${i}`
+          );
+        }
+      });
+    });
+
+    describe('leakage', () => {
+      const secrets = ['a@b.c', 'hunter2', 's3cret', '19700101'];
+
+      const assertNoSecrets = (sql: string) => {
+        const sanitized = sanitize(sql);
+        for (const secret of secrets) {
+          assert.ok(
+            !sanitized.includes(secret),
+            `expected ${secret} to be masked, got: ${sanitized}`
+          );
+        }
+      };
+
+      it('leaves no literal from any construct in the result', () => {
+        assertNoSecrets(
+          "SELECT * FROM u WHERE e='a@b.c' AND n=$$hunter2$$ " +
+            'AND d=19700101 -- pw=s3cret'
+        );
+      });
+
+      // Masking a literal depends on finding where it ends, so every delimiter
+      // that can be left open is a chance to fall back to emitting the rest of
+      // the statement verbatim. Each opener is checked with a body that carries
+      // a literal of its own.
+      it('leaves no literal behind an unclosed delimiter of any kind', () => {
+        for (const opener of [
+          '"',
+          "'",
+          "E'",
+          "B'",
+          "X'",
+          "U&'",
+          '$$',
+          '$tag$',
+          '/*',
+        ]) {
+          assertNoSecrets(
+            `SELECT * FROM u WHERE x = ${opener}a@b.c' AND ` +
+              "pw = 'hunter2' AND d = 19700101 -- s3cret"
+          );
+        }
+      });
+    });
+  });
+});

--- a/packages/sql-common/test/sanitize.test.ts
+++ b/packages/sql-common/test/sanitize.test.ts
@@ -311,6 +311,21 @@ describe('sanitizeSql', () => {
           'SELECT * FROM t WHERE data ? -1',
           'SELECT * FROM t WHERE data ? ?',
         ],
+        [
+          'absorbs a sign directly after a reserved keyword',
+          'SELECT -5',
+          'SELECT ?',
+        ],
+        [
+          'absorbs a sign after a reserved keyword mid-expression',
+          'SELECT * FROM t WHERE a = 1 AND -5 = b',
+          'SELECT * FROM t WHERE a = ? AND ? = b',
+        ],
+        [
+          'keeps a sign after a non-reserved keyword, a known gap',
+          'SELECT * FROM t LIMIT -1',
+          'SELECT * FROM t LIMIT -?',
+        ],
       ]);
     });
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Updates #3471 

## Short description of the changes

- This PR adds a new function, `sanitizeSql`, to `@opentelemetry/sql-common`. The function replaces literal values in a SQL string with `?`. It keeps identifiers and `$n` placeholders as-is.
- `instrumentation-pg` now uses this function by default. The instrumentation applies it only to non-parameterized queries, since a parameterized query never contains literal values in its text.
- Two new options control this: `skipQueryTextSanitization` (default `false`) turns sanitization off. `queryTextSanitizationHook` lets you supply your own function instead of the default.
- **This is a breaking change.** A query built by string concatenation will now show `?` instead of its literal values in `db.query.text`. Set `skipQueryTextSanitization: true` to keep the old behavior.
- Known gaps: the function assumes `standard_conforming_strings` is on (the PostgreSQL default). It also does not mask a sign that follows a non-reserved keyword, for example `LIMIT -1`.
