### PR TITLE
feat(instrumentation-nestjs-core): add support for NestJS 12

### DIFF
--- a/packages/instrumentation-nestjs-core/.tav.yml
+++ b/packages/instrumentation-nestjs-core/.tav.yml
@@ -1,5 +1,19 @@
 "@nestjs/core":
   - versions:
+      include: ">=12.0.0 <13"
+      mode: latest-minors
+    # NestJS 12 is published as ESM and requires Node.js v20.19 or v22.12+
+    # (the versions that can `require()` ESM modules).
+    # https://docs.nestjs.com/migration-guide
+    node: "^20.19.0 || >=22.12.0"
+    peerDependencies:
+        - "@nestjs/common@^12.0.0"
+        - "@nestjs/platform-express@^12.0.0"
+        - "reflect-metadata@^0.2.0"
+        - "rxjs@^7.1.0"
+    commands: npm run test
+
+  - versions:
       include: ">=11.0.0 <12"
       mode: latest-minors
     # NestJS 11 requires Node.js v20 or later.

--- a/packages/instrumentation-nestjs-core/README.md
+++ b/packages/instrumentation-nestjs-core/README.md
@@ -17,7 +17,9 @@ npm install --save @opentelemetry/instrumentation-nestjs-core
 
 ### Supported Versions
 
-- [`@nestjs/core`](https://www.npmjs.com/package/@nestjs/core) versions `>=4.0.0 <12`
+- [`@nestjs/core`](https://www.npmjs.com/package/@nestjs/core) versions `>=4.0.0 <13`
+
+NestJS 12 is published as ESM. CommonJS applications that `require('@nestjs/core')` are instrumented without further setup. ESM applications need the loader hook described in the [ESM support](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/esm-support.md) guide, as with any other instrumentation.
 
 ## Usage
 

--- a/packages/instrumentation-nestjs-core/src/instrumentation.ts
+++ b/packages/instrumentation-nestjs-core/src/instrumentation.ts
@@ -23,7 +23,14 @@ import type { Controller } from '@nestjs/common/interfaces';
 import { PACKAGE_NAME, PACKAGE_VERSION } from './version';
 import { AttributeNames, NestType } from './enums';
 
-const supportedVersions = ['>=4.0.0 <12'];
+const supportedVersions = ['>=4.0.0 <13'];
+
+// The files patched by this instrumentation. Since NestJS 12 the package is
+// published as ESM, see `loadPatchedFiles`.
+const NEST_FACTORY_FILE = '@nestjs/core/nest-factory.js';
+const ROUTER_EXECUTION_CONTEXT_FILE =
+  '@nestjs/core/router/router-execution-context.js';
+const FIRST_ESM_MAJOR = 12;
 
 export class NestInstrumentation extends InstrumentationBase {
   static readonly COMPONENT = '@nestjs/core';
@@ -38,7 +45,11 @@ export class NestInstrumentation extends InstrumentationBase {
   init() {
     const module = new InstrumentationNodeModuleDefinition(
       NestInstrumentation.COMPONENT,
-      supportedVersions
+      supportedVersions,
+      (moduleExports: any, moduleVersion?: string) => {
+        this.loadPatchedFiles(moduleVersion);
+        return moduleExports;
+      }
     );
 
     module.files.push(
@@ -49,9 +60,35 @@ export class NestInstrumentation extends InstrumentationBase {
     return module;
   }
 
+  /**
+   * NestJS 12 publishes `@nestjs/core` as ESM. When a CommonJS application
+   * `require()`s it, Node.js evaluates the package's internal files with the
+   * ESM loader, so they never pass through the `require` hook and the file
+   * patches registered in `init()` would not run. Requiring the two patched
+   * files here routes them through the hook. The ESM loader has already
+   * cached them, so the same class prototypes get wrapped.
+   *
+   * ESM applications load these files through the ESM loader hook instead,
+   * where the file patches apply directly.
+   *
+   * The files are resolved from the application's lookup paths, not from this
+   * package's, so that layouts which do not hoist `@nestjs/core` (pnpm) work.
+   */
+  private loadPatchedFiles(moduleVersion?: string) {
+    const major = Number(moduleVersion?.split('.')[0]);
+    if (!(major >= FIRST_ESM_MAJOR)) {
+      return;
+    }
+    const paths = [...(require.main?.paths ?? []), ...module.paths];
+    for (const file of [NEST_FACTORY_FILE, ROUTER_EXECUTION_CONTEXT_FILE]) {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require(require.resolve(file, { paths }));
+    }
+  }
+
   getNestFactoryFileInstrumentation(versions: string[]) {
     return new InstrumentationNodeModuleFile(
-      '@nestjs/core/nest-factory.js',
+      NEST_FACTORY_FILE,
       versions,
       (NestFactoryStatic: any, moduleVersion?: string) => {
         this.ensureWrapped(
@@ -69,7 +106,7 @@ export class NestInstrumentation extends InstrumentationBase {
 
   getRouterExecutionContextFileInstrumentation(versions: string[]) {
     return new InstrumentationNodeModuleFile(
-      '@nestjs/core/router/router-execution-context.js',
+      ROUTER_EXECUTION_CONTEXT_FILE,
       versions,
       (RouterExecutionContext: any, moduleVersion?: string) => {
         this.ensureWrapped(

--- a/packages/instrumentation-nestjs-core/test/index.test.ts
+++ b/packages/instrumentation-nestjs-core/test/index.test.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as fs from 'fs';
+import * as path from 'path';
 import * as semver from 'semver';
 
 import { context, SpanStatusCode } from '@opentelemetry/api';
@@ -18,7 +20,14 @@ import { getRequester, setup, App } from './setup';
 
 import * as util from 'util';
 
-const LIB_VERSION = require('@nestjs/core/package.json').version;
+// Read package.json through the file system: the "exports" map of
+// `@nestjs/core` 12+ does not expose it to `require()`.
+const LIB_VERSION: string = JSON.parse(
+  fs.readFileSync(
+    path.join(path.dirname(require.resolve('@nestjs/core')), 'package.json'),
+    'utf8'
+  )
+).version;
 
 const instrumentation = new NestInstrumentation();
 const memoryExporter = new InMemorySpanExporter();


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #3732.

NestJS 12 (released 2026-08-27) is not instrumented:

- `supportedVersions` stops at `<12`.
- NestJS 12 publishes `@nestjs/core` as ESM. When a CommonJS application `require()`s it, the package's internal files (`nest-factory.js`, `router/router-execution-context.js`) are evaluated by the ESM loader and never pass through the require hook, so the two file patches this instrumentation relies on never run, even with the gate widened.

## Short description of the changes

- Widen the gate to `>=4.0.0 <13`.
- Add a patch callback on the `@nestjs/core` module definition that, for NestJS 12 and later, `require()`s the two patched files. The ESM loader has already cached them, so the same class prototypes are wrapped. The files are resolved through the application's lookup paths first (`require.main.paths`), falling back to this package's, so layouts that do not hoist `@nestjs/core` keep working. On NestJS 4 to 11 the callback returns early and behaviour is unchanged; the existing `ensureWrapped` guard prevents double patching in every path.
- ESM applications are unaffected: with the loader hook, the internal files are patched directly, as before.
- Tests: `require('@nestjs/core/package.json')` is blocked by the `exports` map of NestJS 12, so the test reads the version from the file system. Add a `.tav.yml` block for `>=12.0.0 <13`, gated on Node.js `^20.19.0 || >=22.12.0`, the versions able to `require()` ESM.
- README: supported range and a note on CommonJS versus ESM applications.

`devDependencies` stay on NestJS 11 on purpose: NestJS 12 requires Node.js 20.19+, and the unit test matrix still includes Node.js 18. Coverage for 12 comes from test-all-versions. When the devDependencies eventually move to 12, the three `import type` lines at the top of `instrumentation.ts` will need attention (TS1479 for the ESM subpaths and TS2307 for `@nestjs/common/interfaces`, which the new `exports` map does not expose); I left them alone here to keep this change focused.

## How Has This Been Tested?

- `packages/instrumentation-nestjs-core`, `mocha 'test/**/*.test.ts'` on the committed devDependencies (`@nestjs/core` 11.0.10): 4 passing.
- Same suite with `@nestjs/core`, `@nestjs/common` and `@nestjs/platform-express` at 12.0.1 and `reflect-metadata` 0.2.2 installed (the steps the new `.tav.yml` block performs): 4 passing. `test-all-versions` itself could not spawn `npm` on my Windows machine (`spawn EINVAL`), so I ran its steps by hand.
- Standalone CommonJS application under pnpm, NestJS 12.0.1, in-memory exporter: this branch emits `Create Nest App`, `AppController.getHello` and `getHello`; the published 0.68.0 emits no spans.
- `tsc -p . --noEmit`, `eslint` (no new warnings), `prettier --check` and `markdownlint-cli2` on the changed files.

## Checklist

- [x] Followed the style guidelines of this project
- [x] Unit tests have been added or updated
- [x] Documentation has been updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
