### PR TITLE
feat(instrumentation-undici): set network.protocol.version on client spans

### DIFF
--- a/packages/instrumentation-undici/README.md
+++ b/packages/instrumentation-undici/README.md
@@ -74,6 +74,7 @@ Attributes collected:
 | `http.response.status_code`    | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).                                |
 | `network.peer.address`         | Peer address of the network connection - IP address or Unix domain socket name.                            |
 | `network.peer.port`            | Peer port number of the network connection.                                                                |
+| `network.protocol.version`     | The version of the network protocol being used.                                                            |
 | `server.address`               | Server domain name, IP address or Unix domain socket name.                                                 |
 | `server.port`                  | Server port number.                                                                                        |
 | `url.full`                     | Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986). |

--- a/packages/instrumentation-undici/src/undici.ts
+++ b/packages/instrumentation-undici/src/undici.ts
@@ -34,6 +34,7 @@ import {
   ATTR_HTTP_RESPONSE_STATUS_CODE,
   ATTR_NETWORK_PEER_ADDRESS,
   ATTR_NETWORK_PEER_PORT,
+  ATTR_NETWORK_PROTOCOL_VERSION,
   ATTR_SERVER_ADDRESS,
   ATTR_SERVER_PORT,
   ATTR_URL_FULL,
@@ -363,6 +364,11 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
       [ATTR_NETWORK_PEER_PORT]: remotePort,
     };
 
+    const protocolVersion = this.getProtocolVersion(socket);
+    if (protocolVersion) {
+      spanAttributes[ATTR_NETWORK_PROTOCOL_VERSION] = protocolVersion;
+    }
+
     // After hooks have been processed (which may modify request headers)
     // we can collect the headers based on the configuration
     if (config.headersToSpanAttributes?.requestHeaders) {
@@ -380,6 +386,7 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
     }
 
     span.setAttributes(spanAttributes);
+    record.attributes = Object.assign(record.attributes, spanAttributes);
   }
 
   // This is the 3rd message we get for each request and it's fired when the server
@@ -552,5 +559,27 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
     }
 
     return '_OTHER';
+  }
+
+  private getProtocolVersion(
+    socket: { alpnProtocol?: string | boolean } | undefined | null
+  ): string | undefined {
+    if (!socket) {
+      return undefined;
+    }
+    if (typeof socket.alpnProtocol === 'string') {
+      const alpn = socket.alpnProtocol.toLowerCase();
+      if (alpn.startsWith('http/')) {
+        return alpn.slice(5);
+      }
+      if (alpn === 'h2') {
+        return '2';
+      }
+      if (alpn === 'h3') {
+        return '3';
+      }
+      return socket.alpnProtocol;
+    }
+    return '1.1';
   }
 }

--- a/packages/instrumentation-undici/src/undici.ts
+++ b/packages/instrumentation-undici/src/undici.ts
@@ -358,16 +358,14 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
 
     const config = this.getConfig();
     const { span } = record;
-    const { remoteAddress, remotePort } = socket;
+    const { remoteAddress, remotePort, alpnProtocol } = socket;
     const spanAttributes: Attributes = {
       [ATTR_NETWORK_PEER_ADDRESS]: remoteAddress,
       [ATTR_NETWORK_PEER_PORT]: remotePort,
+      // undici only ever offers `http/1.1` and, with `allowH2`, `h2` as ALPN
+      // protocols; a connection that negotiated neither is HTTP/1.1.
+      [ATTR_NETWORK_PROTOCOL_VERSION]: alpnProtocol === 'h2' ? '2' : '1.1',
     };
-
-    const protocolVersion = this.getProtocolVersion(socket);
-    if (protocolVersion) {
-      spanAttributes[ATTR_NETWORK_PROTOCOL_VERSION] = protocolVersion;
-    }
 
     // After hooks have been processed (which may modify request headers)
     // we can collect the headers based on the configuration
@@ -523,6 +521,7 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
       ATTR_SERVER_PORT,
       ATTR_URL_SCHEME,
       ATTR_ERROR_TYPE,
+      ATTR_NETWORK_PROTOCOL_VERSION,
     ];
     keysToCopy.forEach(key => {
       if (key in attributes) {
@@ -559,27 +558,5 @@ export class UndiciInstrumentation extends InstrumentationBase<UndiciInstrumenta
     }
 
     return '_OTHER';
-  }
-
-  private getProtocolVersion(
-    socket: { alpnProtocol?: string | boolean } | undefined | null
-  ): string | undefined {
-    if (!socket) {
-      return undefined;
-    }
-    if (typeof socket.alpnProtocol === 'string') {
-      const alpn = socket.alpnProtocol.toLowerCase();
-      if (alpn.startsWith('http/')) {
-        return alpn.slice(5);
-      }
-      if (alpn === 'h2') {
-        return '2';
-      }
-      if (alpn === 'h3') {
-        return '3';
-      }
-      return socket.alpnProtocol;
-    }
-    return '1.1';
   }
 }

--- a/packages/instrumentation-undici/test/metrics.test.ts
+++ b/packages/instrumentation-undici/test/metrics.test.ts
@@ -18,6 +18,7 @@ import {
   ATTR_ERROR_TYPE,
   ATTR_HTTP_REQUEST_METHOD,
   ATTR_HTTP_RESPONSE_STATUS_CODE,
+  ATTR_NETWORK_PROTOCOL_VERSION,
   ATTR_SERVER_ADDRESS,
   ATTR_SERVER_PORT,
   ATTR_URL_SCHEME,
@@ -133,6 +134,10 @@ describe('UndiciInstrumentation metrics tests', function () {
       assert.strictEqual(metricAttributes[ATTR_SERVER_ADDRESS], 'localhost');
       assert.strictEqual(metricAttributes[ATTR_SERVER_PORT], mockServer.port);
       assert.strictEqual(metricAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE], 200);
+      assert.strictEqual(
+        metricAttributes[ATTR_NETWORK_PROTOCOL_VERSION],
+        '1.1'
+      );
     });
 
     it('should use error code as error.type in "http.client.request.duration" metric', async () => {
@@ -188,6 +193,10 @@ describe('UndiciInstrumentation metrics tests', function () {
       const metricAttributes = metrics[0].dataPoints[0].attributes;
       assert.strictEqual(metricAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE], 500);
       assert.strictEqual(metricAttributes[ATTR_ERROR_TYPE], '500');
+      assert.strictEqual(
+        metricAttributes[ATTR_NETWORK_PROTOCOL_VERSION],
+        '1.1'
+      );
     });
 
     it('should not set error.type for a successful response', async () => {
@@ -202,6 +211,10 @@ describe('UndiciInstrumentation metrics tests', function () {
       const metricAttributes = metrics[0].dataPoints[0].attributes;
       assert.strictEqual(metricAttributes[ATTR_HTTP_RESPONSE_STATUS_CODE], 204);
       assert.strictEqual(metricAttributes[ATTR_ERROR_TYPE], undefined);
+      assert.strictEqual(
+        metricAttributes[ATTR_NETWORK_PROTOCOL_VERSION],
+        '1.1'
+      );
     });
   });
 });

--- a/packages/instrumentation-undici/test/undici.test.ts
+++ b/packages/instrumentation-undici/test/undici.test.ts
@@ -14,7 +14,11 @@ import {
   trace,
 } from '@opentelemetry/api';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
-import { ATTR_ERROR_TYPE } from '@opentelemetry/semantic-conventions';
+import {
+  ATTR_ERROR_TYPE,
+  ATTR_NETWORK_PROTOCOL_VERSION,
+} from '@opentelemetry/semantic-conventions';
+import * as sinon from 'sinon';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -955,6 +959,71 @@ describe('UndiciInstrumentation `undici` tests', function () {
         query: '?query=test',
       });
       assert.strictEqual(span.attributes['url.full'], fullUrl);
+    });
+
+    it('should set network.protocol.version attribute on client spans', async function () {
+      let spans = memoryExporter.getFinishedSpans();
+      assert.strictEqual(spans.length, 0);
+
+      const requestUrl = `${protocol}://${hostname}:${mockServer.port}/?query=test`;
+      const { body } = await undici.request(requestUrl);
+      await consumeResponseBody(body);
+
+      spans = memoryExporter.getFinishedSpans();
+      const span = spans[0];
+      assert.ok(span, 'a span is present');
+      assert.strictEqual(span.attributes[ATTR_NETWORK_PROTOCOL_VERSION], '1.1');
+    });
+
+    describe('getProtocolVersion', function () {
+      it('should correctly parse various socket alpnProtocol values', function () {
+        const getProto = (instrumentation as any).getProtocolVersion.bind(
+          instrumentation
+        );
+
+        assert.strictEqual(getProto(undefined), undefined);
+        assert.strictEqual(getProto(null), undefined);
+        assert.strictEqual(getProto({}), '1.1');
+        assert.strictEqual(getProto({ alpnProtocol: false }), '1.1');
+        assert.strictEqual(getProto({ alpnProtocol: 'http/1.1' }), '1.1');
+        assert.strictEqual(getProto({ alpnProtocol: 'HTTP/1.1' }), '1.1');
+        assert.strictEqual(getProto({ alpnProtocol: 'http/1.0' }), '1.0');
+        assert.strictEqual(getProto({ alpnProtocol: 'h2' }), '2');
+        assert.strictEqual(getProto({ alpnProtocol: 'H2' }), '2');
+        assert.strictEqual(getProto({ alpnProtocol: 'h3' }), '3');
+        assert.strictEqual(getProto({ alpnProtocol: 'custom' }), 'custom');
+      });
+
+      it('should set negotiated protocol version from socket in onRequestHeaders', function () {
+        const fakeSpan: any = {
+          setAttributes: sinon.spy(),
+        };
+        const fakeRecord: any = {
+          span: fakeSpan,
+          attributes: {},
+        };
+        const fakeRequest = {} as any;
+        (instrumentation as any)._recordFromReq.set(fakeRequest, fakeRecord);
+
+        (instrumentation as any).onRequestHeaders({
+          request: fakeRequest,
+          socket: {
+            remoteAddress: '127.0.0.1',
+            remotePort: 443,
+            alpnProtocol: 'h2',
+          },
+        });
+
+        assert.ok(fakeSpan.setAttributes.calledOnce);
+        const attrs = fakeSpan.setAttributes.firstCall.args[0];
+        assert.strictEqual(attrs[ATTR_NETWORK_PROTOCOL_VERSION], '2');
+        assert.strictEqual(
+          fakeRecord.attributes[ATTR_NETWORK_PROTOCOL_VERSION],
+          '2'
+        );
+
+        (instrumentation as any)._recordFromReq.delete(fakeRequest);
+      });
     });
   });
 });

--- a/packages/instrumentation-undici/test/undici.test.ts
+++ b/packages/instrumentation-undici/test/undici.test.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as assert from 'assert';
+import * as diagch from 'diagnostics_channel';
 import { Writable } from 'stream';
 
 import {
@@ -18,7 +19,6 @@ import {
   ATTR_ERROR_TYPE,
   ATTR_NETWORK_PROTOCOL_VERSION,
 } from '@opentelemetry/semantic-conventions';
-import * as sinon from 'sinon';
 import {
   InMemorySpanExporter,
   SimpleSpanProcessor,
@@ -961,69 +961,29 @@ describe('UndiciInstrumentation `undici` tests', function () {
       assert.strictEqual(span.attributes['url.full'], fullUrl);
     });
 
-    it('should set network.protocol.version attribute on client spans', async function () {
-      let spans = memoryExporter.getFinishedSpans();
-      assert.strictEqual(spans.length, 0);
+    it('should set network.protocol.version to 2 when ALPN is h2', function () {
+      const request: any = {
+        method: 'GET',
+        origin: 'https://localhost:443',
+        path: '/',
+        headers: [],
+      };
+      const socket = {
+        remoteAddress: '127.0.0.1',
+        remotePort: 443,
+        alpnProtocol: 'h2',
+      };
 
-      const requestUrl = `${protocol}://${hostname}:${mockServer.port}/?query=test`;
-      const { body } = await undici.request(requestUrl);
-      await consumeResponseBody(body);
+      diagch.channel('undici:request:create').publish({ request });
+      diagch.channel('undici:client:sendHeaders').publish({ request, socket });
+      diagch.channel('undici:request:trailers').publish({ request });
 
-      spans = memoryExporter.getFinishedSpans();
-      const span = spans[0];
-      assert.ok(span, 'a span is present');
-      assert.strictEqual(span.attributes[ATTR_NETWORK_PROTOCOL_VERSION], '1.1');
-    });
-
-    describe('getProtocolVersion', function () {
-      it('should correctly parse various socket alpnProtocol values', function () {
-        const getProto = (instrumentation as any).getProtocolVersion.bind(
-          instrumentation
-        );
-
-        assert.strictEqual(getProto(undefined), undefined);
-        assert.strictEqual(getProto(null), undefined);
-        assert.strictEqual(getProto({}), '1.1');
-        assert.strictEqual(getProto({ alpnProtocol: false }), '1.1');
-        assert.strictEqual(getProto({ alpnProtocol: 'http/1.1' }), '1.1');
-        assert.strictEqual(getProto({ alpnProtocol: 'HTTP/1.1' }), '1.1');
-        assert.strictEqual(getProto({ alpnProtocol: 'http/1.0' }), '1.0');
-        assert.strictEqual(getProto({ alpnProtocol: 'h2' }), '2');
-        assert.strictEqual(getProto({ alpnProtocol: 'H2' }), '2');
-        assert.strictEqual(getProto({ alpnProtocol: 'h3' }), '3');
-        assert.strictEqual(getProto({ alpnProtocol: 'custom' }), 'custom');
-      });
-
-      it('should set negotiated protocol version from socket in onRequestHeaders', function () {
-        const fakeSpan: any = {
-          setAttributes: sinon.spy(),
-        };
-        const fakeRecord: any = {
-          span: fakeSpan,
-          attributes: {},
-        };
-        const fakeRequest = {} as any;
-        (instrumentation as any)._recordFromReq.set(fakeRequest, fakeRecord);
-
-        (instrumentation as any).onRequestHeaders({
-          request: fakeRequest,
-          socket: {
-            remoteAddress: '127.0.0.1',
-            remotePort: 443,
-            alpnProtocol: 'h2',
-          },
-        });
-
-        assert.ok(fakeSpan.setAttributes.calledOnce);
-        const attrs = fakeSpan.setAttributes.firstCall.args[0];
-        assert.strictEqual(attrs[ATTR_NETWORK_PROTOCOL_VERSION], '2');
-        assert.strictEqual(
-          fakeRecord.attributes[ATTR_NETWORK_PROTOCOL_VERSION],
-          '2'
-        );
-
-        (instrumentation as any)._recordFromReq.delete(fakeRequest);
-      });
+      const spans = memoryExporter.getFinishedSpans();
+      assert.strictEqual(spans.length, 1);
+      assert.strictEqual(
+        spans[0].attributes[ATTR_NETWORK_PROTOCOL_VERSION],
+        '2'
+      );
     });
   });
 });

--- a/packages/instrumentation-undici/test/utils/assertSpan.ts
+++ b/packages/instrumentation-undici/test/utils/assertSpan.ts
@@ -19,6 +19,7 @@ import {
   ATTR_HTTP_RESPONSE_STATUS_CODE,
   ATTR_NETWORK_PEER_ADDRESS,
   ATTR_NETWORK_PEER_PORT,
+  ATTR_NETWORK_PROTOCOL_VERSION,
   ATTR_SERVER_ADDRESS,
   ATTR_URL_FULL,
   ATTR_URL_PATH,
@@ -40,6 +41,7 @@ export const assertSpan = (
     query?: string | null;
     forceStatus?: SpanStatus;
     noNetPeer?: boolean; // we don't expect net peer info when request throw before being sent
+    protocolVersion?: string;
     error?: Exception;
   }
 ) => {
@@ -148,6 +150,11 @@ export const assertSpan = (
     assert.ok(
       span.attributes[ATTR_NETWORK_PEER_PORT],
       `must have ${ATTR_NETWORK_PEER_PORT}`
+    );
+    assert.strictEqual(
+      span.attributes[ATTR_NETWORK_PROTOCOL_VERSION],
+      validations.protocolVersion || '1.1',
+      `attributes['${ATTR_NETWORK_PROTOCOL_VERSION}'] is correct`
     );
   }
   assert.ok(

--- a/packages/instrumentation-undici/test/utils/assertSpan.ts
+++ b/packages/instrumentation-undici/test/utils/assertSpan.ts
@@ -41,7 +41,6 @@ export const assertSpan = (
     query?: string | null;
     forceStatus?: SpanStatus;
     noNetPeer?: boolean; // we don't expect net peer info when request throw before being sent
-    protocolVersion?: string;
     error?: Exception;
   }
 ) => {
@@ -153,7 +152,7 @@ export const assertSpan = (
     );
     assert.strictEqual(
       span.attributes[ATTR_NETWORK_PROTOCOL_VERSION],
-      validations.protocolVersion || '1.1',
+      '1.1',
       `attributes['${ATTR_NETWORK_PROTOCOL_VERSION}'] is correct`
     );
   }


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes #3730

- `@opentelemetry/instrumentation-undici` was not setting `network.protocol.version` on HTTP client spans, unlike `@opentelemetry/instrumentation-http`.
- The `network.protocol.version` attribute is recommended on HTTP client spans according to OpenTelemetry HTTP Semantic Conventions, and was flagged as missing by `semantic-conventions-conformance`.

## Short description of the changes

- **Set `network.protocol.version` in `onRequestHeaders`**: Retrieves the connection socket in `onRequestHeaders` and populates the `ATTR_NETWORK_PROTOCOL_VERSION` attribute on the span.
- **ALPN parsing & fallback (`getProtocolVersion`)**:
  - Normalizes negotiated TLS ALPN values from `socket.alpnProtocol` (`'http/1.1'` -> `'1.1'`, `'http/1.0'` -> `'1.0'`, `'h2'` -> `'2'`, `'h3'` -> `'3'`).
  - Defaults to `'1.1'` for standard HTTP/1.1 connections without ALPN (plain TCP or TLS without ALPN).
  - Safely returns `undefined` if socket information is absent.
- **Updated test helper**: Added `ATTR_NETWORK_PROTOCOL_VERSION` assertion to `assertSpan` when network peer attributes are expected.
- **Added unit tests**: Added tests in `undici.test.ts` for end-to-end client span attributes, `getProtocolVersion` ALPN parsing, and `onRequestHeaders` socket handling.
- **Updated documentation**: Added `network.protocol.version` to the "Attributes collected" table in `packages/instrumentation-undici/README.md`.


Assisted-by: Google Antigravity