### PR TITLE
fix(instrumentation-mongodb): dedupe shared types and add missing `AGGREGATE` enum value

### DIFF
--- a/packages/instrumentation-mongodb/src/internal-types.ts
+++ b/packages/instrumentation-mongodb/src/internal-types.ts
@@ -3,42 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InstrumentationConfig } from '@opentelemetry/instrumentation';
-import { Span } from '@opentelemetry/api';
-
-export interface MongoDBInstrumentationExecutionResponseHook {
-  (span: Span, responseInfo: MongoResponseHookInformation): void;
-}
-
-/**
- * Function that can be used to serialize db.statement tag
- * @param cmd - MongoDB command object
- *
- * @returns serialized string that will be used as the db.statement attribute.
- */
-export type DbStatementSerializer = (cmd: Record<string, unknown>) => string;
-
-export interface MongoDBInstrumentationConfig extends InstrumentationConfig {
-  /**
-   * If true, additional information about query parameters and
-   * results will be attached (as `attributes`) to spans representing
-   * database operations.
-   */
-  enhancedDatabaseReporting?: boolean;
-
-  /**
-   * Hook that allows adding custom span attributes based on the data
-   * returned from MongoDB actions.
-   *
-   * @default undefined
-   */
-  responseHook?: MongoDBInstrumentationExecutionResponseHook;
-
-  /**
-   * Custom serializer function for the db.statement tag
-   */
-  dbStatementSerializer?: DbStatementSerializer;
-}
+export { MongodbCommandType } from './types';
 
 export type Func<T> = (...args: unknown[]) => T;
 export type MongoInternalCommand = {
@@ -65,17 +30,6 @@ export type CursorState = { cmd: MongoInternalCommand } & Record<
   string,
   unknown
 >;
-
-export interface MongoResponseHookInformation {
-  data: CommandResult;
-}
-
-// https://github.com/mongodb/node-mongodb-native/blob/3.6/lib/core/connection/command_result.js
-export type CommandResult = {
-  result?: unknown;
-  connection?: unknown;
-  message?: unknown;
-};
 
 // https://github.com/mongodb/node-mongodb-native/blob/3.6/lib/core/wireprotocol/index.js
 export type WireProtocolInternal = {
@@ -150,15 +104,6 @@ export type MongoInternalTopology = {
     address?: string;
   };
 };
-
-export enum MongodbCommandType {
-  CREATE_INDEXES = 'createIndexes',
-  FIND_AND_MODIFY = 'findAndModify',
-  IS_MASTER = 'isMaster',
-  COUNT = 'count',
-  AGGREGATE = 'aggregate',
-  UNKNOWN = 'unknown',
-}
 
 // https://github.com/mongodb/js-bson/blob/main/src/bson.ts
 export type Document = {

--- a/packages/instrumentation-mongodb/src/types.ts
+++ b/packages/instrumentation-mongodb/src/types.ts
@@ -61,5 +61,6 @@ export enum MongodbCommandType {
   FIND_AND_MODIFY = 'findAndModify',
   IS_MASTER = 'isMaster',
   COUNT = 'count',
+  AGGREGATE = 'aggregate',
   UNKNOWN = 'unknown',
 }

--- a/packages/instrumentation-mongodb/test/unit/types.test.ts
+++ b/packages/instrumentation-mongodb/test/unit/types.test.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert';
+import { MongodbCommandType } from '../../src';
+import { MongodbCommandType as InternalMongodbCommandType } from '../../src/internal-types';
+
+describe('MongodbCommandType', () => {
+  it('publicly exports every member the instrumentation can produce', () => {
+    // instrumentation.ts's _getCommandType() assigns MongodbCommandType.AGGREGATE
+    // for aggregate commands, so it must be reachable from the public API.
+    assert.strictEqual(MongodbCommandType.AGGREGATE, 'aggregate');
+  });
+
+  it('is the same enum used internally, so the two cannot drift apart again', () => {
+    assert.strictEqual(MongodbCommandType, InternalMongodbCommandType);
+  });
+});


### PR DESCRIPTION
<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

- `packages/instrumentation-mongodb/src/types.ts` and `internal-types.ts` declared duplicate copies of `MongoDBInstrumentationConfig`, `MongodbCommandType`, `DbStatementSerializer`, `CommandResult`, etc.
- The copies had drifted: `types.ts`'s `MongodbCommandType` (the one publicly re-exported from `index.ts`) was missing the `AGGREGATE` member that `internal-types.ts`'s copy had and that `instrumentation.ts` actually assigns for aggregate commands.
- As a result, consumers of the public API had no way to reference `MongodbCommandType.AGGREGATE`, even though the instrumentation produces spans with that operation type.


## Short description of the changes

- Added the missing `AGGREGATE` member to `MongodbCommandType` in `types.ts` (the copy that's actually exported publicly).
- Removed the duplicated type declarations from `internal-types.ts` (`MongoDBInstrumentationConfig`, `MongodbCommandType`, `DbStatementSerializer`, `MongoResponseHookInformation`, `CommandResult`, `MongoDBInstrumentationExecutionResponseHook`); `internal-types.ts` now re-exports `MongodbCommandType` from `types.ts` instead of redeclaring it, so the two files can no longer drift apart.

