### PR TITLE
feat(instrumentation-long-animation-frame): add Long Animation Frames instrumentation

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -64,6 +64,7 @@
   "packages/instrumentation-winston": "0.66.0",
   "packages/instrumentation-document-load": "0.67.0",
   "packages/instrumentation-web-exception": "0.15.0",
+  "packages/instrumentation-long-animation-frame": "0.1.0",
   "packages/instrumentation-long-task": "0.66.0",
   "packages/instrumentation-user-interaction": "0.66.0",
   "packages/plugin-react-load": "0.54.0",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -189,6 +189,7 @@ const baseConfig = tseslint.config(
       '**/packages/**/browser/**/*',
       '**/packages/auto-instrumentations-web/**/*',
       '**/packages/instrumentation-document-load/**/*',
+      '**/packages/instrumentation-long-animation-frame/**/*',
       '**/packages/instrumentation-long-task/**/*',
       '**/packages/instrumentation-user-interaction/**/*',
       '**/packages/instrumentation-web-exception/**/*',

--- a/package-lock.json
+++ b/package-lock.json
@@ -8536,6 +8536,10 @@
       "resolved": "packages/instrumentation-langchain",
       "link": true
     },
+    "node_modules/@opentelemetry/instrumentation-long-animation-frame": {
+      "resolved": "packages/instrumentation-long-animation-frame",
+      "link": true
+    },
     "node_modules/@opentelemetry/instrumentation-long-task": {
       "resolved": "packages/instrumentation-long-task",
       "link": true
@@ -37218,6 +37222,56 @@
         "@opentelemetry/sdk-logs": "^0.222.0",
         "@opentelemetry/sdk-trace": "^2.9.0",
         "langchain": "^1.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "packages/instrumentation-long-animation-frame": {
+      "name": "@opentelemetry/instrumentation-long-animation-frame",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.9.0",
+        "@opentelemetry/instrumentation": "^0.221.0"
+      },
+      "devDependencies": {
+        "@opentelemetry/api": "^1.3.0",
+        "@opentelemetry/sdk-trace": "^2.9.0",
+        "@opentelemetry/sdk-trace-web": "^2.9.0",
+        "zone.js": "^0.11.4 || ^0.13.0 || ^0.14.0 || ^0.15.0 || ^0.16.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "packages/instrumentation-long-animation-frame/node_modules/@opentelemetry/api-logs": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
+      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "packages/instrumentation-long-animation-frame/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.221.0.tgz",
+      "integrity": "sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.221.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"

--- a/packages/instrumentation-long-animation-frame/CHANGELOG.md
+++ b/packages/instrumentation-long-animation-frame/CHANGELOG.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable MD007 MD034 -->
+# Changelog
+
+## Unreleased

--- a/packages/instrumentation-long-animation-frame/README.md
+++ b/packages/instrumentation-long-animation-frame/README.md
@@ -1,0 +1,84 @@
+# OpenTelemetry Long Animation Frames Instrumentation for web
+
+[![NPM Published Version][npm-img]][npm-url]
+[![Apache License][license-image]][license-image]
+
+This module provides automatic instrumentation for the [Long Animation Frames API][mdn-long-animation-frames], which may be loaded using the [`@opentelemetry/sdk-trace-web`](https://www.npmjs.com/package/@opentelemetry/sdk-trace-web) package. It creates a span for every long animation frame (a rendering update delayed beyond 50ms), with the timing breakdown reported via [`PerformanceLongAnimationFrameTiming`][mdn-performance-long-animation-frame-timing] (and its [`PerformanceScriptTiming`][mdn-performance-script-timing] entries) included as span attributes.
+
+The Long Animation Frames API is the successor to the deprecated [Long Tasks API](https://developer.mozilla.org/en-US/docs/Web/API/Long_Tasks_API), which this package is intended to replace.
+
+Compatible with OpenTelemetry JS API and SDK `1.0+`.
+
+## Installation
+
+```bash
+npm install --save @opentelemetry/instrumentation-long-animation-frame
+```
+
+## Usage
+
+```js
+import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace';
+import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+import { LongAnimationFrameInstrumentation } from '@opentelemetry/instrumentation-long-animation-frame';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+
+const provider = new WebTracerProvider({
+  spanProcessors: [
+    new SimpleSpanProcessor({ exporter: new ConsoleSpanExporter() }),
+  ],
+});
+
+registerInstrumentations({
+  tracerProvider: provider,
+  instrumentations: [
+    new LongAnimationFrameInstrumentation({
+      // see under for available configuration
+    }),
+  ],
+});
+```
+
+### Long Animation Frame Instrumentation Options
+
+| Options | Type | Description |
+| --- | --- | --- |
+| `observerCallback` | `ObserverCallback` | Callback executed on observed `long-animation-frame`, allowing additional attributes to be attached to the span. |
+
+The `observerCallback` function is passed the created span and the `long-animation-frame` `PerformanceEntry`,
+allowing the user to add custom attributes to the span with any logic.
+For example, a web app with client-side routing can add contextual information on the current page,
+even if the tracer was instantiated before navigation.
+
+Usage Example:
+
+```js
+const longAnimationFrameInstrumentationConfig = {
+  observerCallback: (span, longAnimationFrameEvent) => {
+    span.setAttribute('location.pathname', window.location.pathname)
+  }
+}
+```
+
+## Semantic Conventions
+
+This package does not currently generate any attributes from semantic conventions.
+
+## Useful links
+
+- For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
+- For more about OpenTelemetry JavaScript: <https://github.com/open-telemetry/opentelemetry-js>
+- For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
+
+## License
+
+Apache 2.0 - See [LICENSE][license-url] for more information.
+
+[discussions-url]: https://github.com/open-telemetry/opentelemetry-js/discussions
+[license-url]: https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/LICENSE
+[license-image]: https://img.shields.io/badge/license-Apache_2.0-green.svg?style=flat
+[npm-url]: https://www.npmjs.com/package/@opentelemetry/instrumentation-long-animation-frame
+[npm-img]: https://badge.fury.io/js/%40opentelemetry%2Finstrumentation-long-animation-frame.svg
+[mdn-long-animation-frames]: https://developer.mozilla.org/en-US/docs/Web/API/Performance_API/Long_animation_frame_timing
+[mdn-performance-long-animation-frame-timing]: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceLongAnimationFrameTiming
+[mdn-performance-script-timing]: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceScriptTiming

--- a/packages/instrumentation-long-animation-frame/karma.conf.js
+++ b/packages/instrumentation-long-animation-frame/karma.conf.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const karmaWebpackConfig = require('../../karma.webpack');
+const karmaBaseConfig = require('../../karma.base');
+
+module.exports = config => {
+  {
+    const plugins = (karmaBaseConfig.plugins = []);
+    const rootPackageJson = require('../../package.json');
+    const toAdd = Object.keys(rootPackageJson.devDependencies || {})
+      .filter(packageName => packageName.startsWith('karma-'))
+      .map(packageName => require(packageName));
+    plugins.push(...toAdd);
+  }
+
+  config.set(
+    Object.assign({}, karmaBaseConfig, {
+      webpack: karmaWebpackConfig,
+    })
+  );
+};

--- a/packages/instrumentation-long-animation-frame/package.json
+++ b/packages/instrumentation-long-animation-frame/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@opentelemetry/instrumentation-long-animation-frame",
+  "version": "0.1.0",
+  "description": "OpenTelemetry instrumentation for the Long Animation Frames Web API",
+  "main": "build/src/index.js",
+  "module": "build/esm/index.js",
+  "esnext": "build/esnext/index.js",
+  "types": "build/src/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/open-telemetry/opentelemetry-js-contrib.git",
+    "directory": "packages/instrumentation-long-animation-frame"
+  },
+  "scripts": {
+    "clean": "tsc --build --clean tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
+    "compile": "tsc --build tsconfig.json tsconfig.esm.json tsconfig.esnext.json",
+    "compile:with-dependencies": "nx run-many -t compile -p @opentelemetry/instrumentation-long-animation-frame",
+    "lint:readme": "node ../../scripts/lint-readme.js",
+    "prepublishOnly": "npm run compile",
+    "tdd": "karma start",
+    "test:browser": "nyc karma start --single-run",
+    "version:update": "node ../../scripts/version-update.js",
+    "watch": "tsc --build --watch tsconfig.json tsconfig.esm.json tsconfig.esnext.json"
+  },
+  "keywords": [
+    "opentelemetry",
+    "web",
+    "tracing",
+    "profiling",
+    "metrics",
+    "stats",
+    "long-animation-frames"
+  ],
+  "author": "OpenTelemetry Authors",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": "^18.19.0 || >=20.6.0"
+  },
+  "files": [
+    "build/esm/**/*.js",
+    "build/esm/**/*.map",
+    "build/esm/**/*.d.ts",
+    "build/esnext/**/*.js",
+    "build/esnext/**/*.map",
+    "build/esnext/**/*.d.ts",
+    "build/src/**/*.js",
+    "build/src/**/*.map",
+    "build/src/**/*.d.ts"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@opentelemetry/api": "^1.3.0",
+    "@opentelemetry/sdk-trace": "^2.9.0",
+    "@opentelemetry/sdk-trace-web": "^2.9.0",
+    "zone.js": "^0.11.4 || ^0.13.0 || ^0.14.0 || ^0.15.0 || ^0.16.0"
+  },
+  "dependencies": {
+    "@opentelemetry/core": "^2.9.0",
+    "@opentelemetry/instrumentation": "^0.221.0"
+  },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.3.0"
+  },
+  "sideEffects": false,
+  "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/packages/instrumentation-long-animation-frame#readme"
+}

--- a/packages/instrumentation-long-animation-frame/src/index.ts
+++ b/packages/instrumentation-long-animation-frame/src/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { LongAnimationFrameInstrumentation } from './instrumentation';
+export type {
+  LongAnimationFrameInstrumentationConfig,
+  ObserverCallback,
+  ObserverCallbackInformation,
+  PerformanceLongAnimationFrameTiming,
+  PerformanceScriptTiming,
+} from './types';

--- a/packages/instrumentation-long-animation-frame/src/instrumentation.ts
+++ b/packages/instrumentation-long-animation-frame/src/instrumentation.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// PerformanceLongAnimationFrameTiming is experimental and may change in future versions.
+// https://developer.mozilla.org/en-US/docs/Web/API/PerformanceLongAnimationFrameTiming
+/* eslint-disable baseline-js/use-baseline */
+
+import { diag } from '@opentelemetry/api';
+import { hrTime } from '@opentelemetry/core';
+import { InstrumentationBase } from '@opentelemetry/instrumentation';
+/** @knipignore */
+import { PACKAGE_NAME, PACKAGE_VERSION } from './version';
+import type {
+  LongAnimationFrameInstrumentationConfig,
+  PerformanceLongAnimationFrameTiming,
+} from './types';
+
+const LONG_ANIMATION_FRAME_PERFORMANCE_TYPE = 'long-animation-frame';
+
+export class LongAnimationFrameInstrumentation extends InstrumentationBase<LongAnimationFrameInstrumentationConfig> {
+  readonly version: string = PACKAGE_VERSION;
+
+  private _observer?: PerformanceObserver;
+
+  constructor(config: LongAnimationFrameInstrumentationConfig = {}) {
+    super(PACKAGE_NAME, PACKAGE_VERSION, config);
+  }
+
+  init() {}
+
+  private isSupported() {
+    if (
+      typeof PerformanceObserver === 'undefined' ||
+      !PerformanceObserver.supportedEntryTypes
+    ) {
+      return false;
+    }
+
+    return PerformanceObserver.supportedEntryTypes.includes(
+      LONG_ANIMATION_FRAME_PERFORMANCE_TYPE
+    );
+  }
+
+  private _createSpanFromEntry(entry: PerformanceLongAnimationFrameTiming) {
+    const span = this.tracer.startSpan(LONG_ANIMATION_FRAME_PERFORMANCE_TYPE, {
+      startTime: hrTime(entry.startTime),
+    });
+    const { observerCallback } = this.getConfig();
+    if (observerCallback) {
+      try {
+        observerCallback(span, { longAnimationFrameEntry: entry });
+      } catch (err) {
+        diag.error(
+          'long-animation-frame instrumentation: observer callback failed',
+          err
+        );
+      }
+    }
+    span.setAttribute('long_animation_frame.name', entry.name);
+    span.setAttribute('long_animation_frame.entry_type', entry.entryType);
+    span.setAttribute('long_animation_frame.duration', entry.duration);
+    span.setAttribute(
+      'long_animation_frame.blocking_duration',
+      entry.blockingDuration
+    );
+    span.setAttribute('long_animation_frame.render_start', entry.renderStart);
+    span.setAttribute(
+      'long_animation_frame.style_and_layout_start',
+      entry.styleAndLayoutStart
+    );
+    span.setAttribute(
+      'long_animation_frame.first_ui_event_timestamp',
+      entry.firstUIEventTimestamp
+    );
+
+    if (Array.isArray(entry.scripts)) {
+      entry.scripts.forEach((script, index) => {
+        const prefix =
+          entry.scripts.length > 1
+            ? `long_animation_frame.script[${index}]`
+            : 'long_animation_frame.script';
+        span.setAttribute(`${prefix}.name`, script.name);
+        span.setAttribute(`${prefix}.entry_type`, script.entryType);
+        span.setAttribute(`${prefix}.start_time`, script.startTime);
+        span.setAttribute(`${prefix}.duration`, script.duration);
+        span.setAttribute(`${prefix}.execution_start`, script.executionStart);
+        span.setAttribute(`${prefix}.invoker`, script.invoker);
+        span.setAttribute(`${prefix}.invoker_type`, script.invokerType);
+        span.setAttribute(`${prefix}.source_url`, script.sourceURL);
+        span.setAttribute(
+          `${prefix}.source_function_name`,
+          script.sourceFunctionName
+        );
+        span.setAttribute(
+          `${prefix}.source_char_position`,
+          script.sourceCharPosition
+        );
+        span.setAttribute(`${prefix}.pause_duration`, script.pauseDuration);
+        span.setAttribute(
+          `${prefix}.forced_style_and_layout_duration`,
+          script.forcedStyleAndLayoutDuration
+        );
+        span.setAttribute(
+          `${prefix}.window_attribution`,
+          script.windowAttribution
+        );
+      });
+    }
+
+    span.end(hrTime(entry.startTime + entry.duration));
+  }
+
+  override enable() {
+    if (!this.isSupported()) {
+      this._diag.debug('Environment not supported');
+      return;
+    }
+
+    if (this._observer) {
+      // Already enabled
+      return;
+    }
+
+    this._observer = new PerformanceObserver(list => {
+      list
+        .getEntries()
+        .forEach(entry =>
+          this._createSpanFromEntry(
+            entry as PerformanceLongAnimationFrameTiming
+          )
+        );
+    });
+    this._observer.observe({
+      type: LONG_ANIMATION_FRAME_PERFORMANCE_TYPE,
+      buffered: true,
+    });
+  }
+
+  override disable() {
+    if (!this._observer) {
+      return;
+    }
+
+    this._observer.disconnect();
+    this._observer = undefined;
+  }
+}

--- a/packages/instrumentation-long-animation-frame/src/types.ts
+++ b/packages/instrumentation-long-animation-frame/src/types.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import type { Span } from '@opentelemetry/api';
+import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
+
+// Currently missing in TypeScript DOM definitions.
+// https://developer.mozilla.org/en-US/docs/Web/API/PerformanceLongAnimationFrameTiming
+export interface PerformanceLongAnimationFrameTiming extends PerformanceEntry {
+  renderStart: DOMHighResTimeStamp;
+  styleAndLayoutStart: DOMHighResTimeStamp;
+  blockingDuration: DOMHighResTimeStamp;
+  firstUIEventTimestamp: DOMHighResTimeStamp;
+  scripts: PerformanceScriptTiming[];
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/API/PerformanceScriptTiming
+export interface PerformanceScriptTiming extends PerformanceEntry {
+  invokerType: string;
+  invoker: string;
+  executionStart: DOMHighResTimeStamp;
+  sourceURL: string;
+  sourceFunctionName: string;
+  sourceCharPosition: number;
+  pauseDuration: DOMHighResTimeStamp;
+  forcedStyleAndLayoutDuration: DOMHighResTimeStamp;
+  windowAttribution: string;
+  window: Window | null;
+}
+
+export interface ObserverCallbackInformation {
+  longAnimationFrameEntry: PerformanceLongAnimationFrameTiming;
+}
+
+export type ObserverCallback = (
+  span: Span,
+  information: ObserverCallbackInformation
+) => void;
+
+export interface LongAnimationFrameInstrumentationConfig
+  extends InstrumentationConfig {
+  /** Callback for adding custom attributes to span */
+  observerCallback?: ObserverCallback;
+}

--- a/packages/instrumentation-long-animation-frame/test/compatibility.test.ts
+++ b/packages/instrumentation-long-animation-frame/test/compatibility.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { trace } from '@opentelemetry/api';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace';
+import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+import { LongAnimationFrameInstrumentation } from '../src';
+import { DummySpanExporter } from './util';
+
+const _globalThis: typeof globalThis =
+  typeof globalThis === 'object'
+    ? globalThis
+    : typeof self === 'object'
+      ? self
+      : typeof window === 'object'
+        ? window
+        : typeof global === 'object'
+          ? global
+          : ({} as typeof globalThis);
+
+describe("LongAnimationFrameInstrumentation doesn't throw in unsupported environments", () => {
+  let webTracerProvider: WebTracerProvider;
+  let dummySpanExporter: DummySpanExporter;
+
+  before(() => {
+    dummySpanExporter = new DummySpanExporter();
+    webTracerProvider = new WebTracerProvider({
+      spanProcessors: [
+        new SimpleSpanProcessor({ exporter: dummySpanExporter }),
+      ],
+    });
+    webTracerProvider.register();
+  });
+
+  after(() => {
+    trace.disable();
+  });
+
+  // Do cleanup for environment changes here so even with test fails won't affect other tests
+  const perfObsDesc = Object.getOwnPropertyDescriptor(
+    _globalThis,
+    'PerformanceObserver'
+  );
+  const supportedDesc = Object.getOwnPropertyDescriptor(
+    PerformanceObserver,
+    'supportedEntryTypes'
+  );
+  afterEach(() => {
+    Object.defineProperty(_globalThis, 'PerformanceObserver', perfObsDesc!);
+    Object.defineProperty(
+      PerformanceObserver,
+      'supportedEntryTypes',
+      supportedDesc!
+    );
+  });
+
+  // tests based on different browser targets in
+  // https://developer.mozilla.org/en-US/docs/Web/API/PerformanceObserver#browser_compatibility
+  it('No support for PerformanceObserver', async () => {
+    // @ts-expect-error Non-optional in types
+    delete _globalThis.PerformanceObserver;
+
+    const instrumentation = new LongAnimationFrameInstrumentation({
+      enabled: false,
+    });
+
+    const deregister = registerInstrumentations({
+      instrumentations: [instrumentation],
+    });
+
+    deregister();
+  });
+
+  it('No supportedEntryTypes', async () => {
+    // @ts-expect-error Non-optional in types
+    delete PerformanceObserver.supportedEntryTypes;
+
+    const instrumentation = new LongAnimationFrameInstrumentation({
+      enabled: false,
+    });
+
+    const deregister = registerInstrumentations({
+      instrumentations: [instrumentation],
+    });
+
+    deregister();
+  });
+
+  it('long-animation-frame not supported', async () => {
+    Object.defineProperty(PerformanceObserver, 'supportedEntryTypes', {
+      get() {
+        return [];
+      },
+      configurable: true,
+      enumerable: false,
+    });
+
+    const instrumentation = new LongAnimationFrameInstrumentation({
+      enabled: false,
+    });
+
+    const deregister = registerInstrumentations({
+      instrumentations: [instrumentation],
+    });
+
+    deregister();
+  });
+});

--- a/packages/instrumentation-long-animation-frame/test/index-webpack.ts
+++ b/packages/instrumentation-long-animation-frame/test/index-webpack.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+const testsContext = require.context('.', true, /test$/);
+testsContext.keys().forEach(testsContext);
+
+const srcContext = require.context('.', true, /src$/);
+srcContext.keys().forEach(srcContext);

--- a/packages/instrumentation-long-animation-frame/test/longAnimationFrame.test.ts
+++ b/packages/instrumentation-long-animation-frame/test/longAnimationFrame.test.ts
@@ -1,0 +1,194 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { trace } from '@opentelemetry/api';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace';
+import { ReadableSpan } from '@opentelemetry/sdk-trace';
+import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { LongAnimationFrameInstrumentation } from '../src';
+import type { PerformanceLongAnimationFrameTiming } from '../src/types';
+import { DummySpanExporter } from './util';
+
+function buildLongAnimationFrameEntry(): PerformanceLongAnimationFrameTiming {
+  return {
+    name: 'long-animation-frame',
+    entryType: 'long-animation-frame',
+    startTime: 100,
+    duration: 60,
+    renderStart: 120,
+    styleAndLayoutStart: 130,
+    blockingDuration: 45,
+    firstUIEventTimestamp: 110,
+    scripts: [
+      {
+        name: 'script-name',
+        entryType: 'script',
+        startTime: 105,
+        duration: 20,
+        executionStart: 106,
+        invoker: 'Window.requestAnimationFrame',
+        invokerType: 'event-listener',
+        sourceURL: 'https://example.com/app.js',
+        sourceFunctionName: 'myFunction',
+        sourceCharPosition: 42,
+        pauseDuration: 0,
+        forcedStyleAndLayoutDuration: 3,
+        windowAttribution: 'self',
+        window: null,
+      },
+    ],
+  } as unknown as PerformanceLongAnimationFrameTiming;
+}
+
+describe('LongAnimationFrameInstrumentation', () => {
+  let sandbox: sinon.SinonSandbox;
+  let webTracerProvider: WebTracerProvider;
+  let dummySpanExporter: DummySpanExporter;
+  let exportSpy: sinon.SinonSpy;
+  let deregister: () => void;
+  let observerCallback: (list: PerformanceObserverEntryList) => void;
+
+  const originalPerformanceObserver = globalThis.PerformanceObserver;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    dummySpanExporter = new DummySpanExporter();
+    exportSpy = sandbox.spy(dummySpanExporter, 'export');
+    webTracerProvider = new WebTracerProvider({
+      spanProcessors: [
+        new SimpleSpanProcessor({ exporter: dummySpanExporter }),
+      ],
+    });
+    webTracerProvider.register();
+
+    class FakePerformanceObserver {
+      static readonly supportedEntryTypes = ['long-animation-frame'];
+      constructor(callback: (list: PerformanceObserverEntryList) => void) {
+        observerCallback = callback;
+      }
+      observe() {}
+      disconnect() {}
+    }
+    globalThis.PerformanceObserver =
+      FakePerformanceObserver as unknown as typeof PerformanceObserver;
+
+    deregister = registerInstrumentations({
+      instrumentations: [
+        new LongAnimationFrameInstrumentation({ enabled: false }),
+      ],
+    });
+  });
+
+  afterEach(() => {
+    globalThis.PerformanceObserver = originalPerformanceObserver;
+    deregister();
+    sandbox.restore();
+    trace.disable();
+  });
+
+  function triggerLongAnimationFrame() {
+    assert.ok(observerCallback, 'observer should be registered');
+    observerCallback({
+      getEntries: () => [buildLongAnimationFrameEntry()],
+    } as unknown as PerformanceObserverEntryList);
+  }
+
+  it('should export a span with long animation frame attributes', () => {
+    triggerLongAnimationFrame();
+
+    assert.strictEqual(exportSpy.callCount, 1, 'should export once');
+    const spans: ReadableSpan[] = exportSpy.args[0][0];
+    assert.strictEqual(spans.length, 1, 'should export one span');
+    const span = spans[0];
+
+    assert.strictEqual(span.name, 'long-animation-frame');
+    assert.strictEqual(
+      span.attributes['long_animation_frame.name'],
+      'long-animation-frame'
+    );
+    assert.strictEqual(
+      span.attributes['long_animation_frame.entry_type'],
+      'long-animation-frame'
+    );
+    assert.strictEqual(span.attributes['long_animation_frame.duration'], 60);
+    assert.strictEqual(
+      span.attributes['long_animation_frame.blocking_duration'],
+      45
+    );
+    assert.strictEqual(
+      span.attributes['long_animation_frame.render_start'],
+      120
+    );
+    assert.strictEqual(
+      span.attributes['long_animation_frame.style_and_layout_start'],
+      130
+    );
+    assert.strictEqual(
+      span.attributes['long_animation_frame.first_ui_event_timestamp'],
+      110
+    );
+    assert.strictEqual(
+      span.attributes['long_animation_frame.script.invoker'],
+      'Window.requestAnimationFrame'
+    );
+    assert.strictEqual(
+      span.attributes['long_animation_frame.script.invoker_type'],
+      'event-listener'
+    );
+    assert.strictEqual(
+      span.attributes['long_animation_frame.script.source_function_name'],
+      'myFunction'
+    );
+    assert.strictEqual(
+      span.attributes['long_animation_frame.script.source_char_position'],
+      42
+    );
+  });
+
+  it('should attach additional attributes from callback', () => {
+    deregister();
+    deregister = registerInstrumentations({
+      instrumentations: [
+        new LongAnimationFrameInstrumentation({
+          enabled: false,
+          observerCallback: span => {
+            span.setAttributes({ foo: 'bar' });
+          },
+        }),
+      ],
+    });
+
+    triggerLongAnimationFrame();
+    const spans: ReadableSpan[] = exportSpy.args[0][0];
+    assert.strictEqual(spans[0].attributes['foo'], 'bar');
+  });
+
+  it('should not fail to export span if observerCallback throws', () => {
+    deregister();
+    const errorCallback = sandbox.stub().throws();
+    deregister = registerInstrumentations({
+      instrumentations: [
+        new LongAnimationFrameInstrumentation({
+          enabled: false,
+          observerCallback: errorCallback,
+        }),
+      ],
+    });
+
+    triggerLongAnimationFrame();
+    assert.strictEqual(
+      errorCallback.threw(),
+      true,
+      'expected callback to throw'
+    );
+    assert.strictEqual(
+      exportSpy.callCount,
+      1,
+      'expected export to be called once'
+    );
+  });
+});

--- a/packages/instrumentation-long-animation-frame/test/util.ts
+++ b/packages/instrumentation-long-animation-frame/test/util.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace';
+
+export class DummySpanExporter implements SpanExporter {
+  export(_spans: ReadableSpan[]) {}
+
+  shutdown() {
+    return Promise.resolve();
+  }
+}

--- a/packages/instrumentation-long-animation-frame/tsconfig.esm.json
+++ b/packages/instrumentation-long-animation-frame/tsconfig.esm.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.esm.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build/esm",
+    "tsBuildInfoFile": "build/esm/tsconfig.esm.tsbuildinfo"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/instrumentation-long-animation-frame/tsconfig.esnext.json
+++ b/packages/instrumentation-long-animation-frame/tsconfig.esnext.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.esnext.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build/esnext",
+    "tsBuildInfoFile": "build/esnext/tsconfig.esnext.tsbuildinfo"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/instrumentation-long-animation-frame/tsconfig.json
+++ b/packages/instrumentation-long-animation-frame/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build"
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ]
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -72,6 +72,7 @@
     "packages/instrumentation-router": {},
     "packages/instrumentation-winston": {},
     "packages/instrumentation-document-load": {},
+    "packages/instrumentation-long-animation-frame": {},
     "packages/instrumentation-long-task": {},
     "packages/instrumentation-user-interaction": {},
     "packages/instrumentation-web-exception": {},


### PR DESCRIPTION
## Which problem is this PR solving?

The Long Tasks API (used by `@opentelemetry/instrumentation-long-task`) is deprecated. #3669 deprecates the long-task package and points users at the Long Animation Frames API, but no LoAF instrumentation exists yet, so users would be left with nothing to migrate to.

This PR adds `@opentelemetry/instrumentation-long-animation-frame`, the successor to `@opentelemetry/instrumentation-long-task`.

Related: #3669, #395

## Short description of the changes

- New package `packages/instrumentation-long-animation-frame`, modeled on `instrumentation-long-task`.
- One span per `PerformanceLongAnimationFrameTiming` entry, with attributes `long_animation_frame.name`, `.entry_type`, `.duration`, `.blocking_duration`, `.render_start`, `.style_and_layout_start`, `.first_ui_event_timestamp`, plus per-script `long_animation_frame.script[*].*` attributes (invoker, invoker type, source URL/function/char position, execution start, pause duration, forced style/layout duration, window attribution).
- `observerCallback` config option, mirroring `instrumentation-long-task`.
- Registered in `release-please-config.json` / `.release-please-manifest.json`, the browser-environment ESLint config, and `package-lock.json`.

## How Has This Been Tested?

- `npm run compile` (tsc) — passes
- `npm run test:browser` (karma + ChromeHeadless) — 6/6 tests pass, 98% line coverage
- `eslint`, `prettier --check`, `markdownlint`, and `npm run lint:readme` — pass
