### PR TITLE
chore: align minimum release age configuration

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 lockfile-version=3
+min-release-age=3

--- a/renovate.json
+++ b/renovate.json
@@ -63,7 +63,8 @@
   ],
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 3am on Monday"]
+    "schedule": ["before 3am on Monday"],
+    "minimumReleaseAge": "0"
   },
   "ignoreDeps": ["@types/node"],
   "ignorePaths": ["archive/**", "examples/**"],
@@ -72,7 +73,7 @@
   "labels": ["dependencies"],
   "semanticCommitType": "feat",
   "constraints": {
-    "npm": ">=11.6.3"
+    "npm": ">=11.18.0"
   },
   "minimumReleaseAge": "1 week"
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Renovate lockfile-maintenance PRs in this repo do not get a working `minimumReleaseAge` check. That setting is not effective for lockfile updates, so those PRs stay blocked (or still install packages that should have been delayed). This aligns the contrib repo with the approach already used in the core repo (`open-telemetry/opentelemetry-js#6935`).

Fixes #3650.

## Short description of the changes

- Add `min-release-age=3` to `.npmrc` so npm itself rejects packages younger than 3 days. This applies to local installs and to Renovate lockfile updates that run `npm`.
- Set `lockFileMaintenance.minimumReleaseAge` to `"0"` so Renovate does not keep applying its own (ineffective) delay to lockfile-maintenance PRs. The existing `enabled` and `schedule` values are unchanged. The `.npmrc` setting is the real safeguard.
- Raise the Renovate npm constraint from `>=11.6.3` to `>=11.18.0`, which is the version that supports `min-release-age`.

This is configuration-only. No runtime code, tests, or changelog updates.

AI assistance: I used Grok 4.6 (xAI) while preparing this change. I reviewed the existing config, the core-repo PR, and the resulting diff myself.

## Validation

```text
python3 -c 'import json; json.load(open("renovate.json"))'
# JSON_OK

npx --yes --package renovate renovate-config-validator renovate.json
# INFO: Config validated successfully against 1 file(s)

npx --yes npm@11.18.0 config get min-release-age
# 3

git diff --check
# no whitespace errors
```

Unit tests were not run; this change does not affect package source.