### PR TITLE
fix(instrumentation-aws-sdk): skip empty propagation values

### DIFF
--- a/packages/instrumentation-aws-sdk/src/services/MessageAttributes.ts
+++ b/packages/instrumentation-aws-sdk/src/services/MessageAttributes.ts
@@ -22,6 +22,10 @@ class ContextSetter
     key: string,
     value: string
   ) {
+    if (value === '') {
+      return;
+    }
+
     carrier[key] = {
       DataType: 'String',
       StringValue: value as string,

--- a/packages/instrumentation-aws-sdk/test/MessageAttributes.test.ts
+++ b/packages/instrumentation-aws-sdk/test/MessageAttributes.test.ts
@@ -58,6 +58,14 @@ describe('MessageAttributes', () => {
       };
       expect(contextCarrier).toStrictEqual(expectedContext);
     });
+
+    it('should not set empty propagation values', () => {
+      const contextCarrier = {};
+
+      contextSetter.set(contextCarrier, 'tracestate', '');
+
+      expect(contextCarrier).toStrictEqual({});
+    });
   });
 
   describe('injectPropagationContext', () => {


### PR DESCRIPTION
Assisted-by: ChatGPT 5.6 Sol

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Fixes #1528.

SQS and SNS message attributes do not allow empty string values. When OpenTelemetry propagation produced an empty value such as an empty tracestate, the AWS SDK instrumentation added it as a message attribute.

## Short description of the changes

-skips empty propagation values in the message attribute context setter.

-Added a regression test verifying that an empty tracestate is not added to the carrier.

-Tested with the focused MessageAttributes.test.ts suite: 9 passing.
