### PR TITLE
fix(instrumentation-express): preserve matched route after handler

### DIFF
--- a/packages/instrumentation-express/src/instrumentation.ts
+++ b/packages/instrumentation-express/src/instrumentation.ts
@@ -192,7 +192,10 @@ export class ExpressInstrumentation extends InstrumentationBase<ExpressInstrumen
         ] as ExpressLayerType;
 
         const rpcMetadata = getRPCMetadata(context.active());
-        if (rpcMetadata?.type === RPCType.HTTP) {
+        if (
+          rpcMetadata?.type === RPCType.HTTP &&
+          (type === ExpressLayerType.REQUEST_HANDLER || req.route === undefined)
+        ) {
           rpcMetadata.route = actualMatchedRoute;
         }
 

--- a/packages/instrumentation-express/test/express.test.ts
+++ b/packages/instrumentation-express/test/express.test.ts
@@ -61,6 +61,43 @@ describe('ExpressInstrumentation', () => {
       server?.close();
     });
 
+    it('should not overwrite route metadata with middleware after request handler', async () => {
+      const rootSpan = tracer.startSpan('rootSpan');
+      let rpcMetadata: RPCMetadata | undefined;
+
+      const httpServer = await serverWithMiddleware(tracer, rootSpan, app => {
+        app.get('/users/:id', (req, res, next) => {
+          rpcMetadata = getRPCMetadata(context.active());
+
+          assert.strictEqual(rpcMetadata?.route, '/users/:id');
+
+          next();
+        });
+
+        app.use('/users', (req, res) => {
+          res.status(200).end('done');
+        });
+      });
+
+      server = httpServer.server;
+      port = httpServer.port;
+
+      await context.with(
+        trace.setSpan(context.active(), rootSpan),
+        async () => {
+          const response = await httpRequest.get(
+            `http://localhost:${port}/users/123`
+          );
+
+          assert.strictEqual(response, 'done');
+
+          rootSpan.end();
+
+          assert.strictEqual(rpcMetadata?.route, '/users/:id');
+        }
+      );
+    });
+
     it('does not attach semantic route attribute for 404 page', async () => {
       const rootSpan = tracer.startSpan('rootSpan');
       const httpServer = await serverWithMiddleware(tracer, rootSpan, app => {


### PR DESCRIPTION
Assisted-by: ChatGPT 5.6 Sol

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Fixes #2884.

Express middleware that runs after a matched request handler can overwrite RPCMetadata.route with a less specific middleware route. This can cause the HTTP server span to report an incorrect http.route.

## Short description of the changes

-Preserve the route set by a request handler when later middleware executes.
-Continue allowing middleware to update route metadata before a request handler has matched.
-Add a regression test covering a /users/:id request handler followed by /users middleware.

Testing

-npm test -- --grep "rpcMetadata\.route|should not overwrite route metadata" — 5 passing
-npm run compile — passing
-git diff --check — passing
