### PR TITLE
fix(instrumentation-document-load): replace deprecated otperformance

### DIFF
--- a/packages/instrumentation-document-load/src/instrumentation.ts
+++ b/packages/instrumentation-document-load/src/instrumentation.ts
@@ -10,7 +10,7 @@ import {
   Span,
   ROOT_CONTEXT,
 } from '@opentelemetry/api';
-import { otperformance, TRACE_PARENT_HEADER } from '@opentelemetry/core';
+import { TRACE_PARENT_HEADER } from '@opentelemetry/core';
 import {
   addSpanNetworkEvent,
   addSpanNetworkEvents,
@@ -69,9 +69,8 @@ export class DocumentLoadInstrumentation extends InstrumentationBase<DocumentLoa
    * @param rootSpan
    */
   private _addResourcesSpans(rootSpan: Span): void {
-    const resources: PerformanceResourceTiming[] = (
-      otperformance as unknown as Performance
-    ).getEntriesByType?.('resource') as PerformanceResourceTiming[];
+    const resources: PerformanceResourceTiming[] =
+      performance.getEntriesByType?.('resource') as PerformanceResourceTiming[];
     if (resources) {
       resources.forEach(resource => {
         this._initResourceSpan(resource, rootSpan);

--- a/packages/instrumentation-document-load/src/utils.ts
+++ b/packages/instrumentation-document-load/src/utils.ts
@@ -4,7 +4,6 @@
  */
 
 import { Span } from '@opentelemetry/api';
-import { otperformance } from '@opentelemetry/core';
 import {
   hasKey,
   PerformanceEntries,
@@ -15,9 +14,9 @@ import { EventNames } from './enums/EventNames';
 
 export const getPerformanceNavigationEntries = (): PerformanceEntries => {
   const entries: PerformanceEntries = {};
-  const performanceNavigationTiming = (
-    otperformance as unknown as Performance
-  ).getEntriesByType?.('navigation')[0] as PerformanceEntries;
+  const performanceNavigationTiming = performance.getEntriesByType?.(
+    'navigation'
+  )[0] as PerformanceEntries;
 
   if (performanceNavigationTiming) {
     const keys = Object.values(PTN);
@@ -31,7 +30,7 @@ export const getPerformanceNavigationEntries = (): PerformanceEntries => {
     });
   } else {
     // // fallback to previous version
-    const perf: typeof otperformance & PerformanceLegacy = otperformance;
+    const perf: Performance & PerformanceLegacy = performance as Performance & PerformanceLegacy;
     const performanceTiming = perf.timing;
     if (performanceTiming) {
       const keys = Object.values(PTN);
@@ -55,9 +54,7 @@ const performancePaintNames = {
 };
 
 export const addSpanPerformancePaintEvents = (span: Span) => {
-  const performancePaintTiming = (
-    otperformance as unknown as Performance
-  ).getEntriesByType?.('paint');
+  const performancePaintTiming = performance.getEntriesByType?.('paint');
   if (performancePaintTiming) {
     performancePaintTiming.forEach(({ name, startTime }) => {
       if (hasKey(performancePaintNames, name)) {

--- a/packages/instrumentation-document-load/src/utils.ts
+++ b/packages/instrumentation-document-load/src/utils.ts
@@ -30,7 +30,10 @@ export const getPerformanceNavigationEntries = (): PerformanceEntries => {
     });
   } else {
     // // fallback to previous version
-    const perf: Performance & PerformanceLegacy = performance as Performance & PerformanceLegacy;
+    const perf: Performance & PerformanceLegacy = performance as Performance &
+      PerformanceLegacy;
+    // PerformanceTiming is required for legacy browser support.
+    // eslint-disable-next-line baseline-js/use-baseline
     const performanceTiming = perf.timing;
     if (performanceTiming) {
       const keys = Object.values(PTN);
@@ -38,7 +41,7 @@ export const getPerformanceNavigationEntries = (): PerformanceEntries => {
         if (hasKey(performanceTiming, key)) {
           const value = performanceTiming[key];
           if (typeof value === 'number') {
-            entries[key] = value;
+            entries[key as keyof PerformanceEntries] = value;
           }
         }
       });


### PR DESCRIPTION
Replace usage of `otperformance` from `@opentelemetry/core` with the global `performance` object directly, following the removal of the deprecated export in opentelemetry-js core in upcoming SDK V3.

See: https://github.com/open-telemetry/opentelemetry-js/pull/7053/changes