### PR TITLE
feat: add @opentelemetry/instrumentation-ibmmq

### DIFF
--- a/.github/component-label-map.yml
+++ b/.github/component-label-map.yml
@@ -106,6 +106,11 @@ pkg:instrumentation-host-metrics:
   - changed-files:
       - any-glob-to-any-file:
           - packages/instrumentation-host-metrics/**
+pkg:instrumentation-ibmmq:
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/instrumentation-ibmmq/**
+          - packages/contrib-test-utils/**
 pkg:instrumentation-ioredis:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/component_owners.yml
+++ b/.github/component_owners.yml
@@ -59,6 +59,8 @@ components:
     - henrinormak
   packages/instrumentation-fs: []
     # Unmaintained
+  packages/instrumentation-ibmmq:
+    - Aryan16138
   packages/instrumentation-kafkajs:
     - seemk
   packages/instrumentation-lru-memoizer:

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -22,6 +22,7 @@
   "packages/instrumentation-cucumber": "0.37.0",
   "packages/instrumentation-dataloader": "0.38.0",
   "packages/instrumentation-fs": "0.40.0",
+  "packages/instrumentation-ibmmq": "0.1.0",
   "packages/instrumentation-kafkajs": "0.30.0",
   "packages/instrumentation-lru-memoizer": "0.65.0",
   "packages/instrumentation-mongoose": "0.67.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8512,6 +8512,10 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/instrumentation-ibmmq": {
+      "resolved": "packages/instrumentation-ibmmq",
+      "link": true
+    },
     "node_modules/@opentelemetry/instrumentation-ioredis": {
       "resolved": "packages/instrumentation-ioredis",
       "link": true
@@ -36501,6 +36505,7 @@
         "@opentelemetry/instrumentation-hapi": "^0.67.0",
         "@opentelemetry/instrumentation-host-metrics": "^0.4.0",
         "@opentelemetry/instrumentation-http": "^0.221.0",
+        "@opentelemetry/instrumentation-ibmmq": "^0.1.0",
         "@opentelemetry/instrumentation-ioredis": "^0.69.0",
         "@opentelemetry/instrumentation-kafkajs": "^0.30.0",
         "@opentelemetry/instrumentation-knex": "^0.65.0",
@@ -37072,6 +37077,25 @@
       "devDependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/sdk-metrics": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "packages/instrumentation-ibmmq": {
+      "name": "@opentelemetry/instrumentation-ibmmq",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.221.0"
+      },
+      "devDependencies": {
+        "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/contrib-test-utils": "^0.68.0",
+        "@opentelemetry/sdk-trace-base": "^2.0.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"

--- a/packages/auto-instrumentations-node/package.json
+++ b/packages/auto-instrumentations-node/package.json
@@ -61,6 +61,7 @@
     "@opentelemetry/instrumentation-hapi": "^0.67.0",
     "@opentelemetry/instrumentation-host-metrics": "^0.4.0",
     "@opentelemetry/instrumentation-http": "^0.221.0",
+    "@opentelemetry/instrumentation-ibmmq": "^0.1.0",
     "@opentelemetry/instrumentation-ioredis": "^0.69.0",
     "@opentelemetry/instrumentation-kafkajs": "^0.30.0",
     "@opentelemetry/instrumentation-knex": "^0.65.0",

--- a/packages/auto-instrumentations-node/src/utils.ts
+++ b/packages/auto-instrumentations-node/src/utils.ts
@@ -23,6 +23,7 @@ import { GrpcInstrumentation } from '@opentelemetry/instrumentation-grpc';
 import { HapiInstrumentation } from '@opentelemetry/instrumentation-hapi';
 import { HostMetricsInstrumentation } from '@opentelemetry/instrumentation-host-metrics';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
+import { IbmMqInstrumentation } from '@opentelemetry/instrumentation-ibmmq';
 import { IORedisInstrumentation } from '@opentelemetry/instrumentation-ioredis';
 import { KafkaJsInstrumentation } from '@opentelemetry/instrumentation-kafkajs';
 import { KnexInstrumentation } from '@opentelemetry/instrumentation-knex';
@@ -102,6 +103,7 @@ const InstrumentationMap = {
   '@opentelemetry/instrumentation-hapi': HapiInstrumentation,
   '@opentelemetry/instrumentation-host-metrics': HostMetricsInstrumentation,
   '@opentelemetry/instrumentation-http': HttpInstrumentation,
+  '@opentelemetry/instrumentation-ibmmq': IbmMqInstrumentation,
   '@opentelemetry/instrumentation-ioredis': IORedisInstrumentation,
   '@opentelemetry/instrumentation-kafkajs': KafkaJsInstrumentation,
   '@opentelemetry/instrumentation-knex': KnexInstrumentation,

--- a/packages/instrumentation-ibmmq/.tav.yml
+++ b/packages/instrumentation-ibmmq/.tav.yml
@@ -1,0 +1,6 @@
+ibmmq:
+  versions:
+    include: ">=2.0.0 <3"
+    mode: latest-minors
+  commands:
+    - npm test

--- a/packages/instrumentation-ibmmq/CHANGELOG.md
+++ b/packages/instrumentation-ibmmq/CHANGELOG.md
@@ -1,0 +1,8 @@
+<!-- markdownlint-disable MD007 MD034 -->
+# Changelog
+
+## Unreleased
+
+### Features
+
+* Initial IBM MQ instrumentation support for the `ibmmq` client library

--- a/packages/instrumentation-ibmmq/LICENSE
+++ b/packages/instrumentation-ibmmq/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/instrumentation-ibmmq/README.md
+++ b/packages/instrumentation-ibmmq/README.md
@@ -1,0 +1,102 @@
+# OpenTelemetry ibmmq Instrumentation for Node.js
+
+[![NPM Published Version][npm-img]][npm-url]
+[![Apache License][license-image]][license-image]
+
+This module provides automatic instrumentation for the [`ibmmq`](https://www.npmjs.com/package/ibmmq) module, the official Node.js client for IBM MQ.
+
+If total installation size is not constrained, it is recommended to use the [`@opentelemetry/auto-instrumentations-node`](https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-node) bundle with [@opentelemetry/sdk-node](https://www.npmjs.com/package/@opentelemetry/sdk-node) for the most seamless instrumentation experience.
+
+Compatible with OpenTelemetry JS API and SDK `1.0+`.
+
+## Installation
+
+```bash
+npm install --save @opentelemetry/instrumentation-ibmmq
+```
+
+### Supported Versions
+
+- [`ibmmq`](https://www.npmjs.com/package/ibmmq) versions `>=2.0.0 <3`
+
+## Usage
+
+OpenTelemetry ibmmq Instrumentation allows the user to automatically collect trace data and export them to the backend of choice, to give observability to distributed systems when working with [`ibmmq`](https://github.com/ibm-messaging/mq-mqi-nodejs).
+
+To enable a specific instrumentation, pass it to `registerInstrumentations()`.
+This is commonly done via `NodeSDK` for fully setting up all OpenTelemetry SDK components:
+
+```js
+const { NodeSDK } = require('@opentelemetry/sdk-node');
+const { IbmMqInstrumentation } = require('@opentelemetry/instrumentation-ibmmq');
+
+const sdk = new NodeSDK({
+  instrumentations: [
+    new IbmMqInstrumentation({
+      // emitQueueManagerId: true,
+    }),
+  ],
+});
+sdk.start();
+process.once('beforeExit', async () => { await sdk.shutdown(); });
+```
+
+This instrumentation supports zero-code setup via `--require @opentelemetry/auto-instrumentations-node/register` (or `--import` for ESM). That entry point has no per-instrumentation configuration hook, so `emitQueueManagerId` also falls back to an environment variable - see [Queue Manager Identifier (QMID)](#queue-manager-identifier-qmid) below.
+
+### ibmmq Instrumentation Options
+
+| Option                | Type      | Default                                                              | Description                                                              |
+| ---------------------- | --------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `emitQueueManagerId`  | `boolean` | `process.env.OTEL_INSTRUMENTATION_IBMMQ_EMIT_QUEUE_MANAGER_ID === 'true'` | Stamp the IBM MQ Queue Manager Identifier (QMID) onto every span. See below. |
+
+### Propagation
+
+Trace context propagation across a queue is handled entirely by the `ibmmq` package's own `lib/mqiotel.js`, which injects `traceparent`/`tracestate` message properties on publish and adds a link to the active span when a message carrying them is consumed. This instrumentation writes no propagation code of its own and exposes no option to configure it.
+
+Parent-child linkage (rather than a link) between a producer's send span and a consumer's process span is a possible future option, but it would require disabling `ibmmq`'s built-in propagation (`MQIJS_NOOTEL=1`) and implementing our own `propagation.extract`/inject in its place.
+
+## Semantic Conventions
+
+This package uses `messaging.system`, `messaging.destination.name`, `messaging.operation.name`, and `messaging.operation.type` from the [OpenTelemetry Semantic Conventions](https://github.com/open-telemetry/semantic-conventions), plus the not-yet-ratified `messaging.ibmmq.queue_manager.id` described below.
+
+### Spans Emitted
+
+This instrumentation creates spans for the following `ibmmq` operations:
+
+| Operation                          | Span name                | Span kind  |
+| ----------------------------------- | ------------------------- | ---------- |
+| `Put` / `PutSync` / `Put1` / `Put1Sync` | `send <queue>`            | `PRODUCER` |
+| `GetSync`                          | `receive <queue>`         | `CLIENT`   |
+| `Get` (per delivered message)      | `process <queue>`         | `CONSUMER` |
+
+`Conn` / `Connx` / `ConnSync` / `ConnxSync` do not produce a span; they only record connection metadata used by the QMID lookup below.
+
+### Queue Manager Identifier (QMID)
+
+IBM MQ's `MQCA_Q_MGR_IDENTIFIER` is a globally unique identifier for a queue manager, unlike its name, which can collide across hosts. When `emitQueueManagerId` is enabled, this instrumentation reads it once per connection (never per message) and stamps it as `messaging.ibmmq.queue_manager.id` on every send/receive/process span for that connection.
+
+This attribute is not yet part of `@opentelemetry/semantic-conventions` (it tracks an unratified proposal) and costs one extra network round trip per connection, so it is disabled by default. Enable it either through the constructor option above, or, when running with `--require @opentelemetry/auto-instrumentations-node/register`, through:
+
+```bash
+OTEL_INSTRUMENTATION_IBMMQ_EMIT_QUEUE_MANAGER_ID=true
+```
+
+## Testing
+
+This package has no `.tav.yml` and no integration test against the real `ibmmq` package. `ibmmq` is a native N-API addon whose `postinstall` downloads the IBM MQ redistributable C client from `public.dhe.ibm.com`, which is not acceptable as a transitive `npm install` side effect of this monorepo. Instead, `test/ibmmq.test.ts` drives a small hand-built stand-in for the module's exports directly - it never `require`s the real `ibmmq`. Please do not "fix" this by adding `ibmmq` back as a dependency; the fake-module approach is deliberate.
+
+## Useful links
+
+- For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
+- For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>
+- For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
+
+## License
+
+Apache 2.0 - See [LICENSE][license-url] for more information.
+
+[discussions-url]: https://github.com/open-telemetry/opentelemetry-js/discussions
+[license-url]: https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/LICENSE
+[license-image]: https://img.shields.io/badge/license-Apache_2.0-green.svg?style=flat
+[npm-url]: https://www.npmjs.com/package/@opentelemetry/instrumentation-ibmmq
+[npm-img]: https://badge.fury.io/js/%40opentelemetry%2Finstrumentation-ibmmq.svg

--- a/packages/instrumentation-ibmmq/package.json
+++ b/packages/instrumentation-ibmmq/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@opentelemetry/instrumentation-ibmmq",
+  "version": "0.1.0",
+  "description": "OpenTelemetry instrumentation for the `ibmmq` IBM MQ client for Node.js",
+  "keywords": [
+    "ibmmq",
+    "ibm mq",
+    "mqi",
+    "instrumentation",
+    "nodejs",
+    "opentelemetry",
+    "tracing",
+    "messaging"
+  ],
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-ibmmq#readme",
+  "license": "Apache-2.0",
+  "author": "OpenTelemetry Authors",
+  "bugs": {
+    "url": "https://github.com/open-telemetry/opentelemetry-js-contrib/issues"
+  },
+  "main": "build/src/index.js",
+  "types": "build/src/index.d.ts",
+  "files": [
+    "build/src/**/*.js",
+    "build/src/**/*.js.map",
+    "build/src/**/*.d.ts"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-telemetry/opentelemetry-js-contrib.git",
+    "directory": "packages/instrumentation-ibmmq"
+  },
+  "scripts": {
+    "clean": "rimraf build/*",
+    "compile": "tsc -p .",
+    "compile:with-dependencies": "nx run-many -t compile -p @opentelemetry/instrumentation-ibmmq",
+    "lint:readme": "node ../../scripts/lint-readme.js",
+    "prepublishOnly": "npm run compile",
+    "tdd": "npm run test -- --watch-extensions ts --watch",
+    "test": "nyc --no-clean mocha --require '@opentelemetry/contrib-test-utils' 'test/**/*.test.ts'",
+    "test-all-versions": "tav",
+    "version:update": "node ../../scripts/version-update.js",
+    "watch": "tsc -w"
+  },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.3.0"
+  },
+  "dependencies": {
+    "@opentelemetry/instrumentation": "^0.221.0"
+  },
+  "devDependencies": {
+    "@opentelemetry/api": "^1.3.0",
+    "@opentelemetry/contrib-test-utils": "^0.68.0",
+    "@opentelemetry/sdk-trace-base": "^2.0.0"
+  },
+  "engines": {
+    "node": "^18.19.0 || >=20.6.0"
+  }
+}

--- a/packages/instrumentation-ibmmq/src/ibmmq.ts
+++ b/packages/instrumentation-ibmmq/src/ibmmq.ts
@@ -1,0 +1,536 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Span, SpanKind, SpanStatusCode, context, trace } from '@opentelemetry/api';
+import {
+  InstrumentationBase,
+  InstrumentationNodeModuleDefinition,
+  isWrapped,
+} from '@opentelemetry/instrumentation';
+import {
+  IbmMqModuleExports,
+  MQObjectLike,
+  MQODLike,
+  MQQueueManagerLike,
+  MqCallback,
+} from './internal-types';
+import {
+  ATTR_MESSAGING_DESTINATION_NAME,
+  MESSAGING_OPERATION_TYPE_VALUE_PROCESS,
+  MESSAGING_OPERATION_TYPE_VALUE_RECEIVE,
+  MESSAGING_OPERATION_TYPE_VALUE_SEND,
+} from './semconv';
+import { DEFAULT_CONFIG, IbmMqInstrumentationConfig } from './types';
+import {
+  buildMessagingAttributes,
+  destinationFromOD,
+  destinationFromObject,
+  ensureQueueManagerId,
+  invalidateOnReconnect,
+  isRoutineNoMessage,
+  recordResolvedName,
+  resolveConnectionOnConnect,
+} from './utils';
+/** @knipignore */
+import { PACKAGE_NAME, PACKAGE_VERSION } from './version';
+
+const supportedVersions = ['>=2.0.0 <3'];
+
+export class IbmMqInstrumentation extends InstrumentationBase<IbmMqInstrumentationConfig> {
+  constructor(config: IbmMqInstrumentationConfig = {}) {
+    super(PACKAGE_NAME, PACKAGE_VERSION, { ...DEFAULT_CONFIG, ...config });
+  }
+
+  override setConfig(config: IbmMqInstrumentationConfig = {}) {
+    super.setConfig({ ...DEFAULT_CONFIG, ...config });
+  }
+
+  protected init() {
+    const module = new InstrumentationNodeModuleDefinition(
+      'ibmmq',
+      supportedVersions,
+      this.patch.bind(this),
+      this.unpatch.bind(this)
+    );
+    return module;
+  }
+
+  private patch(module: any) {
+    // `ibmmq` is CommonJS-only; under `--import`/ESM the loader hands us a
+    // namespace object instead of the raw exports.
+    const moduleExports: IbmMqModuleExports =
+      module[Symbol.toStringTag] === 'Module' ? module.default : module;
+    // `_wrap`'s generic signature demands the wrapper match the exact
+    // per-property type; our patch factories are written generically
+    // against `(...args: unknown[]) => unknown` instead (as amqplib and
+    // other free-function patches in this repo do), so wrap through an
+    // untyped view of the same object.
+    const anyExports: any = moduleExports;
+
+    if (!isWrapped(anyExports.Conn)) {
+      this._wrap(
+        anyExports,
+        'Conn',
+        this.getConnectPatch.bind(this, moduleExports)
+      );
+    }
+    if (!isWrapped(anyExports.Connx)) {
+      this._wrap(
+        anyExports,
+        'Connx',
+        this.getConnectPatch.bind(this, moduleExports)
+      );
+    }
+    if (!isWrapped(anyExports.ConnSync)) {
+      this._wrap(
+        anyExports,
+        'ConnSync',
+        this.getConnectPatch.bind(this, moduleExports)
+      );
+    }
+    if (!isWrapped(anyExports.ConnxSync)) {
+      this._wrap(
+        anyExports,
+        'ConnxSync',
+        this.getConnectPatch.bind(this, moduleExports)
+      );
+    }
+
+    if (!isWrapped(anyExports.Open)) {
+      this._wrap(anyExports, 'Open', this.getOpenPatch.bind(this));
+    }
+    if (!isWrapped(anyExports.OpenSync)) {
+      this._wrap(anyExports, 'OpenSync', this.getOpenPatch.bind(this));
+    }
+
+    if (!isWrapped(anyExports.Put)) {
+      this._wrap(
+        anyExports,
+        'Put',
+        this.getObjectOperationPatch.bind(this, moduleExports, 'send')
+      );
+    }
+    if (!isWrapped(anyExports.PutSync)) {
+      this._wrap(
+        anyExports,
+        'PutSync',
+        this.getObjectOperationPatch.bind(this, moduleExports, 'send')
+      );
+    }
+    if (!isWrapped(anyExports.GetSync)) {
+      this._wrap(
+        anyExports,
+        'GetSync',
+        this.getObjectOperationPatch.bind(this, moduleExports, 'receive')
+      );
+    }
+
+    if (!isWrapped(anyExports.Put1)) {
+      this._wrap(
+        anyExports,
+        'Put1',
+        this.getQueueManagerOperationPatch.bind(this, moduleExports)
+      );
+    }
+    if (!isWrapped(anyExports.Put1Sync)) {
+      this._wrap(
+        anyExports,
+        'Put1Sync',
+        this.getQueueManagerOperationPatch.bind(this, moduleExports)
+      );
+    }
+
+    if (!isWrapped(anyExports.Get)) {
+      this._wrap(
+        anyExports,
+        'Get',
+        this.getGetPatch.bind(this, moduleExports)
+      );
+    }
+    if (!isWrapped(anyExports.Ctl)) {
+      this._wrap(anyExports, 'Ctl', this.getCtlPatch.bind(this));
+    }
+
+    return module;
+  }
+
+  private unpatch(module: any) {
+    const anyExports: any =
+      module[Symbol.toStringTag] === 'Module' ? module.default : module;
+
+    for (const name of [
+      'Conn',
+      'Connx',
+      'ConnSync',
+      'ConnxSync',
+      'Open',
+      'OpenSync',
+      'Put',
+      'PutSync',
+      'GetSync',
+      'Put1',
+      'Put1Sync',
+      'Get',
+      'Ctl',
+    ] as const) {
+      if (isWrapped(anyExports[name])) {
+        this._unwrap(anyExports, name);
+      }
+    }
+  }
+
+  /**
+   * `Conn`/`Connx` (callback required) and `ConnSync`/`ConnxSync` (callback
+   * optional, else throw-or-return) all hand the app's freshly-authenticated
+   * `MQQueueManager` back on success. No span - this patch point only caches
+   * the queue manager name and, if enabled, kicks off the one QMID inquiry
+   * for this connection's lifetime.
+   */
+  private getConnectPatch(
+    moduleExports: IbmMqModuleExports,
+    original: (...args: unknown[]) => unknown
+  ) {
+    const self = this;
+    return function patchedConnect(this: unknown, ...args: unknown[]) {
+      const lastIndex = args.length - 1;
+      const maybeCb = args[lastIndex];
+
+      const onConnected = (hConn: MQQueueManagerLike | undefined) => {
+        const config = self.getConfig();
+        resolveConnectionOnConnect(
+          moduleExports,
+          hConn,
+          config.emitQueueManagerId
+        );
+      };
+
+      if (typeof maybeCb === 'function') {
+        const originalCb = maybeCb as MqCallback<MQQueueManagerLike>;
+        const boundCb = context.bind(
+          context.active(),
+          (err: unknown, hConn?: MQQueueManagerLike) => {
+            if (!err) onConnected(hConn);
+            return (originalCb as (...a: unknown[]) => unknown)(err, hConn);
+          }
+        );
+        const newArgs = args.slice(0, lastIndex);
+        newArgs.push(boundCb);
+        return original.apply(this, newArgs);
+      }
+
+      // Sync variant, no callback: throws on error, else returns hConn.
+      const hConn = original.apply(this, args) as MQQueueManagerLike | undefined;
+      onConnected(hConn);
+      return hConn;
+    };
+  }
+
+  /**
+   * `Open` (callback required) and `OpenSync` (callback optional, else
+   * throw-or-return) create no span - bookkeeping only. MQ mutates the
+   * caller's `MQOD` in place with the resolved queue (and queue manager)
+   * name, which can differ from the requested name for an alias, clustered,
+   * or dynamic reply queue. That resolution never changes for the lifetime
+   * of the returned `MQObject`, so it is captured once here, in a WeakMap
+   * keyed on that object, and consulted at Put/Get time by
+   * `destinationFromObject` instead of the requested `_name`.
+   */
+  private getOpenPatch(original: (...args: unknown[]) => unknown) {
+    return function patchedOpen(this: unknown, ...args: unknown[]) {
+      const jsod = args[1] as MQODLike;
+      const lastIndex = args.length - 1;
+      const maybeCb = args[lastIndex];
+
+      if (typeof maybeCb === 'function') {
+        const originalCb = maybeCb as MqCallback<MQObjectLike>;
+        const boundCb = context.bind(
+          context.active(),
+          (err: unknown, hObj?: MQObjectLike) => {
+            if (!err) recordResolvedName(hObj, jsod);
+            return (originalCb as (...a: unknown[]) => unknown)(err, hObj);
+          }
+        );
+        const newArgs = args.slice(0, lastIndex);
+        newArgs.push(boundCb);
+        return original.apply(this, newArgs);
+      }
+
+      // Sync variant, no callback: throws on error, else returns hObj.
+      const hObj = original.apply(this, args) as MQObjectLike | undefined;
+      recordResolvedName(hObj, jsod);
+      return hObj;
+    };
+  }
+
+  /**
+   * Shared by `Put`/`PutSync` (producer, `send`) and `GetSync` (one-shot
+   * consumer, `receive`). All three take an already-opened `MQObject` as
+   * their first argument, from which both the destination name and the
+   * owning connection are reachable.
+   */
+  private getObjectOperationPatch(
+    moduleExports: IbmMqModuleExports,
+    operationName: 'send' | 'receive',
+    original: (...args: unknown[]) => unknown
+  ) {
+    const self = this;
+    const operationType =
+      operationName === 'send'
+        ? MESSAGING_OPERATION_TYPE_VALUE_SEND
+        : MESSAGING_OPERATION_TYPE_VALUE_RECEIVE;
+    const spanKind =
+      operationName === 'send' ? SpanKind.PRODUCER : SpanKind.CLIENT;
+
+    return function patchedOperation(this: unknown, ...args: unknown[]) {
+      const jsObject = args[0] as MQObjectLike;
+      const hConn = jsObject?._mqQueueManager;
+      const config = self.getConfig();
+      const destination = destinationFromObject(jsObject);
+      const qmid = ensureQueueManagerId(
+        moduleExports,
+        hConn,
+        config.emitQueueManagerId
+      );
+
+      const span = self.tracer.startSpan(`${operationName} ${destination}`, {
+        kind: spanKind,
+        attributes: buildMessagingAttributes(
+          destination,
+          operationType,
+          operationName,
+          qmid
+        ),
+      });
+
+      return context.with(trace.setSpan(context.active(), span), () =>
+        self.callAndEndSpan(span, hConn, original, this, args)
+      );
+    };
+  }
+
+  /**
+   * `Put1`/`Put1Sync` (producer, `send`) take the queue manager and the
+   * `MQOD` that describes the destination directly, with no `MQObject`.
+   * Unlike `Open`, MQ only writes `ResolvedQName` onto the `MQOD` as a side
+   * effect of the Put1 call itself completing - reading it before `original`
+   * has run always sees the pre-call value, so the span is opened on the
+   * requested name and corrected to the resolved one once the call settles
+   * (callback fired, or synchronous return/throw), via `callAndEndSpan`'s
+   * `onSettled` hook.
+   */
+  private getQueueManagerOperationPatch(
+    moduleExports: IbmMqModuleExports,
+    original: (...args: unknown[]) => unknown
+  ) {
+    const self = this;
+    return function patchedPut1(this: unknown, ...args: unknown[]) {
+      const hConn = args[0] as MQQueueManagerLike;
+      const jsod = args[1] as MQODLike;
+      const config = self.getConfig();
+      const requested = jsod.ObjectName || '<<unknown>>';
+      const qmid = ensureQueueManagerId(
+        moduleExports,
+        hConn,
+        config.emitQueueManagerId
+      );
+
+      const span = self.tracer.startSpan(`send ${requested}`, {
+        kind: SpanKind.PRODUCER,
+        attributes: buildMessagingAttributes(
+          requested,
+          MESSAGING_OPERATION_TYPE_VALUE_SEND,
+          'send',
+          qmid
+        ),
+      });
+
+      const resolveDestination = () => {
+        const resolved = destinationFromOD(jsod);
+        if (resolved !== requested) {
+          span.updateName(`send ${resolved}`);
+          span.setAttribute(ATTR_MESSAGING_DESTINATION_NAME, resolved);
+        }
+      };
+
+      return context.with(trace.setSpan(context.active(), span), () =>
+        self.callAndEndSpan(span, hConn, original, this, args, resolveDestination)
+      );
+    };
+  }
+
+  /**
+   * `Get` registers a persistent listener rather than performing a one-shot
+   * get; delivery only starts once `Ctl(hConn, MQOP_START)` is called (see
+   * `getCtlPatch`), and the same callback is invoked once per arriving
+   * message - or per failed/timed-out get attempt - for as long as the
+   * listener stays registered. So, unlike every other patch point, one
+   * `Get()` call produces many spans, each ended before its own callback
+   * invocation returns. MQRC_NO_MSG_AVAILABLE (2033) arrives here on a wait
+   * timeout exactly as it does on `GetSync`; `endSpan`/`markError` is the
+   * shared choke point that leaves that one UNSET instead of ERROR.
+   */
+  private getGetPatch(
+    moduleExports: IbmMqModuleExports,
+    original: (...args: unknown[]) => unknown
+  ) {
+    const self = this;
+    return function patchedGet(this: unknown, ...args: unknown[]) {
+      const jsObject = args[0] as MQObjectLike;
+      const lastIndex = args.length - 1;
+      const originalCb = args[lastIndex] as MqCallback<unknown>;
+
+      const wrappedCb = context.bind(
+        context.active(),
+        (err: unknown, hObj: MQObjectLike, ...rest: unknown[]) => {
+          const config = self.getConfig();
+          const destination = destinationFromObject(hObj ?? jsObject);
+          const hConn = (hObj ?? jsObject)?._mqQueueManager;
+          const qmid = ensureQueueManagerId(
+            moduleExports,
+            hConn,
+            config.emitQueueManagerId
+          );
+
+          const span = self.tracer.startSpan(`process ${destination}`, {
+            kind: SpanKind.CONSUMER,
+            attributes: buildMessagingAttributes(
+              destination,
+              MESSAGING_OPERATION_TYPE_VALUE_PROCESS,
+              'process',
+              qmid
+            ),
+          });
+
+          if (err) {
+            self.endSpan(span, hConn, err);
+            return (originalCb as (...a: unknown[]) => unknown)(
+              err,
+              hObj,
+              ...rest
+            );
+          }
+
+          return context.with(trace.setSpan(context.active(), span), () => {
+            try {
+              return (originalCb as (...a: unknown[]) => unknown)(
+                err,
+                hObj,
+                ...rest
+              );
+            } catch (cbErr) {
+              self.markError(span, hConn, cbErr);
+              throw cbErr;
+            } finally {
+              span.end();
+            }
+          });
+        }
+      );
+
+      const newArgs = args.slice(0, lastIndex);
+      newArgs.push(wrappedCb);
+      return original.apply(this, newArgs);
+    };
+  }
+
+  /**
+   * `Ctl` is the delivery trigger for the async `Get` listener
+   * (`MQOP_START`/`MQOP_STOP`/...), not a message operation itself - no
+   * span, only context propagation for its (optional) callback.
+   */
+  private getCtlPatch(original: (...args: unknown[]) => unknown) {
+    return function patchedCtl(this: unknown, ...args: unknown[]) {
+      const lastIndex = args.length - 1;
+      const maybeCb = args[lastIndex];
+      if (typeof maybeCb === 'function') {
+        const boundCb = context.bind(context.active(), maybeCb);
+        const newArgs = args.slice(0, lastIndex);
+        newArgs.push(boundCb);
+        return original.apply(this, newArgs);
+      }
+      return original.apply(this, args);
+    };
+  }
+
+  /**
+   * Sets error status and, on a reconnect-shaped error, drops the QMID
+   * cache entry. Does not end the span. Skips the status (and records no
+   * exception) for MQRC_NO_MSG_AVAILABLE - a timed-out get against an idle
+   * queue is routine, not a failure; every other error still ends up ERROR.
+   */
+  private markError(
+    span: Span,
+    hConn: MQQueueManagerLike | undefined,
+    err: unknown
+  ): void {
+    invalidateOnReconnect(hConn, err);
+    if (err && !isRoutineNoMessage(err)) {
+      const message = err instanceof Error ? err.message : String(err);
+      span.setStatus({ code: SpanStatusCode.ERROR, message });
+    }
+  }
+
+  private endSpan(
+    span: Span,
+    hConn: MQQueueManagerLike | undefined,
+    err: unknown
+  ): void {
+    this.markError(span, hConn, err);
+    span.end();
+  }
+
+  /**
+   * Shared tail for `Put`/`PutSync`/`Put1`/`Put1Sync`/`GetSync`: they all take
+   * a variable-length argument list ending *optionally* (Sync variants) in an
+   * `(err, ...) => void` callback. If one was supplied, bind it to the calling
+   * context (a native addon calling back into JS may lose the active context,
+   * see the session handoff section 7) and end the span from inside it. If
+   * none was supplied, the verb is being used in its throw-or-return-directly
+   * form, so end the span synchronously around the call instead.
+   *
+   * `onSettled`, if given, runs once the real call has settled (success or
+   * error) but strictly before the span ends - the one hook `Put1`/`Put1Sync`
+   * need to re-read their `MQOD` for `ResolvedQName` only after MQ has
+   * actually written it.
+   */
+  private callAndEndSpan(
+    span: Span,
+    hConn: MQQueueManagerLike | undefined,
+    original: (...args: unknown[]) => unknown,
+    thisArg: unknown,
+    args: unknown[],
+    onSettled?: () => void
+  ): unknown {
+    const lastIndex = args.length - 1;
+    const maybeCb = args[lastIndex];
+    const self = this;
+
+    if (typeof maybeCb === 'function') {
+      const originalCb = maybeCb as MqCallback<unknown>;
+      const boundCb = context.bind(
+        context.active(),
+        (err: unknown, ...rest: unknown[]) => {
+          onSettled?.();
+          self.endSpan(span, hConn, err);
+          return (originalCb as (...a: unknown[]) => unknown)(err, ...rest);
+        }
+      );
+      const newArgs = args.slice(0, lastIndex);
+      newArgs.push(boundCb);
+      return original.apply(thisArg, newArgs);
+    }
+
+    try {
+      const result = original.apply(thisArg, args);
+      onSettled?.();
+      this.endSpan(span, hConn, undefined);
+      return result;
+    } catch (err) {
+      onSettled?.();
+      this.endSpan(span, hConn, err);
+      throw err;
+    }
+  }
+}

--- a/packages/instrumentation-ibmmq/src/index.ts
+++ b/packages/instrumentation-ibmmq/src/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { IbmMqInstrumentation } from './ibmmq';
+export type { IbmMqInstrumentationConfig } from './types';
+export { ATTR_MESSAGING_IBMMQ_QUEUE_MANAGER_ID } from './semconv';

--- a/packages/instrumentation-ibmmq/src/internal-types.ts
+++ b/packages/instrumentation-ibmmq/src/internal-types.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Structural (duck-typed) mirrors of the shapes exposed by the `ibmmq` npm
+ * package (github.com/ibm-messaging/mq-mqi-nodejs). We intentionally do not
+ * `import type` from `ibmmq` itself: the real package is a native N-API
+ * addon that downloads/links the IBM MQ C client at install time, and this
+ * instrumentation must type-check and run without it installed. These
+ * interfaces only need to describe the fields we read.
+ *
+ * Field names and sealing behavior are taken from `lib/mqitypes.js` and
+ * `lib/mqod.js` in `ibmmq@2.1.9`.
+ */
+
+/** Mirrors `MQQueueManager` (lib/mqitypes.js). `Object.seal`ed by ibmmq. */
+export interface MQQueueManagerLike {
+  _hConn: unknown;
+  _name: string;
+}
+
+/** Mirrors `MQObject` (lib/mqitypes.js). `Object.seal`ed by ibmmq. */
+export interface MQObjectLike {
+  _hObj: unknown;
+  _mqQueueManager: MQQueueManagerLike;
+  _name: string;
+}
+
+/** Mirrors `MQAttr` (lib/mqitypes.js), used for Inq() selectors/results. */
+export interface MQAttrLike {
+  selector: number;
+  value: unknown;
+}
+
+/** Mirrors the subset of `MQOD` fields (lib/mqod.js) we read or set. */
+export interface MQODLike {
+  ObjectName: string | null;
+  ObjectType: number;
+  ResolvedQName: string | null;
+}
+
+/** Mirrors the subset of `MQCNO` (lib/mqcno.js) we read at connect time. */
+export interface MQCNOLike {
+  ClientConn?: {
+    ConnectionName?: string;
+    ChannelName?: string;
+  } | null;
+}
+
+/** Mirrors `MQError` (lib/mqitypes.js): a subclass of Error with mqcc/mqrc. */
+export interface MQErrorLike extends Error {
+  mqcc: number;
+  mqrc: number;
+}
+
+export function isMQErrorLike(err: unknown): err is MQErrorLike {
+  return (
+    !!err &&
+    typeof err === 'object' &&
+    typeof (err as MQErrorLike).mqrc === 'number'
+  );
+}
+
+/** What we cache per connection, in the WeakMap keyed on MQQueueManagerLike. */
+export interface ConnectionMeta {
+  qmid?: string;
+  inquiring?: boolean;
+}
+
+/**
+ * The subset of `ibmmq`'s module exports (lib/mqi.js + lib/mqigeta.js) this
+ * instrumentation patches or calls internally (for the QMID inquiry).
+ */
+export interface IbmMqModuleExports {
+  MQC: Record<string, number>;
+  MQOD: new () => MQODLike;
+  MQAttr: new (selector: number, value?: unknown) => MQAttrLike;
+
+  Conn: (qMgrName: string, cb: MqCallback<MQQueueManagerLike>) => void;
+  Connx: (
+    qMgrName: string,
+    cno: MQCNOLike,
+    cb: MqCallback<MQQueueManagerLike>
+  ) => void;
+  ConnSync: (
+    qMgrName: string,
+    cb?: MqCallback<MQQueueManagerLike>
+  ) => MQQueueManagerLike | undefined;
+  ConnxSync: (
+    qMgrName: string,
+    cno: MQCNOLike,
+    cb?: MqCallback<MQQueueManagerLike>
+  ) => MQQueueManagerLike | undefined;
+
+  Open: (
+    hConn: MQQueueManagerLike,
+    jsod: MQODLike,
+    options: number,
+    cb: MqCallback<MQObjectLike>
+  ) => void;
+  OpenSync: (
+    hConn: MQQueueManagerLike,
+    jsod: MQODLike,
+    options: number,
+    cb?: MqCallback<MQObjectLike>
+  ) => MQObjectLike | undefined;
+  CloseSync: (
+    hObj: MQObjectLike,
+    options: number,
+    cb?: MqCallback<void>
+  ) => void;
+  Inq: (
+    hObj: MQObjectLike,
+    selectors: MQAttrLike[],
+    cb: (err: MQErrorLike | null | undefined, selectors: MQAttrLike[]) => void
+  ) => void;
+
+  Put: (...args: unknown[]) => void;
+  PutSync: (...args: unknown[]) => void;
+  Put1: (...args: unknown[]) => void;
+  Put1Sync: (...args: unknown[]) => void;
+  GetSync: (...args: unknown[]) => void;
+  Get: (...args: unknown[]) => void;
+  Ctl: (...args: unknown[]) => void;
+}
+
+export type MqCallback<T> = (
+  err: MQErrorLike | null | undefined,
+  result?: T
+) => void;

--- a/packages/instrumentation-ibmmq/src/semconv.ts
+++ b/packages/instrumentation-ibmmq/src/semconv.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * This file contains a copy of unstable/experimental semantic convention
+ * definitions used by this package.
+ * @see https://github.com/open-telemetry/opentelemetry-js/tree/main/semantic-conventions#unstable-semconv
+ *
+ * `messaging.ibmmq.queue_manager.id` is not (yet) part of
+ * `@opentelemetry/semantic-conventions` - it tracks an unratified proposal
+ * (semantic-conventions PR #4014) - so it is vendored here rather than
+ * imported.
+ */
+
+export const ATTR_MESSAGING_SYSTEM = 'messaging.system' as const;
+export const ATTR_MESSAGING_DESTINATION_NAME =
+  'messaging.destination.name' as const;
+export const ATTR_MESSAGING_OPERATION_NAME =
+  'messaging.operation.name' as const;
+export const ATTR_MESSAGING_OPERATION_TYPE =
+  'messaging.operation.type' as const;
+
+export const MESSAGING_OPERATION_TYPE_VALUE_SEND = 'send' as const;
+export const MESSAGING_OPERATION_TYPE_VALUE_RECEIVE = 'receive' as const;
+export const MESSAGING_OPERATION_TYPE_VALUE_PROCESS = 'process' as const;
+
+/**
+ * `messaging.system` is not yet pinned upstream for IBM MQ (see the Node.js
+ * QMID session handoff, section 16). `'ibmmq'` is this package's own choice,
+ * matching the `messaging.system` value kafkajs/amqplib set for their
+ * respective systems.
+ */
+export const MESSAGING_SYSTEM_VALUE_IBMMQ = 'ibmmq' as const;
+
+/**
+ * The IBM MQ Queue Manager Identifier (QMID) - `MQCA_Q_MGR_IDENTIFIER`,
+ * globally unique, format `<QMNAME>_YYYY-MM-DD_HH.MM.SS`. Not yet part of
+ * `@opentelemetry/semantic-conventions` (semantic-conventions PR #4014,
+ * closed/unratified). See `semantic-conventions/model/messaging/ibmmq.yaml`
+ * and `registry.yaml` in the sibling `semantic-conventions` workstream repo.
+ */
+export const ATTR_MESSAGING_IBMMQ_QUEUE_MANAGER_ID =
+  'messaging.ibmmq.queue_manager.id' as const;

--- a/packages/instrumentation-ibmmq/src/types.ts
+++ b/packages/instrumentation-ibmmq/src/types.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+
+export interface IbmMqInstrumentationConfig extends InstrumentationConfig {
+  /**
+   * Stamp the IBM MQ Queue Manager Identifier (QMID,
+   * `messaging.ibmmq.queue_manager.id`) onto every send/receive/process
+   * span. Gated because the attribute is unratified upstream and costs one
+   * MQINQ network round trip per connection (never per message).
+   *
+   * Defaults from `process.env.OTEL_INSTRUMENTATION_IBMMQ_EMIT_QUEUE_MANAGER_ID
+   * === 'true'`. The env fallback is load-bearing, not belt-and-braces:
+   * `auto-instrumentations-node/register` exposes no per-instrumentation
+   * config hook, so a config-only gate would be unsettable without editing
+   * application code.
+   */
+  emitQueueManagerId?: boolean;
+}
+
+export const DEFAULT_CONFIG: IbmMqInstrumentationConfig = {
+  emitQueueManagerId:
+    process.env.OTEL_INSTRUMENTATION_IBMMQ_EMIT_QUEUE_MANAGER_ID === 'true',
+};

--- a/packages/instrumentation-ibmmq/src/utils.ts
+++ b/packages/instrumentation-ibmmq/src/utils.ts
@@ -1,0 +1,240 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Attributes } from '@opentelemetry/api';
+import {
+  ConnectionMeta,
+  IbmMqModuleExports,
+  MQObjectLike,
+  MQODLike,
+  MQQueueManagerLike,
+  isMQErrorLike,
+} from './internal-types';
+import {
+  ATTR_MESSAGING_DESTINATION_NAME,
+  ATTR_MESSAGING_IBMMQ_QUEUE_MANAGER_ID,
+  ATTR_MESSAGING_OPERATION_NAME,
+  ATTR_MESSAGING_OPERATION_TYPE,
+  ATTR_MESSAGING_SYSTEM,
+  MESSAGING_SYSTEM_VALUE_IBMMQ,
+} from './semconv';
+
+/**
+ * Per-connection cache: MQQueueManager -> { queue manager name, QMID, ... }.
+ * Forced by `Object.seal()` on MQQueueManager (see internal-types.ts) and
+ * correct by construction: entries vanish once the app drops the
+ * connection, no cleanup code needed. Precedent:
+ * `instrumentation-kafkajs`'s `_clusterWeakMap`.
+ */
+export const connectionMetaMap = new WeakMap<
+  MQQueueManagerLike,
+  ConnectionMeta
+>();
+
+/** MQRC_RECONNECTED / MQRC_CONNECTION_BROKEN. */
+const RECONNECT_MQRCS = new Set([2545, 2009]);
+
+export function isReconnectError(err: unknown): boolean {
+  return isMQErrorLike(err) && RECONNECT_MQRCS.has(err.mqrc);
+}
+
+/**
+ * MQRC_NO_MSG_AVAILABLE: the routine outcome of a timed-out get against an
+ * idle queue, not a failure - every polling consumer hits this constantly.
+ * Marking it ERROR would show as a ~100% error rate for an idle consumer.
+ */
+const MQRC_NO_MSG_AVAILABLE = 2033;
+
+export function isRoutineNoMessage(err: unknown): boolean {
+  return isMQErrorLike(err) && err.mqrc === MQRC_NO_MSG_AVAILABLE;
+}
+
+/**
+ * ponytail: invalidating the cache on 2545/2009 is unverified against a real
+ * multi-instance queue manager (none in the lab this was built against) - it
+ * only proves out on the next `ensureQueueManagerId` re-inquiry. Upgrade path
+ * if it's ever wrong: a broker-side reproduction of an automatic client
+ * reconnect landing on a different queue manager.
+ */
+export function invalidateOnReconnect(
+  hConn: MQQueueManagerLike | undefined,
+  err: unknown
+): void {
+  if (hConn && isReconnectError(err)) {
+    connectionMetaMap.delete(hConn);
+  }
+}
+
+/**
+ * One MQINQ round trip (OpenSync MQOT_Q_MGR -> Inq MQCA_Q_MGR_IDENTIFIER ->
+ * CloseSync), proven at 1.5-2.2ms against a live broker. Never call this per
+ * message - see the session handoff, section 21.6. Errors (including
+ * MQRC_NOT_AUTHORIZED) are swallowed: the caller gets `undefined` and the
+ * attribute is simply omitted, matching the "graceful degradation" contract.
+ */
+export function inquireQueueManagerId(
+  mq: IbmMqModuleExports,
+  hConn: MQQueueManagerLike,
+  cb: (qmid: string | undefined) => void
+): void {
+  // This whole chain must complete in the caller's tick, so that the qmid is
+  // cached before the application's connect callback runs its first operation.
+  // `OpenSync`/`CloseSync` pass `async = false` unconditionally in lib/mqi.js,
+  // so neither depends on `hConn._inCB` being set; `Inq` is always synchronous
+  // (a direct blocking native call). `Close` is the one asynchronous verb here,
+  // and its completion has no bearing on the value, so the qmid is delivered
+  // before the handle is closed rather than from the close callback.
+  try {
+    const od: MQODLike = new mq.MQOD();
+    od.ObjectName = null; // MUST be null for MQOT_Q_MGR (else MQRC_NAME_NOT_VALID_FOR_TYPE)
+    od.ObjectType = mq.MQC.MQOT_Q_MGR;
+
+    mq.OpenSync(hConn, od, mq.MQC.MQOO_INQUIRE, (openErr, hObj) => {
+      if (openErr || !hObj) {
+        cb(undefined);
+        return;
+      }
+      let qmid: string | undefined;
+      try {
+        mq.Inq(hObj, [new mq.MQAttr(mq.MQC.MQCA_Q_MGR_IDENTIFIER)], (inqErr, sel) => {
+          const value = sel?.[0]?.value;
+          qmid = !inqErr && typeof value === 'string' ? value.trim() : undefined;
+        });
+      } catch {
+        // Leave qmid undefined; the span simply omits the attribute.
+      }
+      cb(qmid);
+      try {
+        mq.CloseSync(hObj, 0, () => {
+          /* cleanup only, nothing waits on it */
+        });
+      } catch {
+        // A failed close must not surface to the application.
+      }
+    });
+  } catch {
+    // Never let a QMID-inquiry failure surface to the application.
+    cb(undefined);
+  }
+}
+
+/**
+ * Records what we know about a freshly-opened connection, and - if enabled -
+ * kicks off the one-per-connection background QMID inquiry. Called
+ * synchronously from inside the app's own Conn/Connx/ConnSync/ConnxSync
+ * callback; never blocks it.
+ */
+export function resolveConnectionOnConnect(
+  mq: IbmMqModuleExports,
+  hConn: MQQueueManagerLike | undefined,
+  emitQueueManagerId: boolean | undefined
+): void {
+  if (!hConn) return;
+
+  connectionMetaMap.set(hConn, {});
+
+  if (emitQueueManagerId) {
+    fireQueueManagerIdInquiry(mq, hConn);
+  }
+}
+
+function fireQueueManagerIdInquiry(
+  mq: IbmMqModuleExports,
+  hConn: MQQueueManagerLike
+): void {
+  const meta = connectionMetaMap.get(hConn);
+  if (!meta || meta.inquiring) return;
+  meta.inquiring = true;
+  inquireQueueManagerId(mq, hConn, qmid => {
+    const current = connectionMetaMap.get(hConn);
+    if (current) {
+      current.qmid = qmid;
+      current.inquiring = false;
+    }
+  });
+}
+
+/**
+ * Called from every send/receive/process patch site, before building span
+ * attributes. Returns the QMID if it is already cached; otherwise, if
+ * enabled, starts (or lets an in-flight) background inquiry run and returns
+ * `undefined` for *this* operation's span - the next operation on the same
+ * connection will find it cached. Handles both a never-seen connection
+ * (e.g. app required `ibmmq` before the hook installed) and a WeakMap entry
+ * invalidated by `invalidateOnReconnect`.
+ */
+export function ensureQueueManagerId(
+  mq: IbmMqModuleExports,
+  hConn: MQQueueManagerLike | undefined,
+  emitQueueManagerId: boolean | undefined
+): string | undefined {
+  if (!hConn || !emitQueueManagerId) return undefined;
+
+  let meta = connectionMetaMap.get(hConn);
+  if (!meta) {
+    meta = {};
+    connectionMetaMap.set(hConn, meta);
+  }
+  if (meta.qmid === undefined) {
+    fireQueueManagerIdInquiry(mq, hConn);
+    return undefined;
+  }
+  return meta.qmid;
+}
+
+/** Prefer `MQOD.ResolvedQName` (set by MQ after Open) over the requested name. */
+export function destinationFromOD(od: MQODLike): string {
+  return od.ResolvedQName || od.ObjectName || '<<unknown>>';
+}
+
+/**
+ * Per-object cache: MQObject -> the queue name MQ resolved at Open time.
+ * `Put`/`PutSync`/`GetSync`/`Get` only ever hand us an already-opened
+ * `MQObject`, never the `MQOD` that opened it - and for an alias, clustered,
+ * or dynamic reply queue, `MQOD.ResolvedQName` (set by MQ, in place, on the
+ * caller's own MQOD during Open) differs from the name the app requested.
+ * Populated by the `Open`/`OpenSync` patch; forced by `Object.seal()` on
+ * MQObject (see internal-types.ts), same rationale as `connectionMetaMap`.
+ */
+export const resolvedNameMap = new WeakMap<MQObjectLike, string>();
+
+/** Called from the Open/OpenSync patch once MQ has resolved `od` in place. */
+export function recordResolvedName(
+  hObj: MQObjectLike | undefined,
+  od: MQODLike
+): void {
+  if (!hObj) return;
+  const resolvedQName = od.ResolvedQName?.trim();
+  if (!resolvedQName) return;
+  resolvedNameMap.set(hObj, resolvedQName);
+}
+
+/**
+ * Prefers the `ResolvedQName` captured at Open time over `_name` (the
+ * requested name) - see `resolvedNameMap`. Falls back to `_name` for an
+ * MQObject that was never opened through our patch (e.g. built by test code)
+ * or whose resolved name came back empty.
+ */
+export function destinationFromObject(obj: MQObjectLike): string {
+  return resolvedNameMap.get(obj) || obj?._name || '<<unknown>>';
+}
+
+export function buildMessagingAttributes(
+  destination: string,
+  operationType: string,
+  operationName: string,
+  qmid: string | undefined
+): Attributes {
+  const attributes: Attributes = {
+    [ATTR_MESSAGING_SYSTEM]: MESSAGING_SYSTEM_VALUE_IBMMQ,
+    [ATTR_MESSAGING_DESTINATION_NAME]: destination,
+    [ATTR_MESSAGING_OPERATION_TYPE]: operationType,
+    [ATTR_MESSAGING_OPERATION_NAME]: operationName,
+  };
+  if (qmid !== undefined) {
+    attributes[ATTR_MESSAGING_IBMMQ_QUEUE_MANAGER_ID] = qmid;
+  }
+  return attributes;
+}

--- a/packages/instrumentation-ibmmq/test/ibmmq.test.ts
+++ b/packages/instrumentation-ibmmq/test/ibmmq.test.ts
@@ -1,0 +1,568 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as assert from 'assert';
+import { SpanKind, SpanStatusCode } from '@opentelemetry/api';
+import {
+  getTestSpans,
+  registerInstrumentationTesting,
+} from '@opentelemetry/contrib-test-utils';
+import { IbmMqInstrumentation } from '../src';
+import { connectionMetaMap, invalidateOnReconnect } from '../src/utils';
+import {
+  ATTR_MESSAGING_DESTINATION_NAME,
+  ATTR_MESSAGING_IBMMQ_QUEUE_MANAGER_ID,
+  ATTR_MESSAGING_OPERATION_NAME,
+  ATTR_MESSAGING_SYSTEM,
+  MESSAGING_SYSTEM_VALUE_IBMMQ,
+} from '../src/semconv';
+import { MQErrorLike } from '../src/internal-types';
+
+const instrumentation = registerInstrumentationTesting(
+  new IbmMqInstrumentation()
+);
+
+// The 48-byte space-padded field a real `MQINQ` returns; `inquireQueueManagerId`
+// must trim it (session handoff section 21).
+const FAKE_QMID = 'TESTQM_2026-08-31_09.07.16';
+const FAKE_QMID_PADDED = FAKE_QMID.padEnd(48, ' ');
+
+/**
+ * A hand-built stand-in for the `ibmmq` module. The real package is a native
+ * N-API addon whose `postinstall` downloads the IBM MQ redistributable C
+ * client, so it is never a dependency of this test suite (see the package
+ * README) - every function below reproduces just enough of the real
+ * behavior described in `lib/mqi.js` to drive `IbmMqInstrumentation`'s
+ * patches, and every callback fires synchronously so no test needs `done()`.
+ */
+function createFakeMq() {
+  let nextId = 0;
+  let nextPutError: MQErrorLike | null = null;
+  let nextGetError: MQErrorLike | null = null;
+  let capturedGetCb: ((...args: unknown[]) => void) | null = null;
+
+  class MQOD {
+    ObjectName: string | null = '';
+    ObjectType = 0;
+    ResolvedQName: string | null = null;
+    ResolvedQMgrName: string | null = null;
+  }
+
+  class MQAttr {
+    constructor(public selector: number, public value?: unknown) {}
+  }
+
+  const makeQueueManager = (name: string) => ({
+    _hConn: ++nextId,
+    _name: name,
+    _inCB: false,
+  });
+
+  return {
+    MQC: {
+      MQOO_INQUIRE: 0x2000,
+      MQOT_Q_MGR: 6,
+      MQCA_Q_MGR_IDENTIFIER: 2032,
+    },
+    MQOD,
+    MQAttr,
+
+    // Test-only seam: makes the *next* Put/PutSync call fail, to exercise
+    // the reconnect-invalidation path without a real broken connection.
+    __setNextPutError(err: MQErrorLike | null) {
+      nextPutError = err;
+    },
+    // Test-only seam: makes the *next* GetSync call fail, e.g. with the
+    // MQRC_NO_MSG_AVAILABLE timeout every polling consumer sees routinely.
+    __setNextGetError(err: MQErrorLike | null) {
+      nextGetError = err;
+    },
+    // Test-only seam: fires the callback `Get()` registered, standing in
+    // for a real MQGET completion (message or error) on the async listener.
+    __triggerGet(...args: unknown[]) {
+      capturedGetCb?.(...args);
+    },
+
+    Conn(qMgrName: string, cb: (err: null, hConn: unknown) => void) {
+      cb(null, makeQueueManager(qMgrName));
+    },
+    Connx(
+      qMgrName: string,
+      _cno: unknown,
+      cb: (err: null, hConn: unknown) => void
+    ) {
+      cb(null, makeQueueManager(qMgrName));
+    },
+    ConnSync(qMgrName: string, cb?: (err: null, hConn: unknown) => void) {
+      const hConn = makeQueueManager(qMgrName);
+      if (cb) {
+        cb(null, hConn);
+        return undefined;
+      }
+      return hConn;
+    },
+    ConnxSync(
+      qMgrName: string,
+      _cno: unknown,
+      cb?: (err: null, hConn: unknown) => void
+    ) {
+      const hConn = makeQueueManager(qMgrName);
+      if (cb) {
+        cb(null, hConn);
+        return undefined;
+      }
+      return hConn;
+    },
+
+    // Mirrors the live-lab fixture: alias TEST.ALIAS.Q resolves to
+    // DEV.QUEUE.1 on AryanMacOSQM1, same as a real `mq.Open` mutates `jsod`
+    // in place for an alias/clustered/dynamic-reply queue.
+    Open(
+      hConn: unknown,
+      jsod: InstanceType<typeof MQOD>,
+      _options: number,
+      cb: (err: null, hObj: unknown) => void
+    ) {
+      if (jsod.ObjectName === 'TEST.ALIAS.Q') {
+        jsod.ResolvedQName = 'DEV.QUEUE.1';
+        jsod.ResolvedQMgrName = 'AryanMacOSQM1';
+      }
+      cb(null, {
+        _hObj: ++nextId,
+        _mqQueueManager: hConn,
+        _name: jsod.ObjectName,
+      });
+    },
+    OpenSync(
+      hConn: unknown,
+      jsod: InstanceType<typeof MQOD>,
+      _options: number,
+      cb?: (err: null, hObj: unknown) => void
+    ) {
+      if (jsod.ObjectName === 'TEST.ALIAS.Q') {
+        jsod.ResolvedQName = 'DEV.QUEUE.1';
+        jsod.ResolvedQMgrName = 'AryanMacOSQM1';
+      }
+      const hObj = {
+        _hObj: ++nextId,
+        _mqQueueManager: hConn,
+        _name: jsod.ObjectName,
+      };
+      if (cb) {
+        cb(null, hObj);
+        return undefined;
+      }
+      return hObj;
+    },
+    // Real `mq.Close` is asynchronous - it is not among the verbs that consult
+    // `connInCB` to force themselves synchronous. A synchronous fake here is
+    // what previously let the QMID-inquiry deferral bug pass the suite, so it
+    // deliberately defers.
+    Close(_hObj: unknown, _options: number, cb: (err: null) => void) {
+      setImmediate(() => cb(null));
+    },
+    // `CloseSync` passes `async = false` unconditionally in lib/mqi.js.
+    CloseSync(_hObj: unknown, _options: number, cb: (err: null) => void) {
+      cb(null);
+    },
+    Inq(
+      _hObj: unknown,
+      selectors: InstanceType<typeof MQAttr>[],
+      cb: (err: null, selectors: InstanceType<typeof MQAttr>[]) => void
+    ) {
+      cb(
+        null,
+        selectors.map(sel =>
+          sel.selector === 2032
+            ? new MQAttr(sel.selector, FAKE_QMID_PADDED)
+            : sel
+        )
+      );
+    },
+
+    Put(
+      jsObject: unknown,
+      _jsmd: unknown,
+      _jspmo: unknown,
+      _buf: unknown,
+      cb: (err: MQErrorLike | null) => void
+    ) {
+      const err = nextPutError;
+      nextPutError = null;
+      cb(err);
+    },
+    PutSync(
+      _jsObject: unknown,
+      _jsmd: unknown,
+      _jspmo: unknown,
+      _buf: unknown,
+      cb?: (err: MQErrorLike | null) => void
+    ) {
+      const err = nextPutError;
+      nextPutError = null;
+      if (cb) {
+        cb(err);
+        return undefined;
+      }
+      if (err) throw err;
+      return undefined;
+    },
+    // Mirrors the same alias fixture as Open/OpenSync above: MQ only writes
+    // ResolvedQName onto `jsod` as a side effect of the Put1 call itself, not
+    // before it - callers must read it after this function runs.
+    Put1(
+      _hConn: unknown,
+      jsod: InstanceType<typeof MQOD>,
+      _jsmd: unknown,
+      _jspmo: unknown,
+      _buf: unknown,
+      cb: (err: MQErrorLike | null) => void
+    ) {
+      if (jsod.ObjectName === 'TEST.ALIAS.Q') {
+        jsod.ResolvedQName = 'DEV.QUEUE.1';
+        jsod.ResolvedQMgrName = 'AryanMacOSQM1';
+      }
+      const err = nextPutError;
+      nextPutError = null;
+      cb(err);
+    },
+    Put1Sync(
+      _hConn: unknown,
+      jsod: InstanceType<typeof MQOD>,
+      _jsmd: unknown,
+      _jspmo: unknown,
+      _buf: unknown,
+      cb?: (err: MQErrorLike | null) => void
+    ) {
+      if (jsod.ObjectName === 'TEST.ALIAS.Q') {
+        jsod.ResolvedQName = 'DEV.QUEUE.1';
+        jsod.ResolvedQMgrName = 'AryanMacOSQM1';
+      }
+      const err = nextPutError;
+      nextPutError = null;
+      if (cb) {
+        cb(err);
+        return undefined;
+      }
+      if (err) throw err;
+      return undefined;
+    },
+    GetSync(
+      _jsObject: unknown,
+      _jsmd: unknown,
+      _jsgmo: unknown,
+      _buf: unknown,
+      cb?: (err: MQErrorLike | null, len?: number) => void
+    ) {
+      const err = nextGetError;
+      nextGetError = null;
+      if (cb) {
+        cb(err, err ? undefined : 0);
+        return undefined;
+      }
+      if (err) throw err;
+      return 0;
+    },
+    Get(
+      _jsObject: unknown,
+      _jsmd: unknown,
+      _jsgmo: unknown,
+      cb: (...args: unknown[]) => void
+    ) {
+      // Real `Get` never calls back synchronously - delivery is driven by
+      // `Ctl(hConn, MQOP_START)`; tests fire it manually via `__triggerGet`.
+      capturedGetCb = cb;
+    },
+    GetDone() {
+      /* not exercised by these tests */
+    },
+    Ctl(_hConn: unknown, _op: number, cb?: () => void) {
+      cb?.();
+    },
+  };
+}
+
+describe('ibmmq instrumentation', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mq: any;
+
+  beforeEach(() => {
+    mq = createFakeMq();
+    // Bypasses `require-in-the-middle` entirely - this package deliberately
+    // never depends on the real `ibmmq` native addon (see README), so tests
+    // drive the patched module exports directly instead of requiring it.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (instrumentation as any).patch(mq);
+  });
+
+  it('does not stamp a QMID by default', () => {
+    const hConn = mq.ConnSync('TESTQM');
+    const hObj = { _mqQueueManager: hConn, _name: 'TEST.QUEUE' };
+
+    mq.PutSync(hObj, {}, {}, Buffer.from('hi'));
+
+    const spans = getTestSpans();
+    assert.strictEqual(spans.length, 1);
+    const [span] = spans;
+    assert.strictEqual(span.name, 'send TEST.QUEUE');
+    assert.strictEqual(span.kind, SpanKind.PRODUCER);
+    assert.strictEqual(
+      span.attributes[ATTR_MESSAGING_SYSTEM],
+      MESSAGING_SYSTEM_VALUE_IBMMQ
+    );
+    assert.strictEqual(
+      span.attributes[ATTR_MESSAGING_DESTINATION_NAME],
+      'TEST.QUEUE'
+    );
+    assert.strictEqual(span.attributes[ATTR_MESSAGING_OPERATION_NAME], 'send');
+    assert.strictEqual(
+      span.attributes[ATTR_MESSAGING_IBMMQ_QUEUE_MANAGER_ID],
+      undefined
+    );
+  });
+
+  it('prefers the queue name MQ resolved at Open over the requested name', () => {
+    const hConn = mq.ConnSync('TESTQM');
+
+    // Mirrors the live-lab fixture: alias TEST.ALIAS.Q resolves to
+    // DEV.QUEUE.1. `Open` mutates `od` in place, same as a real `mq.Open`.
+    const od = new mq.MQOD();
+    od.ObjectName = 'TEST.ALIAS.Q';
+    const aliasObj = mq.OpenSync(hConn, od, 0);
+    mq.PutSync(aliasObj, {}, {}, Buffer.from('hi'));
+
+    // An MQObject never opened through the Open/OpenSync patch (e.g. built
+    // directly by other test/application code) has no resolved-name entry
+    // and must fall back to `_name`.
+    const plainObj = { _mqQueueManager: hConn, _name: 'TEST.QUEUE' };
+    mq.PutSync(plainObj, {}, {}, Buffer.from('hi'));
+
+    const [aliasSpan, plainSpan] = getTestSpans();
+    assert.strictEqual(
+      aliasSpan.attributes[ATTR_MESSAGING_DESTINATION_NAME],
+      'DEV.QUEUE.1'
+    );
+    assert.strictEqual(
+      plainSpan.attributes[ATTR_MESSAGING_DESTINATION_NAME],
+      'TEST.QUEUE'
+    );
+  });
+
+  it('prefers the queue name MQ resolved during the Put1/Put1Sync call itself over the requested name', () => {
+    const hConn = mq.ConnSync('TESTQM');
+
+    // Unlike Open, MQ only writes ResolvedQName onto the MQOD as a side
+    // effect of Put1 completing - the span must reflect that post-call value,
+    // not whatever ResolvedQName held (nothing) when the span was opened.
+    const put1Od = new mq.MQOD();
+    put1Od.ObjectName = 'TEST.ALIAS.Q';
+    mq.Put1(hConn, put1Od, {}, {}, Buffer.from('hi'), () => {});
+
+    const put1SyncOd = new mq.MQOD();
+    put1SyncOd.ObjectName = 'TEST.ALIAS.Q';
+    mq.Put1Sync(hConn, put1SyncOd, {}, {}, Buffer.from('hi'));
+
+    const [put1Span, put1SyncSpan] = getTestSpans();
+    assert.strictEqual(put1Span.name, 'send DEV.QUEUE.1');
+    assert.strictEqual(
+      put1Span.attributes[ATTR_MESSAGING_DESTINATION_NAME],
+      'DEV.QUEUE.1'
+    );
+    assert.strictEqual(put1SyncSpan.name, 'send DEV.QUEUE.1');
+    assert.strictEqual(
+      put1SyncSpan.attributes[ATTR_MESSAGING_DESTINATION_NAME],
+      'DEV.QUEUE.1'
+    );
+  });
+
+  it('stamps the QMID cached at connect time when enabled', () => {
+    instrumentation.setConfig({ emitQueueManagerId: true });
+
+    const hConn = mq.ConnSync('TESTQM');
+    // This fake resolves the inquiry synchronously; a real broker never
+    // does (session handoff section 21.6 - MQINQ is a network round trip),
+    // but the cache contract is the same either way.
+    assert.strictEqual(connectionMetaMap.get(hConn)?.qmid, FAKE_QMID);
+
+    const hObj = { _mqQueueManager: hConn, _name: 'TEST.QUEUE' };
+    mq.PutSync(hObj, {}, {}, Buffer.from('hi'));
+
+    const [span] = getTestSpans();
+    assert.strictEqual(
+      span.attributes[ATTR_MESSAGING_IBMMQ_QUEUE_MANAGER_ID],
+      FAKE_QMID
+    );
+  });
+
+  it('has the QMID cached before the connect callback runs its first operation', done => {
+    instrumentation.setConfig({ emitQueueManagerId: true });
+
+    // The live failure shape: a short-lived app that connects and immediately
+    // publishes. The inquiry must complete in the connect callback's own tick,
+    // or the very first span silently loses the join key.
+    mq.Connx('TESTQM', {}, (err: unknown, hConn: any) => {
+      assert.ifError(err);
+      assert.strictEqual(connectionMetaMap.get(hConn)?.qmid, FAKE_QMID);
+
+      const od = new mq.MQOD();
+      od.ObjectName = 'TEST.QUEUE';
+      mq.Put1(hConn, od, {}, {}, Buffer.from('immediate'), (perr: unknown) => {
+        assert.ifError(perr);
+
+        const [span] = getTestSpans();
+        assert.strictEqual(
+          span.attributes[ATTR_MESSAGING_IBMMQ_QUEUE_MANAGER_ID],
+          FAKE_QMID
+        );
+        done();
+      });
+    });
+  });
+
+  it('stamps a span for both mq.Put(...) and destructured Put(...) call styles', done => {
+    instrumentation.setConfig({ emitQueueManagerId: true });
+
+    const hConn = mq.ConnSync('TESTQM');
+    const hObj = { _mqQueueManager: hConn, _name: 'TEST.QUEUE' };
+
+    mq.Put(hObj, {}, {}, Buffer.from('a'), (err: unknown) => {
+      assert.ifError(err);
+
+      const { Put } = mq;
+      Put(hObj, {}, {}, Buffer.from('b'), (err2: unknown) => {
+        assert.ifError(err2);
+
+        const spans = getTestSpans();
+        assert.strictEqual(spans.length, 2);
+        for (const span of spans) {
+          assert.strictEqual(span.name, 'send TEST.QUEUE');
+          assert.strictEqual(span.kind, SpanKind.PRODUCER);
+          assert.strictEqual(
+            span.attributes[ATTR_MESSAGING_IBMMQ_QUEUE_MANAGER_ID],
+            FAKE_QMID
+          );
+        }
+        done();
+      });
+    });
+  });
+
+  it('drops the cached QMID and marks the span on a reconnect-shaped MQError', () => {
+    instrumentation.setConfig({ emitQueueManagerId: true });
+
+    const hConn = mq.ConnSync('TESTQM');
+    assert.strictEqual(connectionMetaMap.get(hConn)?.qmid, FAKE_QMID);
+
+    const hObj = { _mqQueueManager: hConn, _name: 'TEST.QUEUE' };
+    const reconnectErr: MQErrorLike = Object.assign(
+      new Error('MQRC_RECONNECTED'),
+      { mqcc: 1, mqrc: 2545, verb: 'MQPUT' }
+    );
+    mq.__setNextPutError(reconnectErr);
+
+    mq.PutSync(hObj, {}, {}, Buffer.from('x'), (err: unknown) => {
+      assert.strictEqual(err, reconnectErr);
+    });
+
+    assert.strictEqual(connectionMetaMap.has(hConn), false);
+
+    const [failedSpan] = getTestSpans();
+    assert.strictEqual(failedSpan.status.code, SpanStatusCode.ERROR);
+
+    // Per `ensureQueueManagerId`'s contract, the operation that finds the
+    // cache empty re-fires the inquiry but reports no QMID on its own span;
+    // the next operation on the same connection finds it cached again.
+    mq.PutSync(hObj, {}, {}, Buffer.from('y'));
+    const [, retrySpan] = getTestSpans();
+    assert.strictEqual(
+      retrySpan.attributes[ATTR_MESSAGING_IBMMQ_QUEUE_MANAGER_ID],
+      undefined
+    );
+
+    mq.PutSync(hObj, {}, {}, Buffer.from('z'));
+    const [, , recachedSpan] = getTestSpans();
+    assert.strictEqual(
+      recachedSpan.attributes[ATTR_MESSAGING_IBMMQ_QUEUE_MANAGER_ID],
+      FAKE_QMID
+    );
+  });
+
+  it('leaves the span UNSET for MQRC_NO_MSG_AVAILABLE but ERROR for a real failure, on GetSync', () => {
+    const hConn = mq.ConnSync('TESTQM');
+    const hObj = { _mqQueueManager: hConn, _name: 'TEST.QUEUE' };
+
+    const noMsgAvailable: MQErrorLike = Object.assign(
+      new Error('MQRC_NO_MSG_AVAILABLE'),
+      { mqcc: 2, mqrc: 2033, verb: 'MQGET' }
+    );
+    mq.__setNextGetError(noMsgAvailable);
+    mq.GetSync(hObj, {}, {}, Buffer.alloc(0), (err: unknown) => {
+      assert.strictEqual(err, noMsgAvailable);
+    });
+
+    const [timeoutSpan] = getTestSpans();
+    assert.strictEqual(timeoutSpan.status.code, SpanStatusCode.UNSET);
+    assert.strictEqual(timeoutSpan.events.length, 0);
+
+    const truncated: MQErrorLike = Object.assign(
+      new Error('MQRC_TRUNCATED_MSG_FAILED'),
+      { mqcc: 2, mqrc: 2080, verb: 'MQGET' }
+    );
+    mq.__setNextGetError(truncated);
+    mq.GetSync(hObj, {}, {}, Buffer.alloc(0), (err: unknown) => {
+      assert.strictEqual(err, truncated);
+    });
+
+    const [, realFailureSpan] = getTestSpans();
+    assert.strictEqual(realFailureSpan.status.code, SpanStatusCode.ERROR);
+  });
+
+  it('applies the same MQRC_NO_MSG_AVAILABLE/real-failure distinction on the async Get callback', () => {
+    const hConn = mq.ConnSync('TESTQM');
+    const hObj = { _mqQueueManager: hConn, _name: 'TEST.QUEUE' };
+
+    mq.Get(hObj, {}, {}, () => {
+      /* app's async delivery callback; not asserted on here */
+    });
+
+    const noMsgAvailable: MQErrorLike = Object.assign(
+      new Error('MQRC_NO_MSG_AVAILABLE'),
+      { mqcc: 2, mqrc: 2033, verb: 'MQGET' }
+    );
+    mq.__triggerGet(noMsgAvailable, undefined);
+
+    const [timeoutSpan] = getTestSpans();
+    assert.strictEqual(timeoutSpan.status.code, SpanStatusCode.UNSET);
+    assert.strictEqual(timeoutSpan.events.length, 0);
+
+    const connectionBroken: MQErrorLike = Object.assign(
+      new Error('MQRC_CONNECTION_BROKEN'),
+      { mqcc: 2, mqrc: 2009, verb: 'MQGET' }
+    );
+    mq.__triggerGet(connectionBroken, undefined);
+
+    const [, realFailureSpan] = getTestSpans();
+    assert.strictEqual(realFailureSpan.status.code, SpanStatusCode.ERROR);
+  });
+
+  it('exposes invalidateOnReconnect as a standalone unit for non-reconnect errors', () => {
+    const hConn = mq.ConnSync('TESTQM');
+    connectionMetaMap.set(hConn, { qmid: FAKE_QMID });
+
+    const notAuthorized: MQErrorLike = Object.assign(
+      new Error('MQRC_NOT_AUTHORIZED'),
+      { mqcc: 2, mqrc: 2035, verb: 'MQPUT' }
+    );
+    invalidateOnReconnect(hConn, notAuthorized);
+    assert.strictEqual(connectionMetaMap.get(hConn)?.qmid, FAKE_QMID);
+
+    const connectionBroken: MQErrorLike = Object.assign(
+      new Error('MQRC_CONNECTION_BROKEN'),
+      { mqcc: 2, mqrc: 2009, verb: 'MQPUT' }
+    );
+    invalidateOnReconnect(hConn, connectionBroken);
+    assert.strictEqual(connectionMetaMap.has(hConn), false);
+  });
+});

--- a/packages/instrumentation-ibmmq/tsconfig.json
+++ b/packages/instrumentation-ibmmq/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build",
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ]
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -29,6 +29,7 @@
     "packages/instrumentation-cucumber": {},
     "packages/instrumentation-dataloader": {},
     "packages/instrumentation-fs": {},
+    "packages/instrumentation-ibmmq": {},
     "packages/instrumentation-kafkajs": {},
     "packages/instrumentation-lru-memoizer": {},
     "packages/instrumentation-mongoose": {},


### PR DESCRIPTION
Requested in #3742.

## Which problem is this PR solving?

There is no OpenTelemetry instrumentation for [`ibmmq`](https://www.npmjs.com/package/ibmmq), IBM's MQI client binding for Node.js. A service that publishes to a queue currently just appears to stop: you get the incoming HTTP span, the database calls, then nothing. The consumer on the other side shows up as work with no visible cause.

The library already ships [`lib/mqiotel.js`](https://github.com/ibm-messaging/mq-mqi-nodejs/blob/master/lib/mqiotel.js), which carries `traceparent` in the RFH2 header, so context survives the queue. What is missing is spans on either end of it.

See #3742 for the fuller case, including why queue manager *names* are not enough to identify a broker.

## Short description of the changes

Adds `@opentelemetry/instrumentation-ibmmq` and registers it with `auto-instrumentations-node`, so it works via `--require @opentelemetry/auto-instrumentations-node/register` with no application code change.

| MQI verb | span | kind |
|---|---|---|
| `Put`, `PutSync`, `Put1`, `Put1Sync` | `send <destination>` | `PRODUCER` |
| `GetSync` | `receive <destination>` | `CLIENT` |
| each delivery of the `Get` listener callback | `process <destination>` | `CONSUMER` |

`Conn`/`Connx`/`ConnSync`/`ConnxSync`, `Open`/`OpenSync` and `Ctl` are hooked for bookkeeping and context binding only, and emit no spans. Note that `Get` registers a listener rather than fetching one message, so a single call produces many spans, and nothing is delivered until `Ctl(hConn, MQOP_START)` runs.

### Two decisions worth reviewing

**A timed-out get is not an error.** A waiting get against an idle queue returns `MQRC_NO_MSG_AVAILABLE` (2033) on every timeout, which a polling consumer hits constantly, so those spans are left `UNSET`. Treating it as an error would report every idle consumer at a 100 percent error rate. All other reason codes still produce `ERROR`.

**The destination is the resolved queue, not the requested one.** MQ writes `ResolvedQName` into the caller's descriptor during `MQOPEN`, and for an alias, clustered or dynamic reply queue that differs from what was asked for. Since `Put`/`Get` only receive the opened `MQObject`, the resolved name is captured at open time in a `WeakMap`. `Put1`/`Put1Sync` are the exception: MQ only fills it in as the call completes, so those spans open on the requested name and are corrected once it settles.

### Queue manager identifier

Optionally records `messaging.ibmmq.queue_manager.id` (`MQCA_Q_MGR_IDENTIFIER`), which unlike the queue manager name is globally unique. One `MQINQ` per connection, never per message, cached in a `WeakMap` keyed on the connection because `MQQueueManager` is `Object.seal`ed. The entry is dropped on a reconnect reason code, since IBM MQ's automatic reconnect can return on a different queue manager and a stale value would be quietly wrong.

Not in `@opentelemetry/semantic-conventions` yet, so it is **off by default**:

```js
new IbmMqInstrumentation({ emitQueueManagerId: true });
```

It also honours `OTEL_INSTRUMENTATION_IBMMQ_EMIT_QUEUE_MANAGER_ID=true`, because `auto-instrumentations-node/register` exposes no per-instrumentation config hook and a config-only switch would be unreachable for zero-code-change users. The proposal is open-telemetry/semantic-conventions#4014, unratified; happy to drop the attribute from an initial release if you would rather not carry it yet.

### Notes

Propagation is left entirely to `mqiotel.js`; no propagation code here. Unstable semconv constants are copied into `src/semconv.ts` per the [semantic-conventions guidance](https://github.com/open-telemetry/opentelemetry-js/tree/main/semantic-conventions#unstable-semconv).

10 unit tests cover all three span shapes, destination resolution including the alias case, the 2033 rule, and the identifier cache with its reconnect invalidation. Also verified against three real IBM MQ 9.4.5 queue managers side by side: all three had a queue named `DEV.QUEUE.1`, so every span came out identically named and only the queue manager identifier distinguished them.

Supported range is `ibmmq@>=2.0.0 <3`, with a `.tav.yml` for test-all-versions.
