### PR TITLE
fix(instrumentation-undici): add error.type to spans and metrics

### DIFF
--- a/packages/instrumentation-undici/src/undici.ts
+++ b/packages/instrumentation-undici/src/undici.ts
@@ -396,9 +396,14 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
     }
 
     const { span, attributes } = record;
+    const isError = response.statusCode >= 400;
     const spanAttributes: Attributes = {
       [ATTR_HTTP_RESPONSE_STATUS_CODE]: response.statusCode,
     };
+
+    if (isError) {
+      spanAttributes[ATTR_ERROR_TYPE] = String(response.statusCode);
+    }
 
     const config = this.getConfig();
 
@@ -432,10 +437,7 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
 
     span.setAttributes(spanAttributes);
     span.setStatus({
-      code:
-        response.statusCode >= 400
-          ? SpanStatusCode.ERROR
-          : SpanStatusCode.UNSET,
+      code: isError ? SpanStatusCode.ERROR : SpanStatusCode.UNSET,
     });
     record.attributes = Object.assign(attributes, spanAttributes);
   }

--- a/packages/instrumentation-undici/test/metrics.test.ts
+++ b/packages/instrumentation-undici/test/metrics.test.ts
@@ -65,6 +65,12 @@ describe('UndiciInstrumentation metrics tests', function () {
         res.destroy();
         return;
       }
+      const status = req.url?.match(/^\/status\/(\d+)/);
+      if (status) {
+        res.statusCode = Number(status[1]);
+        res.end();
+        return;
+      }
       // Return a valid response always
       res.statusCode = 200;
       res.setHeader('content-type', 'application/json');
@@ -168,6 +174,34 @@ describe('UndiciInstrumentation metrics tests', function () {
       assert.strictEqual(metricAttributes[ATTR_SERVER_ADDRESS], hostname);
       assert.strictEqual(metricAttributes[ATTR_SERVER_PORT], mockServer.port);
       assert.strictEqual(metricAttributes[ATTR_ERROR_TYPE], 'UND_ERR_SOCKET');
+    });
+
+    it('should use the status code as error.type in "http.client.request.duration" metric', async () => {
+      const fetchUrl = `${protocol}://${hostname}:${mockServer.port}/status/500`;
+      await fetch(fetchUrl);
+
+      await metricReader.collectAndExport();
+      const resourceMetrics = metricsMemoryExporter.getMetrics();
+      const metrics = resourceMetrics[0].scopeMetrics[0].metrics;
+      assert.strictEqual(metrics[0].dataPoints.length, 1);
+
+      const metricAttributes = metrics[0].dataPoints[0].attributes;
+      assert.strictEqual(metricAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE], 500);
+      assert.strictEqual(metricAttributes[ATTR_ERROR_TYPE], '500');
+    });
+
+    it('should not set error.type for a successful response', async () => {
+      const fetchUrl = `${protocol}://${hostname}:${mockServer.port}/status/204`;
+      await fetch(fetchUrl);
+
+      await metricReader.collectAndExport();
+      const resourceMetrics = metricsMemoryExporter.getMetrics();
+      const metrics = resourceMetrics[0].scopeMetrics[0].metrics;
+      assert.strictEqual(metrics[0].dataPoints.length, 1);
+
+      const metricAttributes = metrics[0].dataPoints[0].attributes;
+      assert.strictEqual(metricAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE], 204);
+      assert.strictEqual(metricAttributes[ATTR_ERROR_TYPE], undefined);
     });
   });
 });

--- a/packages/instrumentation-undici/test/undici.test.ts
+++ b/packages/instrumentation-undici/test/undici.test.ts
@@ -14,6 +14,7 @@ import {
   trace,
 } from '@opentelemetry/api';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import { ATTR_ERROR_TYPE } from '@opentelemetry/semantic-conventions';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -82,6 +83,12 @@ describe('UndiciInstrumentation `undici` tests', function () {
       if (req.url === '/error') {
         // Simulate an error
         res.destroy();
+        return;
+      }
+      const status = req.url?.match(/^\/status\/(\d+)/);
+      if (status) {
+        res.statusCode = Number(status[1]);
+        res.end();
         return;
       }
       // There are some situations where there is no way to access headers
@@ -729,6 +736,41 @@ describe('UndiciInstrumentation `undici` tests', function () {
 
         done();
       });
+    });
+
+    it('should set error.type to the status code for a failing response', async function () {
+      for (const statusCode of [404, 500]) {
+        memoryExporter.reset();
+
+        const requestUrl = `${protocol}://${hostname}:${mockServer.port}/status/${statusCode}`;
+        const response = await undici.request(requestUrl);
+        await response.body.dump();
+
+        const span = memoryExporter.getFinishedSpans()[0];
+        assert.ok(span, 'a span is present');
+        assertSpan(span, {
+          hostname,
+          httpMethod: 'GET',
+          path: `/status/${statusCode}`,
+          httpStatusCode: statusCode,
+        });
+        assert.strictEqual(span.status.code, SpanStatusCode.ERROR);
+        assert.strictEqual(
+          span.attributes[ATTR_ERROR_TYPE],
+          String(statusCode)
+        );
+      }
+    });
+
+    it('should not set error.type for a successful response', async function () {
+      const requestUrl = `${protocol}://${hostname}:${mockServer.port}/status/204`;
+      const response = await undici.request(requestUrl);
+      await response.body.dump();
+
+      const span = memoryExporter.getFinishedSpans()[0];
+      assert.ok(span, 'a span is present');
+      assert.strictEqual(span.status.code, SpanStatusCode.UNSET);
+      assert.strictEqual(span.attributes[ATTR_ERROR_TYPE], undefined);
     });
 
     it('should capture errors while doing request', async function () {

--- a/packages/instrumentation-undici/test/utils/assertSpan.ts
+++ b/packages/instrumentation-undici/test/utils/assertSpan.ts
@@ -14,6 +14,7 @@ import {
 import { hrTimeToNanoseconds } from '@opentelemetry/core';
 import { ReadableSpan } from '@opentelemetry/sdk-trace';
 import {
+  ATTR_ERROR_TYPE,
   ATTR_HTTP_REQUEST_METHOD,
   ATTR_HTTP_RESPONSE_STATUS_CODE,
   ATTR_NETWORK_PEER_ADDRESS,
@@ -117,6 +118,15 @@ export const assertSpan = (
       isStatusUnset ? SpanStatusCode.UNSET : SpanStatusCode.ERROR,
       'span `status.code` is correct'
     );
+
+    // error.type accompanies an error status, carrying the status code
+    if (httpStatusCode !== undefined) {
+      assert.strictEqual(
+        span.attributes[ATTR_ERROR_TYPE],
+        isStatusUnset ? undefined : String(httpStatusCode),
+        `attributes['${ATTR_ERROR_TYPE}'] is correct`
+      );
+    }
   }
 
   assert.ok(span.endTime, 'must be finished');


### PR DESCRIPTION
## Which problem is this PR solving?
This PR adds the conditionally required `error.type` attribute to both spans and metrics when a request has ended with an error. 

This was an issue identified by the [semantic conventions conformance](https://github.com/open-telemetry/semantic-conventions-conformance/) repo.

Fixes: #3729 

## Short description of the changes

- `onResponseHeaders` now sets `error.type` to the status code as a string when the response is an error. 
- metrics inherit `error.type` from `spanAttributes`
- `assertSpan` now checks `error.type`
