### PR TITLE
chore: regenerate component-label-map

### DIFF
--- a/.github/component-label-map.yml
+++ b/.github/component-label-map.yml
@@ -41,6 +41,7 @@ pkg:instrumentation-aws-lambda:
   - changed-files:
       - any-glob-to-any-file:
           - packages/instrumentation-aws-lambda/**
+          - packages/propagator-aws-xray/**
 pkg:instrumentation-aws-sdk:
   - changed-files:
       - any-glob-to-any-file:
@@ -63,6 +64,10 @@ pkg:instrumentation-connect:
   - changed-files:
       - any-glob-to-any-file:
           - packages/instrumentation-connect/**
+pkg:instrumentation-console:
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/instrumentation-console/**
 pkg:instrumentation-cucumber:
   - changed-files:
       - any-glob-to-any-file:
@@ -125,6 +130,11 @@ pkg:instrumentation-koa:
   - changed-files:
       - any-glob-to-any-file:
           - packages/instrumentation-koa/**
+          - packages/contrib-test-utils/**
+pkg:instrumentation-langchain:
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/instrumentation-langchain/**
           - packages/contrib-test-utils/**
 pkg:instrumentation-long-task:
   - changed-files:
@@ -328,12 +338,9 @@ pkg-status:unmaintained:
           - packages/instrumentation-koa/**
           - packages/instrumentation-memcached/**
           - packages/instrumentation-mysql/**
-          - packages/instrumentation-nestjs-core/**
           - packages/instrumentation-restify/**
           - packages/instrumentation-router/**
-          - packages/instrumentation-tedious/**
           - packages/propagator-aws-xray-lambda/**
           - packages/propagator-ot-trace/**
           - packages/redis-common/**
           - packages/resource-detector-github/**
-          - packages/sql-common/**


### PR DESCRIPTION
Runs scripts/gen-component-label-map.mjs to bring the labeler config back in sync with component_owners.yml and the current workspace.

- Remove instrumentation-nestjs-core, instrumentation-tedious, and sql-common from pkg-status:unmaintained
- Add pkg:instrumentation-console and pkg:instrumentation-langchain labels
- Include propagator-aws-xray under pkg:instrumentation-aws-lambda via the dependency graph.