### PR TITLE
fix(resource-detector-gcp): add gcp.project_id attribute

### DIFF
--- a/packages/resource-detector-gcp/src/detectors/GcpDetector.ts
+++ b/packages/resource-detector-gcp/src/detectors/GcpDetector.ts
@@ -14,6 +14,7 @@ import {
   CLOUD_PLATFORM_VALUE_GCP_KUBERNETES_ENGINE,
   CLOUD_PROVIDER_VALUE_GCP,
   ATTR_CLOUD_ACCOUNT_ID,
+  ATTR_GCP_PROJECT_ID,
   ATTR_CLOUD_AVAILABILITY_ZONE,
   ATTR_CLOUD_PLATFORM,
   ATTR_CLOUD_PROVIDER,
@@ -52,6 +53,7 @@ const ATTRIBUTE_NAMES = [
   ATTR_HOST_NAME,
   ATTR_CLOUD_PROVIDER,
   ATTR_CLOUD_ACCOUNT_ID,
+  ATTR_GCP_PROJECT_ID,
   ATTR_FAAS_NAME,
   ATTR_FAAS_VERSION,
   ATTR_FAAS_INSTANCE,
@@ -188,6 +190,7 @@ async function makeResource(attrs: GcpResourceAttributes): Promise<Resource> {
   return resourceFromAttributes({
     [ATTR_CLOUD_PROVIDER]: CLOUD_PROVIDER_VALUE_GCP,
     [ATTR_CLOUD_ACCOUNT_ID]: project,
+    [ATTR_GCP_PROJECT_ID]: project,
     ...attrs,
   } satisfies GcpResourceAttributes);
 }

--- a/packages/resource-detector-gcp/src/semconv.ts
+++ b/packages/resource-detector-gcp/src/semconv.ts
@@ -20,6 +20,16 @@
 export const ATTR_CLOUD_ACCOUNT_ID = 'cloud.account.id' as const;
 
 /**
+ * The Google Cloud project ID.
+ *
+ * @example my-project
+ * @example 233510669999
+ *
+ * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ */
+export const ATTR_GCP_PROJECT_ID = 'gcp.project_id' as const;
+
+/**
  * Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running.
  *
  * @example us-east-1c

--- a/packages/resource-detector-gcp/test/detectors/GcpDetector.test.ts
+++ b/packages/resource-detector-gcp/test/detectors/GcpDetector.test.ts
@@ -56,6 +56,7 @@ describe('gcpDetector', () => {
       const resource = await detectAndWait();
       assert.deepStrictEqual(resource.attributes, {
         'cloud.account.id': 'fake-project-id',
+        'gcp.project_id': 'fake-project-id',
         'cloud.availability_zone': 'us-east4-b',
         'cloud.platform': 'gcp_kubernetes_engine',
         'cloud.provider': 'gcp',
@@ -71,6 +72,7 @@ describe('gcpDetector', () => {
       const resource = await detectAndWait();
       assert.deepStrictEqual(resource.attributes, {
         'cloud.account.id': 'fake-project-id',
+        'gcp.project_id': 'fake-project-id',
         'cloud.platform': 'gcp_kubernetes_engine',
         'cloud.provider': 'gcp',
         'cloud.region': 'us-east4',
@@ -97,6 +99,7 @@ describe('gcpDetector', () => {
     const resource = await detectAndWait();
     assert.deepStrictEqual(resource.attributes, {
       'cloud.account.id': 'fake-project-id',
+      'gcp.project_id': 'fake-project-id',
       'cloud.availability_zone': 'us-east4-b',
       'cloud.platform': 'gcp_compute_engine',
       'cloud.provider': 'gcp',
@@ -121,6 +124,7 @@ describe('gcpDetector', () => {
     const resource = await detectAndWait();
     assert.deepStrictEqual(resource.attributes, {
       'cloud.account.id': 'fake-project-id',
+      'gcp.project_id': 'fake-project-id',
       'cloud.platform': 'gcp_cloud_run',
       'cloud.provider': 'gcp',
       'cloud.region': 'us-east4',
@@ -144,6 +148,7 @@ describe('gcpDetector', () => {
     const resource = await detectAndWait();
     assert.deepStrictEqual(resource.attributes, {
       'cloud.account.id': 'fake-project-id',
+      'gcp.project_id': 'fake-project-id',
       'cloud.platform': 'gcp_cloud_functions',
       'cloud.provider': 'gcp',
       'cloud.region': 'us-east4',
@@ -166,6 +171,7 @@ describe('gcpDetector', () => {
     const resource = await detectAndWait();
     assert.deepStrictEqual(resource.attributes, {
       'cloud.account.id': 'fake-project-id',
+      'gcp.project_id': 'fake-project-id',
       'cloud.availability_zone': 'us-east4-b',
       'cloud.platform': 'gcp_app_engine',
       'cloud.provider': 'gcp',
@@ -187,6 +193,7 @@ describe('gcpDetector', () => {
     const resource = await detectAndWait();
     assert.deepStrictEqual(resource.attributes, {
       'cloud.account.id': 'fake-project-id',
+      'gcp.project_id': 'fake-project-id',
       'cloud.availability_zone': 'us-east4-b',
       'cloud.platform': 'gcp_app_engine',
       'cloud.provider': 'gcp',


### PR DESCRIPTION
## Which problem is this PR solving?

The `gcpDetector` does not set the `gcp.project_id` resource attribute, despite the [OTLP migration guide](https://github.com/GoogleCloudPlatform/opentelemetry-operations-js/blob/main/MIGRATION.md#resource-detection-recommended-for-all-signals) claiming it does. This causes 400 (`INVALID_ARGUMENT`) errors when exporting to `telemetry.googleapis.com`, which requires `gcp.project_id` to route telemetry data to the correct Google Cloud project.

The [Google Cloud Trace OTLP migration docs](https://docs.cloud.google.com/trace/docs/migrate-to-otlp-endpoints#node.js) explicitly instruct users to set this attribute:

> Add to the `OTEL_RESOURCE_ATTRIBUTES` environment variable the key-value pair that specifies your project. For the key, use `gcp.project_id`. For the value, use the ID of your Google Cloud project.
>
> Example: `export OTEL_RESOURCE_ATTRIBUTES="gcp.project_id=PROJECT_ID"`

Users following the migration guide who install this detector as the recommended way to populate resource attributes are silently missing `gcp.project_id`, and must work around it manually.

## Short description of the changes

Adds `gcp.project_id` as a new resource attribute populated from the GCP Metadata `project-id` field. Uses the same source and follows the same pattern as the existing `cloud.account.id`. The new attribute is added to `semconv.ts`, included in `ATTRIBUTE_NAMES`, and set in `makeResource()` alongside `cloud.account.id`.
