### PR TITLE
feat(redis-common, instrumentation-redis, instrumentation-ioredis): add serializeKeys option

### DIFF
--- a/packages/instrumentation-ioredis/README.md
+++ b/packages/instrumentation-ioredis/README.md
@@ -100,7 +100,7 @@ requestHook: function (
 By default, commands that accept only a key are serialized without it, so every
 call looks the same:
 
-```
+```text
 hgetall [1 other arguments]
 ttl [1 other arguments]
 ```

--- a/packages/instrumentation-ioredis/README.md
+++ b/packages/instrumentation-ioredis/README.md
@@ -95,6 +95,54 @@ requestHook: function (
 
 ```
 
+#### Serializing redis keys
+
+By default, commands that accept only a key are serialized without it, so every
+call looks the same:
+
+```
+hgetall [1 other arguments]
+ttl [1 other arguments]
+```
+
+Set `serializeKeys` to `true` to record the key instead. Segments that identify
+a single entity are replaced with `?`, so the key pattern is visible without
+`db.query.text` becoming high cardinality:
+
+```javascript
+const { IORedisInstrumentation } = require('@opentelemetry/instrumentation-ioredis');
+
+const instrumentation = new IORedisInstrumentation({
+  serializeKeys: true,
+});
+```
+
+| default | `serializeKeys: true` |
+| --- | --- |
+| `hgetall [1 other arguments]` | `hgetall player:?:stats` |
+| `hgetall [1 other arguments]` | `hgetall tournament:leaderboard:sc:daily` |
+| `ttl [1 other arguments]` | `ttl auth_revoked:?` |
+| `mget [2 other arguments]` | `mget player:?:stats player:?:stats` |
+| `set session:42 [1 other arguments]` | `set session:? [1 other arguments]` |
+
+Only commands whose arguments are keys, hash fields, patterns, numbers or fixed
+tokens are affected. Commands that accept values, such as `set`, `hset` and
+`eval`, keep their values redacted either way.
+
+A segment is masked when it looks like a number, uuid, hex digest, ulid or email
+address. Segments that describe a class of keys, such as `queue:high` or
+`feature_flags`, are left alone, as is the command name.
+
+Pass `maskStatementHook` to replace the masking rule, or
+`statement => statement` to record keys unmasked:
+
+```javascript
+const instrumentation = new IORedisInstrumentation({
+  serializeKeys: true,
+  maskStatementHook: statement => statement.replace(/tenant:[^\s]+/g, 'tenant:?'),
+});
+```
+
 ## Semantic Conventions
 
 The `instrumentation-ioredis` versions 0.68.0 and later emit the stable v1.33.0+ semantic conventions.

--- a/packages/instrumentation-ioredis/src/instrumentation.ts
+++ b/packages/instrumentation-ioredis/src/instrumentation.ts
@@ -27,7 +27,14 @@ import {
 import { DB_SYSTEM_NAME_VALUE_REDIS } from './semconv';
 import { safeExecuteInTheMiddle } from '@opentelemetry/instrumentation';
 import { endSpan } from './utils';
-import { defaultDbStatementSerializer } from '@opentelemetry/redis-common';
+import {
+  createDbStatementSerializer,
+  defaultDbStatementMaskingHook,
+  defaultDbStatementSerializer,
+} from '@opentelemetry/redis-common';
+
+// built once, the option is read per command but the serializer is stateless
+const keySerializer = createDbStatementSerializer({ serializeKeys: true });
 /** @knipignore */
 import { PACKAGE_NAME, PACKAGE_VERSION } from './version';
 
@@ -108,7 +115,8 @@ export class IORedisInstrumentation extends InstrumentationBase<IORedisInstrumen
       }
       const config = instrumentation.getConfig();
       const dbStatementSerializer =
-        config.dbStatementSerializer || defaultDbStatementSerializer;
+        config.dbStatementSerializer ||
+        (config.serializeKeys ? keySerializer : defaultDbStatementSerializer);
 
       const hasNoParentSpan = trace.getSpan(context.active()) === undefined;
       if (config.requireParentSpan === true && hasNoParentSpan) {
@@ -147,7 +155,12 @@ export class IORedisInstrumentation extends InstrumentationBase<IORedisInstrumen
 
       const { host, port } = this.options;
 
-      const dbQueryText = dbStatementSerializer(cmd.name, cmd.args);
+      let dbQueryText = dbStatementSerializer(cmd.name, cmd.args);
+      if (config.serializeKeys) {
+        dbQueryText = (
+          config.maskStatementHook || defaultDbStatementMaskingHook
+        )(dbQueryText);
+      }
       attributes[ATTR_DB_SYSTEM_NAME] = DB_SYSTEM_NAME_VALUE_REDIS;
       attributes[ATTR_DB_QUERY_TEXT] = dbQueryText;
       attributes[ATTR_SERVER_ADDRESS] = host;

--- a/packages/instrumentation-ioredis/src/types.ts
+++ b/packages/instrumentation-ioredis/src/types.ts
@@ -46,9 +46,48 @@ export interface RedisResponseCustomAttributeFunction {
 /**
  * Options available for the IORedis Instrumentation (see [documentation](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/packages/instrumentation-ioredis/README.md#ioredis-instrumentation-options))
  */
+/**
+ * Function that can be used to mask the db.query.text attribute before it is
+ * set on the span.
+ * @param statement - The serialized statement, as produced by the
+ *  {@link DbStatementSerializer}
+ *
+ * @returns the string that will be used as the db.query.text attribute.
+ */
+export type DbStatementMaskingHook = (statement: string) => string;
+
 export interface IORedisInstrumentationConfig extends InstrumentationConfig {
   /** Custom serializer function for the db.statement tag */
   dbStatementSerializer?: DbStatementSerializer;
+
+  /**
+   * If true, commands that accept only keys, hash fields, patterns, numbers or
+   * fixed tokens also serialize their arguments, and the resulting statement is
+   * masked using {@link maskStatementHook}.
+   *
+   * Without it those commands are serialized as `HGETALL [1 other arguments]`,
+   * so every invocation looks the same. With it they become
+   * `HGETALL player:?:stats`, which identifies the key pattern without
+   * recording which entity was touched.
+   *
+   * Commands that accept values, such as `SET`, `HSET` and `EVAL`, are not
+   * affected, and their values stay redacted either way.
+   *
+   * @default false
+   * @see maskStatementHook
+   */
+  serializeKeys?: boolean;
+
+  /**
+   * Hook that masks the statement when {@link serializeKeys} is true. Ignored
+   * otherwise.
+   *
+   * Pass `statement => statement` to record keys without masking them.
+   *
+   * @default defaultDbStatementMaskingHook, which replaces identifier shaped
+   *  key segments with '?'
+   */
+  maskStatementHook?: DbStatementMaskingHook;
 
   /** Function for adding custom attributes on db request */
   requestHook?: RedisRequestCustomAttributeFunction;

--- a/packages/instrumentation-redis/README.md
+++ b/packages/instrumentation-redis/README.md
@@ -79,7 +79,7 @@ const redisInstrumentation = new RedisInstrumentation({
 By default, commands that accept only a key are serialized without it, so every
 call looks the same:
 
-```
+```text
 HGETALL [1 other arguments]
 TTL [1 other arguments]
 ```

--- a/packages/instrumentation-redis/README.md
+++ b/packages/instrumentation-redis/README.md
@@ -50,6 +50,8 @@ Redis instrumentation has a few options available to choose from. You can set th
 | `dbStatementSerializer` | `DbStatementSerializer` (function)                | Redis instrumentation will serialize the command to the `db.statement` attribute using the specified function. |
 | `responseHook`          | `RedisResponseCustomAttributeFunction` (function) | Function for adding custom attributes on db response. Receives params: `span, moduleVersion, cmdName, cmdArgs` |
 | `requireParentSpan`     | `boolean`                                         | Require parent to create redis span, default when unset is false.                                              |
+| `serializeKeys`         | `boolean`                                         | Serialize the key for commands that accept only keys, masked with `maskStatementHook`. Default is false.       |
+| `maskStatementHook`     | `DbStatementMaskingHook` (function)               | Hook used to mask the statement when `serializeKeys` is true.                                                  |
 
 #### Custom `db.statement` Serializer
 
@@ -69,6 +71,54 @@ const redisInstrumentation = new RedisInstrumentation({
   dbStatementSerializer: function (cmdName, cmdArgs) {
     return [cmdName, ...cmdArgs].join(" ");
   },
+});
+```
+
+#### Serializing redis keys
+
+By default, commands that accept only a key are serialized without it, so every
+call looks the same:
+
+```
+HGETALL [1 other arguments]
+TTL [1 other arguments]
+```
+
+Set `serializeKeys` to `true` to record the key instead. Segments that identify
+a single entity are replaced with `?`, so the key pattern is visible without
+`db.query.text` becoming high cardinality:
+
+```javascript
+const { RedisInstrumentation } = require('@opentelemetry/instrumentation-redis');
+
+const instrumentation = new RedisInstrumentation({
+  serializeKeys: true,
+});
+```
+
+| default | `serializeKeys: true` |
+| --- | --- |
+| `HGETALL [1 other arguments]` | `HGETALL player:?:stats` |
+| `HGETALL [1 other arguments]` | `HGETALL tournament:leaderboard:sc:daily` |
+| `TTL [1 other arguments]` | `TTL auth_revoked:?` |
+| `MGET [2 other arguments]` | `MGET player:?:stats player:?:stats` |
+| `SET session:42 [1 other arguments]` | `SET session:? [1 other arguments]` |
+
+Only commands whose arguments are keys, hash fields, patterns, numbers or fixed
+tokens are affected. Commands that accept values, such as `SET`, `HSET` and
+`EVAL`, keep their values redacted either way.
+
+A segment is masked when it looks like a number, uuid, hex digest, ulid or email
+address. Segments that describe a class of keys, such as `queue:high` or
+`feature_flags`, are left alone, as is the command name.
+
+Pass `maskStatementHook` to replace the masking rule, or
+`statement => statement` to record keys unmasked:
+
+```javascript
+const instrumentation = new RedisInstrumentation({
+  serializeKeys: true,
+  maskStatementHook: statement => statement.replace(/tenant:[^\s]+/g, 'tenant:?'),
 });
 ```
 

--- a/packages/instrumentation-redis/src/types.ts
+++ b/packages/instrumentation-redis/src/types.ts
@@ -19,6 +19,16 @@ export type DbStatementSerializer = (
 ) => string;
 
 /**
+ * Function that can be used to mask the db.query.text attribute before it is
+ * set on the span.
+ * @param statement - The serialized statement, as produced by the
+ *  {@link DbStatementSerializer}
+ *
+ * @returns the string that will be used as the db.query.text attribute.
+ */
+export type DbStatementMaskingHook = (statement: string) => string;
+
+/**
  * Function that can be used to add custom attributes to span on response from redis server
  * @param span - The span created for the redis command, on which attributes can be set
  * @param cmdName - The name of the command (eg. set, get, mset)
@@ -39,6 +49,35 @@ export interface RedisResponseCustomAttributeFunction {
 export interface RedisInstrumentationConfig extends InstrumentationConfig {
   /** Custom serializer function for the db.query.text attribute */
   dbStatementSerializer?: DbStatementSerializer;
+
+  /**
+   * If true, commands that accept only keys, hash fields, patterns, numbers or
+   * fixed tokens also serialize their arguments, and the resulting statement is
+   * masked using {@link maskStatementHook}.
+   *
+   * Without it those commands are serialized as `HGETALL [1 other arguments]`,
+   * so every invocation looks the same. With it they become
+   * `HGETALL player:?:stats`, which identifies the key pattern without
+   * recording which entity was touched.
+   *
+   * Commands that accept values, such as `SET`, `HSET` and `EVAL`, are not
+   * affected, and their values stay redacted either way.
+   *
+   * @default false
+   * @see maskStatementHook
+   */
+  serializeKeys?: boolean;
+
+  /**
+   * Hook that masks the statement when {@link serializeKeys} is true. Ignored
+   * otherwise.
+   *
+   * Pass `statement => statement` to record keys without masking them.
+   *
+   * @default defaultDbStatementMaskingHook, which replaces identifier shaped
+   *  key segments with '?'
+   */
+  maskStatementHook?: DbStatementMaskingHook;
 
   /** Function for adding custom attributes on db response */
   responseHook?: RedisResponseCustomAttributeFunction;

--- a/packages/instrumentation-redis/src/v2-v3/instrumentation.ts
+++ b/packages/instrumentation-redis/src/v2-v3/instrumentation.ts
@@ -27,7 +27,14 @@ import {
   ATTR_SERVER_PORT,
 } from '@opentelemetry/semantic-conventions';
 import { DB_SYSTEM_NAME_VALUE_REDIS } from '../semconv';
-import { defaultDbStatementSerializer } from '@opentelemetry/redis-common';
+import {
+  createDbStatementSerializer,
+  defaultDbStatementMaskingHook,
+  defaultDbStatementSerializer,
+} from '@opentelemetry/redis-common';
+
+// built once, the option is read per command but the serializer is stateless
+const keySerializer = createDbStatementSerializer({ serializeKeys: true });
 
 export class RedisInstrumentationV2_V3 extends InstrumentationBase<RedisInstrumentationConfig> {
   static readonly COMPONENT = 'redis';
@@ -118,14 +125,24 @@ export class RedisInstrumentationV2_V3 extends InstrumentationBase<RedisInstrume
           return original.apply(this, arguments);
         }
 
-        const dbStatementSerializer =
-          config?.dbStatementSerializer || defaultDbStatementSerializer;
+        const serializer =
+          config?.dbStatementSerializer ||
+          (config?.serializeKeys
+            ? keySerializer
+            : defaultDbStatementSerializer);
+
+        let dbQueryText = serializer(cmd.command, cmd.args);
+        if (config?.serializeKeys) {
+          dbQueryText = (
+            config.maskStatementHook || defaultDbStatementMaskingHook
+          )(dbQueryText);
+        }
 
         const attributes: Attributes = {};
         Object.assign(attributes, {
           [ATTR_DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_REDIS,
           [ATTR_DB_OPERATION_NAME]: cmd.command,
-          [ATTR_DB_QUERY_TEXT]: dbStatementSerializer(cmd.command, cmd.args),
+          [ATTR_DB_QUERY_TEXT]: dbQueryText,
         });
 
         const span = instrumentation.tracer.startSpan(

--- a/packages/instrumentation-redis/src/v4-v5/instrumentation.ts
+++ b/packages/instrumentation-redis/src/v4-v5/instrumentation.ts
@@ -17,7 +17,14 @@ import {
   InstrumentationNodeModuleFile,
 } from '@opentelemetry/instrumentation';
 import { getClientAttributes } from './utils';
-import { defaultDbStatementSerializer } from '@opentelemetry/redis-common';
+import {
+  createDbStatementSerializer,
+  defaultDbStatementMaskingHook,
+  defaultDbStatementSerializer,
+} from '@opentelemetry/redis-common';
+
+// built once, the option is read per command but the serializer is stateless
+const keySerializer = createDbStatementSerializer({ serializeKeys: true });
 import { RedisInstrumentationConfig } from '../types';
 /** @knipignore */
 import { PACKAGE_NAME, PACKAGE_VERSION } from '../version';
@@ -481,20 +488,30 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
     const commandName = redisCommandArguments[0] as string; // types also allows it to be a Buffer, but in practice it only string
     const commandArgs = redisCommandArguments.slice(1);
 
-    const dbStatementSerializer =
-      this.getConfig().dbStatementSerializer || defaultDbStatementSerializer;
+    const { dbStatementSerializer, serializeKeys, maskStatementHook } =
+      this.getConfig();
+    const serializer =
+      dbStatementSerializer ||
+      (serializeKeys ? keySerializer : defaultDbStatementSerializer);
 
     const attributes = getClientAttributes(clientOptions);
     attributes[ATTR_DB_OPERATION_NAME] = commandName;
     try {
-      const dbStatement = dbStatementSerializer(commandName, commandArgs);
+      let dbStatement = serializer(commandName, commandArgs);
+      if (dbStatement != null && serializeKeys) {
+        dbStatement = (maskStatementHook || defaultDbStatementMaskingHook)(
+          dbStatement
+        );
+      }
       if (dbStatement != null) {
         attributes[ATTR_DB_QUERY_TEXT] = dbStatement;
       }
     } catch (e) {
-      this._diag.error('dbStatementSerializer throw an exception', e, {
-        commandName,
-      });
+      this._diag.error(
+        'dbStatementSerializer or maskStatementHook threw an exception',
+        e,
+        { commandName }
+      );
     }
 
     const span = this.tracer.startSpan(

--- a/packages/redis-common/src/index.ts
+++ b/packages/redis-common/src/index.ts
@@ -7,7 +7,7 @@
  * List of regexes and the number of arguments that should be serialized for matching commands.
  * For example, HSET should serialize which key and field it's operating on, but not its value.
  * Setting the subset to -1 will serialize all arguments.
- * Commands without a match will have their first argument serialized.
+ * Commands without a match will have none of their arguments serialized.
  *
  * Refer to https://redis.io/commands/ for the full list.
  */
@@ -44,29 +44,157 @@ export type DbStatementSerializer = (
 ) => string;
 
 /**
+ * Additional subsets consulted only when the `serializeKeys` option is enabled.
+ *
+ * Every argument of these commands is a key, hash field, pattern, number or
+ * fixed token, so serializing them cannot expose a stored value. They are kept
+ * out of the default because emitting the key turns `db.query.text` into a high
+ * cardinality attribute for commands that currently produce a constant string,
+ * which would change the shape and cost of existing metrics and dashboards.
+ *
+ * These regexes must not overlap with `serializationSubsets`, so that enabling
+ * the option can never widen a command whose arguments carry caller data.
+ */
+const keySerializationSubsets = [
+  {
+    regex:
+      /^(BGSAVE|COPY|DUMP|FLUSH|HDEL|HEXISTS|HGET|HKEYS|HLEN|HRANDFIELD|HSTRLEN|HVALS|KEYS|LCS|LINDEX|LOLWUT|LPOP|MGET|MOVE|RENAME|SELECT|SHUTDOWN|SPOP|STRLEN|SWAPDB|TOUCH|TTL|TYPE|UNLINK|WAIT|WATCH|ZUNION)/i,
+    args: -1,
+  },
+];
+
+export interface DbStatementSerializerOptions {
+  /**
+   * Serialize the arguments of commands that accept only keys, hash fields,
+   * patterns, numbers or fixed tokens, such as `HGETALL`, `TTL` and `MGET`.
+   * Without it those commands are serialized as `HGETALL [1 other arguments]`,
+   * which makes every invocation indistinguishable.
+   *
+   * No stored value can be exposed by this option, but the resulting
+   * `db.query.text` is high cardinality unless it is also masked, so it
+   * defaults to `false`.
+   *
+   * @default false
+   */
+  serializeKeys?: boolean;
+}
+
+/**
+ * Builds a serializer that combines the command name with the arguments allowed
+ * by `serializationSubsets`, and by `keySerializationSubsets` when the
+ * `serializeKeys` option is enabled.
+ *
+ * @param options see {@link DbStatementSerializerOptions}
+ * @returns a `DbStatementSerializer` honouring `options`
+ */
+export const createDbStatementSerializer = (
+  options: DbStatementSerializerOptions = {}
+): DbStatementSerializer => {
+  const subsets = options.serializeKeys
+    ? [...serializationSubsets, ...keySerializationSubsets]
+    : serializationSubsets;
+
+  return (cmdName, cmdArgs) => {
+    if (Array.isArray(cmdArgs) && cmdArgs.length) {
+      const nArgsToSerialize =
+        subsets.find(({ regex }) => {
+          return regex.test(cmdName);
+        })?.args ?? 0;
+      const argsToSerialize =
+        nArgsToSerialize >= 0 ? cmdArgs.slice(0, nArgsToSerialize) : cmdArgs;
+      if (cmdArgs.length > argsToSerialize.length) {
+        argsToSerialize.push(
+          `[${cmdArgs.length - nArgsToSerialize} other arguments]`
+        );
+      }
+      return `${cmdName} ${argsToSerialize.join(' ')}`;
+    }
+    return cmdName;
+  };
+};
+
+/**
  * Given the redis command name and arguments, return a combination of the
  * command name + the allowed arguments according to `serializationSubsets`.
  * @param cmdName The redis command name
  * @param cmdArgs The redis command arguments
  * @returns a combination of the command name + args according to `serializationSubsets`.
  */
-export const defaultDbStatementSerializer: DbStatementSerializer = (
-  cmdName,
-  cmdArgs
-) => {
-  if (Array.isArray(cmdArgs) && cmdArgs.length) {
-    const nArgsToSerialize =
-      serializationSubsets.find(({ regex }) => {
-        return regex.test(cmdName);
-      })?.args ?? 0;
-    const argsToSerialize =
-      nArgsToSerialize >= 0 ? cmdArgs.slice(0, nArgsToSerialize) : cmdArgs;
-    if (cmdArgs.length > argsToSerialize.length) {
-      argsToSerialize.push(
-        `[${cmdArgs.length - nArgsToSerialize} other arguments]`
-      );
-    }
-    return `${cmdName} ${argsToSerialize.join(' ')}`;
+export const defaultDbStatementSerializer: DbStatementSerializer =
+  createDbStatementSerializer();
+
+export type DbStatementMaskingHook = (statement: string) => string;
+
+const MASK = '?';
+
+/**
+ * Trailing redaction placeholder produced by the serializer, for example the
+ * `[2 other arguments]` in `SET key [2 other arguments]`. It is generated text
+ * rather than caller input, so masking must leave it alone.
+ */
+const REDACTION_PLACEHOLDER = /\s\[\d+ other arguments\]$/;
+
+/**
+ * Redis cluster hash tag, the `{1234}` in `user:{1234}:profile`. The braces are
+ * meaningful to redis, so only their contents are considered for masking.
+ */
+const HASH_TAG = /^\{(.*)\}$/;
+
+/**
+ * Shapes that identify a single entity, and so make a key unique per user,
+ * session or request. These are what turn `db.query.text` into a high
+ * cardinality attribute.
+ */
+const IDENTIFIER_SHAPES = [
+  /^\d+$/, // 42
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, // uuid
+  /^[^\s@]+@[^\s@]+\.[^\s@]+$/, // alice@example.com
+  /^[0-9a-f]{8,}$/i, // hex digest, or a uuid without dashes
+  /^[0-9A-HJKMNP-TV-Z]{26}$/, // ulid
+  /^(?=.*\d)[A-Za-z0-9_-]{16,}$/, // nanoid, base64url and similar opaque tokens
+];
+
+const isIdentifier = (segment: string): boolean =>
+  IDENTIFIER_SHAPES.some(shape => shape.test(segment));
+
+const maskSegment = (segment: string): string => {
+  const hashTag = HASH_TAG.exec(segment);
+  if (hashTag) {
+    return `{${isIdentifier(hashTag[1]) ? MASK : hashTag[1]}}`;
   }
-  return cmdName;
+  return isIdentifier(segment) ? MASK : segment;
 };
+
+/**
+ * Masks the parts of a serialized statement that identify a single entity,
+ * keeping the parts that describe which access pattern was used.
+ *
+ * Redis keys are conventionally colon delimited, so each argument is split on
+ * `:` and every segment that looks like an identifier is replaced with `?`.
+ * `HGETALL player:1261821:stats` becomes `HGETALL player:?:stats`, so the shape
+ * of the key survives while the identity does not.
+ *
+ * The command name and the redaction placeholder are never masked, and
+ * segments that are not identifier shaped, such as `queue:high` or
+ * `feature_flags`, are left as they are.
+ *
+ * @param statement a statement produced by a `DbStatementSerializer`
+ * @returns the statement with identifier shaped segments replaced by `?`
+ */
+export const defaultDbStatementMaskingHook: DbStatementMaskingHook =
+  statement => {
+    const placeholder = REDACTION_PLACEHOLDER.exec(statement);
+    const head = placeholder
+      ? statement.slice(0, placeholder.index)
+      : statement;
+
+    const masked = head
+      .split(' ')
+      // the first token is the command name, which is never caller data
+      .map((token, i) =>
+        i === 0 ? token : token.split(':').map(maskSegment).join(':')
+      )
+      .join(' ');
+
+    return placeholder ? `${masked}${placeholder[0]}` : masked;
+  };

--- a/packages/redis-common/test/masking.test.ts
+++ b/packages/redis-common/test/masking.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { defaultDbStatementMaskingHook } from '../src/index';
+import * as assert from 'assert';
+
+describe('#defaultDbStatementMaskingHook()', () => {
+  describe('replaces segments that identify one entity', () => {
+    [
+      { statement: 'HGETALL user:1', expected: 'HGETALL user:?' },
+      { statement: 'TTL session:42', expected: 'TTL session:?' },
+      {
+        statement: 'HGETALL user:0f8fad5b-d9cb-469f-a165-70867728950e:cart',
+        expected: 'HGETALL user:?:cart',
+      },
+      {
+        statement: 'GET session:550e8400e29b41d4a716446655440000',
+        expected: 'GET session:?',
+      },
+      {
+        statement: 'HGETALL user:alice@example.com',
+        expected: 'HGETALL user:?',
+      },
+      { statement: 'GET token:V1StGXR8Z5jdHi6BmyT', expected: 'GET token:?' },
+      {
+        statement: 'GET event:01ARZ3NDEKTSV4RRFFQ69G5FAV',
+        expected: 'GET event:?',
+      },
+      { statement: 'MGET user:1 user:2', expected: 'MGET user:? user:?' },
+      // redis cluster hash tags keep their braces, only the contents are masked
+      {
+        statement: 'HGETALL user:{1234}:profile',
+        expected: 'HGETALL user:{?}:profile',
+      },
+    ].forEach(({ statement, expected }) => {
+      it(`should mask ${statement}`, () => {
+        assert.strictEqual(defaultDbStatementMaskingHook(statement), expected);
+      });
+    });
+  });
+
+  describe('keeps the shape of the key', () => {
+    [
+      { statement: 'GET feature_flags', expected: 'GET feature_flags' },
+      { statement: 'LLEN queue:high', expected: 'LLEN queue:high' },
+      { statement: 'GET cache:v2:landing', expected: 'GET cache:v2:landing' },
+      // a pattern describes a class of keys rather than one entity
+      { statement: 'KEYS user:*', expected: 'KEYS user:*' },
+      // hash field names are not identifiers
+      { statement: 'HGET user:1 name', expected: 'HGET user:? name' },
+      // the command name is never masked
+      { statement: 'GET 1234', expected: 'GET ?' },
+      { statement: 'PING', expected: 'PING' },
+    ].forEach(({ statement, expected }) => {
+      it(`should keep ${statement}`, () => {
+        assert.strictEqual(defaultDbStatementMaskingHook(statement), expected);
+      });
+    });
+  });
+
+  describe('leaves the redaction placeholder alone', () => {
+    [
+      {
+        statement: 'SET session:42 [1 other arguments]',
+        expected: 'SET session:? [1 other arguments]',
+      },
+      {
+        statement: 'HSET user:1 name [1 other arguments]',
+        expected: 'HSET user:? name [1 other arguments]',
+      },
+      {
+        statement: 'ACL SETUSER [6 other arguments]',
+        expected: 'ACL SETUSER [6 other arguments]',
+      },
+      {
+        statement: 'UNKNOWN [1 other arguments]',
+        expected: 'UNKNOWN [1 other arguments]',
+      },
+    ].forEach(({ statement, expected }) => {
+      it(`should not touch the placeholder in ${statement}`, () => {
+        assert.strictEqual(defaultDbStatementMaskingHook(statement), expected);
+      });
+    });
+  });
+});

--- a/packages/redis-common/test/serialize-keys.test.ts
+++ b/packages/redis-common/test/serialize-keys.test.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {
+  createDbStatementSerializer,
+  defaultDbStatementMaskingHook,
+  defaultDbStatementSerializer,
+} from '../src/index';
+import * as assert from 'assert';
+
+const withKeys = createDbStatementSerializer({ serializeKeys: true });
+const masked = (cmdName: string, cmdArgs: any[]) =>
+  defaultDbStatementMaskingHook(withKeys(cmdName, cmdArgs));
+
+describe('serializeKeys', () => {
+  describe('is off unless asked for', () => {
+    [
+      { cmdName: 'HGETALL', cmdArgs: ['user:1'] },
+      { cmdName: 'TTL', cmdArgs: ['session:42'] },
+      { cmdName: 'MGET', cmdArgs: ['user:1', 'user:2'] },
+      { cmdName: 'KEYS', cmdArgs: ['user:*'] },
+    ].forEach(({ cmdName, cmdArgs }) => {
+      it(`should keep ${cmdName} redacted by default`, () => {
+        assert.strictEqual(
+          defaultDbStatementSerializer(cmdName, cmdArgs),
+          `${cmdName} [${cmdArgs.length} other arguments]`
+        );
+      });
+    });
+
+    it('should not change commands that already serialize their key', () => {
+      const cases: Array<[string, any[]]> = [
+        ['GET', ['session:42']],
+        ['SET', ['session:42', 'secret_value']],
+        ['HSET', ['user:1', 'name', 'secret_value']],
+        ['HMGET', ['user:1', 'name', 'email']],
+        ['ACL', ['SETUSER', 'alice', '>MySecretPass']],
+      ];
+      for (const [cmdName, cmdArgs] of cases) {
+        assert.strictEqual(
+          withKeys(cmdName, cmdArgs.slice()),
+          defaultDbStatementSerializer(cmdName, cmdArgs.slice()),
+          `${cmdName} should be unaffected by serializeKeys`
+        );
+      }
+    });
+  });
+
+  describe('serializes the key when enabled', () => {
+    [
+      { cmdName: 'HGETALL', cmdArgs: ['user:1'], expected: 'HGETALL user:1' },
+      {
+        cmdName: 'HGET',
+        cmdArgs: ['user:1', 'name'],
+        expected: 'HGET user:1 name',
+      },
+      { cmdName: 'TTL', cmdArgs: ['session:42'], expected: 'TTL session:42' },
+      {
+        cmdName: 'MGET',
+        cmdArgs: ['user:1', 'user:2'],
+        expected: 'MGET user:1 user:2',
+      },
+      { cmdName: 'KEYS', cmdArgs: ['user:*'], expected: 'KEYS user:*' },
+      {
+        cmdName: 'RENAMENX',
+        cmdArgs: ['user:1', 'user:2'],
+        expected: 'RENAMENX user:1 user:2',
+      },
+    ].forEach(({ cmdName, cmdArgs, expected }) => {
+      it(`should serialize ${cmdName}`, () => {
+        assert.strictEqual(withKeys(cmdName, cmdArgs), expected);
+      });
+    });
+
+    it('should never widen a command that carries a value', () => {
+      assert.strictEqual(
+        withKeys('SET', ['session:42', 'secret_value']),
+        'SET session:42 [1 other arguments]'
+      );
+      // EVAL already serializes every argument without the option, so enabling
+      // it must not change the command in either direction.
+      const evalArgs = ['return 1', 1, 'user:1', 'secret_arg'];
+      assert.strictEqual(
+        withKeys('EVAL', evalArgs.slice()),
+        defaultDbStatementSerializer('EVAL', evalArgs.slice())
+      );
+    });
+  });
+
+  describe('masked, as the instrumentations emit it', () => {
+    [
+      {
+        cmdName: 'HGETALL',
+        cmdArgs: ['player:1261821:stats'],
+        expected: 'HGETALL player:?:stats',
+      },
+      {
+        cmdName: 'HGETALL',
+        cmdArgs: ['tournament:config:0f8fad5b-d9cb-469f-a165-70867728950e'],
+        expected: 'HGETALL tournament:config:?',
+      },
+      {
+        cmdName: 'HGETALL',
+        cmdArgs: ['tournament:leaderboard:sc:daily'],
+        expected: 'HGETALL tournament:leaderboard:sc:daily',
+      },
+      {
+        cmdName: 'TTL',
+        cmdArgs: ['auth_revoked:1261821'],
+        expected: 'TTL auth_revoked:?',
+      },
+      {
+        cmdName: 'MGET',
+        cmdArgs: ['player:1:stats', 'player:2:stats'],
+        expected: 'MGET player:?:stats player:?:stats',
+      },
+      {
+        cmdName: 'HSET',
+        cmdArgs: ['player:1261821:stats', 'score', 'secret_value'],
+        expected: 'HSET player:?:stats score [1 other arguments]',
+      },
+    ].forEach(({ cmdName, cmdArgs, expected }) => {
+      it(`should emit ${expected}`, () => {
+        assert.strictEqual(masked(cmdName, cmdArgs), expected);
+      });
+    });
+
+    it('should collapse keys that differ only by identifier', () => {
+      const statements = [1, 2, 3].map(id =>
+        masked('HGETALL', [`player:${id}:stats`])
+      );
+      assert.strictEqual(new Set(statements).size, 1);
+    });
+
+    it('should never expose a value that the serializer redacted', () => {
+      const statement = masked('SET', ['session:42', 'SECRET_VALUE']);
+      assert.ok(!statement.includes('SECRET_VALUE'));
+      assert.strictEqual(statement, 'SET session:? [1 other arguments]');
+    });
+  });
+});


### PR DESCRIPTION
## Which problem is this PR solving?

This PR is to address #3697.

I implemented it in a way to avoid breaking current users. But I'm ok if you think we should implement this in a different way.

The list in `redis-common/src/index.ts` maps each Redis command to a number of arguments to serialize. Anything that does not match, removes all of them. Some commands were not taken into account.

Just adding them to the list would fix the inconsistency but it would also produce high cardinality output for commands that currently produce a constant string, which changes the cost and shape of existing metrics (or derived from spans like the ones generated by `span metrics` connector from the OTEL Collector) without anyone opting in. So this adds an option instead, and leaves the default exactly as it is.

## Short description of the changes

A new `serializeKeys` option, off by default. When it is on, those 37 commands serialize their arguments, and the statement is masked so that the parts identifying a single entity are replaced with `?` (following semantic conventions).

```javascript
const { RedisInstrumentation } = require('@opentelemetry/instrumentation-redis');

const redisInstrumentation = new RedisInstrumentation({
  serializeKeys: true,
});
```

The same option is available on `IORedisInstrumentation`.

Given an application doing this:

```javascript
await client.hGetAll('player:1261821:stats');
await client.hGetAll('player:1261822:stats');
await client.hGetAll('tournament:leaderboard:sc:daily');
await client.ttl('auth_revoked:1261821');
await client.mGet(['player:1261821:stats', 'player:1261822:stats']);
await client.set('session:42', 'some value');
```

the `db.query.text` attribute comes out like this:

| default | `serializeKeys: true` |
| - | - |
| `HGETALL [1 other arguments]` | `HGETALL player:?:stats` |
| `HGETALL [1 other arguments]` | `HGETALL player:?:stats` |
| `HGETALL [1 other arguments]` | `HGETALL tournament:leaderboard:sc:daily` |
| `TTL [1 other arguments]` | `TTL auth_revoked:?` |
| `MGET [2 other arguments]` | `MGET player:?:stats player:?:stats` |
| `SET session:42 [1 other arguments]` | `SET session:? [1 other arguments]` |