### PR TITLE
fix(document-load): ignore zero-valued navigation timings

### DIFF
--- a/packages/instrumentation-document-load/src/instrumentation.ts
+++ b/packages/instrumentation-document-load/src/instrumentation.ts
@@ -109,7 +109,8 @@ export class DocumentLoadInstrumentation extends InstrumentationBase<DocumentLoa
             addSpanNetworkEvents(
               fetchSpan,
               entries,
-              this.getConfig().ignoreNetworkEvents
+              this.getConfig().ignoreNetworkEvents,
+              true
             );
             this._addCustomAttributesOnSpan(
               fetchSpan,

--- a/packages/instrumentation-document-load/test/documentLoad.test.ts
+++ b/packages/instrumentation-document-load/test/documentLoad.test.ts
@@ -372,6 +372,30 @@ describe('DocumentLoad Instrumentation', () => {
       });
     });
 
+    it(
+      'should ignore zero valued secureConnectionStart for navigation entries',
+      done => {
+  const navigationEntry = {
+    ...entries,
+    secureConnectionStart: 0,
+  };
+
+  spyEntries.withArgs('navigation').returns([navigationEntry]);
+
+  plugin.enable();
+
+  setTimeout(() => {
+    const fetchSpan = exporter.getFinishedSpans()[0] as ReadableSpan;
+
+    const eventNames = fetchSpan.events.map(event => event.name);
+
+    assert.notInclude(eventNames, PTN.SECURE_CONNECTION_START);
+
+    done();
+   });
+  }
+);
+
     describe('AND window has information about server root span', () => {
       let spyGetElementsByTagName: any;
       beforeEach(() => {


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

For navigation entries, `startTime` is always `0`. When a navigation entry has a zero-valued network timing such as `secureConnectionStart`, `addSpanNetworkEvents` can emit the event at `timeOrigin`.

The `documentFetch` span starts at `fetchStart`, so the zero-valued event can be timestamped before the span starts.

This PR fixes the issue by ignoring zero-valued network timings specifically for the navigation `documentFetch` span.

## Short description of the changes

- Pass `ignoreZeros: true` when adding network events to the navigation `documentFetch` span.
- Preserve the existing behavior for resource fetch spans.
- Add a regression test for zero-valued `secureConnectionStart` on navigation entries.

## Testing

- `npm run test:browser --workspace=@opentelemetry/instrumentation-document-load`
- 19 tests passed
- 0 tests failed
- Code coverage: 97.82%

Related issue: [open-telemetry/opentelemetry-js#7017](https://github.com/open-telemetry/opentelemetry-js/issues/7017)