### PR TITLE
fix(instrumentation-restify): end callback spans on next

### DIFF
--- a/packages/instrumentation-restify/src/instrumentation.ts
+++ b/packages/instrumentation-restify/src/instrumentation.ts
@@ -190,21 +190,42 @@ export class RestifyInstrumentation extends InstrumentationBase<RestifyInstrumen
           );
         }
 
+        let spanEnded = false;
+
+        const endSpan = () => {
+          if (!spanEnded) {
+            spanEnded = true;
+            span.end();
+          }
+        };
+
         const patchedNext = (err?: any) => {
-          span.end();
+          endSpan();
           next(err);
         };
-        patchedNext.ifError = next.ifError;
+
+        const nextIfError = next.ifError;
+
+        if (nextIfError) {
+          patchedNext.ifError = (err?: any) => {
+            if (err) {
+              endSpan();
+            }
+            return nextIfError.call(patchedNext, err);
+          };
+        } else {
+          patchedNext.ifError = nextIfError;
+        }
 
         const wrapPromise = (promise: Promise<unknown>) => {
           return promise
             .then(value => {
-              span.end();
+              endSpan();
               return value;
             })
             .catch(err => {
               span.recordException(err);
-              span.end();
+              endSpan();
               throw err;
             });
         };
@@ -221,11 +242,10 @@ export class RestifyInstrumentation extends InstrumentationBase<RestifyInstrumen
               if (isPromise(result)) {
                 return wrapPromise(result);
               }
-              span.end();
               return result;
             } catch (err: any) {
               span.recordException(err);
-              span.end();
+              endSpan();
               throw err;
             }
           },

--- a/packages/instrumentation-restify/test/restify.test.ts
+++ b/packages/instrumentation-restify/test/restify.test.ts
@@ -75,6 +75,7 @@ const useHandler: restify.RequestHandler = (req, res, next) => {
 };
 const getHandler: restify.RequestHandler = (req, res, next) => {
   res.send({ route: req?.params?.param });
+  return next();
 };
 const throwError: restify.RequestHandler = (req, res, next) => {
   throw new AppError('NOK');
@@ -83,8 +84,11 @@ const returnError: restify.RequestHandler = (req, res, next) => {
   next(new AppError('NOK'));
 };
 
-const createServer = async (setupRoutes?: Function) => {
-  const server = restify.createServer();
+const createServer = async (
+  setupRoutes?: Function,
+  options?: restify.ServerOptions
+) => {
+  const server = restify.createServer(options);
 
   if (typeof setupRoutes === 'function') {
     setupRoutes(server);
@@ -404,6 +408,89 @@ describe('Restify Instrumentation', () => {
           assert.strictEqual(span.attributes['restify.name'], 'asyncHandler');
           assertIsVersion(span.attributes['restify.version']);
         }
+      } finally {
+        testLocalServer.close();
+      }
+    });
+
+    it('should keep span open until next is called for callback-style async handlers', async () => {
+      const { promise: work, resolve: resolveWork } = defer();
+      const { promise: started, resolve: resolveStarted } = defer();
+      let status = 'uninit';
+
+      const callbackHandler: restify.RequestHandler = (req, res, next) => {
+        status = 'started';
+        resolveStarted();
+
+        work.then(() => {
+          status = 'done';
+          res.send({ route: req?.params?.param });
+          next();
+        });
+      };
+
+      const testLocalServer = await createServer((server: restify.Server) => {
+        server.get('/route/:param', callbackHandler);
+      });
+      const testLocalPort = testLocalServer.address().port;
+
+      try {
+        const requestPromise = httpRequest
+          .get(`http://localhost:${testLocalPort}/route/hello`)
+          .then(res => {
+            assert.strictEqual(res, '{"route":"hello"}');
+          });
+
+        assert.strictEqual(status, 'uninit');
+        await started;
+
+        assert.strictEqual(status, 'started');
+        assert.strictEqual(memoryExporter.getFinishedSpans().length, 0);
+
+        resolveWork();
+        await requestPromise;
+
+        assert.strictEqual(status, 'done');
+        assert.strictEqual(memoryExporter.getFinishedSpans().length, 1);
+
+        const span = memoryExporter.getFinishedSpans()[0];
+        assert.notStrictEqual(span, undefined);
+        assert.strictEqual(span.attributes['http.route'], '/route/:param');
+        assert.strictEqual(span.attributes['restify.method'], 'get');
+        assert.strictEqual(span.attributes['restify.type'], 'request_handler');
+        assert.strictEqual(span.attributes['restify.name'], 'callbackHandler');
+        assertIsVersion(span.attributes['restify.version']);
+      } finally {
+        resolveWork();
+        testLocalServer.close();
+      }
+    });
+
+    it('should end span when async next.ifError is called', async () => {
+      if (!semver.satisfies(LIB_VERSION, '>=5 <7')) {
+        return;
+      }
+
+      const serverOptions = {
+        handleUncaughtExceptions: true,
+      } as restify.ServerOptions & {
+        handleUncaughtExceptions: boolean;
+      };
+
+      const testLocalServer = await createServer((server: restify.Server) => {
+        server.get('/async-error', (req, res, next) => {
+          setTimeout(() => {
+            next.ifError(new Error('async error'));
+          }, 10);
+        });
+      }, serverOptions);
+
+      const testLocalPort = testLocalServer.address().port;
+
+      try {
+        await httpRequest.get(`http://localhost:${testLocalPort}/async-error`);
+
+        assert.strictEqual(memoryExporter.getFinishedSpans().length, 1);
       } finally {
         testLocalServer.close();
       }


### PR DESCRIPTION
Assisted-by: ChatGPT 5.6 Sol

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Fixes #1988.

Callback-style Restify handlers can return before their asynchronous work is finished and call next() later. The instrumentation was ending the span as soon as the handler function returned, which made those spans too short.

## Short description of the changes

- This change keeps callback-style handler spans open until next() is called, while using a shared endSpan() helper so Promise, error, and callback completion paths only end the span once.

- I also updated the shared test handler to call next() after sending the response, matching Restify's normal handler contract, and added a regression test for delayed next().

Validation:

- restify.test.ts: 12 passing
- npm run compile: passed
- Prettier and git diff --check: passed
