### PR TITLE
feat(auto-configuration-propagators)!: remove jaeger propagator support

### DIFF
--- a/packages/auto-configuration-propagators/README.md
+++ b/packages/auto-configuration-propagators/README.md
@@ -33,7 +33,6 @@ The specification defines a list of [known propagators][env-var-url] for the `OT
 - "baggage": [W3C Baggage](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-core)
 - "b3": [B3 Single](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-b3)
 - "b3multi": [B3 Multi](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-b3)
-- "jaeger": [Jaeger](https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-propagator-jaeger)
 - "xray": [AWS X-Ray (third party)](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/propagator-aws-xray)
 - "xray-lambda": [AWS X-Ray Lambda (third party)](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/propagator-aws-xray-lambda)
 - "ottrace": [OT Trace (third party)](https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/propagator-ot-trace)

--- a/packages/auto-configuration-propagators/package.json
+++ b/packages/auto-configuration-propagators/package.json
@@ -41,7 +41,6 @@
     "@opentelemetry/propagator-aws-xray": "^2.2.0",
     "@opentelemetry/propagator-aws-xray-lambda": "^0.56.0",
     "@opentelemetry/propagator-b3": "^2.0.0",
-    "@opentelemetry/propagator-jaeger": "^2.0.0",
     "@opentelemetry/propagator-ot-trace": "^0.29.0"
   },
   "files": [

--- a/packages/auto-configuration-propagators/src/utils.ts
+++ b/packages/auto-configuration-propagators/src/utils.ts
@@ -10,7 +10,6 @@ import {
   W3CTraceContextPropagator,
 } from '@opentelemetry/core';
 import { B3InjectEncoding, B3Propagator } from '@opentelemetry/propagator-b3';
-import { JaegerPropagator } from '@opentelemetry/propagator-jaeger';
 import { OTTracePropagator } from '@opentelemetry/propagator-ot-trace';
 import { AWSXRayPropagator } from '@opentelemetry/propagator-aws-xray';
 import { AWSXRayLambdaPropagator } from '@opentelemetry/propagator-aws-xray-lambda';
@@ -28,7 +27,6 @@ const propagatorMap = new Map<string, PropagatorFactoryFunction>([
     'b3multi',
     () => new B3Propagator({ injectEncoding: B3InjectEncoding.MULTI_HEADER }),
   ],
-  ['jaeger', () => new JaegerPropagator()],
   ['xray', () => new AWSXRayPropagator()],
   ['xray-lambda', () => new AWSXRayLambdaPropagator()],
   ['ottrace', () => new OTTracePropagator()],

--- a/packages/auto-configuration-propagators/test/utils.test.ts
+++ b/packages/auto-configuration-propagators/test/utils.test.ts
@@ -47,8 +47,8 @@ describe('utils', () => {
     });
 
     it('should return the selected propagators when multiple are in the list', () => {
-      process.env.OTEL_PROPAGATORS = 'b3,jaeger';
-      assert.deepStrictEqual(getPropagator().fields(), ['b3', 'uber-trace-id']);
+      process.env.OTEL_PROPAGATORS = 'b3,ottrace';
+      assert.deepStrictEqual(getPropagator().fields(), ['b3', 'ot-tracer-span-id', 'ot-tracer-trace-id', 'ot-tracer-sampled']);
     });
 
     it('should return no-op propagator if all propagators are unknown', () => {

--- a/packages/auto-configuration-propagators/test/utils.test.ts
+++ b/packages/auto-configuration-propagators/test/utils.test.ts
@@ -48,7 +48,12 @@ describe('utils', () => {
 
     it('should return the selected propagators when multiple are in the list', () => {
       process.env.OTEL_PROPAGATORS = 'b3,ottrace';
-      assert.deepStrictEqual(getPropagator().fields(), ['b3', 'ot-tracer-traceid', 'ot-tracer-spanid', 'ot-tracer-sampled']);
+      assert.deepStrictEqual(getPropagator().fields(), [
+        'b3',
+        'ot-tracer-traceid',
+        'ot-tracer-spanid',
+        'ot-tracer-sampled',
+      ]);
     });
 
     it('should return no-op propagator if all propagators are unknown', () => {

--- a/packages/auto-configuration-propagators/test/utils.test.ts
+++ b/packages/auto-configuration-propagators/test/utils.test.ts
@@ -48,7 +48,7 @@ describe('utils', () => {
 
     it('should return the selected propagators when multiple are in the list', () => {
       process.env.OTEL_PROPAGATORS = 'b3,ottrace';
-      assert.deepStrictEqual(getPropagator().fields(), ['b3', 'ot-tracer-span-id', 'ot-tracer-trace-id', 'ot-tracer-sampled']);
+      assert.deepStrictEqual(getPropagator().fields(), ['b3', 'ot-tracer-traceid', 'ot-tracer-spanid', 'ot-tracer-sampled']);
     });
 
     it('should return no-op propagator if all propagators are unknown', () => {


### PR DESCRIPTION
## Which problem is this PR solving?

* The `@opentelemetry/propagator-jaeger` package will be removed from OpenTelemetry JS SDK v3 because the Jaeger propagator is deprecated in favor of `W3CTraceContextPropagator`.
* This PR removes the Jaeger propagator references from this repo.

reference: https://github.com/open-telemetry/opentelemetry-js/pull/7077
