### PR TITLE
fix(instrumentation-dns): preserve promisified lookup result

### DIFF
--- a/packages/instrumentation-dns/src/instrumentation.ts
+++ b/packages/instrumentation-dns/src/instrumentation.ts
@@ -83,7 +83,19 @@ export class DnsInstrumentation extends InstrumentationBase<DnsInstrumentationCo
    */
   private _getLookup() {
     return (original: (hostname: string, ...args: unknown[]) => void) => {
-      return this._getPatchLookupFunction(original);
+      const patchedLookup = this._getPatchLookupFunction(original);
+
+      // Preserve symbols such as Node.js' internal customPromisifyArgs.
+      // util.promisify() relies on it to combine address and family into an
+      // object instead of resolving with only the address string.
+      for (const symbol of Object.getOwnPropertySymbols(original)) {
+        const descriptor = Object.getOwnPropertyDescriptor(original, symbol);
+        if (descriptor !== undefined) {
+          Object.defineProperty(patchedLookup, symbol, descriptor);
+        }
+      }
+
+      return patchedLookup;
     };
   }
 

--- a/packages/instrumentation-dns/test/integrations/dns-lookup.test.ts
+++ b/packages/instrumentation-dns/test/integrations/dns-lookup.test.ts
@@ -14,6 +14,7 @@ import * as dns from 'dns';
 import * as utils from '../utils/utils';
 import { assertSpan } from '../utils/assertSpan';
 import { SpanStatusCode } from '@opentelemetry/api';
+import { promisify } from 'util';
 
 const memoryExporter = new InMemorySpanExporter();
 const provider = new TracerProvider({
@@ -73,6 +74,19 @@ describe('dns.lookup()', () => {
   });
 
   describe('with no options param', () => {
+    it('should preserve the result shape when promisified', async () => {
+      const hostname = 'google.com';
+      const { address, family } = await promisify(dns.lookup)(hostname);
+
+      assert.ok(address);
+      assert.ok(family);
+
+      const spans = memoryExporter.getFinishedSpans();
+      const [span] = spans;
+      assert.strictEqual(spans.length, 1);
+      assertSpan(span, { addresses: [{ address, family }], hostname });
+    });
+
     it('should export a valid span', done => {
       const hostname = 'google.com';
       dns.lookup(hostname, (err, address, family) => {


### PR DESCRIPTION
## Which problem is this PR solving?

When `dns.lookup` is patched, its non-enumerable symbol properties are not preserved. This drops the Node.js internal `Symbol(customPromisifyArgs)` metadata that `util.promisify()` uses for callbacks with multiple success values.

As a result, `promisify(dns.lookup)(hostname)` resolves with only the address string while DNS instrumentation is enabled, instead of the native `{ address, family }` object. Applications that rely on the documented promisified result shape can then observe `result.address` as `undefined`.

## Short description of the changes

- Copy symbol property descriptors from the original `dns.lookup` function to the patched function.
- Add an integration test confirming that `util.promisify(dns.lookup)` preserves `{ address, family }` and still exports a DNS span.

## Testing

- `npm run compile:with-dependencies` in `packages/instrumentation-dns`
- `npm test` in `packages/instrumentation-dns` (48 passing)
- ESLint on both changed files (no errors)
- Prettier check on both changed files

## AI use disclosure

This contribution was prepared with Codex assistance for investigation, implementation, test drafting, and PR preparation. The reported behavior and the resulting patch were reproduced and verified with the package test suite.