### PR TITLE
fix(instrumentation-kafkajs): record exceptions and handle synchronous errors to prevent span leaks

### DIFF
--- a/packages/instrumentation-kafkajs/src/instrumentation.ts
+++ b/packages/instrumentation-kafkajs/src/instrumentation.ts
@@ -713,7 +713,6 @@ export class KafkaJsInstrumentation extends InstrumentationBase<KafkaJsInstrumen
     return Promise.resolve(sendPromise)
       .then(result => {
         pendingMetrics.forEach(m => m());
-        spans.forEach(span => span.end());
         return result;
       })
       .catch(reason => {
@@ -722,6 +721,7 @@ export class KafkaJsInstrumentation extends InstrumentationBase<KafkaJsInstrumen
         if (typeof reason === 'string' || reason === undefined) {
           errorMessage = reason;
         } else if (
+          reason !== null &&
           typeof reason === 'object' &&
           Object.prototype.hasOwnProperty.call(reason, 'message')
         ) {
@@ -739,10 +739,12 @@ export class KafkaJsInstrumentation extends InstrumentationBase<KafkaJsInstrumen
             code: SpanStatusCode.ERROR,
             message: errorMessage,
           });
-          span.end();
         });
 
         throw reason;
+      })
+      .finally(() => {
+        spans.forEach(span => span.end());
       });
   }
 

--- a/packages/instrumentation-kafkajs/src/instrumentation.ts
+++ b/packages/instrumentation-kafkajs/src/instrumentation.ts
@@ -387,12 +387,17 @@ export class KafkaJsInstrumentation extends InstrumentationBase<KafkaJsInstrumen
           }),
         ];
 
-        const eachMessagePromise = context.with(
-          trace.setSpan(propagatedContext, span),
-          () => {
-            return original!.apply(this, args);
-          }
-        );
+        let eachMessagePromise: Promise<void>;
+        try {
+          eachMessagePromise = context.with(
+            trace.setSpan(propagatedContext, span),
+            () => {
+              return original!.apply(this, args);
+            }
+          );
+        } catch (err: any) {
+          eachMessagePromise = Promise.reject(err);
+        }
         return instrumentation._endSpansOnPromise(
           [span],
           pendingMetrics,
@@ -485,10 +490,12 @@ export class KafkaJsInstrumentation extends InstrumentationBase<KafkaJsInstrumen
                 )
               );
             });
-            const batchMessagePromise: Promise<void> = original!.apply(
-              this,
-              args
-            );
+            let batchMessagePromise: Promise<void>;
+            try {
+              batchMessagePromise = original!.apply(this, args);
+            } catch (err: any) {
+              batchMessagePromise = Promise.reject(err);
+            }
             spans.unshift(receivingSpan);
             return instrumentation._endSpansOnPromise(
               spans,
@@ -510,7 +517,12 @@ export class KafkaJsInstrumentation extends InstrumentationBase<KafkaJsInstrumen
       ): ReturnType<Producer['transaction']> {
         const transactionSpan = instrumentation.tracer.startSpan('transaction');
 
-        const transactionPromise = original.apply(this, args);
+        let transactionPromise: Promise<kafkaJs.Transaction>;
+        try {
+          transactionPromise = original.apply(this, args);
+        } catch (err: any) {
+          transactionPromise = Promise.reject(err);
+        }
 
         transactionPromise
           .then((transaction: kafkaJs.Transaction) => {
@@ -637,10 +649,12 @@ export class KafkaJsInstrumentation extends InstrumentationBase<KafkaJsInstrumen
             );
           });
         });
-        const origSendResult: Promise<RecordMetadata[]> = original.apply(
-          this,
-          args
-        );
+        let origSendResult: Promise<RecordMetadata[]>;
+        try {
+          origSendResult = original.apply(this, args);
+        } catch (err: any) {
+          origSendResult = Promise.reject(err);
+        }
         return instrumentation._endSpansOnPromise(
           spans,
           pendingMetrics,
@@ -676,10 +690,12 @@ export class KafkaJsInstrumentation extends InstrumentationBase<KafkaJsInstrumen
               : {}),
           })
         );
-        const origSendResult: Promise<RecordMetadata[]> = original.apply(
-          this,
-          args
-        );
+        let origSendResult: Promise<RecordMetadata[]>;
+        try {
+          origSendResult = original.apply(this, args);
+        } catch (err: any) {
+          origSendResult = Promise.reject(err);
+        }
         return instrumentation._endSpansOnPromise(
           spans,
           pendingMetrics,
@@ -697,6 +713,7 @@ export class KafkaJsInstrumentation extends InstrumentationBase<KafkaJsInstrumen
     return Promise.resolve(sendPromise)
       .then(result => {
         pendingMetrics.forEach(m => m());
+        spans.forEach(span => span.end());
         return result;
       })
       .catch(reason => {
@@ -714,17 +731,18 @@ export class KafkaJsInstrumentation extends InstrumentationBase<KafkaJsInstrumen
         pendingMetrics.forEach(m => m(errorType));
 
         spans.forEach(span => {
+          if (reason !== undefined && reason !== null) {
+            span.recordException(reason);
+          }
           span.setAttribute(ATTR_ERROR_TYPE, errorType);
           span.setStatus({
             code: SpanStatusCode.ERROR,
             message: errorMessage,
           });
+          span.end();
         });
 
         throw reason;
-      })
-      .finally(() => {
-        spans.forEach(span => span.end());
       });
   }
 

--- a/packages/instrumentation-kafkajs/test/kafkajs.test.ts
+++ b/packages/instrumentation-kafkajs/test/kafkajs.test.ts
@@ -539,60 +539,60 @@ describe('instrumentation-kafkajs', () => {
         });
       });
 
-    describe('synchronous failed send', () => {
-      beforeEach(async () => {
-        instrumentation.disable();
-        patchProducerSend(() => {
-          throw new Error('Sync send error');
+      describe('synchronous failed send', () => {
+        beforeEach(async () => {
+          instrumentation.disable();
+          patchProducerSend(() => {
+            throw new Error('Sync send error');
+          });
+          instrumentation.enable();
+          producer = kafka.producer();
         });
-        instrumentation.enable();
-        producer = kafka.producer();
+
+        it('handles synchronous throw in producer.send and records exception', async () => {
+          let caughtError;
+          try {
+            await producer.send({
+              topic: 'topic-name-1',
+              messages: [{ value: 'test' }],
+            });
+          } catch (e) {
+            caughtError = e;
+          }
+
+          assert.ok(caughtError);
+          const spans = getTestSpans();
+          assert.strictEqual(spans.length, 1);
+          const span = spans[0];
+          assert.strictEqual(span.status.code, SpanStatusCode.ERROR);
+          assert.strictEqual(span.status.message, 'Sync send error');
+          assert.ok(span.events.some(e => e.name === 'exception'));
+        });
+
+        it('handles synchronous throw in producer.sendBatch and records exception', async () => {
+          let caughtError;
+          try {
+            await producer.sendBatch({
+              topicMessages: [
+                {
+                  topic: 'topic-name-1',
+                  messages: [{ value: 'test' }],
+                },
+              ],
+            });
+          } catch (e) {
+            caughtError = e;
+          }
+
+          assert.ok(caughtError);
+          const spans = getTestSpans();
+          assert.strictEqual(spans.length, 1);
+          const span = spans[0];
+          assert.strictEqual(span.status.code, SpanStatusCode.ERROR);
+          assert.strictEqual(span.status.message, 'Sync send error');
+          assert.ok(span.events.some(e => e.name === 'exception'));
+        });
       });
-
-      it('handles synchronous throw in producer.send and records exception', async () => {
-        let caughtError;
-        try {
-          await producer.send({
-            topic: 'topic-name-1',
-            messages: [{ value: 'test' }],
-          });
-        } catch (e) {
-          caughtError = e;
-        }
-
-        assert.ok(caughtError);
-        const spans = getTestSpans();
-        assert.strictEqual(spans.length, 1);
-        const span = spans[0];
-        assert.strictEqual(span.status.code, SpanStatusCode.ERROR);
-        assert.strictEqual(span.status.message, 'Sync send error');
-        assert.ok(span.events.some(e => e.name === 'exception'));
-      });
-
-      it('handles synchronous throw in producer.sendBatch and records exception', async () => {
-        let caughtError;
-        try {
-          await producer.sendBatch({
-            topicMessages: [
-              {
-                topic: 'topic-name-1',
-                messages: [{ value: 'test' }],
-              },
-            ],
-          });
-        } catch (e) {
-          caughtError = e;
-        }
-
-        assert.ok(caughtError);
-        const spans = getTestSpans();
-        assert.strictEqual(spans.length, 1);
-        const span = spans[0];
-        assert.strictEqual(span.status.code, SpanStatusCode.ERROR);
-        assert.strictEqual(span.status.message, 'Sync send error');
-        assert.ok(span.events.some(e => e.name === 'exception'));
-      });
-    });
     });
 
     describe('producer hook successful', () => {
@@ -1460,7 +1460,9 @@ describe('instrumentation-kafkajs', () => {
         it('records exception event when eachMessage rejects asynchronously', async () => {
           const asyncError = new Error('Async consumer error');
           consumer.run({
-            eachMessage: async (_payload: EachMessagePayload): Promise<void> => {
+            eachMessage: async (
+              _payload: EachMessagePayload
+            ): Promise<void> => {
               throw asyncError;
             },
           });

--- a/packages/instrumentation-kafkajs/test/kafkajs.test.ts
+++ b/packages/instrumentation-kafkajs/test/kafkajs.test.ts
@@ -593,6 +593,38 @@ describe('instrumentation-kafkajs', () => {
           assert.ok(span.events.some(e => e.name === 'exception'));
         });
       });
+
+      describe('rejection with null reason', () => {
+        beforeEach(async () => {
+          instrumentation.disable();
+          patchProducerSend((): Promise<RecordMetadata[]> => {
+            return Promise.reject(null);
+          });
+          instrumentation.enable();
+          producer = kafka.producer();
+        });
+
+        it('ends the span and does not leak when send rejects with null', async () => {
+          let caughtError;
+          try {
+            await producer.send({
+              topic: 'topic-name-1',
+              messages: [{ value: 'test' }],
+            });
+          } catch (e) {
+            caughtError = e;
+          }
+
+          assert.strictEqual(caughtError, null);
+          const spans = getTestSpans();
+          assert.strictEqual(spans.length, 1);
+          const span = spans[0] as ReadableSpan;
+          assert.ok(span.ended);
+          assert.strictEqual(span.status.code, SpanStatusCode.ERROR);
+          assert.strictEqual(span.status.message, undefined);
+          assert.ok(!span.events.some(e => e.name === 'exception'));
+        });
+      });
     });
 
     describe('producer hook successful', () => {

--- a/packages/instrumentation-kafkajs/test/kafkajs.test.ts
+++ b/packages/instrumentation-kafkajs/test/kafkajs.test.ts
@@ -93,8 +93,12 @@ describe('instrumentation-kafkajs', () => {
       rejectSend?: boolean;
     }
   ) => {
-    const origProducerFactory = kafkajs.Kafka.prototype.producer;
-    kafkajs.Kafka.prototype.producer = function (...args): Producer {
+    const kafkaProto = kafkajs.Kafka.prototype as any;
+    if (!kafkaProto._origProducer) {
+      kafkaProto._origProducer = kafkaProto.producer;
+    }
+    const origProducerFactory = kafkaProto._origProducer;
+    kafkaProto.producer = function (...args: any[]): Producer {
       const producer = origProducerFactory.apply(this, args);
 
       producer.send = function (record: ProducerRecord) {
@@ -534,6 +538,61 @@ describe('instrumentation-kafkajs', () => {
           },
         });
       });
+
+    describe('synchronous failed send', () => {
+      beforeEach(async () => {
+        instrumentation.disable();
+        patchProducerSend(() => {
+          throw new Error('Sync send error');
+        });
+        instrumentation.enable();
+        producer = kafka.producer();
+      });
+
+      it('handles synchronous throw in producer.send and records exception', async () => {
+        let caughtError;
+        try {
+          await producer.send({
+            topic: 'topic-name-1',
+            messages: [{ value: 'test' }],
+          });
+        } catch (e) {
+          caughtError = e;
+        }
+
+        assert.ok(caughtError);
+        const spans = getTestSpans();
+        assert.strictEqual(spans.length, 1);
+        const span = spans[0];
+        assert.strictEqual(span.status.code, SpanStatusCode.ERROR);
+        assert.strictEqual(span.status.message, 'Sync send error');
+        assert.ok(span.events.some(e => e.name === 'exception'));
+      });
+
+      it('handles synchronous throw in producer.sendBatch and records exception', async () => {
+        let caughtError;
+        try {
+          await producer.sendBatch({
+            topicMessages: [
+              {
+                topic: 'topic-name-1',
+                messages: [{ value: 'test' }],
+              },
+            ],
+          });
+        } catch (e) {
+          caughtError = e;
+        }
+
+        assert.ok(caughtError);
+        const spans = getTestSpans();
+        assert.strictEqual(spans.length, 1);
+        const span = spans[0];
+        assert.strictEqual(span.status.code, SpanStatusCode.ERROR);
+        assert.strictEqual(span.status.message, 'Sync send error');
+        assert.ok(span.events.some(e => e.name === 'exception'));
+      });
+    });
     });
 
     describe('producer hook successful', () => {
@@ -1361,14 +1420,105 @@ describe('instrumentation-kafkajs', () => {
           ],
         });
       });
+
+      describe('synchronous error handling & exception recording', () => {
+        beforeEach(() => {
+          storeRunConfig();
+          instrumentation.disable();
+          instrumentation.enable();
+          consumer = kafka.consumer({
+            groupId: 'testing-group-id',
+          });
+        });
+
+        it('handles synchronous throw in eachMessage callback and records exception event', async () => {
+          const syncError = new Error('Sync consumer error');
+          consumer.run({
+            eachMessage: (_payload: EachMessagePayload): Promise<void> => {
+              throw syncError;
+            },
+          });
+
+          const payload: EachMessagePayload = createEachMessagePayload();
+          let caughtError;
+          try {
+            await runConfig?.eachMessage!(payload);
+          } catch (e) {
+            caughtError = e;
+          }
+
+          assert.strictEqual(caughtError, syncError);
+
+          const spans = getTestSpans();
+          assert.strictEqual(spans.length, 1);
+          const span = spans[0];
+          assert.strictEqual(span.status.code, SpanStatusCode.ERROR);
+          assert.strictEqual(span.status.message, 'Sync consumer error');
+          assert.ok(span.events.some(e => e.name === 'exception'));
+        });
+
+        it('records exception event when eachMessage rejects asynchronously', async () => {
+          const asyncError = new Error('Async consumer error');
+          consumer.run({
+            eachMessage: async (_payload: EachMessagePayload): Promise<void> => {
+              throw asyncError;
+            },
+          });
+
+          const payload: EachMessagePayload = createEachMessagePayload();
+          let caughtError;
+          try {
+            await runConfig?.eachMessage!(payload);
+          } catch (e) {
+            caughtError = e;
+          }
+
+          assert.strictEqual(caughtError, asyncError);
+
+          const spans = getTestSpans();
+          assert.strictEqual(spans.length, 1);
+          const span = spans[0];
+          assert.strictEqual(span.status.code, SpanStatusCode.ERROR);
+          assert.strictEqual(span.status.message, 'Async consumer error');
+          assert.ok(span.events.some(e => e.name === 'exception'));
+        });
+      });
     });
 
     describe('successful eachBatch', () => {
       beforeEach(async () => {
+        storeRunConfig();
         instrumentation.disable();
         instrumentation.enable();
         consumer = kafka.consumer({
           groupId: 'testing-group-id',
+        });
+      });
+
+      it('handles synchronous throw in eachBatch callback and records exception events', async () => {
+        const syncError = new Error('Sync batch error');
+        consumer.run({
+          eachBatch: (_payload: EachBatchPayload): Promise<void> => {
+            throw syncError;
+          },
+        });
+
+        const payload: EachBatchPayload = createEachBatchPayload();
+        let caughtError;
+        try {
+          await runConfig?.eachBatch!(payload);
+        } catch (e) {
+          caughtError = e;
+        }
+
+        assert.strictEqual(caughtError, syncError);
+
+        const spans = getTestSpans();
+        assert.strictEqual(spans.length, 3);
+        spans.forEach(span => {
+          assert.strictEqual(span.status.code, SpanStatusCode.ERROR);
+          assert.strictEqual(span.status.message, 'Sync batch error');
+          assert.ok(span.events.some(e => e.name === 'exception'));
         });
       });
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Fixes #3691

## Short description of the changes

- Call `span.recordException(reason)` in `_endSpansOnPromise` when a promise rejects to record exception events, stack traces, and error type attributes in accordance with OpenTelemetry trace semantic conventions.
- Wrap `original.apply` invocations in `_getConsumerEachMessagePatch`, `_getConsumerEachBatchPatch`, `_getSendPatch`, `_getSendBatchPatch`, and `_getProducerTransactionPatch` in `try...catch` blocks so synchronous throws produce rejected promises passed to `_endSpansOnPromise`, preventing unended span leaks and memory leaks.
- Call `span.end()` inside `.then()` and `.catch()` callbacks in `_endSpansOnPromise` so spans end immediately upon promise settlement.
- Added comprehensive unit tests in `packages/instrumentation-kafkajs/test/kafkajs.test.ts` verifying synchronous throw error handling and exception event recording across `eachMessage`, `eachBatch`, producer `send`, and `sendBatch`.
