### PR TITLE
chore: add aryamohanan as component owner for instrumentation-tedious

### DIFF
--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -71,8 +71,8 @@ components:
     - seemk
     - t2t2
     - mhennoch
-  packages/instrumentation-tedious: []
-    # Unmaintained
+  packages/instrumentation-tedious:
+    - aryamohanan
   packages/instrumentation-typeorm:
     - seemk
     - weyert


### PR DESCRIPTION
## Which problem is this PR solving?

Add @aryamohanan as a component owner for `packages/instrumentation-tedious` to help maintain and support this currently unmaintained component.

#closes #3695