### PR TITLE
fix(deps): move unused @types packages out of runtime dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11564,6 +11564,7 @@
       "version": "1.8.11",
       "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.11.tgz",
       "integrity": "sha512-758fRH7umIMk5qt5ELmRMff4mLDlN+xyYzC+dkPTdKwbSkJFvz6xwyScrytPU0QIBbRRwbiE8/BIg8bpajerNQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -11897,6 +11898,7 @@
       "version": "2.15.27",
       "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz",
       "integrity": "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -11922,6 +11924,7 @@
       "version": "6.10.4",
       "resolved": "https://registry.npmjs.org/@types/oracledb/-/oracledb-6.10.4.tgz",
       "integrity": "sha512-VztLwr8PQsStRD5MEr6FVRv9LN+JeeTrTGVUFenAmTP/8X+mfNYwz02qvMc8B41CVeDdR3enQhaWmT9iBgNJSA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -12112,6 +12115,7 @@
       "version": "4.0.14",
       "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
       "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -36771,8 +36775,7 @@
       "dependencies": {
         "@opentelemetry/api-logs": "^0.221.0",
         "@opentelemetry/instrumentation": "^0.221.0",
-        "@opentelemetry/semantic-conventions": "^1.41.1",
-        "@types/bunyan": "1.8.11"
+        "@opentelemetry/semantic-conventions": "^1.41.1"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -36780,6 +36783,7 @@
         "@opentelemetry/resources": "^2.0.0",
         "@opentelemetry/sdk-logs": "^0.221.0",
         "@opentelemetry/sdk-trace": "^2.9.0",
+        "@types/bunyan": "1.8.11",
         "bunyan": "1.8.15"
       },
       "engines": {
@@ -37307,8 +37311,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.221.0",
-        "@opentelemetry/semantic-conventions": "^1.33.0",
-        "@types/mysql": "2.15.27"
+        "@opentelemetry/semantic-conventions": "^1.33.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -37316,6 +37319,7 @@
         "@opentelemetry/contrib-test-utils": "^0.68.0",
         "@opentelemetry/sdk-metrics": "^2.9.0",
         "@opentelemetry/sdk-trace": "^2.9.0",
+        "@types/mysql": "2.15.27",
         "mysql": "2.18.1"
       },
       "engines": {
@@ -37424,14 +37428,14 @@
       "dependencies": {
         "@opentelemetry/core": "^2.9.0",
         "@opentelemetry/instrumentation": "^0.221.0",
-        "@opentelemetry/semantic-conventions": "^1.34.0",
-        "@types/oracledb": "^6.10.4"
+        "@opentelemetry/semantic-conventions": "^1.34.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^2.9.0",
         "@opentelemetry/contrib-test-utils": "^0.68.0",
         "@opentelemetry/sdk-trace": "^2.9.0",
+        "@types/oracledb": "^6.10.4",
         "oracledb": "^6.7.0"
       },
       "engines": {
@@ -37654,14 +37658,14 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.221.0",
-        "@opentelemetry/semantic-conventions": "^1.33.0",
-        "@types/tedious": "^4.0.14"
+        "@opentelemetry/semantic-conventions": "^1.33.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/context-async-hooks": "^2.9.0",
         "@opentelemetry/contrib-test-utils": "^0.68.0",
         "@opentelemetry/sdk-trace": "^2.9.0",
+        "@types/tedious": "^4.0.14",
         "tedious": "17.0.0"
       },
       "engines": {

--- a/packages/instrumentation-bunyan/package.json
+++ b/packages/instrumentation-bunyan/package.json
@@ -50,13 +50,13 @@
     "@opentelemetry/resources": "^2.0.0",
     "@opentelemetry/sdk-logs": "^0.221.0",
     "@opentelemetry/sdk-trace": "^2.9.0",
+    "@types/bunyan": "1.8.11",
     "bunyan": "1.8.15"
   },
   "dependencies": {
     "@opentelemetry/api-logs": "^0.221.0",
     "@opentelemetry/instrumentation": "^0.221.0",
-    "@opentelemetry/semantic-conventions": "^1.41.1",
-    "@types/bunyan": "1.8.11"
+    "@opentelemetry/semantic-conventions": "^1.41.1"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-bunyan#readme"
 }

--- a/packages/instrumentation-mysql/package.json
+++ b/packages/instrumentation-mysql/package.json
@@ -53,12 +53,12 @@
     "@opentelemetry/contrib-test-utils": "^0.68.0",
     "@opentelemetry/sdk-metrics": "^2.9.0",
     "@opentelemetry/sdk-trace": "^2.9.0",
+    "@types/mysql": "2.15.27",
     "mysql": "2.18.1"
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.221.0",
-    "@opentelemetry/semantic-conventions": "^1.33.0",
-    "@types/mysql": "2.15.27"
+    "@opentelemetry/semantic-conventions": "^1.33.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-mysql#readme"
 }

--- a/packages/instrumentation-oracledb/package.json
+++ b/packages/instrumentation-oracledb/package.json
@@ -58,13 +58,13 @@
     "@opentelemetry/context-async-hooks": "^2.9.0",
     "@opentelemetry/contrib-test-utils": "^0.68.0",
     "@opentelemetry/sdk-trace": "^2.9.0",
+    "@types/oracledb": "^6.10.4",
     "oracledb": "^6.7.0"
   },
   "dependencies": {
     "@opentelemetry/core": "^2.9.0",
     "@opentelemetry/instrumentation": "^0.221.0",
-    "@opentelemetry/semantic-conventions": "^1.34.0",
-    "@types/oracledb": "^6.10.4"
+    "@opentelemetry/semantic-conventions": "^1.34.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-oracledb#readme"
 }

--- a/packages/instrumentation-tedious/package.json
+++ b/packages/instrumentation-tedious/package.json
@@ -57,12 +57,12 @@
     "@opentelemetry/context-async-hooks": "^2.9.0",
     "@opentelemetry/contrib-test-utils": "^0.68.0",
     "@opentelemetry/sdk-trace": "^2.9.0",
+    "@types/tedious": "^4.0.14",
     "tedious": "17.0.0"
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.221.0",
-    "@opentelemetry/semantic-conventions": "^1.33.0",
-    "@types/tedious": "^4.0.14"
+    "@opentelemetry/semantic-conventions": "^1.33.0"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-tedious#readme"
 }


### PR DESCRIPTION
## Which problem is this PR solving?

None of these packages are used in the public API of the consuming packages. A few others (`pg` most notably) still remain that need to depend on these types as they are used in the public API - these are not touched by this PR.

I'll follow up with changing the types on `@opentelemetry/instrumentation-pg` later as it's blocking #3538