### PR TITLE
fix(instrumentation-ioredis): prevent duplicate span completion

### DIFF
--- a/packages/instrumentation-ioredis/src/instrumentation.ts
+++ b/packages/instrumentation-ioredis/src/instrumentation.ts
@@ -156,6 +156,12 @@ export class IORedisInstrumentation extends InstrumentationBase<IORedisInstrumen
         kind: SpanKind.CLIENT,
         attributes,
       });
+      let spanCompletionStarted = false;
+      const startSpanCompletion = (): boolean => {
+        if (spanCompletionStarted) return false;
+        spanCompletionStarted = true;
+        return true;
+      };
 
       const { requestHook } = config;
       if (requestHook) {
@@ -181,29 +187,38 @@ export class IORedisInstrumentation extends InstrumentationBase<IORedisInstrumen
         const origResolve = cmd.resolve;
         /* eslint-disable @typescript-eslint/no-explicit-any */
         cmd.resolve = function (result: any) {
-          safeExecuteInTheMiddle(
-            () => config.responseHook?.(span, cmd.name, cmd.args, result),
-            e => {
-              if (e) {
-                diag.error('ioredis instrumentation: response hook failed', e);
-              }
-            },
-            true
-          );
+          if (startSpanCompletion()) {
+            safeExecuteInTheMiddle(
+              () => config.responseHook?.(span, cmd.name, cmd.args, result),
+              e => {
+                if (e) {
+                  diag.error(
+                    'ioredis instrumentation: response hook failed',
+                    e
+                  );
+                }
+              },
+              true
+            );
 
-          endSpan(span, null);
+            endSpan(span, null);
+          }
           origResolve(result);
         };
 
         const origReject = cmd.reject;
         cmd.reject = function (err: Error) {
-          endSpan(span, err);
+          if (startSpanCompletion()) {
+            endSpan(span, err);
+          }
           origReject(err);
         };
 
         return result;
       } catch (error: any) {
-        endSpan(span, error);
+        if (startSpanCompletion()) {
+          endSpan(span, error);
+        }
         throw error;
       }
     };

--- a/packages/instrumentation-ioredis/test/ioredis.test.ts
+++ b/packages/instrumentation-ioredis/test/ioredis.test.ts
@@ -73,6 +73,79 @@ const sanitizeEventForAssertion = (span: ReadableSpan) => {
   });
 };
 
+describe('command completion', () => {
+  it('completes the span once when command callbacks run repeatedly', () => {
+    const recordException = sinon.spy();
+    const setStatus = sinon.spy();
+    const end = sinon.spy();
+    const responseHook = sinon.spy();
+    const commandSpan = {
+      recordException,
+      setStatus,
+      end,
+    } as unknown as Span;
+    const testInstrumentation = new IORedisInstrumentation({
+      enabled: false,
+      requireParentSpan: false,
+      responseHook,
+    });
+    testInstrumentation.setTracerProvider({
+      getTracer: () => ({ startSpan: () => commandSpan }),
+    } as unknown as TracerProvider);
+
+    const originalResolve = sinon.spy();
+    const originalReject = sinon.spy();
+    const command = {
+      name: 'get',
+      args: ['test-key'],
+      resolve: originalResolve,
+      reject: originalReject,
+    } as unknown as ioredisTypes.Command;
+    const result = Promise.resolve();
+    const originalSendCommand = sinon.stub().returns(result);
+    const tracedSendCommand = (
+      testInstrumentation as unknown as {
+        _traceSendCommand(
+          original: (...args: unknown[]) => unknown
+        ): (
+          this: { options: { host: string; port: number } },
+          cmd: ioredisTypes.Command
+        ) => unknown;
+      }
+    )._traceSendCommand(originalSendCommand);
+
+    assert.strictEqual(
+      tracedSendCommand.call(
+        { options: { host: 'localhost', port: 6379 } },
+        command
+      ),
+      result
+    );
+
+    const timeoutError = new Error('Command timed out');
+    const connectionError = new Error('Connection is closed');
+    const lateResult = 'late result';
+    command.reject(timeoutError);
+    command.resolve(lateResult);
+    command.reject(connectionError);
+
+    assert.strictEqual(responseHook.callCount, 0);
+    assert.strictEqual(recordException.callCount, 1);
+    assert.strictEqual(recordException.firstCall.firstArg, timeoutError);
+    assert.strictEqual(setStatus.callCount, 1);
+    assert.deepStrictEqual(setStatus.firstCall.firstArg, {
+      code: SpanStatusCode.ERROR,
+      message: timeoutError.message,
+    });
+    assert.strictEqual(end.callCount, 1);
+    assert.strictEqual(originalResolve.callCount, 1);
+    assert.deepStrictEqual(originalResolve.firstCall.args, [lateResult]);
+    assert.strictEqual(originalReject.callCount, 2);
+    assert.deepStrictEqual(originalReject.firstCall.args, [timeoutError]);
+    assert.deepStrictEqual(originalReject.secondCall.args, [connectionError]);
+  });
+});
+
 describe('ioredis', () => {
   const provider = new TracerProvider({
     spanProcessors: [new SimpleSpanProcessor({ exporter: memoryExporter })],


### PR DESCRIPTION
## Problem

Fixes #2874.

An `ioredis` command can reach more than one completion callback, such as a
rejection followed by a late response. The instrumentation allows each callback
to use and end the same span.

## Changes

- Allow only the first resolve or reject callback to invoke the response hook and complete the span.
- Continue forwarding every callback to the original `ioredis` resolve or reject handler.
- Add a deterministic regression test for reject, late resolve, and another reject.

## Tests

- Focused regression test: 1 passing
- `ioredis` package test with Redis: 34 passing, 2 pending
- Package compile, `ESLint`, Prettier, and diff whitespace check
