### PR TITLE
fix(instrumentation-aws-lambda): force flush logger provider on invocation completion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36689,6 +36689,7 @@
       "version": "0.74.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@opentelemetry/api-logs": "^0.222.0",
         "@opentelemetry/instrumentation": "^0.222.0",
         "@opentelemetry/propagator-aws-xray": "^2.1.4",
         "@opentelemetry/semantic-conventions": "^1.27.0",
@@ -36699,6 +36700,7 @@
         "@opentelemetry/context-async-hooks": "^2.9.0",
         "@opentelemetry/core": "^2.9.0",
         "@opentelemetry/propagator-aws-xray-lambda": "^0.56.0",
+        "@opentelemetry/sdk-logs": "^0.222.0",
         "@opentelemetry/sdk-metrics": "^2.9.0",
         "@opentelemetry/sdk-trace": "^2.9.0"
       },

--- a/packages/instrumentation-aws-lambda/package.json
+++ b/packages/instrumentation-aws-lambda/package.json
@@ -48,10 +48,12 @@
     "@opentelemetry/context-async-hooks": "^2.9.0",
     "@opentelemetry/core": "^2.9.0",
     "@opentelemetry/propagator-aws-xray-lambda": "^0.56.0",
+    "@opentelemetry/sdk-logs": "^0.222.0",
     "@opentelemetry/sdk-metrics": "^2.9.0",
     "@opentelemetry/sdk-trace": "^2.9.0"
   },
   "dependencies": {
+    "@opentelemetry/api-logs": "^0.222.0",
     "@opentelemetry/instrumentation": "^0.222.0",
     "@opentelemetry/propagator-aws-xray": "^2.1.4",
     "@opentelemetry/semantic-conventions": "^1.27.0",

--- a/packages/instrumentation-aws-lambda/src/instrumentation.ts
+++ b/packages/instrumentation-aws-lambda/src/instrumentation.ts
@@ -740,7 +740,18 @@ export class AwsLambdaInstrumentation extends InstrumentationBase<AwsLambdaInstr
     if (!loggerProvider) return undefined;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const currentProvider: any = loggerProvider;
+    let currentProvider: any = loggerProvider;
+
+    // A LoggerProvider obtained via @opentelemetry/api-logs is a delegating
+    // proxy (ProxyLoggerProvider), like ProxyTracerProvider, so unwrap it to
+    // reach the SDK provider that actually has forceFlush. The logs proxy
+    // exposes the delegate as _getDelegate(); fall back to getDelegate() for
+    // any provider that uses the non-underscore name.
+    if (typeof currentProvider._getDelegate === 'function') {
+      currentProvider = currentProvider._getDelegate();
+    } else if (typeof currentProvider.getDelegate === 'function') {
+      currentProvider = currentProvider.getDelegate();
+    }
 
     if (typeof currentProvider.forceFlush === 'function') {
       return currentProvider.forceFlush.bind(currentProvider);

--- a/packages/instrumentation-aws-lambda/src/instrumentation.ts
+++ b/packages/instrumentation-aws-lambda/src/instrumentation.ts
@@ -38,6 +38,7 @@ import {
   ATTR_SERVER_ADDRESS,
   ATTR_URL_FULL,
 } from '@opentelemetry/semantic-conventions';
+import { LoggerProvider } from '@opentelemetry/api-logs';
 import {
   ATTR_AWS_SQS_QUEUE_URL,
   ATTR_CLOUD_ACCOUNT_ID,
@@ -121,6 +122,7 @@ export class AwsLambdaInstrumentation extends InstrumentationBase<AwsLambdaInstr
   private readonly _xrayPropagator = new AWSXRayPropagator();
   declare private _traceForceFlusher?: () => Promise<void>;
   declare private _metricForceFlusher?: () => Promise<void>;
+  declare private _logForceFlusher?: () => Promise<void>;
 
   constructor(config: AwsLambdaInstrumentationConfig = {}) {
     super(PACKAGE_NAME, PACKAGE_VERSION, config);
@@ -729,6 +731,24 @@ export class AwsLambdaInstrumentation extends InstrumentationBase<AwsLambdaInstr
     return undefined;
   }
 
+  override setLoggerProvider(loggerProvider: LoggerProvider) {
+    super.setLoggerProvider(loggerProvider);
+    this._logForceFlusher = this._logForceFlush(loggerProvider);
+  }
+
+  private _logForceFlush(loggerProvider: LoggerProvider) {
+    if (!loggerProvider) return undefined;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const currentProvider: any = loggerProvider;
+
+    if (typeof currentProvider.forceFlush === 'function') {
+      return currentProvider.forceFlush.bind(currentProvider);
+    }
+
+    return undefined;
+  }
+
   private _wrapCallback(
     original: Callback,
     span: Span,
@@ -798,6 +818,13 @@ export class AwsLambdaInstrumentation extends InstrumentationBase<AwsLambdaInstr
     } else {
       diag.debug(
         'Metrics may not be exported for the lambda function because we are not force flushing before handler completion.'
+      );
+    }
+    if (this._logForceFlusher) {
+      flushers.push(this._logForceFlusher());
+    } else {
+      diag.debug(
+        'Logs may not be exported for the lambda function because we are not force flushing before handler completion.'
       );
     }
 

--- a/packages/instrumentation-aws-lambda/test/integrations/lambda-handler.force-flush.test.ts
+++ b/packages/instrumentation-aws-lambda/test/integrations/lambda-handler.force-flush.test.ts
@@ -25,11 +25,17 @@ import {
   MeterProvider,
   PeriodicExportingMetricReader,
 } from '@opentelemetry/sdk-metrics';
+import {
+  InMemoryLogRecordExporter,
+  LoggerProvider,
+  SimpleLogRecordProcessor,
+} from '@opentelemetry/sdk-logs';
 
 const traceMemoryExporter = new InMemorySpanExporter();
 const metricMemoryExporter = new InMemoryMetricExporter(
   AggregationTemporality.CUMULATIVE
 );
+const logMemoryExporter = new InMemoryLogRecordExporter();
 
 describe('force flush', () => {
   let instrumentation: AwsLambdaInstrumentation;
@@ -62,6 +68,16 @@ describe('force flush', () => {
     instrumentation.setMeterProvider(provider);
   };
 
+  const initializeHandlerLogging = (
+    handler: string,
+    provider: LoggerProvider
+  ) => {
+    process.env._HANDLER = handler;
+
+    instrumentation = new AwsLambdaInstrumentation();
+    instrumentation.setLoggerProvider(provider);
+  };
+
   const lambdaRequire = (module: string) =>
     require(path.resolve(__dirname, '..', module));
 
@@ -76,6 +92,7 @@ describe('force flush', () => {
 
     traceMemoryExporter.reset();
     metricMemoryExporter.reset();
+    logMemoryExporter.reset();
   });
 
   it('should force flush TracerProvider', async () => {
@@ -140,6 +157,26 @@ describe('force flush', () => {
     assert.strictEqual(forceFlushed, true);
   });
 
+  it('should force flush LoggerProvider', async () => {
+    const provider = new LoggerProvider({
+      processors: [
+        new SimpleLogRecordProcessor({ exporter: logMemoryExporter }),
+      ],
+    });
+    let forceFlushed = false;
+    const forceFlush = () =>
+      new Promise<void>(resolve => {
+        forceFlushed = true;
+        resolve();
+      });
+    provider.forceFlush = forceFlush;
+    initializeHandlerLogging('lambda-test/sync.handler', provider);
+
+    await lambdaRequire('lambda-test/sync').handler('arg', ctx);
+
+    assert.strictEqual(forceFlushed, true);
+  });
+
   it('should complete handler after force flush providers', async () => {
     const nodeTracerProvider = new TracerProvider({
       spanProcessors: [
@@ -169,15 +206,30 @@ describe('force flush', () => {
       });
     meterProvider.forceFlush = meterForceFlush;
 
+    const loggerProvider = new LoggerProvider({
+      processors: [
+        new SimpleLogRecordProcessor({ exporter: logMemoryExporter }),
+      ],
+    });
+    let loggerForceFlushed = false;
+    const loggerForceFlush = () =>
+      new Promise<void>(resolve => {
+        loggerForceFlushed = true;
+        resolve();
+      });
+    loggerProvider.forceFlush = loggerForceFlush;
+
     process.env._HANDLER = 'lambda-test/sync.handler';
 
     instrumentation = new AwsLambdaInstrumentation();
     instrumentation.setTracerProvider(tracerProvider);
     instrumentation.setMeterProvider(meterProvider);
+    instrumentation.setLoggerProvider(loggerProvider);
 
     await lambdaRequire('lambda-test/sync').handler('arg', ctx);
 
     assert.strictEqual(tracerForceFlushed, true);
     assert.strictEqual(meterForceFlushed, true);
+    assert.strictEqual(loggerForceFlushed, true);
   });
 });

--- a/packages/instrumentation-aws-lambda/test/integrations/lambda-handler.force-flush.test.ts
+++ b/packages/instrumentation-aws-lambda/test/integrations/lambda-handler.force-flush.test.ts
@@ -90,6 +90,8 @@ describe('force flush', () => {
   afterEach(() => {
     process.env = oldEnv;
     instrumentation.disable();
+    // Reset the global logger provider so the delegating-proxy test starts clean.
+    logs.disable();
 
     traceMemoryExporter.reset();
     metricMemoryExporter.reset();
@@ -179,10 +181,11 @@ describe('force flush', () => {
   });
 
   it('should force flush a LoggerProvider obtained via the API (delegating proxy)', async () => {
-    // Obtaining the provider from the API before a global is registered yields a
-    // delegating ProxyLoggerProvider. setGlobalLoggerProvider then wires the
-    // delegate, mirroring how instrumentations capture the provider at load time.
-    logs.disable();
+    // A LoggerProvider obtained from the logs API is a delegating
+    // ProxyLoggerProvider. We wire its delegate to a real LoggerProvider and
+    // then hand the proxy to the instrumentation, mirroring the
+    // ProxyTracerProvider test above. The delegate is wired before
+    // setLoggerProvider because the force-flusher is resolved at that point.
     const provider = logs.getLoggerProvider();
 
     const loggerProvider = new LoggerProvider({
@@ -206,7 +209,6 @@ describe('force flush', () => {
     await lambdaRequire('lambda-test/sync').handler('arg', ctx);
 
     assert.strictEqual(forceFlushed, true);
-    logs.disable();
   });
 
   it('should complete handler after force flush providers', async () => {

--- a/packages/instrumentation-aws-lambda/test/integrations/lambda-handler.force-flush.test.ts
+++ b/packages/instrumentation-aws-lambda/test/integrations/lambda-handler.force-flush.test.ts
@@ -30,6 +30,7 @@ import {
   LoggerProvider,
   SimpleLogRecordProcessor,
 } from '@opentelemetry/sdk-logs';
+import { logs } from '@opentelemetry/api-logs';
 
 const traceMemoryExporter = new InMemorySpanExporter();
 const metricMemoryExporter = new InMemoryMetricExporter(
@@ -175,6 +176,37 @@ describe('force flush', () => {
     await lambdaRequire('lambda-test/sync').handler('arg', ctx);
 
     assert.strictEqual(forceFlushed, true);
+  });
+
+  it('should force flush a LoggerProvider obtained via the API (delegating proxy)', async () => {
+    // Obtaining the provider from the API before a global is registered yields a
+    // delegating ProxyLoggerProvider. setGlobalLoggerProvider then wires the
+    // delegate, mirroring how instrumentations capture the provider at load time.
+    logs.disable();
+    const provider = logs.getLoggerProvider();
+
+    const loggerProvider = new LoggerProvider({
+      processors: [
+        new SimpleLogRecordProcessor({ exporter: logMemoryExporter }),
+      ],
+    });
+    let forceFlushed = false;
+    const forceFlush = () =>
+      new Promise<void>(resolve => {
+        forceFlushed = true;
+        resolve();
+      });
+    loggerProvider.forceFlush = forceFlush;
+    logs.setGlobalLoggerProvider(loggerProvider);
+
+    process.env._HANDLER = 'lambda-test/sync.handler';
+    instrumentation = new AwsLambdaInstrumentation();
+    instrumentation.setLoggerProvider(provider);
+
+    await lambdaRequire('lambda-test/sync').handler('arg', ctx);
+
+    assert.strictEqual(forceFlushed, true);
+    logs.disable();
   });
 
   it('should complete handler after force flush providers', async () => {


### PR DESCRIPTION
## Which problem is this PR solving?

The `AwsLambdaInstrumentation` force-flushes the tracer and meter providers when the wrapped handler settles (`_endInvocationSpanAndFlush`), but it has no awareness of the logger provider. Log records buffered in a `BatchLogRecordProcessor` are therefore dropped when AWS freezes the Lambda execution environment right after the handler returns, unless the application manually calls `forceFlush()`.

Related (downstream report): open-telemetry/opentelemetry-lambda#2537

## Short description of the changes

- Add a `setLoggerProvider` override plus a `_logForceFlusher`, mirroring the existing `setMeterProvider` / `_metricForceFlush` handling.
- Include the logger force-flush in the invocation-end flush so buffered logs are exported alongside spans and metrics, with no application code changes.
- Add `@opentelemetry/api-logs` as a dependency (used by the new method signature); the added tests use `@opentelemetry/sdk-logs`.
- Extend `lambda-handler.force-flush.test.ts` with a `should force flush LoggerProvider` case and assert the logger provider is also flushed in the combined "complete handler after force flush providers" test.
