### PR TITLE
fix(instrumentation-undici): overwrite existing propagation headers

### DIFF
--- a/packages/instrumentation-undici/src/undici.ts
+++ b/packages/instrumentation-undici/src/undici.ts
@@ -213,6 +213,40 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
     return result;
   }
 
+  // Drop every instance of `name` so a later inject can overwrite instead of
+  // appending. Header names are matched case-insensitively.
+  private removeRequestHeader(request: UndiciRequest, name: string): void {
+    const needle = name.toLowerCase();
+
+    if (Array.isArray(request.headers)) {
+      // headers are an array [k1, v1, k2, v2] (undici v6+)
+      for (let i = request.headers.length - 2; i >= 0; i -= 2) {
+        const key = request.headers[i];
+        if (typeof key === 'string' && key.toLowerCase() === needle) {
+          request.headers.splice(i, 2);
+        }
+      }
+      return;
+    }
+
+    if (typeof request.headers === 'string') {
+      // headers are a raw string (undici v5)
+      const lines = request.headers.split('\r\n');
+      request.headers = lines
+        .filter(line => {
+          if (!line) {
+            return true;
+          }
+          const colonIndex = line.indexOf(':');
+          if (colonIndex === -1) {
+            return true;
+          }
+          return line.substring(0, colonIndex).trim().toLowerCase() !== needle;
+        })
+        .join('\r\n');
+    }
+  }
+
   // This is the 1st message we receive for each request (fired after request creation). Here we will
   // create the span and populate some atttributes, then link the span to the request for further
   // span processing
@@ -323,10 +357,22 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
     );
 
     // Context propagation goes last so no hook can tamper
-    // the propagation headers
+    // the propagation headers. undici's header APIs append, so a
+    // pre-set traceparent/tracestate would otherwise become a second
+    // value. Receivers fold that into one malformed header and drop
+    // the parent. Remove the fields we are about to write first so
+    // injection overwrites, matching instrumentation-http.
     const requestContext = trace.setSpan(context.active(), span);
     const addedHeaders: Record<string, string> = {};
     propagation.inject(requestContext, addedHeaders);
+
+    const namesToReplace = new Set<string>([
+      ...propagation.fields(),
+      ...Object.keys(addedHeaders),
+    ]);
+    for (const name of namesToReplace) {
+      this.removeRequestHeader(request, name);
+    }
 
     const headerEntries = Object.entries(addedHeaders);
 

--- a/packages/instrumentation-undici/test/fetch.test.ts
+++ b/packages/instrumentation-undici/test/fetch.test.ts
@@ -18,6 +18,8 @@ import {
   TracerProvider,
 } from '@opentelemetry/sdk-trace';
 
+import { W3CTraceContextPropagator } from '@opentelemetry/core';
+
 import { UndiciInstrumentation } from '../src/undici';
 
 import { MockPropagation } from './utils/mock-propagation';
@@ -66,6 +68,22 @@ describe('UndiciInstrumentation `fetch` tests', function () {
       if (req.url === '/error') {
         // Simulate an error
         res.destroy();
+        return;
+      }
+      if (req.url?.startsWith('/echo-headers')) {
+        res.statusCode = 200;
+        res.setHeader('content-type', 'application/json');
+        res.write(
+          JSON.stringify({
+            [MockPropagation.TRACE_CONTEXT_KEY]:
+              req.headers[MockPropagation.TRACE_CONTEXT_KEY],
+            [MockPropagation.SPAN_CONTEXT_KEY]:
+              req.headers[MockPropagation.SPAN_CONTEXT_KEY],
+            traceparent: req.headers.traceparent,
+            tracestate: req.headers.tracestate,
+          })
+        );
+        res.end();
         return;
       }
       // There are some situations where there is no way to access headers
@@ -496,6 +514,64 @@ describe('UndiciInstrumentation `fetch` tests', function () {
         'genuine errors should record an exception event'
       );
       assert.ok(fetchError, 'fetch should have thrown');
+    });
+
+    it('should overwrite a pre-set propagation header instead of appending a second value', async function () {
+      const fetchUrl = `${protocol}://${hostname}:${mockServer.port}/echo-headers`;
+      const response = await fetch(fetchUrl, {
+        headers: {
+          [MockPropagation.TRACE_CONTEXT_KEY]: 'preset-trace-id',
+          [MockPropagation.SPAN_CONTEXT_KEY]: 'preset-span-id',
+        },
+      });
+      const echoed = (await response.json()) as Record<string, string>;
+      const spans = memoryExporter.getFinishedSpans();
+      const span = spans[0];
+
+      assert.ok(span, 'a span is present');
+      assert.strictEqual(
+        echoed[MockPropagation.TRACE_CONTEXT_KEY],
+        span.spanContext().traceId
+      );
+      assert.strictEqual(
+        echoed[MockPropagation.SPAN_CONTEXT_KEY],
+        span.spanContext().spanId
+      );
+      assert.ok(
+        !String(echoed[MockPropagation.TRACE_CONTEXT_KEY]).includes(','),
+        'trace header must not be a folded duplicate'
+      );
+    });
+
+    it('should overwrite a caller-supplied W3C traceparent instead of appending', async function () {
+      // The API accepts only one global propagator registration at a time.
+      propagation.disable();
+      propagation.setGlobalPropagator(new W3CTraceContextPropagator());
+      try {
+        const fetchUrl = `${protocol}://${hostname}:${mockServer.port}/echo-headers`;
+        const preset =
+          '00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01';
+        const response = await fetch(fetchUrl, {
+          headers: { Traceparent: preset },
+        });
+        const echoed = (await response.json()) as Record<string, string>;
+        const spans = memoryExporter.getFinishedSpans();
+        const span = spans[0];
+
+        assert.ok(span, 'a span is present');
+        assert.strictEqual(typeof echoed.traceparent, 'string');
+        assert.ok(
+          !String(echoed.traceparent).includes(','),
+          'traceparent must not be a folded duplicate'
+        );
+        assert.notStrictEqual(echoed.traceparent, preset);
+        assert.ok(
+          String(echoed.traceparent).includes(span.spanContext().traceId)
+        );
+      } finally {
+        propagation.disable();
+        propagation.setGlobalPropagator(new MockPropagation());
+      }
     });
   });
 });

--- a/packages/instrumentation-undici/test/undici.test.ts
+++ b/packages/instrumentation-undici/test/undici.test.ts
@@ -91,6 +91,20 @@ describe('UndiciInstrumentation `undici` tests', function () {
         res.end();
         return;
       }
+      if (req.url?.startsWith('/echo-headers')) {
+        res.statusCode = 200;
+        res.setHeader('content-type', 'application/json');
+        res.write(
+          JSON.stringify({
+            [MockPropagation.TRACE_CONTEXT_KEY]:
+              req.headers[MockPropagation.TRACE_CONTEXT_KEY],
+            [MockPropagation.SPAN_CONTEXT_KEY]:
+              req.headers[MockPropagation.SPAN_CONTEXT_KEY],
+          })
+        );
+        res.end();
+        return;
+      }
       // There are some situations where there is no way to access headers
       // for trace propagation asserts like:
       // const resp = await fetch('http://host:port')
@@ -218,6 +232,41 @@ describe('UndiciInstrumentation `undici` tests', function () {
 
       spans = memoryExporter.getFinishedSpans();
       assert.ok(spans.length === 0, 'ignoreRequestHook is filtering requests');
+    });
+
+    it('should overwrite a pre-set propagation header instead of appending a second value', async function () {
+      const requestUrl = `${protocol}://${hostname}:${mockServer.port}/echo-headers`;
+      const { statusCode, body } = await undici.request(requestUrl, {
+        headers: {
+          [MockPropagation.TRACE_CONTEXT_KEY]: 'preset-trace-id',
+          [MockPropagation.SPAN_CONTEXT_KEY]: 'preset-span-id',
+        },
+      });
+      const chunks: Buffer[] = [];
+      for await (const chunk of body) {
+        chunks.push(Buffer.from(chunk));
+      }
+      const echoed = JSON.parse(Buffer.concat(chunks).toString()) as Record<
+        string,
+        string
+      >;
+      const spans = memoryExporter.getFinishedSpans();
+      const span = spans[0];
+
+      assert.strictEqual(statusCode, 200);
+      assert.ok(span, 'a span is present');
+      assert.strictEqual(
+        echoed[MockPropagation.TRACE_CONTEXT_KEY],
+        span.spanContext().traceId
+      );
+      assert.strictEqual(
+        echoed[MockPropagation.SPAN_CONTEXT_KEY],
+        span.spanContext().spanId
+      );
+      assert.ok(
+        !String(echoed[MockPropagation.TRACE_CONTEXT_KEY]).includes(','),
+        'trace header must not be a folded duplicate'
+      );
     });
 
     it('should create valid spans for different request methods', async function () {


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #3711.

`UndiciInstrumentation` injects context by appending headers. If the outgoing `fetch`/`request` already carries `traceparent` (or any other propagator field), the wire request ends up with two values. Receivers fold those into one comma-joined header, the W3C propagator rejects it as malformed, and the downstream span starts as an orphan.

`@opentelemetry/instrumentation-http` already overwrites a keyed header object. The undici path is the outlier because undici's `addHeader` / header-array APIs append.

## Short description of the changes

Before calling `addHeader` / pushing onto the header list, drop every existing instance of the fields the current propagator is about to write (`propagation.fields()` plus the injected keys). Header names are matched case-insensitively, for both the undici v6 `[k, v, …]` array and the v5 raw-string form.

Injection then writes a single valid `traceparent` / `tracestate` (or the current mock/custom propagator fields). A caller-supplied value is replaced, not concatenated.

## Verification

From the repository root, after `npm ci`:

```sh
npm run compile:with-dependencies -w @opentelemetry/instrumentation-undici
npm test -w @opentelemetry/instrumentation-undici
```

Result: 40 passing, including regressions for a pre-set mock propagator header on both `fetch` and `undici.request`, a caller-supplied mixed-case W3C `Traceparent` on `fetch`, and the current response-status `error.type` coverage.

## Generative AI disclosure

I used an AI coding assistant to inspect the instrumentation paths, help resolve the upstream rebase conflict, and draft the regression tests. I reviewed the resulting diff and ran the verification commands above.
