### PR TITLE
fix(instrumentation-nestjs-core): remove ESM loading workaround

### DIFF
--- a/packages/instrumentation-nestjs-core/.tav.yml
+++ b/packages/instrumentation-nestjs-core/.tav.yml
@@ -12,6 +12,8 @@
         - "reflect-metadata@^0.2.0"
         - "rxjs@^7.1.0"
     commands: npm run test
+    env:
+      - NODE_OPTIONS=--experimental-loader=@opentelemetry/instrumentation/hook.mjs
 
   - versions:
       include: ">=11.0.0 <12"

--- a/packages/instrumentation-nestjs-core/README.md
+++ b/packages/instrumentation-nestjs-core/README.md
@@ -19,7 +19,7 @@ npm install --save @opentelemetry/instrumentation-nestjs-core
 
 - [`@nestjs/core`](https://www.npmjs.com/package/@nestjs/core) versions `>=4.0.0 <13`
 
-NestJS 12 is published as ESM. CommonJS applications that `require('@nestjs/core')` are instrumented without further setup. ESM applications need the loader hook described in the [ESM support](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/esm-support.md) guide, as with any other instrumentation.
+NestJS 12 is published as ESM. Instrumenting NestJS 12 requires the loader hook described in the [ESM support](https://github.com/open-telemetry/opentelemetry-js/blob/main/doc/esm-support.md) guide, including when the application itself is CommonJS.
 
 ## Usage
 

--- a/packages/instrumentation-nestjs-core/src/instrumentation.ts
+++ b/packages/instrumentation-nestjs-core/src/instrumentation.ts
@@ -25,12 +25,10 @@ import { AttributeNames, NestType } from './enums';
 
 const supportedVersions = ['>=4.0.0 <13'];
 
-// The files patched by this instrumentation. Since NestJS 12 the package is
-// published as ESM, see `loadPatchedFiles`.
+// The files patched by this instrumentation.
 const NEST_FACTORY_FILE = '@nestjs/core/nest-factory.js';
 const ROUTER_EXECUTION_CONTEXT_FILE =
   '@nestjs/core/router/router-execution-context.js';
-const FIRST_ESM_MAJOR = 12;
 
 export class NestInstrumentation extends InstrumentationBase {
   static readonly COMPONENT = '@nestjs/core';
@@ -45,11 +43,7 @@ export class NestInstrumentation extends InstrumentationBase {
   init() {
     const module = new InstrumentationNodeModuleDefinition(
       NestInstrumentation.COMPONENT,
-      supportedVersions,
-      (moduleExports: any, moduleVersion?: string) => {
-        this.loadPatchedFiles(moduleVersion);
-        return moduleExports;
-      }
+      supportedVersions
     );
 
     module.files.push(
@@ -58,32 +52,6 @@ export class NestInstrumentation extends InstrumentationBase {
     );
 
     return module;
-  }
-
-  /**
-   * NestJS 12 publishes `@nestjs/core` as ESM. When a CommonJS application
-   * `require()`s it, Node.js evaluates the package's internal files with the
-   * ESM loader, so they never pass through the `require` hook and the file
-   * patches registered in `init()` would not run. Requiring the two patched
-   * files here routes them through the hook. The ESM loader has already
-   * cached them, so the same class prototypes get wrapped.
-   *
-   * ESM applications load these files through the ESM loader hook instead,
-   * where the file patches apply directly.
-   *
-   * The files are resolved from the application's lookup paths, not from this
-   * package's, so that layouts which do not hoist `@nestjs/core` (pnpm) work.
-   */
-  private loadPatchedFiles(moduleVersion?: string) {
-    const major = Number(moduleVersion?.split('.')[0]);
-    if (!(major >= FIRST_ESM_MAJOR)) {
-      return;
-    }
-    const paths = [...(require.main?.paths ?? []), ...module.paths];
-    for (const file of [NEST_FACTORY_FILE, ROUTER_EXECUTION_CONTEXT_FILE]) {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      require(require.resolve(file, { paths }));
-    }
   }
 
   getNestFactoryFileInstrumentation(versions: string[]) {


### PR DESCRIPTION
Assisted-by: ChatGPT 5.6 Sol

<!--
We appreciate your contribution to the OpenTelemetry project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- Please provide enough information so that others can review your pull request
- You have read the guide for contributing
  - See https://github.com/open-telemetry/opentelemetry-js/blob/main/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/open-telemetry/community/blob/main/guides/contributor#sign-the-cla
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Fixes #xxx". This will auto-close
  the issue that your PR fixes (if such)
-->

## Which problem is this PR solving?

Fixes #3752.

For NestJS 12, the instrumentation was manually loading the patched files with require() instead of relying on the OpenTelemetry ESM loader.

## Short description of the changes

- Removes loadPatchedFiles() and relies on the normal OpenTelemetry ESM loader path.
- Enables the ESM loader for the NestJS 12 TAV tests.
- Updates the README to document that NestJS 12 requires the ESM loader, including for CommonJS applications.


Testing

- NestJS 12: all four tests failed without the ESM loader and passed with it enabled.
- NestJS 11: all four tests passed.
- npm run compile passed.
