### PR TITLE
ci: retry starting test services

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,7 +100,20 @@ jobs:
         if: ${{ matrix.node == '22' }}
         run: npm run test:browser:ci:affected
       - name: Start Test Services (Delta)
-        run: npm run test-services:start:affected
+        run: |
+          for attempt in 1 2 3; do
+            if npm run test-services:start:affected; then
+              break
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+
+            echo "Failed to start test services, retrying in 5 seconds..."
+            npm run test-services:stop || true
+            sleep 5
+          done
       - name: Unit tests (Nodejs - Delta)
         run: npm run test:ci:affected
       - name: Stop Test Services (Delta)
@@ -146,7 +159,20 @@ jobs:
       - name: Compile (Delta)
         run: npm run compile:ci:affected
       - name: Start Test Services (Delta)
-        run: npm run test-services:start:affected
+        run: |
+          for attempt in 1 2 3; do
+            if npm run test-services:start:affected; then
+              break
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+
+            echo "Failed to start test services, retrying in 5 seconds..."
+            npm run test-services:stop || true
+            sleep 5
+          done
       - name: Test All Versions (Delta)
         run: npm run test-all-versions:ci:affected
       - name: Stop Test Services (Delta)


### PR DESCRIPTION
Assisted-by: ChatGPT 5.6 Sol

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Fixes #3550.

- Starting test services in CI can fail intermittently because of transient Docker errors, including port binding conflicts and image pull failures.

## Short description of the changes

-Retry test-services:start:affected up to three times.
-Clean up partially started test services before retrying.
-Wait 5 seconds between attempts.
-Apply the retry behavior to both workflow jobs that start affected test services.

Validation

-npx prettier --check .github/workflows/test.yml
-git diff --check
-Verified the retry loop succeeds when a later attempt succeeds.
-Verified the retry loop exits with status 1 after three failed attempts.
