### PR TITLE
ci: avoid workflow failure when update PR already exists

### DIFF
--- a/.github/workflows/update-otel-deps.yaml
+++ b/.github/workflows/update-otel-deps.yaml
@@ -42,6 +42,11 @@ jobs:
           node ./scripts/update-otel-deps.js
           git commit -am "feat(deps): update deps matching '@opentelemetry/*'"
           git push --set-upstream origin otelbot/update-otel-deps --force
-          gh pr create --title "feat(deps): update deps matching '@opentelemetry/*'" --body 'Updates all `@opentelemetry/*` dependencies to latest'
+          # The force-push above already updated an open PR, if there is one.
+          if [[ -n "$(gh pr list --head otelbot/update-otel-deps --state open --json number --jq '.[].number')" ]]; then
+            echo "PR for otelbot/update-otel-deps already exists, skipping 'gh pr create'"
+          else
+            gh pr create --title "feat(deps): update deps matching '@opentelemetry/*'" --body 'Updates all `@opentelemetry/*` dependencies to latest'
+          fi
         env:
           GITHUB_TOKEN: ${{ steps.otelbot-token.outputs.token }}


### PR DESCRIPTION
## Which problem is this PR solving?

When the PR update PR already exists, the workflow currently pushes the changes but fails on PR creation. That makes it look like it did not succeed, but it actually worked fine.

This PR fixes that by adding a check if the PR already exists. If it does exist, it just logs that and the script exits cleanly.