### PR TITLE
feat(auto-instrumentations-node): support HTTP header capture via env…

### DIFF
--- a/packages/auto-instrumentations-node/README.md
+++ b/packages/auto-instrumentations-node/README.md
@@ -39,8 +39,7 @@ env NODE_OPTIONS="--require @opentelemetry/auto-instrumentations-node/register"
 ```
 
 The module is highly configurable using environment variables.
-Many aspects of the auto instrumentation's behavior can be configured for your needs, such as resource detectors, exporter choice, exporter configuration, trace context propagation headers, and much more.
-Instrumentation configuration is not yet supported through environment variables. Users that require instrumentation configuration must initialize OpenTelemetry programmatically.
+Many aspects of the auto instrumentation's behavior can be configured for your needs, such as resource detectors, exporter choice, exporter configuration, trace context propagation headers, and HTTP request/response header capture.
 
 ```shell
 export OTEL_TRACES_EXPORTER="otlp"
@@ -52,6 +51,10 @@ export OTEL_EXPORTER_OTLP_TRACES_HEADERS="x-api-key=your-api-key"
 export OTEL_RESOURCE_ATTRIBUTES="service.namespace=my-namespace"
 export OTEL_NODE_RESOURCE_DETECTORS="host,os,serviceinstance,env"
 export OTEL_SERVICE_NAME="client"
+export OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_REQUEST_HEADERS="content-type,accept"
+export OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_RESPONSE_HEADERS="content-length"
+export OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_REQUEST_HEADERS="x-custom-header"
+export OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_RESPONSE_HEADERS="cache-control"
 export NODE_OPTIONS="--require @opentelemetry/auto-instrumentations-node/register"
 node app.js
 ```

--- a/packages/auto-instrumentations-node/src/utils.ts
+++ b/packages/auto-instrumentations-node/src/utils.ts
@@ -199,7 +199,23 @@ export function getNodeAutoInstrumentations(
   >) {
     const Instance = InstrumentationMap[name];
     // Defaults are defined by the instrumentation itself
-    const userConfig: any = inputConfigs[name] ?? {};
+    const userConfig: any = { ...inputConfigs[name] };
+
+    if (name === '@opentelemetry/instrumentation-http') {
+      const envHeaders = getHeadersToSpanAttributesFromEnv();
+      if (envHeaders) {
+        userConfig.headersToSpanAttributes = {
+          server: {
+            ...envHeaders.server,
+            ...userConfig.headersToSpanAttributes?.server,
+          },
+          client: {
+            ...envHeaders.client,
+            ...userConfig.headersToSpanAttributes?.client,
+          },
+        };
+      }
+    }
 
     const shouldDisable = shouldDisableInstrumentation(
       name,
@@ -221,6 +237,47 @@ export function getNodeAutoInstrumentations(
   }
 
   return instrumentations;
+}
+
+function parseHeaderListFromEnv(
+  envVar: string | undefined
+): string[] | undefined {
+  if (!envVar) return undefined;
+  const headers = envVar
+    .split(',')
+    .map(header => header.trim())
+    .filter(header => header.length > 0);
+  return headers.length > 0 ? headers : undefined;
+}
+
+function getHeadersToSpanAttributesFromEnv() {
+  const serverReq = parseHeaderListFromEnv(
+    process.env.OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_REQUEST_HEADERS
+  );
+  const serverRes = parseHeaderListFromEnv(
+    process.env.OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_RESPONSE_HEADERS
+  );
+  const clientReq = parseHeaderListFromEnv(
+    process.env.OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_REQUEST_HEADERS
+  );
+  const clientRes = parseHeaderListFromEnv(
+    process.env.OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_RESPONSE_HEADERS
+  );
+
+  if (!serverReq && !serverRes && !clientReq && !clientRes) {
+    return undefined;
+  }
+
+  return {
+    server: {
+      ...(serverReq && { requestHeaders: serverReq }),
+      ...(serverRes && { responseHeaders: serverRes }),
+    },
+    client: {
+      ...(clientReq && { requestHeaders: clientReq }),
+      ...(clientRes && { responseHeaders: clientRes }),
+    },
+  };
 }
 
 function checkManuallyProvidedInstrumentationNames(

--- a/packages/auto-instrumentations-node/test/utils.test.ts
+++ b/packages/auto-instrumentations-node/test/utils.test.ts
@@ -247,6 +247,73 @@ describe('utils', () => {
         delete process.env.OTEL_NODE_DISABLED_INSTRUMENTATIONS;
       }
     });
+
+    it('should parse HTTP header capture env vars and set headersToSpanAttributes on HttpInstrumentation', () => {
+      process.env.OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_REQUEST_HEADERS =
+        'content-type, x-custom-request';
+      process.env.OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_RESPONSE_HEADERS =
+        'content-length';
+      process.env.OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_REQUEST_HEADERS =
+        'accept';
+      process.env.OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_RESPONSE_HEADERS =
+        'cache-control';
+
+      try {
+        const instrumentations = getNodeAutoInstrumentations();
+        const httpInstr = instrumentations.find(
+          i => i.instrumentationName === '@opentelemetry/instrumentation-http'
+        ) as any;
+
+        assert.deepStrictEqual(httpInstr._config.headersToSpanAttributes, {
+          server: {
+            requestHeaders: ['content-type', 'x-custom-request'],
+            responseHeaders: ['content-length'],
+          },
+          client: {
+            requestHeaders: ['accept'],
+            responseHeaders: ['cache-control'],
+          },
+        });
+      } finally {
+        delete process.env
+          .OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_REQUEST_HEADERS;
+        delete process.env
+          .OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_RESPONSE_HEADERS;
+        delete process.env
+          .OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_REQUEST_HEADERS;
+        delete process.env
+          .OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_RESPONSE_HEADERS;
+      }
+    });
+
+    it('should allow user programmatic headersToSpanAttributes config to take precedence over env vars', () => {
+      process.env.OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_REQUEST_HEADERS =
+        'from-env';
+      try {
+        const instrumentations = getNodeAutoInstrumentations({
+          '@opentelemetry/instrumentation-http': {
+            headersToSpanAttributes: {
+              server: {
+                requestHeaders: ['from-user-config'],
+              },
+            },
+          },
+        });
+        const httpInstr = instrumentations.find(
+          i => i.instrumentationName === '@opentelemetry/instrumentation-http'
+        ) as any;
+
+        assert.deepStrictEqual(
+          httpInstr._config.headersToSpanAttributes.server,
+          {
+            requestHeaders: ['from-user-config'],
+          }
+        );
+      } finally {
+        delete process.env
+          .OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_REQUEST_HEADERS;
+      }
+    });
   });
 
   describe('getResourceDetectorsFromEnv', () => {


### PR DESCRIPTION
…ironment variables (#3002)

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

-Adds support for capturing HTTP request and response headers using environment variables in `@opentelemetry/auto-instrumentations-node` without needing code-level hooks.

## Short description of the changes

-Added env var parsing for:
  - `OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_REQUEST_HEADERS`
  - `OTEL_INSTRUMENTATION_HTTP_SERVER_CAPTURE_RESPONSE_HEADERS`
  - `OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_REQUEST_HEADERS`
  - `OTEL_INSTRUMENTATION_HTTP_CLIENT_CAPTURE_RESPONSE_HEADERS`
- Passed parsed header lists into `headersToSpanAttributes` for `@opentelemetry/instrumentation-http`.
- Programmatic user config still takes precedence over env vars.
- Updated README and added unit tests in `utils.test.ts`.

## How has this been tested? (Proof of changes)
Ran local unit test suite using:
```bash
npm test --prefix packages/auto-instrumentations-node
