### PR TITLE
fix(instrumentation-aws-sdk): omit empty propagation attributes

### DIFF
--- a/packages/instrumentation-aws-sdk/src/services/MessageAttributes.ts
+++ b/packages/instrumentation-aws-sdk/src/services/MessageAttributes.ts
@@ -22,6 +22,9 @@ class ContextSetter
     key: string,
     value: string
   ) {
+    if (value.length === 0) {
+      return;
+    }
     carrier[key] = {
       DataType: 'String',
       StringValue: value as string,
@@ -63,11 +66,16 @@ export const injectPropagationContext = (
   attributesMap?: SQS.MessageBodyAttributeMap | SNS.MessageAttributeMap
 ): SQS.MessageBodyAttributeMap | SNS.MessageAttributeMap => {
   const attributes = attributesMap ?? {};
-  if (
-    Object.keys(attributes).length + propagation.fields().length <=
-    MAX_MESSAGE_ATTRIBUTES
-  ) {
-    propagation.inject(context.active(), attributes, contextSetter);
+  const propagationAttributes:
+    | SQS.MessageBodyAttributeMap
+    | SNS.MessageAttributeMap = {};
+  propagation.inject(context.active(), propagationAttributes, contextSetter);
+  const attributeCount = new Set([
+    ...Object.keys(attributes),
+    ...Object.keys(propagationAttributes),
+  ]).size;
+  if (attributeCount <= MAX_MESSAGE_ATTRIBUTES) {
+    Object.assign(attributes, propagationAttributes);
   } else {
     diag.warn(
       'aws-sdk instrumentation: cannot set context propagation on SQS/SNS message due to maximum amount of MessageAttributes'

--- a/packages/instrumentation-aws-sdk/test/MessageAttributes.test.ts
+++ b/packages/instrumentation-aws-sdk/test/MessageAttributes.test.ts
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { propagation } from '@opentelemetry/api';
+import { context, TraceFlags, trace } from '@opentelemetry/api';
+import type { SpanContext } from '@opentelemetry/api';
+import { TraceState } from '@opentelemetry/core';
 import { expect } from 'expect';
-import * as sinon from 'sinon';
 import {
   MAX_MESSAGE_ATTRIBUTES,
   contextGetter,
@@ -16,6 +17,42 @@ import {
 import { SNS, SQS } from '../src/aws-sdk.types';
 
 describe('MessageAttributes', () => {
+  const traceId = '0af7651916cd43dd8448eb211c80319c';
+  const spanId = 'b7ad6b7169203331';
+  const traceparent = `00-${traceId}-${spanId}-01`;
+
+  const createMessageAttributes = (
+    count: number
+  ): SQS.MessageBodyAttributeMap => {
+    const attributes: SQS.MessageBodyAttributeMap = {};
+    for (let index = 1; index <= count; index++) {
+      attributes[`key${index}`] = {
+        DataType: 'String',
+        StringValue: `value${index}`,
+      };
+    }
+    return attributes;
+  };
+
+  const injectWithTraceState = (
+    attributes: SQS.MessageBodyAttributeMap,
+    traceState: TraceState
+  ) => {
+    const spanContext: SpanContext = {
+      traceId,
+      spanId,
+      traceFlags: TraceFlags.SAMPLED,
+      traceState,
+    };
+    const activeContext = trace.setSpan(
+      context.active(),
+      trace.wrapSpanContext(spanContext)
+    );
+    return context.with(activeContext, () =>
+      injectPropagationContext(attributes)
+    );
+  };
+
   describe('MAX_MESSAGE_ATTRIBUTES', () => {
     it('should be 10', () => {
       expect(MAX_MESSAGE_ATTRIBUTES).toBe(10);
@@ -61,41 +98,98 @@ describe('MessageAttributes', () => {
   });
 
   describe('injectPropagationContext', () => {
-    it('should inject context if there are available attributes', () => {
-      sinon.spy(propagation, 'inject');
-      const contextAttributes = {
-        key1: { DataType: 'String', StringValue: 'value1' },
-        key2: { DataType: 'String', StringValue: 'value2' },
-        key3: { DataType: 'String', StringValue: 'value3' },
-        key4: { DataType: 'String', StringValue: 'value4' },
-        key5: { DataType: 'String', StringValue: 'value5' },
-      };
+    it('injects traceparent without an empty tracestate attribute', () => {
+      const attributes = injectWithTraceState({}, new TraceState());
 
-      injectPropagationContext(contextAttributes);
-      // @ts-expect-error Property 'calledOnce' does not exist on type
-      expect(propagation.inject.calledOnce).toBe(true);
-      sinon.restore();
+      expect(attributes).toStrictEqual({
+        traceparent: { DataType: 'String', StringValue: traceparent },
+      });
     });
 
-    it('should not inject context if there not enough available attributes', () => {
-      sinon.spy(propagation, 'inject');
-      const contextAttributes = {
-        key1: { DataType: 'String', StringValue: 'value1' },
-        key2: { DataType: 'String', StringValue: 'value2' },
-        key3: { DataType: 'String', StringValue: 'value3' },
-        key4: { DataType: 'String', StringValue: 'value4' },
-        key5: { DataType: 'String', StringValue: 'value5' },
-        key6: { DataType: 'String', StringValue: 'value6' },
-        key7: { DataType: 'String', StringValue: 'value7' },
-        key8: { DataType: 'String', StringValue: 'value8' },
-        key9: { DataType: 'String', StringValue: 'value9' },
-        key10: { DataType: 'String', StringValue: 'value10' },
+    it('injects traceparent and a non-empty tracestate', () => {
+      const attributes = injectWithTraceState(
+        {},
+        new TraceState('vendor=value')
+      );
+
+      expect(attributes).toStrictEqual({
+        traceparent: { DataType: 'String', StringValue: traceparent },
+        tracestate: { DataType: 'String', StringValue: 'vendor=value' },
+      });
+    });
+
+    it('injects two non-empty propagation fields at the attribute limit', () => {
+      const attributes = injectWithTraceState(
+        createMessageAttributes(8),
+        new TraceState('vendor=value')
+      );
+
+      expect(Object.keys(attributes)).toHaveLength(MAX_MESSAGE_ATTRIBUTES);
+      expect(attributes.traceparent).toStrictEqual({
+        DataType: 'String',
+        StringValue: traceparent,
+      });
+      expect(attributes.tracestate).toStrictEqual({
+        DataType: 'String',
+        StringValue: 'vendor=value',
+      });
+    });
+
+    it('counts an existing propagation key once at the attribute limit', () => {
+      const existingAttributes = createMessageAttributes(8);
+      existingAttributes.traceparent = {
+        DataType: 'String',
+        StringValue: 'stale',
       };
 
-      injectPropagationContext(contextAttributes);
-      // @ts-expect-error Property 'calledOnce' does not exist on type
-      expect(propagation.inject.calledOnce).toBe(false);
-      sinon.restore();
+      const attributes = injectWithTraceState(
+        existingAttributes,
+        new TraceState('vendor=value')
+      );
+
+      expect(Object.keys(attributes)).toHaveLength(MAX_MESSAGE_ATTRIBUTES);
+      expect(attributes.traceparent).toStrictEqual({
+        DataType: 'String',
+        StringValue: traceparent,
+      });
+      expect(attributes.tracestate).toStrictEqual({
+        DataType: 'String',
+        StringValue: 'vendor=value',
+      });
+    });
+
+    it('injects only traceparent at the attribute limit for empty tracestate', () => {
+      const attributes = injectWithTraceState(
+        createMessageAttributes(9),
+        new TraceState()
+      );
+
+      expect(Object.keys(attributes)).toHaveLength(MAX_MESSAGE_ATTRIBUTES);
+      expect(attributes.traceparent).toStrictEqual({
+        DataType: 'String',
+        StringValue: traceparent,
+      });
+      expect(attributes.tracestate).toBeUndefined();
+    });
+
+    it('does not partially inject when non-empty propagation fields exceed the limit', () => {
+      const originalAttributes = createMessageAttributes(9);
+      const attributes = injectWithTraceState(
+        { ...originalAttributes },
+        new TraceState('vendor=value')
+      );
+
+      expect(attributes).toStrictEqual(originalAttributes);
+    });
+
+    it('does not inject into a carrier already at the attribute limit', () => {
+      const originalAttributes = createMessageAttributes(10);
+      const attributes = injectWithTraceState(
+        { ...originalAttributes },
+        new TraceState()
+      );
+
+      expect(attributes).toStrictEqual(originalAttributes);
     });
   });
 


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #1528.

Amazon Simple Queue Service (SQS) and Amazon Simple Notification Service (SNS) reject message attributes with empty string values. When context propagation produces an empty `tracestate`, the instrumentation adds it as a message attribute.

## Short description of the changes

* Exclude propagation fields whose serialized values are empty.
* Build propagation attributes in a temporary carrier so that only the keys added by the instrumentation are counted.
* Apply propagation attributes only when the total number of unique keys across existing and propagation attributes is 10 or fewer. If the total exceeds 10, leave the carrier unchanged.
* Add unit tests for cases near the 10-attribute limit, covering both empty and populated `tracestate` values.

## Testing

* Compiled the package with dependencies
* Package tests: 61 passed, 1 pending
* Targeted unit tests: 13 passed
* Affected package compilation
* Instrumentation version matrix
* Repository lint
