### PR TITLE
fix(instrumentation-aws-sdk): handle Uint8Array body in InvokeModel requestPreSpanHook

### DIFF
--- a/packages/instrumentation-aws-sdk/src/services/bedrock-runtime.ts
+++ b/packages/instrumentation-aws-sdk/src/services/bedrock-runtime.ts
@@ -167,7 +167,12 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
     }
 
     if (request.commandInput?.body) {
-      const requestBody = JSON.parse(request.commandInput.body);
+      const rawBody = request.commandInput.body;
+      const requestBody = JSON.parse(
+        rawBody instanceof Uint8Array
+          ? Buffer.from(rawBody).toString('utf-8')
+          : rawBody
+      );
       if (modelId.includes('amazon.titan')) {
         if (requestBody.textGenerationConfig?.temperature !== undefined) {
           spanAttributes[ATTR_GEN_AI_REQUEST_TEMPERATURE] =

--- a/packages/instrumentation-aws-sdk/test/bedrock-runtime.test.ts
+++ b/packages/instrumentation-aws-sdk/test/bedrock-runtime.test.ts
@@ -632,6 +632,33 @@ describe('Bedrock', () => {
         [ATTR_GEN_AI_RESPONSE_FINISH_REASONS]: ['max_tokens'],
       });
     });
+
+    it('does not throw when body is a Uint8Array AWS SDK v3 serialization', async () => {
+      const modelId = 'amazon.titan-embed-text-v2:0';
+      const nativeRequest = {
+        inputText: 'hello world',
+        dimensions: 1024,
+        normalize: true,
+      };
+      // AWS SDK v3 >= ~3.600 serializes the body to Uint8Array before instrumentation
+      // hooks run. Passing it directly reproduces the real-world shape.
+      const command = new InvokeModelCommand({
+        modelId,
+        body: new TextEncoder().encode(JSON.stringify(nativeRequest)),
+      });
+      // Must not throw SyntaxError from JSON.parse(Uint8Array)
+      await client.send(command);
+
+      const testSpans: ReadableSpan[] = getTestSpans();
+      const invokeModelSpans: ReadableSpan[] = testSpans.filter(
+        (s: ReadableSpan) => s.name === 'BedrockRuntime.InvokeModel'
+      );
+      expect(invokeModelSpans.length).toBe(1);
+      expect(invokeModelSpans[0].attributes).toMatchObject({
+        [ATTR_GEN_AI_SYSTEM]: GEN_AI_SYSTEM_VALUE_AWS_BEDROCK,
+        [ATTR_GEN_AI_REQUEST_MODEL]: modelId,
+      });
+    });
   });
 
   describe('InvokeModelWithStreams', () => {

--- a/packages/instrumentation-aws-sdk/test/mock-responses/bedrock-invokemodel-does-not-throw-when-body-is-a-uint8array-aws-sdk-v3-serialization.json
+++ b/packages/instrumentation-aws-sdk/test/mock-responses/bedrock-invokemodel-does-not-throw-when-body-is-a-uint8array-aws-sdk-v3-serialization.json
@@ -1,0 +1,30 @@
+[
+    {
+        "scope": "https://bedrock-runtime.us-east-1.amazonaws.com:443",
+        "method": "POST",
+        "path": "/model/amazon.titan-embed-text-v2:0/invoke",
+        "body": {
+            "inputText": "hello world",
+            "dimensions": 1024,
+            "normalize": true
+        },
+        "status": 200,
+        "response": {
+            "embedding": [0.1, 0.2, 0.3],
+            "inputTextTokenCount": 2
+        },
+        "rawHeaders": [
+            "Date",
+            "Mon, 10 Feb 2025 01:39:12 GMT",
+            "Content-Type",
+            "application/json",
+            "Content-Length",
+            "52",
+            "Connection",
+            "keep-alive",
+            "x-amzn-RequestId",
+            "91139412-bc01-4c17-a89f-12534a3aca0b"
+        ],
+        "responseIsBinary": false
+    }
+]


### PR DESCRIPTION
## Which problem is this PR solving?

`requestPreSpanHookInvokeModel` calls `JSON.parse(request.commandInput.body)` assuming the body is
a `string`. With AWS SDK for JavaScript v3 ≥ ~3.600 the Smithy-based serde layer serialises the
`InvokeModelCommand` body to a `Uint8Array` _before_ instrumentation hooks run. Calling
`JSON.parse` on a `Uint8Array` coerces it via `.toString()`, producing a comma-separated list of
byte values (e.g. `"123,34,105,110,..."`) instead of JSON. This causes a
`SyntaxError: Unexpected non-whitespace character after JSON at position 3` that propagates out of
the hook and crashes the `client.send()` call entirely — breaking every `InvokeModel` invocation
for users on recent AWS SDK versions.

The same byte-array-to-string pattern is already handled correctly in `parseChunk()` in the same
file using `Buffer.from(bytes).toString('utf-8')`.

## Short description of the changes

- **`src/services/bedrock-runtime.ts`** — In `requestPreSpanHookInvokeModel`, decode the request
  body before parsing: if `body` is a `Uint8Array` (new AWS SDK v3 serde), convert it with
  `Buffer.from(rawBody).toString('utf-8')` first; otherwise pass it through as-is (existing
  behaviour for callers that still supply a plain `string`).

- **`test/bedrock-runtime.test.ts`** — Adds a regression test inside `describe('InvokeModel')`
  that passes a `Uint8Array` body for `amazon.titan-embed-text-v2:0` (the exact shape produced by
  the new AWS SDK serialiser) and asserts the span is created without throwing.

- **`test/mock-responses/bedrock-invokemodel-does-not-throw-when-body-is-a-uint8array-aws-sdk-v3-serialization.json`**
  — nock-back fixture for the new test case.
