### PR TITLE
feat(instrumentation-redis): add aggregate batch spans

### DIFF
--- a/packages/instrumentation-redis/README.md
+++ b/packages/instrumentation-redis/README.md
@@ -50,6 +50,14 @@ Redis instrumentation has a few options available to choose from. You can set th
 | `dbStatementSerializer` | `DbStatementSerializer` (function)                | Redis instrumentation will serialize the command to the `db.statement` attribute using the specified function. |
 | `responseHook`          | `RedisResponseCustomAttributeFunction` (function) | Function for adding custom attributes on db response. Receives params: `span, moduleVersion, cmdName, cmdArgs` |
 | `requireParentSpan`     | `boolean`                                         | Require parent to create redis span, default when unset is false.                                              |
+| `aggregateMultiCommandSpans` | `boolean`                                    | Emit one span with `db.operation.batch.size` for a transaction or pipeline instead of one span per queued command. Defaults to `false`. |
+
+When `aggregateMultiCommandSpans` is enabled, the aggregate span's operation
+name is `MULTI <command>` or `PIPELINE <command>` when every command is the
+same, and `MULTI` or `PIPELINE` for mixed commands. `responseHook` is invoked
+once for each successful command response with the same aggregate span.
+Batch spans omit `db.query.text` to avoid replacing span amplification with a
+potentially large concatenated attribute.
 
 #### Custom `db.statement` Serializer
 

--- a/packages/instrumentation-redis/README.md
+++ b/packages/instrumentation-redis/README.md
@@ -53,9 +53,13 @@ Redis instrumentation has a few options available to choose from. You can set th
 | `aggregateMultiCommandSpans` | `boolean`                                    | Emit one span with `db.operation.batch.size` for a transaction or pipeline instead of one span per queued command. Defaults to `false`. |
 
 When `aggregateMultiCommandSpans` is enabled, the aggregate span's operation
-name is `MULTI <command>` or `PIPELINE <command>` when every command is the
-same, and `MULTI` or `PIPELINE` for mixed commands. `responseHook` is invoked
-once for each successful command response with the same aggregate span.
+name for batches of two or more commands is `MULTI <command>` or
+`PIPELINE <command>` when every command is the same, and `MULTI` or `PIPELINE`
+for mixed commands. A single-command operation uses the command name and omits
+`db.operation.batch.size`.
+
+`responseHook` is invoked once for the aggregate operation. For a batch, it
+receives the operation name, an empty arguments array, and the replies array.
 Batch spans omit `db.query.text` to avoid replacing span amplification with a
 potentially large concatenated attribute.
 

--- a/packages/instrumentation-redis/src/redis.ts
+++ b/packages/instrumentation-redis/src/redis.ts
@@ -16,6 +16,7 @@ import { RedisInstrumentationV4_V5 } from './v4-v5/instrumentation';
 
 const DEFAULT_CONFIG: RedisInstrumentationConfig = {
   requireParentSpan: false,
+  aggregateMultiCommandSpans: false,
 };
 
 // Wrapper RedisInstrumentation that address all supported versions

--- a/packages/instrumentation-redis/src/types.ts
+++ b/packages/instrumentation-redis/src/types.ts
@@ -45,4 +45,12 @@ export interface RedisInstrumentationConfig extends InstrumentationConfig {
 
   /** Require parent to create redis span, default when unset is false */
   requireParentSpan?: boolean;
+
+  /**
+   * Emit one span for a MULTI transaction or pipeline instead of one span per
+   * queued command. The aggregate span includes db.operation.batch.size.
+   *
+   * @default false
+   */
+  aggregateMultiCommandSpans?: boolean;
 }

--- a/packages/instrumentation-redis/src/v4-v5/instrumentation.ts
+++ b/packages/instrumentation-redis/src/v4-v5/instrumentation.ts
@@ -22,6 +22,7 @@ import { RedisInstrumentationConfig } from '../types';
 /** @knipignore */
 import { PACKAGE_NAME, PACKAGE_VERSION } from '../version';
 import {
+  ATTR_DB_OPERATION_BATCH_SIZE,
   ATTR_DB_OPERATION_NAME,
   ATTR_DB_QUERY_TEXT,
 } from '@opentelemetry/semantic-conventions';
@@ -33,11 +34,20 @@ const OTEL_OPEN_SPANS = Symbol(
 const MULTI_COMMAND_OPTIONS = Symbol(
   'opentelemetry.instrumentation.redis.multi_command_options'
 );
+const AGGREGATE_MULTI_COMMAND_SPANS = Symbol(
+  'opentelemetry.instrumentation.redis.aggregate_multi_command_spans'
+);
+const MULTI_COMMANDS = Symbol(
+  'opentelemetry.instrumentation.redis.multi_commands'
+);
 
-interface MultiCommandInfo {
-  span: Span;
+interface MultiCommand {
   commandName: string;
   commandArgs: Array<string | Buffer>;
+}
+
+interface MultiCommandInfo extends MultiCommand {
+  span: Span;
 }
 
 export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrumentationConfig> {
@@ -336,6 +346,15 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
     const plugin = this;
     return function execPatchWrapper(original: Function) {
       return function execPatch(this: any) {
+        if (this[AGGREGATE_MULTI_COMMAND_SPANS]) {
+          return plugin._traceMultiCommand(
+            original,
+            this,
+            arguments,
+            isPipeline
+          );
+        }
+
         const execRes = original.apply(this, arguments);
         if (typeof execRes?.then !== 'function') {
           plugin._diag.error(
@@ -396,21 +415,27 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
     };
   }
   private _getPatchRedisClusterMulti() {
+    const plugin = this;
     return function multiPatchWrapper(original: Function) {
       return function multiPatch(this: any) {
         const multiRes = original.apply(this, arguments);
         // Store cluster options so _traceClientCommand can read connection attributes
         multiRes[MULTI_COMMAND_OPTIONS] = this._options;
+        multiRes[AGGREGATE_MULTI_COMMAND_SPANS] =
+          plugin.getConfig().aggregateMultiCommandSpans;
         return multiRes;
       };
     };
   }
 
   private _getPatchRedisClientMulti() {
+    const plugin = this;
     return function multiPatchWrapper(original: Function) {
       return function multiPatch(this: any) {
         const multiRes = original.apply(this, arguments);
         multiRes[MULTI_COMMAND_OPTIONS] = this.options;
+        multiRes[AGGREGATE_MULTI_COMMAND_SPANS] =
+          plugin.getConfig().aggregateMultiCommandSpans;
         return multiRes;
       };
     };
@@ -471,6 +496,16 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
     origArguments: IArguments,
     redisCommandArguments: Array<string | Buffer>
   ) {
+    if (origThis[AGGREGATE_MULTI_COMMAND_SPANS]) {
+      const res = origFunction.apply(origThis, origArguments);
+      res[MULTI_COMMANDS] = res[MULTI_COMMANDS] || [];
+      res[MULTI_COMMANDS].push({
+        commandName: redisCommandArguments[0].toString(),
+        commandArgs: redisCommandArguments.slice(1),
+      });
+      return res;
+    }
+
     const hasNoParentSpan = trace.getSpan(context.active()) === undefined;
     if (hasNoParentSpan && this.getConfig().requireParentSpan) {
       return origFunction.apply(origThis, origArguments);
@@ -536,6 +571,137 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
       });
     }
     return res;
+  }
+
+  private _traceMultiCommand(
+    origFunction: Function,
+    origThis: any,
+    origArguments: IArguments,
+    isPipeline: boolean
+  ) {
+    const hasNoParentSpan = trace.getSpan(context.active()) === undefined;
+    if (hasNoParentSpan && this.getConfig().requireParentSpan) {
+      return origFunction.apply(origThis, origArguments);
+    }
+
+    const commands: MultiCommand[] = origThis[MULTI_COMMANDS] || [];
+    const operationName = this._getMultiOperationName(commands, isPipeline);
+    const attributes = getClientAttributes(origThis[MULTI_COMMAND_OPTIONS]);
+    attributes[ATTR_DB_OPERATION_NAME] = operationName;
+    if (commands.length === 1) {
+      const { commandName, commandArgs } = commands[0];
+      const dbStatementSerializer =
+        this.getConfig().dbStatementSerializer || defaultDbStatementSerializer;
+      try {
+        const dbStatement = dbStatementSerializer(commandName, commandArgs);
+        if (dbStatement != null) {
+          attributes[ATTR_DB_QUERY_TEXT] = dbStatement;
+        }
+      } catch (error) {
+        this._diag.error('dbStatementSerializer throw an exception', error, {
+          commandName,
+        });
+      }
+    } else {
+      attributes[ATTR_DB_OPERATION_BATCH_SIZE] = commands.length;
+    }
+
+    const span = this.tracer.startSpan(
+      `${RedisInstrumentationV4_V5.COMPONENT}-${operationName}`,
+      {
+        kind: SpanKind.CLIENT,
+        attributes,
+      }
+    );
+
+    let execRes;
+    try {
+      execRes = context.with(trace.setSpan(context.active(), span), () =>
+        origFunction.apply(origThis, origArguments)
+      );
+    } catch (error) {
+      this._endMultiCommandSpan(span, commands, [], error as Error);
+      throw error;
+    }
+
+    if (typeof execRes?.then !== 'function') {
+      this._diag.error(
+        'non-promise result when patching aggregate exec/execAsPipeline'
+      );
+      span.end();
+      return execRes;
+    }
+
+    return execRes.then(
+      (replies: unknown[]) => {
+        this._endMultiCommandSpan(span, commands, replies);
+        return replies;
+      },
+      (error: Error) => {
+        const replies =
+          error.constructor.name === 'MultiErrorReply'
+            ? (error as MultiErrorReply).replies
+            : [];
+        this._endMultiCommandSpan(span, commands, replies, error);
+        return Promise.reject(error);
+      }
+    );
+  }
+
+  private _getMultiOperationName(
+    commands: MultiCommand[],
+    isPipeline: boolean
+  ): string {
+    const batchName = isPipeline ? 'PIPELINE' : 'MULTI';
+    if (commands.length === 0) {
+      return batchName;
+    }
+
+    const firstCommand = commands[0].commandName;
+    return commands.every(({ commandName }) => commandName === firstCommand)
+      ? `${batchName} ${firstCommand}`
+      : batchName;
+  }
+
+  private _endMultiCommandSpan(
+    span: Span,
+    commands: MultiCommand[],
+    replies: unknown[],
+    error?: Error
+  ) {
+    const { responseHook } = this.getConfig();
+    for (let index = 0; index < commands.length; index++) {
+      const reply = replies[index];
+      if (reply instanceof Error) {
+        span.recordException(reply);
+        continue;
+      }
+      if (!responseHook || index >= replies.length) {
+        continue;
+      }
+
+      try {
+        const { commandName, commandArgs } = commands[index];
+        responseHook(span, commandName, commandArgs, reply);
+      } catch (hookError) {
+        this._diag.error('responseHook throw an exception', hookError);
+      }
+    }
+
+    const replyError = replies.find(reply => reply instanceof Error) as
+      | Error
+      | undefined;
+    const spanError = error || replyError;
+    if (spanError) {
+      if (!replyError) {
+        span.recordException(spanError);
+      }
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: spanError.message,
+      });
+    }
+    span.end();
   }
 
   private _endSpansWithRedisReplies(

--- a/packages/instrumentation-redis/src/v4-v5/instrumentation.ts
+++ b/packages/instrumentation-redis/src/v4-v5/instrumentation.ts
@@ -156,6 +156,9 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
         if (isWrapped(redisClientMultiCommandPrototype?.exec)) {
           this._unwrap(redisClientMultiCommandPrototype, 'exec');
         }
+        if (isWrapped(redisClientMultiCommandPrototype?.execAsPipeline)) {
+          this._unwrap(redisClientMultiCommandPrototype, 'execAsPipeline');
+        }
         if (isWrapped(redisClientMultiCommandPrototype?.addCommand)) {
           this._unwrap(redisClientMultiCommandPrototype, 'addCommand');
         }
@@ -270,6 +273,15 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
           this._getPatchMultiCommandsExec(false)
         );
 
+        if (isWrapped(redisClusterMultiCommandPrototype?.execAsPipeline)) {
+          this._unwrap(redisClusterMultiCommandPrototype, 'execAsPipeline');
+        }
+        this._wrap(
+          redisClusterMultiCommandPrototype,
+          'execAsPipeline',
+          this._getPatchMultiCommandsExec(true)
+        );
+
         if (isWrapped(redisClusterMultiCommandPrototype?.addCommand)) {
           this._unwrap(redisClusterMultiCommandPrototype, 'addCommand');
         }
@@ -286,6 +298,9 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
           moduleExports?.default?.prototype;
         if (isWrapped(redisClusterMultiCommandPrototype?.exec)) {
           this._unwrap(redisClusterMultiCommandPrototype, 'exec');
+        }
+        if (isWrapped(redisClusterMultiCommandPrototype?.execAsPipeline)) {
+          this._unwrap(redisClusterMultiCommandPrototype, 'execAsPipeline');
         }
         if (isWrapped(redisClusterMultiCommandPrototype?.addCommand)) {
           this._unwrap(redisClusterMultiCommandPrototype, 'addCommand');
@@ -581,6 +596,7 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
   ) {
     const hasNoParentSpan = trace.getSpan(context.active()) === undefined;
     if (hasNoParentSpan && this.getConfig().requireParentSpan) {
+      delete origThis[MULTI_COMMANDS];
       return origFunction.apply(origThis, origArguments);
     }
 
@@ -620,7 +636,14 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
         origFunction.apply(origThis, origArguments)
       );
     } catch (error) {
-      this._endMultiCommandSpan(span, commands, [], error as Error);
+      delete origThis[MULTI_COMMANDS];
+      this._endMultiCommandSpan(
+        span,
+        commands,
+        [],
+        operationName,
+        error as Error
+      );
       throw error;
     }
 
@@ -628,13 +651,15 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
       this._diag.error(
         'non-promise result when patching aggregate exec/execAsPipeline'
       );
+      delete origThis[MULTI_COMMANDS];
       span.end();
       return execRes;
     }
 
     return execRes.then(
       (replies: unknown[]) => {
-        this._endMultiCommandSpan(span, commands, replies);
+        delete origThis[MULTI_COMMANDS];
+        this._endMultiCommandSpan(span, commands, replies, operationName);
         return replies;
       },
       (error: Error) => {
@@ -642,7 +667,14 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
           error.constructor.name === 'MultiErrorReply'
             ? (error as MultiErrorReply).replies
             : [];
-        this._endMultiCommandSpan(span, commands, replies, error);
+        delete origThis[MULTI_COMMANDS];
+        this._endMultiCommandSpan(
+          span,
+          commands,
+          replies,
+          operationName,
+          error
+        );
         return Promise.reject(error);
       }
     );
@@ -658,6 +690,9 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
     }
 
     const firstCommand = commands[0].commandName;
+    if (commands.length === 1) {
+      return firstCommand;
+    }
     return commands.every(({ commandName }) => commandName === firstCommand)
       ? `${batchName} ${firstCommand}`
       : batchName;
@@ -667,30 +702,15 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
     span: Span,
     commands: MultiCommand[],
     replies: unknown[],
+    operationName: string,
     error?: Error
   ) {
     const { responseHook } = this.getConfig();
-    for (let index = 0; index < commands.length; index++) {
-      const reply = replies[index];
-      if (reply instanceof Error) {
-        span.recordException(reply);
-        continue;
-      }
-      if (!responseHook || index >= replies.length) {
-        continue;
-      }
-
-      try {
-        const { commandName, commandArgs } = commands[index];
-        responseHook(span, commandName, commandArgs, reply);
-      } catch (hookError) {
-        this._diag.error('responseHook throw an exception', hookError);
-      }
-    }
-
-    const replyError = replies.find(reply => reply instanceof Error) as
-      | Error
-      | undefined;
+    const replyErrors = replies.filter(
+      (reply): reply is Error => reply instanceof Error
+    );
+    replyErrors.forEach(replyError => span.recordException(replyError));
+    const replyError = replyErrors[0];
     const spanError = error || replyError;
     if (spanError) {
       if (!replyError) {
@@ -700,6 +720,19 @@ export class RedisInstrumentationV4_V5 extends InstrumentationBase<RedisInstrume
         code: SpanStatusCode.ERROR,
         message: spanError.message,
       });
+    }
+
+    if (!spanError && responseHook) {
+      try {
+        if (commands.length === 1) {
+          const { commandName, commandArgs } = commands[0];
+          responseHook(span, commandName, commandArgs, replies[0]);
+        } else {
+          responseHook(span, operationName, [], replies);
+        }
+      } catch (hookError) {
+        this._diag.error('responseHook throw an exception', hookError);
+      }
     }
     span.end();
   }

--- a/packages/instrumentation-redis/test/v4-v5/redis.cluster.mock.test.ts
+++ b/packages/instrumentation-redis/test/v4-v5/redis.cluster.mock.test.ts
@@ -153,6 +153,28 @@ describe('redis v4-v5 cluster mock (no live Redis required)', () => {
           assert.strictEqual(s.attributes[ATTR_DB_OPERATION_NAME], 'MULTI SET');
         });
     });
+
+    it('should instrument commands run as a cluster pipeline', async () => {
+      const multi = makeMultiCommand([5, 3]);
+
+      multi.addCommand('key1', true, ['ZCARD', 'key1'], undefined);
+      multi.addCommand(
+        'key2',
+        false,
+        ['ZREMRANGEBYSCORE', 'key2', '-inf', '+inf'],
+        undefined
+      );
+
+      try {
+        await multi.execAsPipeline();
+      } catch {}
+
+      const spans = getTestSpans();
+      assert.strictEqual(spans.length, 2);
+      spans.forEach((span: any) =>
+        assert.strictEqual(span.attributes[ATTR_DB_OPERATION_NAME], 'PIPELINE')
+      );
+    });
   });
 
   describe('cluster exec — error paths', () => {

--- a/packages/instrumentation-redis/test/v4-v5/redis.test.ts
+++ b/packages/instrumentation-redis/test/v4-v5/redis.test.ts
@@ -29,6 +29,7 @@ import {
 } from '@opentelemetry/api';
 import {
   ATTR_DB_SYSTEM_NAME,
+  ATTR_DB_OPERATION_BATCH_SIZE,
   ATTR_DB_OPERATION_NAME,
   ATTR_DB_QUERY_TEXT,
   ATTR_SERVER_ADDRESS,
@@ -550,6 +551,126 @@ describe('redis v4-v5', () => {
         multiGetSpan.attributes['test.db.response'],
         'another-value'
       );
+    });
+  });
+
+  describe('aggregate multi command spans', () => {
+    beforeEach(() => {
+      instrumentation.setConfig({ aggregateMultiCommandSpans: true });
+    });
+
+    afterEach(() => {
+      instrumentation.setConfig({});
+    });
+
+    it('emits one span for a transaction containing the same command', async () => {
+      const replies = await client
+        .multi()
+        .set('key-1', 'value-1')
+        .set('key-2', 'value-2')
+        .exec();
+
+      assert.deepStrictEqual(replies, ['OK', 'OK']);
+      const [span] = getTestSpans();
+      assert.strictEqual(getTestSpans().length, 1);
+      assert.strictEqual(span.name, 'redis-MULTI SET');
+      assert.strictEqual(span.kind, SpanKind.CLIENT);
+      assert.strictEqual(span.attributes[ATTR_DB_OPERATION_NAME], 'MULTI SET');
+      assert.strictEqual(span.attributes[ATTR_DB_OPERATION_BATCH_SIZE], 2);
+      assert.strictEqual(span.attributes[ATTR_DB_SYSTEM_NAME], 'redis');
+      assert.strictEqual(span.attributes[ATTR_DB_QUERY_TEXT], undefined);
+    });
+
+    it('uses a generic operation name for a transaction containing mixed commands', async () => {
+      await context.with(suppressTracing(context.active()), () =>
+        client.set('another-key', 'another-value')
+      );
+      const replies = await client
+        .multi()
+        .set('key', 'value')
+        .get('another-key')
+        .exec();
+
+      assert.deepStrictEqual(replies, ['OK', 'another-value']);
+      const [span] = getTestSpans();
+      assert.strictEqual(getTestSpans().length, 1);
+      assert.strictEqual(span.name, 'redis-MULTI');
+      assert.strictEqual(span.attributes[ATTR_DB_OPERATION_NAME], 'MULTI');
+      assert.strictEqual(span.attributes[ATTR_DB_OPERATION_BATCH_SIZE], 2);
+    });
+
+    it('does not mark a single-command transaction as a batch', async () => {
+      await client.multi().set('key', 'value').exec();
+
+      const [span] = getTestSpans();
+      assert.strictEqual(getTestSpans().length, 1);
+      assert.strictEqual(span.name, 'redis-MULTI SET');
+      assert.strictEqual(
+        span.attributes[ATTR_DB_OPERATION_BATCH_SIZE],
+        undefined
+      );
+      assert.strictEqual(
+        span.attributes[ATTR_DB_QUERY_TEXT],
+        'SET key [1 other arguments]'
+      );
+    });
+
+    it('emits one span for a pipeline', async () => {
+      const replies = await client
+        .multi()
+        .set('key-1', 'value-1')
+        .set('key-2', 'value-2')
+        .execAsPipeline();
+
+      assert.deepStrictEqual(replies, ['OK', 'OK']);
+      const [span] = getTestSpans();
+      assert.strictEqual(getTestSpans().length, 1);
+      assert.strictEqual(span.name, 'redis-PIPELINE SET');
+      assert.strictEqual(
+        span.attributes[ATTR_DB_OPERATION_NAME],
+        'PIPELINE SET'
+      );
+      assert.strictEqual(span.attributes[ATTR_DB_OPERATION_BATCH_SIZE], 2);
+    });
+
+    it('records transaction command errors on the aggregate span', async () => {
+      await context.with(suppressTracing(context.active()), () =>
+        client.set('key', 'value')
+      );
+
+      let replies;
+      try {
+        replies = await client
+          .multi()
+          .set('other-key', 'value')
+          .incr('key')
+          .exec();
+      } catch (error) {
+        replies = (error as MultiErrorReply).replies;
+      }
+      assert.ok(replies[1] instanceof Error);
+
+      const [span] = getTestSpans();
+      assert.strictEqual(getTestSpans().length, 1);
+      assert.strictEqual(span.name, 'redis-MULTI');
+      assert.strictEqual(span.status.code, SpanStatusCode.ERROR);
+      assert.strictEqual(
+        span.events.filter(event => event.name === 'exception').length,
+        1
+      );
+    });
+
+    it('invokes the response hook for each reply using the aggregate span', async () => {
+      const commands: string[] = [];
+      instrumentation.setConfig({
+        aggregateMultiCommandSpans: true,
+        responseHook: (_span, commandName) => commands.push(commandName),
+      });
+
+      await client.multi().set('key', 'value').get('key').exec();
+
+      assert.deepStrictEqual(commands, ['SET', 'GET']);
+      assert.strictEqual(getTestSpans().length, 1);
     });
   });
 

--- a/packages/instrumentation-redis/test/v4-v5/redis.test.ts
+++ b/packages/instrumentation-redis/test/v4-v5/redis.test.ts
@@ -604,7 +604,8 @@ describe('redis v4-v5', () => {
 
       const [span] = getTestSpans();
       assert.strictEqual(getTestSpans().length, 1);
-      assert.strictEqual(span.name, 'redis-MULTI SET');
+      assert.strictEqual(span.name, 'redis-SET');
+      assert.strictEqual(span.attributes[ATTR_DB_OPERATION_NAME], 'SET');
       assert.strictEqual(
         span.attributes[ATTR_DB_OPERATION_BATCH_SIZE],
         undefined
@@ -613,6 +614,16 @@ describe('redis v4-v5', () => {
         span.attributes[ATTR_DB_QUERY_TEXT],
         'SET key [1 other arguments]'
       );
+    });
+
+    it('marks an empty transaction as a zero-size batch', async () => {
+      await client.multi().exec();
+
+      const [span] = getTestSpans();
+      assert.strictEqual(getTestSpans().length, 1);
+      assert.strictEqual(span.name, 'redis-MULTI');
+      assert.strictEqual(span.attributes[ATTR_DB_OPERATION_NAME], 'MULTI');
+      assert.strictEqual(span.attributes[ATTR_DB_OPERATION_BATCH_SIZE], 0);
     });
 
     it('emits one span for a pipeline', async () => {
@@ -660,16 +671,27 @@ describe('redis v4-v5', () => {
       );
     });
 
-    it('invokes the response hook for each reply using the aggregate span', async () => {
-      const commands: string[] = [];
+    it('invokes the response hook once for the aggregate operation', async () => {
+      const calls: Array<{
+        commandName: string;
+        commandArgs: Array<string | Buffer>;
+        response: unknown;
+      }> = [];
       instrumentation.setConfig({
         aggregateMultiCommandSpans: true,
-        responseHook: (_span, commandName) => commands.push(commandName),
+        responseHook: (_span, commandName, commandArgs, response) =>
+          calls.push({ commandName, commandArgs, response }),
       });
 
       await client.multi().set('key', 'value').get('key').exec();
 
-      assert.deepStrictEqual(commands, ['SET', 'GET']);
+      assert.deepStrictEqual(calls, [
+        {
+          commandName: 'MULTI',
+          commandArgs: [],
+          response: ['OK', 'value'],
+        },
+      ]);
       assert.strictEqual(getTestSpans().length, 1);
     });
   });


### PR DESCRIPTION
## Which problem is this PR solving?

`redis.multi().exec()` and `execAsPipeline()` currently emit one span per queued command. A large batch therefore creates thousands of Redis spans for one logical database operation, amplifying SDK and collector memory usage.

The database semantic conventions model a batch as one client span with [`db.operation.batch.size`](https://opentelemetry.io/docs/specs/semconv/db/database-spans/#batch-operations).

## Short description of the changes

- adds the opt-in `aggregateMultiCommandSpans` instrumentation option; the existing per-command behavior remains the default
- emits one client span when `exec()` or `execAsPipeline()` performs the batch
- sets `db.operation.batch.size` for multi-command and empty batches, while omitting it for one command
- names homogeneous batches `MULTI <command>` / `PIPELINE <command>` and mixed batches `MULTI` / `PIPELINE`
- models a single queued command as that command without `db.operation.batch.size`
- records command errors on the aggregate span and invokes `responseHook` once per aggregate operation
- clears retained command metadata after execution to avoid retaining it on reused objects
- patches and unpatches cluster `execAsPipeline()` consistently with the regular client
- omits `db.query.text` for multi-command batches to avoid replacing span amplification with a very large concatenated attribute

The implementation uses the instrumentation's existing node-redis patches, so the option works across supported node-redis v4-v6 clients without depending on v6-only diagnostics channels.

## Testing

- package TypeScript compile
- package test suite: 44 passing, 4 pending live-cluster integration tests
- `test-all-versions`: passing for the supported `redis` version matrix (`>=2.6.0 <7`)
- ESLint, Prettier, Markdownlint, and README link checks
