### PR TITLE
fix(instrumentation-undici): add `error.type` span attribute for requests that fail without a server response

### DIFF
--- a/packages/instrumentation-undici/README.md
+++ b/packages/instrumentation-undici/README.md
@@ -68,7 +68,7 @@ Attributes collected:
 
 | Attribute                      | Short Description                                                                                          |
 |--------------------------------|------------------------------------------------------------------------------------------------------------|
-| `error.type`                   | Describes a class of error the operation ended with.                                                       |
+| `error.type`                   | An HTTP status code, as a string, for HTTP responses >=400; or [an `'UND_ERR_*'` code](https://undici.nodejs.org/api/Errors) if the request errored without a server response. Excluded if the request suceeded. |
 | `http.request.method`          | HTTP request method.                                                                                       |
 | `http.request.method_original` | Original HTTP method sent by the client in the request line.                                               |
 | `http.response.status_code`    | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).                                |

--- a/packages/instrumentation-undici/README.md
+++ b/packages/instrumentation-undici/README.md
@@ -68,7 +68,7 @@ Attributes collected:
 
 | Attribute                      | Short Description                                                                                          |
 |--------------------------------|------------------------------------------------------------------------------------------------------------|
-| `error.type`                   | An HTTP status code, as a string, for HTTP responses >=400; or [an `'UND_ERR_*'` code](https://undici.nodejs.org/api/Errors) if the request errored without a server response. Excluded if the request suceeded. |
+| `error.type`                   | An HTTP status code, as a string, for HTTP responses >=400; or [an `'UND_ERR_*'` code](https://undici.nodejs.org/api/Errors) if the request errored without a server response. Excluded if the request succeeded. |
 | `http.request.method`          | HTTP request method.                                                                                       |
 | `http.request.method_original` | Original HTTP method sent by the client in the request line.                                               |
 | `http.response.status_code`    | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).                                |

--- a/packages/instrumentation-undici/src/undici.ts
+++ b/packages/instrumentation-undici/src/undici.ts
@@ -493,7 +493,7 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
       // message.
       const errorType = error.code || error.name || 'Error';
       attributes[ATTR_ERROR_TYPE] = errorType;
-      span.setAttribute(ATTR_ERROR_TYPE, errorType)
+      span.setAttribute(ATTR_ERROR_TYPE, errorType);
 
       span.recordException(error);
       span.setStatus({

--- a/packages/instrumentation-undici/src/undici.ts
+++ b/packages/instrumentation-undici/src/undici.ts
@@ -487,18 +487,20 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
     if (isAbort) {
       span.end();
     } else {
+      // error.type must be a low-cardinality class of error per semconv, and an
+      // empty value collapses into a duplicate series on Prometheus-based
+      // exporters. Use the error code/name, never the free-form, possibly empty
+      // message.
+      const errorType = error.code || error.name || 'Error';
+      attributes[ATTR_ERROR_TYPE] = errorType;
+      span.setAttribute(ATTR_ERROR_TYPE, errorType)
+
       span.recordException(error);
       span.setStatus({
         code: SpanStatusCode.ERROR,
         message: error.message,
       });
       span.end();
-
-      // error.type must be a low-cardinality class of error per semconv, and an
-      // empty value collapses into a duplicate series on Prometheus-based
-      // exporters. Use the error code/name, never the free-form, possibly empty
-      // message.
-      attributes[ATTR_ERROR_TYPE] = error.code || error.name || 'Error';
     }
 
     this._recordFromReq.delete(request);

--- a/packages/instrumentation-undici/test/fetch.test.ts
+++ b/packages/instrumentation-undici/test/fetch.test.ts
@@ -381,6 +381,7 @@ describe('UndiciInstrumentation `fetch` tests', function () {
         httpMethod: 'GET',
         path: '/error',
         error: fetchError,
+        errorType: 'UND_ERR_SOCKET',
         noNetPeer: true, // do not check network attribs
         forceStatus: {
           code: SpanStatusCode.ERROR,

--- a/packages/instrumentation-undici/test/undici.test.ts
+++ b/packages/instrumentation-undici/test/undici.test.ts
@@ -795,6 +795,7 @@ describe('UndiciInstrumentation `undici` tests', function () {
         httpMethod: 'GET',
         path: '/error',
         error: fetchError,
+        errorType: 'UND_ERR_SOCKET',
         noNetPeer: true, // do not check network attribs
         forceStatus: {
           code: SpanStatusCode.ERROR,

--- a/packages/instrumentation-undici/test/utils/assertSpan.ts
+++ b/packages/instrumentation-undici/test/utils/assertSpan.ts
@@ -38,6 +38,7 @@ export const assertSpan = (
     reqHeaders?: Headers | IncomingHttpHeaders;
     path?: string | null;
     query?: string | null;
+    errorType?: string;
     forceStatus?: SpanStatus;
     noNetPeer?: boolean; // we don't expect net peer info when request throw before being sent
     error?: Exception;
@@ -70,6 +71,14 @@ export const assertSpan = (
       span.attributes[ATTR_URL_QUERY],
       validations.query,
       `attributes['${ATTR_URL_QUERY}'] is correct`
+    );
+  }
+
+  if (validations.errorType) {
+    assert.strictEqual(
+      span.attributes[ATTR_ERROR_TYPE],
+      validations.errorType,
+      `attributes['${ATTR_ERROR_TYPE}'] is correct`
     );
   }
 


### PR DESCRIPTION
In earlier PRs `error.type` was added to spans for HTTP response codes
above 400, and also to HTTP client *metrics* for when a request fails
without a server response (e.g. the server crashes). This PR adds
the `error.type` attribute *to the span* for the latter case.

The HTTP span semconv (https://opentelemetry.io/docs/specs/semconv/http/http-spans/) also states:

> Instrumentations SHOULD document the list of errors they report.

so I've updated the semconv table in the README with some specifics.
