### PR TITLE
ci: disable minimum release age on OTel core update workflow

### DIFF
--- a/.github/workflows/update-otel-deps.yaml
+++ b/.github/workflows/update-otel-deps.yaml
@@ -45,3 +45,6 @@ jobs:
           gh pr create --title "feat(deps): update deps matching '@opentelemetry/*'" --body 'Updates all `@opentelemetry/*` dependencies to latest'
         env:
           GITHUB_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+          # The script runs `npm install`/`npm update` for freshly released packages
+          # that may be younger than the `min-release-age` set in `.npmrc`.
+          NPM_CONFIG_MIN_RELEASE_AGE: 0


### PR DESCRIPTION
## Which problem is this PR solving?

The update workflow does not update to the latest OTel versions because they're younger than 3 days.
This PR disables the minimum release age setting for that workflow.

refs: https://github.com/open-telemetry/opentelemetry-js-contrib/pull/3716#issuecomment-5481759343
